### PR TITLE
feat(no-gc): complete phase 5 static-sink context pushes

### DIFF
--- a/crates/cljrs-gc/README.md
+++ b/crates/cljrs-gc/README.md
@@ -19,8 +19,10 @@ the GC heap or a bump-allocated region; `clone` is O(1); `drop` is a no-op.
 **`no-gc` build:** every function call and every `loop` iteration pushes a
 scratch `Region`; intermediates are freed when the scope exits.  Return values
 and `recur` arguments are evaluated in the caller's context (the
-"return-expression-in-caller" mechanism).  Top-level `def`, `atom`, and `reset!`
-values go to the global `StaticArena` and live for the program lifetime.
+"return-expression-in-caller" mechanism).  Static-sink expressions (`def`,
+`defn`, `defmacro`, `atom`, `agent`, `volatile!`, `reset!`, `vreset!`,
+`swap!`, `vswap!`, `alter-var-root`, `intern`) go to the global `StaticArena`
+and live for the program lifetime.
 No `GcHeap`, no stop-the-world pauses, no `Trace` overhead at runtime.
 
 ---

--- a/crates/cljrs-interp/README.md
+++ b/crates/cljrs-interp/README.md
@@ -1,3 +1,84 @@
 # cljrs-interp
 
 Self-contained tree-walking interpreter for Clojure.
+
+**Phase:** Core interpreter — implemented.  `no-gc` region/static-sink support (phases 4–5 of `docs/no-gc-plan.md`) — implemented.
+
+---
+
+## Purpose
+
+Evaluates Clojure `Form` ASTs produced by `cljrs-reader`, managing lexical
+environments, special forms, function application, and the recur trampoline.
+Under the `no-gc` Cargo feature, applies the allocation-context stack protocol
+(scratch regions for function/loop scopes; `StaticArena` for static-sink
+expressions).
+
+---
+
+## File layout
+
+```
+src/
+  lib.rs         — crate entry point; re-exports Interpreter
+  eval.rs        — top-level eval dispatch; symbol/keyword/collection eval
+  special.rs     — special form evaluators: def, defn, defmacro, fn*, if, let*,
+                   loop*, recur, quote, var, set!, throw, try, do, ns, require,
+                   letfn, in-ns, alias, defprotocol, extend-type, extend-protocol,
+                   defmulti, defmethod, defrecord, reify, binding, with-out-str
+  apply.rs       — eval_call: macro expansion, native-fn dispatch, CljxFn
+                   application, recur trampoline; special env-needing handlers
+                   (apply, atom, reset!, swap!, volatile!, vreset!, vswap!,
+                   agent, send/send-off, with-bindings*, alter-var-root,
+                   vary-meta, find-ns, all-ns, create-ns, ns-aliases, remove-ns,
+                   alter-meta!, ns-resolve, resolve, intern, bound-fn*)
+  arity.rs       — fresh arity ID generator
+  destructure.rs — pattern destructuring (vector, map, & rest)
+  macros.rs      — macro expansion helpers
+  syntax_quote.rs — syntax-quote (backtick) expansion
+  virtualize.rs  — let-chain virtualization: assoc/conj chains → transients
+```
+
+---
+
+## Public API
+
+### `eval(form, env) -> EvalResult`
+
+Evaluate a single `Form` in `env`.  Entry point for the interpreter.
+
+### `eval_call(func_form, arg_forms, env) -> EvalResult`
+
+Evaluate a function-call form.  Handles macros, native-function special cases,
+and user-defined `CljxFn` application with the recur trampoline.
+
+### `eval_body(forms, env) -> EvalResult`
+
+Evaluate a sequence of forms, returning the value of the last one.
+
+### `eval_loop(args, env) -> EvalResult`
+
+Evaluate a `loop*` form.  Under `no-gc`, pushes a `ScratchGuard` on each
+iteration and pops it before the tail expression (recur args or return value)
+so intermediate allocations are freed per iteration.
+
+### `eval_defn(args, env) -> EvalResult`
+
+Evaluate a `defn` form.  Under `no-gc`, wraps fn creation in `StaticCtxGuard`
+so the `CljxFn` object lands in the `StaticArena`.
+
+### Special handlers in `apply.rs`
+
+Each handler evaluates its key expressions under the correct allocation context:
+
+| Handler | Static-sink guard coverage |
+|---|---|
+| `handle_atom_call` | initial value |
+| `handle_reset_bang` | new value |
+| `handle_swap_call` | function return value |
+| `handle_volatile` | initial value |
+| `handle_vreset` | new value |
+| `handle_vswap` | function return value |
+| `handle_agent_call` | initial value |
+| `handle_alter_var_root` | function return value |
+| `handle_intern` | value expression (3-arg form) |

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -4,8 +4,8 @@ use cljrs_builtins::form::form_to_value;
 use cljrs_gc::GcPtr;
 use cljrs_reader::{Form, FormKind};
 use cljrs_value::{
-    AgentFn, AgentMsg, Atom, CljxFn, CljxFnArity, Delay, LazySeq, MapValue, PersistentList, Symbol,
-    Thunk, Value,
+    Agent, AgentFn, AgentMsg, Atom, CljxFn, CljxFnArity, Delay, LazySeq, MapValue,
+    PersistentList, Symbol, Thunk, Value, Volatile,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -132,6 +132,9 @@ pub fn eval_call(func_form: &Form, arg_forms: &[Form], env: &mut Env) -> EvalRes
             "atom" => return handle_atom_call(arg_forms, env),
             "reset!" => return handle_reset_bang(arg_forms, env),
             "swap!" => return handle_swap_call(arg_forms, env),
+            "volatile!" => return handle_volatile(arg_forms, env),
+            "vreset!" => return handle_vreset(arg_forms, env),
+            "agent" => return handle_agent_call(arg_forms, env),
             "make-lazy-seq" => return handle_make_lazy_seq(arg_forms, env),
             "make-delay" => return handle_make_delay(arg_forms, env),
             "vswap!" => return handle_vswap(arg_forms, env),
@@ -712,6 +715,10 @@ fn handle_vswap(arg_forms: &[Form], env: &mut Env) -> EvalResult {
             let cur = v.get().deref();
             let mut call_args = vec![cur];
             call_args.extend(extra);
+            // Under no-gc: the value written into the volatile must live in the
+            // StaticArena since the volatile outlives all scratch regions.
+            #[cfg(feature = "no-gc")]
+            let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
             let new_val = cljrs_env::apply::apply_value(&f, call_args, env)?;
             v.get().reset(new_val.clone());
             Ok(new_val)
@@ -721,6 +728,99 @@ fn handle_vswap(arg_forms: &[Form], env: &mut Env) -> EvalResult {
             other.type_name()
         ))),
     }
+}
+
+// ── volatile! ────────────────────────────────────────────────────────────────
+
+/// Handle `(volatile! init-val)`.
+fn handle_volatile(arg_forms: &[Form], env: &mut Env) -> EvalResult {
+    if arg_forms.is_empty() {
+        return Err(EvalError::Arity {
+            name: "volatile!".into(),
+            expected: "1".into(),
+            got: 0,
+        });
+    }
+    // Under no-gc: volatile initial value must live in the StaticArena since
+    // the Volatile container outlives all scratch regions.
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    let initial = eval(&arg_forms[0], env)?;
+    Ok(Value::Volatile(GcPtr::new(Volatile::new(initial))))
+}
+
+// ── vreset! ──────────────────────────────────────────────────────────────────
+
+/// Handle `(vreset! vol new-val)`.
+fn handle_vreset(arg_forms: &[Form], env: &mut Env) -> EvalResult {
+    if arg_forms.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "vreset!".into(),
+            expected: "2".into(),
+            got: arg_forms.len(),
+        });
+    }
+    let vol_val = eval(&arg_forms[0], env)?;
+    // Under no-gc: the new value written into the volatile must live in the
+    // StaticArena since the volatile outlives all scratch regions.
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    let new_val = eval(&arg_forms[1], env)?;
+    match &vol_val {
+        Value::Volatile(v) => {
+            v.get().reset(new_val.clone());
+            Ok(new_val)
+        }
+        other => Err(EvalError::Runtime(format!(
+            "vreset!: expected volatile, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+// ── agent ────────────────────────────────────────────────────────────────────
+
+/// Handle `(agent init-val & opts)`.
+fn handle_agent_call(arg_forms: &[Form], env: &mut Env) -> EvalResult {
+    if arg_forms.is_empty() {
+        return Err(EvalError::Arity {
+            name: "agent".into(),
+            expected: "1+".into(),
+            got: 0,
+        });
+    }
+    // Under no-gc: agent initial value must live in the StaticArena since the
+    // Agent container outlives all scratch regions.
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    let init = eval(&arg_forms[0], env)?;
+
+    let (tx, rx) = std::sync::mpsc::sync_channel::<AgentMsg>(1024);
+    let state_arc = std::sync::Arc::new(std::sync::Mutex::new(init));
+    let error_arc: std::sync::Arc<std::sync::Mutex<Option<Value>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(None));
+    let worker_state = state_arc.clone();
+    let worker_error = error_arc.clone();
+    std::thread::spawn(move || {
+        while let Ok(msg) = rx.recv() {
+            match msg {
+                AgentMsg::Update(f) => {
+                    let cur = worker_state.lock().unwrap().clone();
+                    match f(cur) {
+                        Ok(next) => *worker_state.lock().unwrap() = next,
+                        Err(e) => *worker_error.lock().unwrap() = Some(e),
+                    }
+                }
+                AgentMsg::Shutdown => break,
+            }
+        }
+    });
+    Ok(Value::Agent(GcPtr::new(Agent {
+        state: state_arc,
+        error: error_arc,
+        sender: std::sync::Mutex::new(tx),
+        watches: std::sync::Mutex::new(Vec::new()),
+    })))
 }
 
 /// Handle `(send agent f & extra)` / `(send-off agent f & extra)`.
@@ -933,6 +1033,10 @@ fn handle_swap_call(arg_forms: &[Form], env: &mut Env) -> EvalResult {
     let old_val = atom.get().deref();
     let mut args = vec![old_val.clone()];
     args.extend(evaled);
+    // Under no-gc: the value written into the atom must live in the StaticArena
+    // since the atom outlives all scratch regions.
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
     let new_val = cljrs_env::apply::apply_value(&f, args, env)?;
     validate_atom_value(&atom, &new_val, env)?;
     atom.get().reset(new_val.clone());
@@ -1004,6 +1108,10 @@ fn handle_alter_var_root(arg_forms: &[Form], env: &mut Env) -> EvalResult {
     let old_val = vp.get().deref().unwrap_or(Value::Nil);
     let mut call_args = vec![old_val.clone()];
     call_args.extend(extra);
+    // Under no-gc: the new Var root value must live in the StaticArena since
+    // Vars outlive all scratch regions.
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
     let new_val = cljrs_env::apply::apply_value(&f, call_args, env)?;
     vp.get().bind(new_val.clone());
     fire_watches(&vp.get().watches, &var_val, &old_val, &new_val, env);
@@ -1304,6 +1412,10 @@ fn handle_intern(arg_forms: &[Form], env: &mut Env) -> EvalResult {
     };
     let ns = ns.ok_or_else(|| EvalError::Runtime(format!("No namespace: {ns_name} found")))?;
     let var = if arg_forms.len() == 3 {
+        // Under no-gc: interned Var values live in the StaticArena since they
+        // are namespace-scoped and outlive all scratch regions.
+        #[cfg(feature = "no-gc")]
+        let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
         let val = eval(&arg_forms[2], env)?;
         let mut interns = ns.get().interns.lock().unwrap();
         if let Some(var) = interns.get(&var_name) {

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -4,8 +4,8 @@ use cljrs_builtins::form::form_to_value;
 use cljrs_gc::GcPtr;
 use cljrs_reader::{Form, FormKind};
 use cljrs_value::{
-    Agent, AgentFn, AgentMsg, Atom, CljxFn, CljxFnArity, Delay, LazySeq, MapValue,
-    PersistentList, Symbol, Thunk, Value, Volatile,
+    Agent, AgentFn, AgentMsg, Atom, CljxFn, CljxFnArity, Delay, LazySeq, MapValue, PersistentList,
+    Symbol, Thunk, Value, Volatile,
 };
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -802,6 +802,10 @@ pub fn eval_defn(args: &[Form], env: &mut Env) -> EvalResult {
         args[0].span.clone(),
     )];
     fn_args.extend_from_slice(&args[rest_start..]);
+    // Under no-gc: the Fn object must live in the StaticArena since the Var
+    // intern outlives all scratch regions.
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
     let fn_val = eval_fn(&fn_args, env)?;
     let var = env
         .globals
@@ -859,6 +863,10 @@ fn eval_defmacro(args: &[Form], env: &mut Env) -> EvalResult {
     for form in &args[rest_start..] {
         fn_args.push(prepend_macro_params(form));
     }
+    // Under no-gc: the Macro object must live in the StaticArena since the Var
+    // intern outlives all scratch regions.
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
     let fn_val = eval_fn(&fn_args, env)?;
 
     // Convert Fn → Macro by setting is_macro = true.


### PR DESCRIPTION
Extends the no-gc allocation context to cover all static-sink expressions
beyond the def/atom/reset! trio already handled:

- swap!: StaticCtxGuard wraps the function invocation so the new atom
  value lands in the StaticArena, not the current scratch region.
- vswap!: same treatment as swap! for volatiles.
- vreset!: routed through a new handle_vreset special handler (like
  reset! → handle_reset_bang) so the new-value expression is evaluated
  under StaticCtxGuard.
- volatile!: routed through a new handle_volatile special handler so the
  initial value lands in the StaticArena.
- agent: routed through a new handle_agent_call special handler so the
  initial value lands in the StaticArena.
- alter-var-root: StaticCtxGuard wraps the function invocation so the
  new Var root lands in the StaticArena.
- intern (3-arg form): StaticCtxGuard wraps the value-expression eval.
- defn / defmacro: StaticCtxGuard wraps eval_fn so the CljxFn/Macro
  object is allocated in the StaticArena even when defn appears inside a
  loop body.

Also adds Agent and Volatile to the top-level cljrs_value import in
apply.rs, and updates README files.

https://claude.ai/code/session_019t9BVzn7dBfnYVpBLVJP7w