### PR TITLE
Add per-feature debug/trace logging with -X CLI flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,7 @@ jobs:
           # Publish order: leaves first, then dependents
           # Sleep between publishes to let crates.io index catch up
           CRATES=(
+            cljrs-logging
             cljrs-types
             cljrs-gc
             cljrs-ir

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           # Update workspace dependency table to use the new version
           CRATES=(cljrs-types cljrs-gc cljrs-ir cljrs-reader cljrs-value cljrs-eval cljrs-interop cljrs-runtime cljrs-stdlib cljrs-compiler cljrs)
           for crate in "${CRATES[@]}"; do
-            sed -i "s/^${crate}.*=.*{.*path/${crate} = { version = \"=$VERSION\", path/" Cargo.toml
+            sed -i "s/^${crate} *= *{.*path/${crate} = { version = \"=$VERSION\", path/" Cargo.toml
           done
 
           echo "--- Workspace Cargo.toml ---"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "cljrs-eval",
  "cljrs-gc",
  "cljrs-interop",
+ "cljrs-logging",
  "cljrs-reader",
  "cljrs-runtime",
  "cljrs-stdlib",
@@ -282,6 +283,7 @@ name = "cljrs-gc"
 version = "0.1.0"
 dependencies = [
  "bigdecimal",
+ "cljrs-logging",
  "num-bigint",
  "num-rational",
  "regex",
@@ -303,6 +305,10 @@ version = "0.1.0"
 dependencies = [
  "cljrs-types",
 ]
+
+[[package]]
+name = "cljrs-logging"
+version = "0.1.0"
 
 [[package]]
 name = "cljrs-reader"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/cljrs-ir",
     "crates/cljrs-compiler",
     "crates/cljrs-interop",
+    "crates/cljrs-logging",
     "crates/cljrs",
     "examples/rust-interop",
 ]
@@ -30,6 +31,7 @@ cljrs-runtime  = { path = "crates/cljrs-runtime" }
 cljrs-ir       = { path = "crates/cljrs-ir" }
 cljrs-compiler = { path = "crates/cljrs-compiler" }
 cljrs-interop  = { path = "crates/cljrs-interop" }
+cljrs-logging  = { path = "crates/cljrs-logging" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/crates/cljrs-gc/Cargo.toml
+++ b/crates/cljrs-gc/Cargo.toml
@@ -11,3 +11,4 @@ num-bigint   = { workspace = true }
 bigdecimal   = { workspace = true }
 num-rational = { workspace = true }
 regex        = { workspace = true }
+cljrs-logging = { workspace = true }

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -416,7 +416,10 @@ impl GcHeap {
     pub fn collect_auto(&self) -> bool {
         cljrs_logging::feat_debug!("gc", "automatic collection requested");
         let Some(_stw_guard) = cancellation::begin_stw() else {
-            cljrs_logging::feat_debug!("gc", "automatic collection skipped: another thread is already collecting");
+            cljrs_logging::feat_debug!(
+                "gc",
+                "automatic collection skipped: another thread is already collecting"
+            );
             return false;
         };
         cljrs_logging::feat_debug!(

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -316,12 +316,26 @@ impl GcHeap {
     /// Must only be called when no other thread is creating or dereferencing
     /// `GcPtr` values.  `trace_roots` must visit every live root.
     pub fn collect<F: FnOnce(&mut MarkVisitor)>(&self, trace_roots: F) {
+        let pre_count = self.inner.lock().unwrap().count;
+        let pre_memory = self.memory_in_use.load(Ordering::Relaxed);
+        cljrs_logging::feat_debug!(
+            "gc",
+            "starting collection: {} objects, ~{} bytes in use",
+            pre_count,
+            pre_memory
+        );
+
+        let mark_start = std::time::Instant::now();
+
         // Mark phase: populate grey set from roots, then drain it.
         let mut visitor = MarkVisitor::new();
         trace_roots(&mut visitor);
         visitor.drain();
 
+        let mark_elapsed = mark_start.elapsed();
+
         // Sweep phase: partition into live and dead, then free dead objects.
+        let sweep_start = std::time::Instant::now();
         let mut inner = self.inner.lock().unwrap();
         let mut live: Vec<*mut GcBoxHeader> = Vec::with_capacity(inner.count);
         let mut dead: Vec<*mut GcBoxHeader> = Vec::new();
@@ -360,6 +374,19 @@ impl GcHeap {
         // Estimate memory freed (rough approximation)
         let freed_bytes = freed_count * ESTIMATED_OBJECT_SIZE;
         self.memory_in_use.fetch_sub(freed_bytes, Ordering::Relaxed);
+
+        let sweep_elapsed = sweep_start.elapsed();
+        let post_memory = self.memory_in_use.load(Ordering::Relaxed);
+        cljrs_logging::feat_debug!(
+            "gc",
+            "collection complete: freed {} objects (~{} bytes), {} objects remaining (~{} bytes), mark={:.2?} sweep={:.2?}",
+            freed_count,
+            freed_bytes,
+            inner.count,
+            post_memory,
+            mark_elapsed,
+            sweep_elapsed
+        );
     }
 
     /// Number of currently live GC allocations.
@@ -387,10 +414,16 @@ impl GcHeap {
     /// Returns `true` if collection ran, `false` if another thread is
     /// already collecting.
     pub fn collect_auto(&self) -> bool {
+        cljrs_logging::feat_debug!("gc", "automatic collection requested");
         let Some(_stw_guard) = cancellation::begin_stw() else {
-            // Another thread is already collecting — just return.
+            cljrs_logging::feat_debug!("gc", "automatic collection skipped: another thread is already collecting");
             return false;
         };
+        cljrs_logging::feat_debug!(
+            "gc",
+            "stop-the-world acquired, {} mutator thread(s) parked",
+            cancellation::registered_threads()
+        );
         // All other threads are now parked.  Run collection with registered roots.
         self.collect(|visitor| {
             self.trace_registered_roots(visitor);

--- a/crates/cljrs-logging/Cargo.toml
+++ b/crates/cljrs-logging/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cljrs-logging"
+version = "0.1.0"
+edition = "2024"
+description = "Feature-gated debug/trace logging for clojurust"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]

--- a/crates/cljrs-logging/README.md
+++ b/crates/cljrs-logging/README.md
@@ -1,0 +1,21 @@
+# cljrs-logging
+
+Feature-gated debug/trace logging for clojurust.
+
+## Status
+
+Implemented. Provides runtime-configurable per-feature logging at debug and trace levels.
+
+## File layout
+
+- `src/lib.rs` — global feature level state, `parse_x_flag`, `feat_debug!` / `feat_trace!` macros
+
+## Public API
+
+- `enum Level` — `Off`, `Debug`, `Trace` (ordered by verbosity)
+- `fn set_feature_level(feature: &str, level: Level)` — set the log level for a feature
+- `fn feature_level(feature: &str) -> Level` — query the current level for a feature
+- `fn is_enabled(feature: &str, level: Level) -> bool` — check if a feature is enabled at a level
+- `fn parse_x_flag(value: &str) -> Result<(), String>` — parse a `-X debug:gc,jit` style flag string
+- `feat_debug!(feature, fmt, args...)` — log at debug level for a feature (to stderr)
+- `feat_trace!(feature, fmt, args...)` — log at trace level for a feature (to stderr)

--- a/crates/cljrs-logging/src/lib.rs
+++ b/crates/cljrs-logging/src/lib.rs
@@ -1,0 +1,141 @@
+//! Feature-gated logging for clojurust.
+//!
+//! Provides per-feature debug and trace logging controlled at runtime via CLI flags.
+//! Features are arbitrary strings (e.g. "gc", "jit", "reader") — any feature name
+//! is accepted even if no code ever logs with it.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! // Set features from CLI flags
+//! cljrs_logging::set_feature_level("gc", Level::Debug);
+//! cljrs_logging::set_feature_level("jit", Level::Trace);
+//!
+//! // In code:
+//! feat_debug!("gc", "starting collection, heap_size={}", heap_size);
+//! feat_trace!("gc", "visiting object at {:p}", ptr);
+//! ```
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+static FEATURE_LEVELS: RwLock<Option<HashMap<String, Level>>> = RwLock::new(None);
+
+/// Log level for a feature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Level {
+    /// No logging (default for unregistered features).
+    Off = 0,
+    /// Debug-level messages.
+    Debug = 1,
+    /// Trace-level messages (most verbose).
+    Trace = 2,
+}
+
+/// Set the logging level for a single feature.
+pub fn set_feature_level(feature: &str, level: Level) {
+    let mut guard = FEATURE_LEVELS.write().unwrap();
+    let map = guard.get_or_insert_with(HashMap::new);
+    map.insert(feature.to_string(), level);
+}
+
+/// Get the logging level for a feature. Returns `Level::Off` if the feature
+/// has not been configured.
+pub fn feature_level(feature: &str) -> Level {
+    let guard = FEATURE_LEVELS.read().unwrap();
+    guard
+        .as_ref()
+        .and_then(|m| m.get(feature).copied())
+        .unwrap_or(Level::Off)
+}
+
+/// Returns true if the given feature is enabled at least at `level`.
+#[inline]
+pub fn is_enabled(feature: &str, level: Level) -> bool {
+    feature_level(feature) >= level
+}
+
+/// Parse a `-X` flag value like `"debug:gc,jit"` or `"trace:reader"` and
+/// register the appropriate feature levels.
+///
+/// Format: `<level>:<feature1>,<feature2>,...`
+///
+/// Returns `Err` with a message if the format is invalid.
+pub fn parse_x_flag(value: &str) -> Result<(), String> {
+    let (level_str, features_str) = value
+        .split_once(':')
+        .ok_or_else(|| format!("expected <level>:<features>, got: {value}"))?;
+
+    let level = match level_str {
+        "debug" => Level::Debug,
+        "trace" => Level::Trace,
+        other => return Err(format!("unknown level '{other}', expected 'debug' or 'trace'")),
+    };
+
+    for feature in features_str.split(',') {
+        let feature = feature.trim();
+        if feature.is_empty() {
+            continue;
+        }
+        set_feature_level(feature, level);
+    }
+    Ok(())
+}
+
+/// Log a message at debug level for a feature. Only prints if the feature
+/// is enabled at debug level or higher.
+///
+/// ```ignore
+/// feat_debug!("gc", "heap size: {}", size);
+/// ```
+#[macro_export]
+macro_rules! feat_debug {
+    ($feature:expr, $fmt:literal $(, $arg:expr)* $(,)?) => {
+        if $crate::is_enabled($feature, $crate::Level::Debug) {
+            eprint!("[DEBUG:{}] ", $feature);
+            eprintln!($fmt $(, $arg)*);
+        }
+    };
+}
+
+/// Log a message at trace level for a feature.
+///
+/// ```ignore
+/// feat_trace!("gc", "visiting {:p}", ptr);
+/// ```
+#[macro_export]
+macro_rules! feat_trace {
+    ($feature:expr, $fmt:literal $(, $arg:expr)* $(,)?) => {
+        if $crate::is_enabled($feature, $crate::Level::Trace) {
+            eprint!("[TRACE:{}] ", $feature);
+            eprintln!($fmt $(, $arg)*);
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_x_flag() {
+        parse_x_flag("debug:gc,jit").unwrap();
+        assert_eq!(feature_level("gc"), Level::Debug);
+        assert_eq!(feature_level("jit"), Level::Debug);
+        assert_eq!(feature_level("reader"), Level::Off);
+    }
+
+    #[test]
+    fn test_parse_x_flag_trace() {
+        parse_x_flag("trace:reader").unwrap();
+        assert_eq!(feature_level("reader"), Level::Trace);
+        assert!(is_enabled("reader", Level::Debug));
+        assert!(is_enabled("reader", Level::Trace));
+    }
+
+    #[test]
+    fn test_parse_x_flag_invalid() {
+        assert!(parse_x_flag("bogus").is_err());
+        assert!(parse_x_flag("warn:gc").is_err());
+    }
+}

--- a/crates/cljrs-logging/src/lib.rs
+++ b/crates/cljrs-logging/src/lib.rs
@@ -69,7 +69,11 @@ pub fn parse_x_flag(value: &str) -> Result<(), String> {
     let level = match level_str {
         "debug" => Level::Debug,
         "trace" => Level::Trace,
-        other => return Err(format!("unknown level '{other}', expected 'debug' or 'trace'")),
+        other => {
+            return Err(format!(
+                "unknown level '{other}', expected 'debug' or 'trace'"
+            ));
+        }
     };
 
     for feature in features_str.split(',') {

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -20,6 +20,7 @@ cljrs-stdlib   = { workspace = true }
 cljrs-runtime  = { workspace = true }
 cljrs-compiler = { workspace = true }
 cljrs-interop  = { workspace = true }
+cljrs-logging  = { workspace = true }
 clap          = { workspace = true }
 miette        = { workspace = true }
 tracing-subscriber = "0.3.23"

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -34,6 +34,13 @@ struct Cli {
     #[arg(long, global = true, help = "Enable trace logging (implies --debug)")]
     trace: bool,
 
+    /// Feature-level logging flags: -X debug:gc,jit or -X trace:reader
+    ///
+    /// Format: <level>:<feature1>,<feature2>,...
+    /// Levels: debug, trace
+    #[arg(short = 'X', global = true, value_name = "LEVEL:FEATURES")]
+    x_flags: Vec<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -147,6 +154,12 @@ fn main() -> miette::Result<()> {
             tracing::Level::INFO
         })
         .try_init();
+
+    // Parse -X feature logging flags
+    for flag in &cli.x_flags {
+        cljrs_logging::parse_x_flag(flag)
+            .map_err(|e| miette::miette!("invalid -X flag: {e}"))?;
+    }
 
     let stack_size = cli
         .stack_size_mb

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -157,8 +157,7 @@ fn main() -> miette::Result<()> {
 
     // Parse -X feature logging flags
     for flag in &cli.x_flags {
-        cljrs_logging::parse_x_flag(flag)
-            .map_err(|e| miette::miette!("invalid -X flag: {e}"))?;
+        cljrs_logging::parse_x_flag(flag).map_err(|e| miette::miette!("invalid -X flag: {e}"))?;
     }
 
     let stack_size = cli


### PR DESCRIPTION
New cljrs-logging crate provides runtime-configurable, per-feature logging via feat_debug!/feat_trace! macros. Features are arbitrary strings gated by CLI flags like `-X debug:gc,jit` or `-X trace:reader`. Added GC collection logging (object counts, memory, mark/sweep timing) behind the "gc" feature.