### PR TITLE
Fix three IR interpreter bugs that caused compiler tests to fail

### DIFF
--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -212,21 +212,21 @@ fn collect_defn_arities(
                     // Only consider zero-capture closures (top-level defns).
                     closure_templates.insert(*dst, template.clone());
                 }
-                Inst::DefVar(_, ns, name, val)
-                    if let Some(template) = closure_templates.get(val) =>
-                {
-                    let arities: Vec<ArityInfo> = template
-                        .arity_fn_names
-                        .iter()
-                        .zip(template.param_counts.iter())
-                        .zip(template.is_variadic.iter())
-                        .map(|((fn_name, &param_count), &is_variadic)| ArityInfo {
-                            fn_name: fn_name.clone(),
-                            param_count,
-                            is_variadic,
-                        })
-                        .collect();
-                    defns.insert((ns.clone(), name.clone()), arities);
+                Inst::DefVar(_, ns, name, val) => {
+                    if let Some(template) = closure_templates.get(val) {
+                        let arities: Vec<ArityInfo> = template
+                            .arity_fn_names
+                            .iter()
+                            .zip(template.param_counts.iter())
+                            .zip(template.is_variadic.iter())
+                            .map(|((fn_name, &param_count), &is_variadic)| ArityInfo {
+                                fn_name: fn_name.clone(),
+                                param_count,
+                                is_variadic,
+                            })
+                            .collect();
+                        defns.insert((ns.clone(), name.clone()), arities);
+                    }
                 }
                 _ => {}
             }

--- a/crates/cljrs-eval/src/apply.rs
+++ b/crates/cljrs-eval/src/apply.rs
@@ -3,7 +3,7 @@ use cljrs_env::env::Env;
 use cljrs_env::error::EvalResult;
 use cljrs_gc::GcPtr;
 use cljrs_interp::apply::select_arity;
-use cljrs_value::{CljxFn, Value};
+use cljrs_value::{CljxFn, PersistentList, Value};
 
 /// Whether eager IR lowering at function definition time is enabled.
 ///
@@ -84,9 +84,22 @@ fn execute_ir(
     // call back into the interpreter.
     cljrs_env::callback::push_eval_context(&env);
 
-    // Build IR args: the IR function's params are the positional params
-    // (and rest param if variadic). These map to VarIds in the IR.
-    let ir_args = args.to_vec();
+    // Build IR args: positional params map 1:1, but the rest param (if any)
+    // must receive a list of the remaining args, not individual values.
+    let ir_args = if arity.rest_param.is_some() {
+        let n = arity.params.len();
+        let mut ir_args = args[..n.min(args.len())].to_vec();
+        let rest_items: Vec<Value> = args[n.min(args.len())..].to_vec();
+        let rest_val = if rest_items.is_empty() {
+            Value::Nil
+        } else {
+            Value::List(GcPtr::new(PersistentList::from_iter(rest_items)))
+        };
+        ir_args.push(rest_val);
+        ir_args
+    } else {
+        args.to_vec()
+    };
 
     let result = crate::ir_interp::interpret_ir(
         ir_func,

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -766,11 +766,26 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
         | KnownFn::Juxt
         | KnownFn::Comp
         | KnownFn::Partial
-        | KnownFn::Complement
-        | KnownFn::Apply => {
+        | KnownFn::Complement => {
             let fn_name = known_fn_to_name(known_fn);
             let callee = load_builtin(env, fn_name)?;
             apply_value(&callee, args, env)
+        }
+
+        KnownFn::Apply => {
+            if args.len() < 2 {
+                return Err(EvalError::Arity {
+                    name: "apply".into(),
+                    expected: "2+".into(),
+                    got: args.len(),
+                });
+            }
+            let mut args = args;
+            let f = args.remove(0);
+            let last = args.pop().unwrap();
+            let spread = cljrs_interp::destructure::value_to_seq_vec(&last);
+            args.extend(spread);
+            apply_value(&f, args, env)
         }
 
         // ── Dynamic binding / exception handling ────────────────────────


### PR DESCRIPTION
1. aot.rs: replace unstable `if let` match-arm guard (E0658) with stable `if let` inside the match body.

2. ir_interp.rs: implement KnownFn::Apply correctly instead of calling the sentinel builtin. The ANF compiler always lowers `(apply f ...)` to a 2-arg CallKnown(:apply, [f, arglist]), so the handler spreads the arglist and calls apply_value(f, spread_args, env).

3. apply.rs: when building IR args for a variadic function, collect the rest args into a PersistentList rather than passing them as raw positional values. Previously, calling e.g. `(update m k f extra)` via prebuilt IR bound the rest param `args` to `extra` directly instead of `(extra)`, causing `(cons [] args)` to spread the map as key-value pairs and corrupt the IR instruction vector.

https://claude.ai/code/session_017ko2KwBTjGsqeic1SFedPB