### PR TITLE
Fix vararg/apply regressions and BigInt comparisons in IR interpreter

### DIFF
--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -777,6 +777,7 @@ fn link_with_cargo(harness_dir: &Path, out_path: &Path) -> AotResult<()> {
     let output = std::process::Command::new("cargo")
         .arg("build")
         .arg("--release")
+        .arg("--offline")
         .current_dir(harness_dir)
         .output()?;
 
@@ -808,6 +809,7 @@ fn link_with_cargo_test_harness(harness_dir: &Path, out_path: &Path) -> AotResul
     let output = std::process::Command::new("cargo")
         .arg("build")
         .arg("--release")
+        .arg("--offline")
         .current_dir(harness_dir)
         .output()?;
 

--- a/crates/cljrs-env/src/apply.rs
+++ b/crates/cljrs-env/src/apply.rs
@@ -165,6 +165,7 @@ pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResul
             }
             None => Ok(Value::Nil),
         },
+        Value::WithMeta(inner, _) => apply_value(inner, args, env),
         other => Err(EvalError::NotCallable(format!(
             "<{}> is not callable",
             other.type_name()

--- a/crates/cljrs-env/src/callback.rs
+++ b/crates/cljrs-env/src/callback.rs
@@ -112,6 +112,8 @@ pub fn invoke(f: &Value, args: Vec<Value>) -> ValueResult<Value> {
     let mut env = Env::new(globals, &ns);
     // Fast path for Clojure functions: call directly through the GlobalEnv
     // function pointer, bypassing the large apply_value stack frame.
+    // Unwrap metadata so a WithMeta-wrapped fn is callable.
+    let f = f.unwrap_meta();
     let result = if let Value::Fn(cljx_fn) = f {
         env.call_cljrs_fn(cljx_fn.get(), &args)
     } else {

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -953,7 +953,18 @@ fn builtin_compare(known_fn: &KnownFn, args: &[Value]) -> EvalResult {
                 _ => false,
             }
         }
-        _ => false,
+        _ => {
+            // Delegate to the native comparison function for all other types
+            // (BigInt, Ratio, mixed, etc.) so they compare correctly.
+            let op = match known_fn {
+                KnownFn::Lt => "<",
+                KnownFn::Gt => ">",
+                KnownFn::Lte => "<=",
+                KnownFn::Gte => ">=",
+                _ => return Ok(Value::Bool(false)),
+            };
+            return builtin_call_native(op, args);
+        }
     };
     Ok(Value::Bool(result))
 }

--- a/crates/cljrs-eval/src/lower.rs
+++ b/crates/cljrs-eval/src/lower.rs
@@ -83,6 +83,19 @@ fn lower_arity_inner(
         })?;
     let lower_fn_val = lower_fn.get().deref().unwrap_or(Value::Nil);
 
+    // Macro-expand the body forms before lowering to IR.
+    // The ANF compiler does not expand macros; we must do it here so that
+    // macro calls (e.g. `cond`, `when`, `and`) become their `if`-chain
+    // expansions rather than unresolvable function calls at runtime.
+    let expanded_body: Vec<Form> = body
+        .iter()
+        .map(|f| {
+            cljrs_interp::macros::macroexpand_all(f, env)
+                .unwrap_or_else(|_| f.clone())
+        })
+        .collect();
+    let body = expanded_body.as_slice();
+
     // Build arguments:
     // 1. fname (string or nil)
     let fname_val = match name {


### PR DESCRIPTION
Three bugs, all in the IR execution path:

1. WithMeta-wrapped callables not handled in apply_value and invoke: Functions stored with metadata (Value::WithMeta(Fn, meta)) were rejected as "not callable". Added WithMeta arm to apply_value that unwraps and recurses, and updated invoke's fast path to call unwrap_meta() before the Fn pattern match.

2. IR lowering without macro expansion: The ANF compiler (lower_arity_inner in lower.rs) passed body forms directly to the Clojure lower-fn-body function without expanding macros first. This caused bootstrap functions like min/max (which use cond in their inner lambdas) to compile IR with Inst::Call nodes targeting Value::Macro values — which fail at runtime with "not callable". Fixed by running macroexpand_all on body forms before lowering. The stdlib prebuild IR is regenerated on the next build.

3. BigInt/Ratio comparison in IR builtin_compare: The IR interpreter's builtin_compare function only handled Long×Long and Double×Double cases, returning false for everything else. This caused (< 1N 2N) to evaluate to false in IR-compiled code. Fixed the fallthrough arm to delegate to the native comparison function via builtin_call_native for all non-numeric-primitive pairs.

Also adds --offline to cargo build invocations in the AOT test harness so it works in network-restricted CI environments.

https://claude.ai/code/session_01Juzfuwmf4fzjcWo911TT41