### PR TITLE
Reformat macro expansion closure to single line

### DIFF
--- a/crates/cljrs-eval/src/lower.rs
+++ b/crates/cljrs-eval/src/lower.rs
@@ -89,10 +89,7 @@ fn lower_arity_inner(
     // expansions rather than unresolvable function calls at runtime.
     let expanded_body: Vec<Form> = body
         .iter()
-        .map(|f| {
-            cljrs_interp::macros::macroexpand_all(f, env)
-                .unwrap_or_else(|_| f.clone())
-        })
+        .map(|f| cljrs_interp::macros::macroexpand_all(f, env).unwrap_or_else(|_| f.clone()))
         .collect();
     let body = expanded_body.as_slice();
 


### PR DESCRIPTION
This PR contains a minor formatting change to improve code readability.

**Summary**
Reformatted a multi-line closure in the macro expansion logic to fit on a single line, making the code more concise while maintaining the same functionality.

**Key changes**
- Collapsed the `map` closure from 4 lines to 1 line in `lower_arity_inner` function
- The closure that calls `cljrs_interp::macros::macroexpand_all` with fallback error handling is now more compact

**Implementation details**
- No functional changes; this is purely a formatting/style improvement
- The logic remains identical: attempt macro expansion and fall back to cloning the original form on error

https://claude.ai/code/session_015FXZamKRNQJqf4pq4mNXWj