### PR TITLE
Add cargo check step and package descriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Check
+        run: cargo check --workspace
+
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/crates/cljrs-builtins/Cargo.toml
+++ b/crates/cljrs-builtins/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cljrs-builtins"
 version = "0.1.0"
 edition = "2024"
+description = "Built-in function implementations for clojurust (arithmetic, collections, I/O, regex)"
 license.workspace = true
 repository.workspace = true
 

--- a/crates/cljrs-env/Cargo.toml
+++ b/crates/cljrs-env/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cljrs-env"
 version = "0.1.0"
 edition = "2024"
+description = "Namespace and environment management for clojurust"
 license.workspace = true
 repository.workspace = true
 

--- a/crates/cljrs-interp/Cargo.toml
+++ b/crates/cljrs-interp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cljrs-interp"
 version = "0.1.0"
 edition = "2024"
+description = "Tree-walking interpreter for clojurust (special forms, macros, destructuring)"
 license.workspace = true
 repository.workspace = true
 

--- a/crates/cljrs-ir-prebuild/Cargo.toml
+++ b/crates/cljrs-ir-prebuild/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cljrs-ir-prebuild"
 version = "0.1.0"
 edition = "2024"
+description = "Pre-compilation tool that serialises standard library forms to IR for clojurust"
 license.workspace = true
 repository.workspace = true
 


### PR DESCRIPTION
## Summary
This PR adds a `cargo check` step to the CI pipeline and includes descriptive metadata for all workspace crates.

## Key Changes
- **CI Pipeline**: Added a `cargo check --workspace` step in the GitHub Actions workflow to catch compilation errors earlier in the CI process, positioned between formatting checks and clippy
- **Package Descriptions**: Added descriptive `description` fields to all crate manifests:
  - `cljrs-builtins`: Built-in function implementations for clojurust (arithmetic, collections, I/O, regex)
  - `cljrs-env`: Namespace and environment management for clojurust
  - `cljrs-interp`: Tree-walking interpreter for clojurust (special forms, macros, destructuring)
  - `cljrs-ir-prebuild`: Pre-compilation tool that serialises standard library forms to IR for clojurust

## Implementation Details
The `cargo check` step provides early feedback on compilation issues without running the full build, improving CI feedback speed. The package descriptions improve discoverability and clarity about each crate's purpose within the workspace.

https://claude.ai/code/session_01TD4BjWKSUELudfgU9sA3Uj