### PR TITLE
Add no-gc blacklist analysis and debug provenance tracking

### DIFF
--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -9,7 +9,7 @@ ANF lowering and escape analysis are written in Clojure (`cljrs.compiler.anf`,
 layer (`ir_convert.rs`) translates these back to the `IrFunction` structs that the
 Cranelift codegen backend consumes.
 
-**Phase:** 8.1 (optimization) + 11 (AOT compilation) — end-to-end AOT working for multi-file programs with variadic functions, protocols, escape analysis optimization, apply, core HOFs (map/filter/reduce/mapv/filterv/some/every?/into), sequence ops (range/take/drop/concat/reverse/sort), collection ops (keys/vals/merge/update/get-in/assoc-in), type predicates, atom constructor, and inline expansions (inc/dec/not/not=/zero?/pos?/neg?/even?/odd?/max/min/empty?).
+**Phase:** 8.1 (optimization) + 11 (AOT compilation) + no-gc phases 6–7 — end-to-end AOT working for multi-file programs with variadic functions, protocols, escape analysis optimization, apply, core HOFs, sequence/collection ops, type predicates, atom constructor, and inline expansions.  Under the `no-gc` feature the AOT driver also runs the **blacklist analysis** (`escape.rs`) which rejects programs that cannot be safely compiled without a GC.
 
 ---
 
@@ -23,6 +23,7 @@ src/
   rt_abi.rs     — C-ABI runtime bridge: ~40 extern "C" functions called by compiled code
   codegen.rs    — Cranelift code generator: IrFunction → native object code
   aot.rs        — AOT driver: source → parse → expand → lower → codegen → cargo build → binary
+  escape.rs     — (no-gc only) blacklist analysis: 4 checks that reject no-gc–unsafe IR patterns
   clojure/compiler/
     ir.cljrs      — IR data constructors + mutable builder context (atom-based)
     known.cljrs   — Known function symbol → keyword resolution table
@@ -96,9 +97,25 @@ impl Compiler {
 ```rust
 pub fn compile_file(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf]) -> AotResult<()>;
 pub fn lower_via_clojure(name: Option<&str>, ns: &str, params: &[Arc<str>], forms: &[Form], env: &mut Env) -> AotResult<IrFunction>;
+
+pub enum AotError { Io, Parse, Codegen, Eval, Link, NoGcBlacklist(Vec<BlacklistViolation>) /* no-gc only */ }
 ```
 
-Pipeline: read source → parse → evaluate preamble (ns/require/defmacro) → macro-expand → discover required namespaces → ANF lower (Clojure) → optimize (escape analysis + region alloc) → IR convert → Cranelift codegen → generate Cargo harness (with bundled dependency sources) → `cargo build --release` → copy binary.
+Pipeline: read source → parse → evaluate preamble → macro-expand → discover required namespaces → ANF lower (Clojure) → optimize (escape analysis + region alloc) → IR convert → **[no-gc] blacklist check** → Cranelift codegen → generate Cargo harness → `cargo build --release` → copy binary.
+
+### No-GC blacklist (`escape.rs`, no-gc only)
+
+```rust
+pub enum BlacklistViolation { InteriorPointerReturn { .. }, RegionToStaticStore { .. }, LazySeqEscape { .. }, EscapingClosure { .. } }
+pub fn check(func: &IrFunction) -> Vec<BlacklistViolation>;
+pub fn check_function(func: &IrFunction) -> Vec<BlacklistViolation>;
+```
+
+Detects four classes of no-gc memory-safety violations in IR functions:
+1. **InteriorPointerReturn** — return var is (transitively via phi) an allocation from the function's scratch region.
+2. **RegionToStaticStore** — allocation result flows into `DefVar` / `SetBang` without the static context.
+3. **LazySeqEscape** — lazy-producing call result is bound as an intermediate and returned unrealized.
+4. **EscapingClosure** — `AllocClosure` stored in a static container.
 
 Multi-file support: when the source file uses `(ns ... (:require [...]))`, the required namespaces are loaded during compilation. Their source files are discovered from `src_dirs`, bundled into the harness as builtin sources, and made available at runtime so the binary is self-contained.
 

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -28,6 +28,10 @@ pub enum AotError {
     Codegen(crate::codegen::CodegenError),
     Eval(String),
     Link(String),
+    /// One or more no-gc memory-safety violations were found by the blacklist
+    /// analysis.  Only emitted when the `no-gc` Cargo feature is active.
+    #[cfg(feature = "no-gc")]
+    NoGcBlacklist(Vec<crate::escape::BlacklistViolation>),
 }
 
 impl std::fmt::Display for AotError {
@@ -38,6 +42,14 @@ impl std::fmt::Display for AotError {
             AotError::Codegen(e) => write!(f, "codegen error: {e:?}"),
             AotError::Eval(e) => write!(f, "eval/lowering error: {e}"),
             AotError::Link(e) => write!(f, "link error: {e}"),
+            #[cfg(feature = "no-gc")]
+            AotError::NoGcBlacklist(vs) => {
+                writeln!(f, "no-gc blacklist violations:")?;
+                for v in vs {
+                    writeln!(f, "  • {v}")?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -178,8 +190,20 @@ fn lower_via_clojure_inner(
         .map_err(|e| AotError::Eval(format!("Optimization failed: {e:?}")))?;
 
     // Convert the result Value → IrFunction.
-    ir_convert::value_to_ir_function(&optimized)
-        .map_err(|e| AotError::Eval(format!("IR conversion failed: {e}")))
+    let ir_func = ir_convert::value_to_ir_function(&optimized)
+        .map_err(|e| AotError::Eval(format!("IR conversion failed: {e}")))?;
+
+    // Under no-gc: run the blacklist analysis and reject programs that contain
+    // patterns the AOT code generator cannot safely compile.
+    #[cfg(feature = "no-gc")]
+    {
+        let violations = crate::escape::check(&ir_func);
+        if !violations.is_empty() {
+            return Err(AotError::NoGcBlacklist(violations));
+        }
+    }
+
+    Ok(ir_func)
 }
 
 // ── Direct call optimization ────────────────────────────────────────────────

--- a/crates/cljrs-compiler/src/escape.rs
+++ b/crates/cljrs-compiler/src/escape.rs
@@ -1,0 +1,588 @@
+//! No-GC blacklist analysis for the AOT compilation pipeline.
+//!
+//! In `no-gc` mode every function pushes a scratch `Region` for intermediates
+//! and pops it before evaluating the tail / return expression so that the
+//! return value lands in the **caller's** allocation context.  Three patterns
+//! cannot be compiled correctly in that model and are flagged here:
+//!
+//! 1. **Interior-pointer return** — the return variable is (transitively
+//!    through phi nodes) the result of an allocation instruction within the
+//!    function body.  Such values live in the scratch region and dangle as
+//!    soon as the region is reset after the function returns.
+//!
+//! 2. **Region → static store** — an allocation result flows directly into a
+//!    `DefVar` or `SetBang` instruction.  These operations write into
+//!    program-lifetime containers (`Var` root / `set!`), so the stored value
+//!    must come from the static arena, not a scratch region.
+//!
+//! 3. **Lazy-sequence escape** — a lazy-sequence-producing call result is
+//!    bound as an intermediate (used more than once) and then returned.  The
+//!    thunk captures references into the scratch region that dangle after reset.
+//!
+//! 4. **Escaping closure** — an `AllocClosure` result that captures
+//!    region-local values is stored in a static container (`DefVar` / `SetBang`).
+//!
+//! These checks run on the Rust-level `IrFunction` after the Clojure-level
+//! escape analysis and optimization passes.  They are only compiled when the
+//! `no-gc` Cargo feature is enabled.
+
+#![cfg(feature = "no-gc")]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use cljrs_ir::{IrFunction, Inst, KnownFn, Terminator, VarId};
+
+// ── Violation type ───────────────────────────────────────────────────────────
+
+/// A no-gc memory-safety violation detected in an IR function.
+#[derive(Debug, Clone)]
+pub enum BlacklistViolation {
+    /// The return variable was produced by an allocation instruction within
+    /// the function body and would dangle after the scratch region is reset.
+    InteriorPointerReturn {
+        function: Option<Arc<str>>,
+        var: VarId,
+    },
+
+    /// An allocation result flows directly into a `DefVar` or `SetBang`
+    /// without being computed in the static context, so it would store a
+    /// scratch-region pointer in a program-lifetime container.
+    RegionToStaticStore {
+        function: Option<Arc<str>>,
+        var: VarId,
+    },
+
+    /// A lazy-sequence-producing call result was bound as an intermediate
+    /// (used more than once) and is then returned unrealized.  The captured
+    /// thunk references would dangle after the scratch region resets.
+    LazySeqEscape {
+        function: Option<Arc<str>>,
+        var: VarId,
+    },
+
+    /// An `AllocClosure` that captures region-local values is stored in a
+    /// static container (`DefVar` / `SetBang`).  Calling the closure later
+    /// would access freed memory.
+    EscapingClosure {
+        function: Option<Arc<str>>,
+        var: VarId,
+    },
+}
+
+impl std::fmt::Display for BlacklistViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InteriorPointerReturn { function, var } => write!(
+                f,
+                "no-gc: function {fn_name} returns {var} which was allocated in its own \
+                 scratch region — the return expression must produce a fresh value via a \
+                 function call (e.g. use `(assoc ...)` rather than returning a let-bound map)",
+                fn_name = fn_display(function),
+            ),
+            Self::RegionToStaticStore { function, var } => write!(
+                f,
+                "no-gc: function {fn_name} stores scratch-region allocation {var} in a \
+                 static container (def / set!) — compute the value inside the sink so it \
+                 is allocated in the static context",
+                fn_name = fn_display(function),
+            ),
+            Self::LazySeqEscape { function, var } => write!(
+                f,
+                "no-gc: function {fn_name} lets unrealized lazy sequence {var} escape its \
+                 scratch region via a non-tail binding — wrap with `doall` / `vec` / `into` \
+                 before returning, or make the lazy producer the direct return expression",
+                fn_name = fn_display(function),
+            ),
+            Self::EscapingClosure { function, var } => write!(
+                f,
+                "no-gc: function {fn_name} stores closure {var} (which captures \
+                 region-local values) in a static container — ensure all captured values \
+                 are computed in the static context before the closure is stored",
+                fn_name = fn_display(function),
+            ),
+        }
+    }
+}
+
+fn fn_display(name: &Option<Arc<str>>) -> String {
+    match name {
+        Some(n) => format!("`{n}`"),
+        None => "<anonymous>".to_string(),
+    }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// VarIds produced by allocation instructions (including region-backed ones).
+fn collect_alloc_vars(func: &IrFunction) -> HashSet<VarId> {
+    let mut allocs = HashSet::new();
+    for block in &func.blocks {
+        for inst in block.phis.iter().chain(block.insts.iter()) {
+            if let Some(dst) = alloc_dst(inst) {
+                allocs.insert(dst);
+            }
+        }
+    }
+    allocs
+}
+
+fn alloc_dst(inst: &Inst) -> Option<VarId> {
+    match inst {
+        Inst::AllocVector(dst, _)
+        | Inst::AllocMap(dst, _)
+        | Inst::AllocSet(dst, _)
+        | Inst::AllocList(dst, _) => Some(*dst),
+        Inst::AllocCons(dst, _, _) => Some(*dst),
+        Inst::AllocClosure(dst, _, _) => Some(*dst),
+        Inst::RegionAlloc(dst, _, _, _) => Some(*dst),
+        _ => None,
+    }
+}
+
+/// Phi-node inputs: `phi_inputs[dst]` = list of source VarIds.
+fn collect_phi_inputs(func: &IrFunction) -> HashMap<VarId, Vec<VarId>> {
+    let mut phi_inputs: HashMap<VarId, Vec<VarId>> = HashMap::new();
+    for block in &func.blocks {
+        for inst in &block.phis {
+            if let Inst::Phi(dst, entries) = inst {
+                phi_inputs
+                    .entry(*dst)
+                    .or_default()
+                    .extend(entries.iter().map(|(_, v)| *v));
+            }
+        }
+    }
+    phi_inputs
+}
+
+/// Returns `true` if `var` is (transitively through phi nodes) the result of
+/// an allocation instruction.
+fn is_alloc_derived(
+    var: VarId,
+    alloc_vars: &HashSet<VarId>,
+    phi_inputs: &HashMap<VarId, Vec<VarId>>,
+) -> bool {
+    let mut visited = HashSet::new();
+    let mut stack = vec![var];
+    while let Some(v) = stack.pop() {
+        if !visited.insert(v) {
+            continue;
+        }
+        if alloc_vars.contains(&v) {
+            return true;
+        }
+        if let Some(inputs) = phi_inputs.get(&v) {
+            stack.extend_from_slice(inputs);
+        }
+    }
+    false
+}
+
+/// Value operands of `DefVar` and `SetBang` instructions.
+fn collect_static_sink_vals(func: &IrFunction) -> Vec<VarId> {
+    let mut sinks = Vec::new();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            match inst {
+                Inst::DefVar(_, _, _, val) => sinks.push(*val),
+                Inst::SetBang(_, val) => sinks.push(*val),
+                _ => {}
+            }
+        }
+    }
+    sinks
+}
+
+/// New-value operands of `AtomReset` / extra-arg operands of `AtomSwap`.
+fn collect_atom_sink_vals(func: &IrFunction) -> Vec<VarId> {
+    let mut sinks = Vec::new();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if let Inst::CallKnown(_, kfn, args) = inst {
+                match kfn {
+                    KnownFn::AtomReset if args.len() >= 2 => sinks.push(args[1]),
+                    KnownFn::AtomSwap if args.len() >= 3 => {
+                        // args = [atom, f, extra1, extra2, ...]
+                        // extra args are passed to f and their values end up
+                        // in the atom; flag them.
+                        sinks.extend_from_slice(&args[2..]);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    sinks
+}
+
+/// VarIds produced by lazy-sequence–producing known calls.
+fn collect_lazy_vars(func: &IrFunction) -> HashSet<VarId> {
+    let mut lazy = HashSet::new();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if let Inst::CallKnown(dst, kfn, _) = inst {
+                if is_lazy_producing(kfn) {
+                    lazy.insert(*dst);
+                }
+            }
+        }
+    }
+    lazy
+}
+
+fn is_lazy_producing(kfn: &KnownFn) -> bool {
+    matches!(
+        kfn,
+        KnownFn::LazySeq
+            | KnownFn::Map
+            | KnownFn::Filter
+            | KnownFn::Cons
+            | KnownFn::Rest
+            | KnownFn::Next
+            | KnownFn::Concat
+            | KnownFn::Range1
+            | KnownFn::Range2
+            | KnownFn::Range3
+            | KnownFn::Take
+            | KnownFn::Drop
+            | KnownFn::Keep
+            | KnownFn::Remove
+    )
+}
+
+/// VarIds produced by `AllocClosure`.
+fn collect_closure_vars(func: &IrFunction) -> HashSet<VarId> {
+    let mut closures = HashSet::new();
+    for block in &func.blocks {
+        for inst in block.phis.iter().chain(block.insts.iter()) {
+            if let Inst::AllocClosure(dst, _, _) = inst {
+                closures.insert(*dst);
+            }
+        }
+    }
+    closures
+}
+
+/// Count how many times `var` is referenced across all instructions and
+/// terminators in the function.
+fn count_uses(var: VarId, func: &IrFunction) -> usize {
+    let mut count = 0;
+    for block in &func.blocks {
+        for inst in block.phis.iter().chain(block.insts.iter()) {
+            count += uses_in_inst(var, inst);
+        }
+        count += uses_in_terminator(var, &block.terminator);
+    }
+    count
+}
+
+fn uses_in_inst(var: VarId, inst: &Inst) -> usize {
+    match inst {
+        Inst::CallKnown(_, _, args) => args.iter().filter(|&&a| a == var).count(),
+        Inst::Call(_, callee, args) => {
+            (if *callee == var { 1 } else { 0 }) + args.iter().filter(|&&a| a == var).count()
+        }
+        Inst::CallDirect(_, _, args) => args.iter().filter(|&&a| a == var).count(),
+        Inst::AllocVector(_, elems) | Inst::AllocSet(_, elems) | Inst::AllocList(_, elems) => {
+            elems.iter().filter(|&&e| e == var).count()
+        }
+        Inst::AllocMap(_, pairs) => pairs
+            .iter()
+            .filter(|(k, v)| *k == var || *v == var)
+            .count(),
+        Inst::AllocCons(_, head, tail) => {
+            (if *head == var { 1 } else { 0 }) + (if *tail == var { 1 } else { 0 })
+        }
+        Inst::AllocClosure(_, _, captures) => captures.iter().filter(|&&c| c == var).count(),
+        Inst::DefVar(_, _, _, val) => usize::from(*val == var),
+        Inst::SetBang(_, val) => usize::from(*val == var),
+        Inst::Phi(_, entries) => entries.iter().filter(|(_, v)| *v == var).count(),
+        Inst::Deref(_, src) => usize::from(*src == var),
+        Inst::Throw(v) => usize::from(*v == var),
+        Inst::Recur(args) => args.iter().filter(|&&a| a == var).count(),
+        Inst::RegionAlloc(_, region, _, operands) => {
+            usize::from(*region == var) + operands.iter().filter(|&&o| o == var).count()
+        }
+        _ => 0,
+    }
+}
+
+fn uses_in_terminator(var: VarId, term: &Terminator) -> usize {
+    match term {
+        Terminator::Return(v) => usize::from(*v == var),
+        Terminator::Branch { cond, .. } => usize::from(*cond == var),
+        Terminator::RecurJump { args, .. } => args.iter().filter(|&&a| a == var).count(),
+        _ => 0,
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Run all four blacklist checks on a single IR function (not its subfunctions).
+pub fn check_function(func: &IrFunction) -> Vec<BlacklistViolation> {
+    let mut violations = Vec::new();
+
+    let alloc_vars = collect_alloc_vars(func);
+    let phi_inputs = collect_phi_inputs(func);
+    let static_sink_vals = collect_static_sink_vals(func);
+    let atom_sink_vals = collect_atom_sink_vals(func);
+    let all_sink_vals: Vec<VarId> = static_sink_vals
+        .iter()
+        .chain(atom_sink_vals.iter())
+        .copied()
+        .collect();
+    let lazy_vars = collect_lazy_vars(func);
+    let closure_vars = collect_closure_vars(func);
+
+    // ── Check 1: Interior-pointer return ─────────────────────────────────────
+    //
+    // Flag any return whose var is (transitively via phi) an allocation from
+    // within this function body.  In the AOT-compiled no-gc path the value
+    // would have been placed in the scratch region and dangles after reset.
+    for block in &func.blocks {
+        if let Terminator::Return(ret_var) = &block.terminator {
+            if is_alloc_derived(*ret_var, &alloc_vars, &phi_inputs) {
+                violations.push(BlacklistViolation::InteriorPointerReturn {
+                    function: func.name.clone(),
+                    var: *ret_var,
+                });
+            }
+        }
+    }
+
+    // ── Check 2: Region → static store ───────────────────────────────────────
+    //
+    // Flag allocation vars that flow directly into DefVar / SetBang / AtomReset.
+    // The interpreter handles this via StaticCtxGuard (Phase 5), but the AOT
+    // codegen cannot inject a context switch around a pre-computed variable.
+    for &sink_val in &all_sink_vals {
+        if is_alloc_derived(sink_val, &alloc_vars, &phi_inputs) {
+            violations.push(BlacklistViolation::RegionToStaticStore {
+                function: func.name.clone(),
+                var: sink_val,
+            });
+        }
+    }
+
+    // ── Check 3: Lazy-sequence escape ─────────────────────────────────────────
+    //
+    // A lazy-producing call result that is used more than once was bound as an
+    // intermediate binding (not just the direct tail expression) and then
+    // returned.  The thunk's captured pointers would dangle.
+    for block in &func.blocks {
+        if let Terminator::Return(ret_var) = &block.terminator {
+            if lazy_vars.contains(ret_var) {
+                // Use-count > 1 means the var was used somewhere else too
+                // (e.g. printed, passed to another fn) before being returned,
+                // indicating it was an intermediate binding.
+                if count_uses(*ret_var, func) > 1 {
+                    violations.push(BlacklistViolation::LazySeqEscape {
+                        function: func.name.clone(),
+                        var: *ret_var,
+                    });
+                }
+            }
+        }
+    }
+
+    // ── Check 4: Escaping closure ─────────────────────────────────────────────
+    //
+    // A closure stored in a static container may be called after the scratch
+    // region that held its captured bindings has been reset.
+    for &sink_val in &all_sink_vals {
+        if closure_vars.contains(&sink_val) {
+            violations.push(BlacklistViolation::EscapingClosure {
+                function: func.name.clone(),
+                var: sink_val,
+            });
+        }
+    }
+
+    violations
+}
+
+/// Run blacklist checks on `func` and all of its nested subfunctions.
+pub fn check(func: &IrFunction) -> Vec<BlacklistViolation> {
+    let mut v = check_function(func);
+    for sub in &func.subfunctions {
+        v.extend(check(sub));
+    }
+    v
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cljrs_ir::{Block, BlockId, ClosureTemplate, IrFunction, Terminator, VarId};
+
+    fn make_func(name: &str, blocks: Vec<Block>) -> IrFunction {
+        let max_var = blocks.iter().flat_map(|b| {
+            b.phis.iter().chain(b.insts.iter()).filter_map(|i| match i {
+                Inst::AllocVector(d, _) | Inst::AllocMap(d, _) | Inst::AllocSet(d, _)
+                | Inst::AllocList(d, _) | Inst::AllocClosure(d, _, _) | Inst::Const(d, _)
+                | Inst::LoadLocal(d, _) | Inst::LoadGlobal(d, _, _) | Inst::RegionAlloc(d, _, _, _)
+                | Inst::DefVar(d, _, _, _) | Inst::CallKnown(d, _, _) | Inst::Call(d, _, _) => Some(d.0 + 1),
+                Inst::AllocCons(d, _, _) => Some(d.0 + 1),
+                _ => None,
+            })
+        }).max().unwrap_or(0);
+        IrFunction {
+            name: Some(Arc::from(name)),
+            params: vec![],
+            blocks,
+            next_var: max_var,
+            next_block: 1,
+            span: None,
+            subfunctions: vec![],
+        }
+    }
+
+    fn simple_block(id: u32, insts: Vec<Inst>, term: Terminator) -> Block {
+        Block { id: BlockId(id), phis: vec![], insts, terminator: term }
+    }
+
+    #[test]
+    fn interior_pointer_return_flagged() {
+        // %0 = alloc-map []; return %0  → error
+        let v0 = VarId(0);
+        let func = make_func(
+            "bad",
+            vec![simple_block(
+                0,
+                vec![Inst::AllocMap(v0, vec![])],
+                Terminator::Return(v0),
+            )],
+        );
+        let violations = check_function(&func);
+        assert!(
+            violations.iter().any(|v| matches!(v, BlacklistViolation::InteriorPointerReturn { .. })),
+            "expected InteriorPointerReturn, got {violations:?}"
+        );
+    }
+
+    #[test]
+    fn call_return_not_flagged() {
+        // %0 = load-global "m"; %1 = call-known assoc [%0]; return %1  → OK
+        let v0 = VarId(0);
+        let v1 = VarId(1);
+        let func = make_func(
+            "ok",
+            vec![simple_block(
+                0,
+                vec![
+                    Inst::LoadGlobal(v0, Arc::from("user"), Arc::from("m")),
+                    Inst::CallKnown(v1, KnownFn::Assoc, vec![v0]),
+                ],
+                Terminator::Return(v1),
+            )],
+        );
+        let violations = check_function(&func);
+        assert!(
+            !violations
+                .iter()
+                .any(|v| matches!(v, BlacklistViolation::InteriorPointerReturn { .. })),
+            "expected no InteriorPointerReturn, got {violations:?}"
+        );
+    }
+
+    #[test]
+    fn region_to_static_store_flagged() {
+        // %0 = alloc-map []; %1 = def-var ns/x %0  → error
+        let v0 = VarId(0);
+        let v1 = VarId(1);
+        let func = make_func(
+            "bad-def",
+            vec![simple_block(
+                0,
+                vec![
+                    Inst::AllocMap(v0, vec![]),
+                    Inst::DefVar(v1, Arc::from("user"), Arc::from("x"), v0),
+                ],
+                Terminator::Return(v1),
+            )],
+        );
+        let violations = check_function(&func);
+        assert!(
+            violations.iter().any(|v| matches!(v, BlacklistViolation::RegionToStaticStore { .. })),
+            "expected RegionToStaticStore, got {violations:?}"
+        );
+    }
+
+    #[test]
+    fn lazy_seq_direct_return_not_flagged() {
+        // %0 = call-known :map [...]; return %0  (used exactly once) → OK
+        let v0 = VarId(0);
+        let func = make_func(
+            "ok-lazy",
+            vec![simple_block(
+                0,
+                vec![Inst::CallKnown(v0, KnownFn::Map, vec![])],
+                Terminator::Return(v0),
+            )],
+        );
+        let violations = check_function(&func);
+        assert!(
+            !violations
+                .iter()
+                .any(|v| matches!(v, BlacklistViolation::LazySeqEscape { .. })),
+            "direct lazy return should not be flagged, got {violations:?}"
+        );
+    }
+
+    #[test]
+    fn lazy_seq_intermediate_flagged() {
+        // %0 = call-known :map []; %1 = call-known :println [%0]; return %0
+        // → %0 used twice → LazySeqEscape
+        let v0 = VarId(0);
+        let v1 = VarId(1);
+        let func = make_func(
+            "bad-lazy",
+            vec![simple_block(
+                0,
+                vec![
+                    Inst::CallKnown(v0, KnownFn::Map, vec![]),
+                    Inst::CallKnown(v1, KnownFn::Println, vec![v0]),
+                ],
+                Terminator::Return(v0),
+            )],
+        );
+        let violations = check_function(&func);
+        assert!(
+            violations.iter().any(|v| matches!(v, BlacklistViolation::LazySeqEscape { .. })),
+            "expected LazySeqEscape, got {violations:?}"
+        );
+    }
+
+    #[test]
+    fn escaping_closure_flagged() {
+        // %0 = alloc-closure []; %1 = def-var ns/f %0  → EscapingClosure
+        let v0 = VarId(0);
+        let v1 = VarId(1);
+        let tmpl = ClosureTemplate {
+            name: None,
+            arity_fn_names: vec![],
+            param_counts: vec![],
+            is_variadic: vec![],
+            capture_names: vec![],
+        };
+        let func = make_func(
+            "bad-closure",
+            vec![simple_block(
+                0,
+                vec![
+                    Inst::AllocClosure(v0, tmpl, vec![]),
+                    Inst::DefVar(v1, Arc::from("user"), Arc::from("f"), v0),
+                ],
+                Terminator::Return(v1),
+            )],
+        );
+        let violations = check_function(&func);
+        assert!(
+            violations.iter().any(|v| matches!(v, BlacklistViolation::EscapingClosure { .. })),
+            "expected EscapingClosure, got {violations:?}"
+        );
+    }
+}

--- a/crates/cljrs-compiler/src/escape.rs
+++ b/crates/cljrs-compiler/src/escape.rs
@@ -31,7 +31,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use cljrs_ir::{IrFunction, Inst, KnownFn, Terminator, VarId};
+use cljrs_ir::{Inst, IrFunction, KnownFn, Terminator, VarId};
 
 // ── Violation type ───────────────────────────────────────────────────────────
 
@@ -221,10 +221,10 @@ fn collect_lazy_vars(func: &IrFunction) -> HashSet<VarId> {
     let mut lazy = HashSet::new();
     for block in &func.blocks {
         for inst in &block.insts {
-            if let Inst::CallKnown(dst, kfn, _) = inst {
-                if is_lazy_producing(kfn) {
-                    lazy.insert(*dst);
-                }
+            if let Inst::CallKnown(dst, kfn, _) = inst
+                && is_lazy_producing(kfn)
+            {
+                lazy.insert(*dst);
             }
         }
     }
@@ -287,10 +287,7 @@ fn uses_in_inst(var: VarId, inst: &Inst) -> usize {
         Inst::AllocVector(_, elems) | Inst::AllocSet(_, elems) | Inst::AllocList(_, elems) => {
             elems.iter().filter(|&&e| e == var).count()
         }
-        Inst::AllocMap(_, pairs) => pairs
-            .iter()
-            .filter(|(k, v)| *k == var || *v == var)
-            .count(),
+        Inst::AllocMap(_, pairs) => pairs.iter().filter(|(k, v)| *k == var || *v == var).count(),
         Inst::AllocCons(_, head, tail) => {
             (if *head == var { 1 } else { 0 }) + (if *tail == var { 1 } else { 0 })
         }
@@ -341,13 +338,13 @@ pub fn check_function(func: &IrFunction) -> Vec<BlacklistViolation> {
     // within this function body.  In the AOT-compiled no-gc path the value
     // would have been placed in the scratch region and dangles after reset.
     for block in &func.blocks {
-        if let Terminator::Return(ret_var) = &block.terminator {
-            if is_alloc_derived(*ret_var, &alloc_vars, &phi_inputs) {
-                violations.push(BlacklistViolation::InteriorPointerReturn {
-                    function: func.name.clone(),
-                    var: *ret_var,
-                });
-            }
+        if let Terminator::Return(ret_var) = &block.terminator
+            && is_alloc_derived(*ret_var, &alloc_vars, &phi_inputs)
+        {
+            violations.push(BlacklistViolation::InteriorPointerReturn {
+                function: func.name.clone(),
+                var: *ret_var,
+            });
         }
     }
 
@@ -371,17 +368,17 @@ pub fn check_function(func: &IrFunction) -> Vec<BlacklistViolation> {
     // intermediate binding (not just the direct tail expression) and then
     // returned.  The thunk's captured pointers would dangle.
     for block in &func.blocks {
-        if let Terminator::Return(ret_var) = &block.terminator {
-            if lazy_vars.contains(ret_var) {
-                // Use-count > 1 means the var was used somewhere else too
-                // (e.g. printed, passed to another fn) before being returned,
-                // indicating it was an intermediate binding.
-                if count_uses(*ret_var, func) > 1 {
-                    violations.push(BlacklistViolation::LazySeqEscape {
-                        function: func.name.clone(),
-                        var: *ret_var,
-                    });
-                }
+        if let Terminator::Return(ret_var) = &block.terminator
+            && lazy_vars.contains(ret_var)
+        {
+            // Use-count > 1 means the var was used somewhere else too
+            // (e.g. printed, passed to another fn) before being returned,
+            // indicating it was an intermediate binding.
+            if count_uses(*ret_var, func) > 1 {
+                violations.push(BlacklistViolation::LazySeqEscape {
+                    function: func.name.clone(),
+                    var: *ret_var,
+                });
             }
         }
     }
@@ -419,16 +416,28 @@ mod tests {
     use cljrs_ir::{Block, BlockId, ClosureTemplate, IrFunction, Terminator, VarId};
 
     fn make_func(name: &str, blocks: Vec<Block>) -> IrFunction {
-        let max_var = blocks.iter().flat_map(|b| {
-            b.phis.iter().chain(b.insts.iter()).filter_map(|i| match i {
-                Inst::AllocVector(d, _) | Inst::AllocMap(d, _) | Inst::AllocSet(d, _)
-                | Inst::AllocList(d, _) | Inst::AllocClosure(d, _, _) | Inst::Const(d, _)
-                | Inst::LoadLocal(d, _) | Inst::LoadGlobal(d, _, _) | Inst::RegionAlloc(d, _, _, _)
-                | Inst::DefVar(d, _, _, _) | Inst::CallKnown(d, _, _) | Inst::Call(d, _, _) => Some(d.0 + 1),
-                Inst::AllocCons(d, _, _) => Some(d.0 + 1),
-                _ => None,
+        let max_var = blocks
+            .iter()
+            .flat_map(|b| {
+                b.phis.iter().chain(b.insts.iter()).filter_map(|i| match i {
+                    Inst::AllocVector(d, _)
+                    | Inst::AllocMap(d, _)
+                    | Inst::AllocSet(d, _)
+                    | Inst::AllocList(d, _)
+                    | Inst::AllocClosure(d, _, _)
+                    | Inst::Const(d, _)
+                    | Inst::LoadLocal(d, _)
+                    | Inst::LoadGlobal(d, _, _)
+                    | Inst::RegionAlloc(d, _, _, _)
+                    | Inst::DefVar(d, _, _, _)
+                    | Inst::CallKnown(d, _, _)
+                    | Inst::Call(d, _, _) => Some(d.0 + 1),
+                    Inst::AllocCons(d, _, _) => Some(d.0 + 1),
+                    _ => None,
+                })
             })
-        }).max().unwrap_or(0);
+            .max()
+            .unwrap_or(0);
         IrFunction {
             name: Some(Arc::from(name)),
             params: vec![],
@@ -441,7 +450,12 @@ mod tests {
     }
 
     fn simple_block(id: u32, insts: Vec<Inst>, term: Terminator) -> Block {
-        Block { id: BlockId(id), phis: vec![], insts, terminator: term }
+        Block {
+            id: BlockId(id),
+            phis: vec![],
+            insts,
+            terminator: term,
+        }
     }
 
     #[test]
@@ -458,7 +472,9 @@ mod tests {
         );
         let violations = check_function(&func);
         assert!(
-            violations.iter().any(|v| matches!(v, BlacklistViolation::InteriorPointerReturn { .. })),
+            violations
+                .iter()
+                .any(|v| matches!(v, BlacklistViolation::InteriorPointerReturn { .. })),
             "expected InteriorPointerReturn, got {violations:?}"
         );
     }
@@ -506,7 +522,9 @@ mod tests {
         );
         let violations = check_function(&func);
         assert!(
-            violations.iter().any(|v| matches!(v, BlacklistViolation::RegionToStaticStore { .. })),
+            violations
+                .iter()
+                .any(|v| matches!(v, BlacklistViolation::RegionToStaticStore { .. })),
             "expected RegionToStaticStore, got {violations:?}"
         );
     }
@@ -551,7 +569,9 @@ mod tests {
         );
         let violations = check_function(&func);
         assert!(
-            violations.iter().any(|v| matches!(v, BlacklistViolation::LazySeqEscape { .. })),
+            violations
+                .iter()
+                .any(|v| matches!(v, BlacklistViolation::LazySeqEscape { .. })),
             "expected LazySeqEscape, got {violations:?}"
         );
     }
@@ -581,7 +601,9 @@ mod tests {
         );
         let violations = check_function(&func);
         assert!(
-            violations.iter().any(|v| matches!(v, BlacklistViolation::EscapingClosure { .. })),
+            violations
+                .iter()
+                .any(|v| matches!(v, BlacklistViolation::EscapingClosure { .. })),
             "expected EscapingClosure, got {violations:?}"
         );
     }

--- a/crates/cljrs-compiler/src/lib.rs
+++ b/crates/cljrs-compiler/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod aot;
 pub mod codegen;
+pub mod escape;
 pub mod ir;
 pub mod rt_abi;
 

--- a/crates/cljrs-env/src/gc_roots.rs
+++ b/crates/cljrs-env/src/gc_roots.rs
@@ -1,5 +1,8 @@
+#[cfg(not(feature = "no-gc"))]
 use crate::dynamics;
-use crate::env::{Env, GlobalEnv};
+use crate::env::Env;
+#[cfg(not(feature = "no-gc"))]
+use crate::env::GlobalEnv;
 use std::cell::RefCell;
 
 // ── Thread-local Env root registry ──────────────────────────────────────────

--- a/crates/cljrs-gc/README.md
+++ b/crates/cljrs-gc/README.md
@@ -4,7 +4,7 @@ Non-moving, stop-the-world mark-and-sweep garbage collector for clojurust;
 or, with the `no-gc` Cargo feature, a region-based allocator with no GC pauses.
 
 **Phase:** 8.1 (GcVisitor + Trace infrastructure) + 8.2 (GcBox/GcHeap
-raw-pointer implementation) — implemented.  `no-gc` mode (Phase 1–5 of
+raw-pointer implementation) — implemented.  `no-gc` mode (Phases 1–7 of
 `docs/no-gc-plan.md`) — implemented.
 
 ---
@@ -25,6 +25,12 @@ and `recur` arguments are evaluated in the caller's context (the
 and live for the program lifetime.
 No `GcHeap`, no stop-the-world pauses, no `Trace` overhead at runtime.
 
+**Phase 7 (debug provenance):** in `debug_assertions` builds with `no-gc`,
+`StaticArena` tracks chunk ranges and exposes `is_static_addr(usize) -> bool`.
+`GcPtr::is_static_alloc()` uses this to check pointer provenance at O(chunks)
+cost.  `Atom::reset`, `Var::bind`, and `Volatile::reset` use `debug_assert!`
+to catch region-local values being stored in program-lifetime containers.
+
 ---
 
 ## File layout
@@ -36,7 +42,8 @@ src/
   gc_header       — (GC mode only) GcBoxHeader, drop/trace fns
   gc_full         — (GC mode only) GcHeap, ALLOC_ROOTS, AllocRootGuard
   nogc_stubs      — (no-gc mode) stub GcHeap, GcConfig, cancellation stubs
-  static_arena.rs — (no-gc mode) global program-lifetime bump allocator
+  static_arena.rs — (no-gc mode) global program-lifetime bump allocator;
+                    in debug builds, tracks chunk ranges for is_static_addr()
   alloc_ctx.rs    — (no-gc mode) thread-local allocation context stack;
                     ScratchGuard, StaticCtxGuard
   region.rs       — Region bump allocator, RegionGuard, thread-local region stack
@@ -81,12 +88,22 @@ Built-in leaf impls: `String`, `i64`, `f64`, `bool`,
 pub struct GcPtr<T: Trace + 'static>(NonNull<GcBox<T>>);
 
 impl<T: Trace + 'static> GcPtr<T> {
-    pub fn new(value: T) -> Self        // allocates on HEAP
+    pub fn new(value: T) -> Self        // allocates on HEAP (or ctx in no-gc)
     pub fn get(&self) -> &T             // borrow; invalid after collect frees it
     pub fn ptr_eq(a: &Self, b: &Self) -> bool
+
+    // no-gc + debug_assertions only:
+    pub fn is_static_alloc(&self) -> bool  // true if allocated in StaticArena
 }
 impl<T: Trace + 'static> Clone for GcPtr<T> { /* O(1) raw-pointer copy */ }
 impl<T: Trace + 'static> Drop  for GcPtr<T> { /* no-op */ }
+```
+
+### Free functions (no-gc only)
+
+```rust
+// debug_assertions only:
+pub fn is_static_addr(addr: usize) -> bool;  // checks the StaticArena chunk registry
 ```
 
 ### `GcHeap`

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -38,6 +38,15 @@ pub use nogc_stubs::{
     unpark_thread, wait_for_threads_to_park,
 };
 
+/// Return `true` if `addr` was allocated by the global `StaticArena`.
+///
+/// Available only in `no-gc` debug builds.  Downstream crates (`cljrs-value`)
+/// use this to implement write-site provenance assertions.
+#[cfg(all(feature = "no-gc", debug_assertions))]
+pub fn is_static_addr(addr: usize) -> bool {
+    static_arena::is_static_addr(addr)
+}
+
 // ── Trace trait ───────────────────────────────────────────────────────────────
 
 /// Implemented by every type that can be stored behind a [`GcPtr`].
@@ -311,6 +320,16 @@ impl<T: Trace + 'static> GcPtr<T> {
 
     pub fn ptr_eq(a: &Self, b: &Self) -> bool {
         a.0 == b.0
+    }
+
+    /// Return `true` if this pointer was allocated by the global `StaticArena`.
+    ///
+    /// Only meaningful (and only compiled) in `no-gc` debug builds.  Used by
+    /// write-site assertions in `Atom::reset` / `Var::bind` to catch
+    /// region-local values being stored in program-lifetime containers.
+    #[cfg(all(feature = "no-gc", debug_assertions))]
+    pub fn is_static_alloc(&self) -> bool {
+        static_arena::is_static_addr(self.0.as_ptr() as usize)
     }
 }
 

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -648,6 +648,11 @@ mod nogc_stubs {
     }
 
     pub struct GcHeap;
+    impl Default for GcHeap {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl GcHeap {
         pub const fn new() -> Self {
             Self

--- a/crates/cljrs-gc/src/static_arena.rs
+++ b/crates/cljrs-gc/src/static_arena.rs
@@ -7,6 +7,14 @@
 //! The arena is a thread-safe bump allocator backed by a chain of
 //! `Box<[u8]>`-backed chunks.  Destructors for allocated values are intentionally
 //! NOT run — values stored here are semantically immutable program-lifetime data.
+//!
+//! ## Debug provenance (Phase 7)
+//!
+//! Under `cfg(all(feature = "no-gc", debug_assertions))` the arena maintains a
+//! registry of all addresses it has ever allocated.  [`is_static_addr`] checks
+//! whether a raw pointer came from the arena, which lets the write-site
+//! assertions in `Atom::reset` / `Var::bind` catch region-local values being
+//! stored in program-lifetime containers.
 
 use std::alloc::{self, Layout};
 use std::ptr::NonNull;
@@ -75,6 +83,19 @@ impl Inner {
         self.chunks.push(Chunk { data, layout: cl });
         aligned as *mut u8
     }
+
+    /// Check whether `addr` falls inside any chunk owned by this arena.
+    #[cfg(debug_assertions)]
+    fn contains_addr(&self, addr: usize) -> bool {
+        for chunk in &self.chunks {
+            let base = chunk.data.as_ptr() as usize;
+            let end = base + chunk.layout.size();
+            if addr >= base && addr < end {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 /// Thread-safe bump allocator whose memory is never reclaimed.
@@ -102,6 +123,15 @@ impl StaticArena {
         unsafe { std::ptr::write(gc_box, GcBox { value }) };
         GcPtr(unsafe { NonNull::new_unchecked(gc_box) })
     }
+
+    /// Return `true` if `addr` was allocated by this arena.
+    ///
+    /// Used by debug-mode provenance assertions to distinguish static-arena
+    /// pointers from scratch-region pointers.
+    #[cfg(debug_assertions)]
+    pub fn contains_addr(&self, addr: usize) -> bool {
+        self.inner.lock().unwrap().contains_addr(addr)
+    }
 }
 
 static STATIC_ARENA: OnceLock<StaticArena> = OnceLock::new();
@@ -109,4 +139,18 @@ static STATIC_ARENA: OnceLock<StaticArena> = OnceLock::new();
 /// Return the global static arena singleton.
 pub fn static_arena() -> &'static StaticArena {
     STATIC_ARENA.get_or_init(StaticArena::new)
+}
+
+/// Return `true` if the raw pointer address was allocated by the static arena.
+///
+/// This is an O(chunks) scan (typically 1–2 chunks) and is only intended for
+/// use in `debug_assert!` write-site checks.
+#[cfg(debug_assertions)]
+pub fn is_static_addr(addr: usize) -> bool {
+    // If the arena has not been initialised yet, no allocation has ever been
+    // made, so the address cannot be static.
+    match STATIC_ARENA.get() {
+        Some(arena) => arena.contains_addr(addr),
+        None => false,
+    }
 }

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -429,9 +429,8 @@ pub fn call_cljrs_fn(f: &CljxFn, args: &[Value], caller_env: &mut Env) -> EvalRe
         #[cfg(feature = "no-gc")]
         let result = {
             let mut scratch = cljrs_gc::alloc_ctx::ScratchGuard::new();
-            let r = eval_body_with_scratch(&arity.body, &mut scratch, &mut env);
-            r
             // scratch drops here: resets the region (frees intermediates)
+            eval_body_with_scratch(&arity.body, &mut scratch, &mut env)
         };
         env.pop_frame();
 
@@ -508,6 +507,7 @@ pub fn bind_fn_params(arity: &CljxFnArity, args: &[Value], env: &mut Env) -> Eva
 }
 
 /// Eval a function body, propagating Recur up (does not catch it).
+#[cfg(not(feature = "no-gc"))]
 fn eval_body_recur_fn(body: &[cljrs_reader::Form], env: &mut Env) -> EvalResult {
     let mut result = Value::Nil;
     for form in body {

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -248,7 +248,8 @@ impl Var {
             value_gcptr_is_static(&v),
             "no-gc: Var::bind({}/{}) received a region-local value — store violations \
              indicate a missing StaticCtxGuard around the value expression",
-            self.namespace, self.name
+            self.namespace,
+            self.name
         );
         *self.value.lock().unwrap() = Some(v);
     }

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -11,6 +11,92 @@ use cljrs_reader::Form;
 
 use crate::Value;
 
+// ── No-GC debug provenance helper ────────────────────────────────────────────
+
+/// In `no-gc` debug builds: return `true` if the top-level `GcPtr` inside
+/// `value` (if any) was allocated by the global `StaticArena`.
+///
+/// Primitives (`Nil`, `Bool`, `Long`, `Double`, `Char`) contain no `GcPtr`
+/// and always return `true`.  `Resource` is Arc-managed and also returns
+/// `true`.  All other variants have a `GcPtr` that is checked against the
+/// static arena's chunk range.
+///
+/// This check is intentionally **shallow** (top-level pointer only).  If the
+/// value was produced inside a `StaticCtxGuard`, ALL allocations during its
+/// evaluation go to the static arena — so a static top-level pointer implies
+/// static contents.
+#[cfg(all(feature = "no-gc", debug_assertions))]
+pub(crate) fn value_gcptr_is_static(value: &Value) -> bool {
+    use crate::value::MapValue;
+    use crate::value::SetValue;
+    match value {
+        // Inline scalars — no GcPtr.
+        Value::Nil
+        | Value::Bool(_)
+        | Value::Long(_)
+        | Value::Double(_)
+        | Value::Char(_)
+        | Value::Uuid(_) => true,
+        // Arc-managed — not GcPtr.
+        Value::Resource(_) => true,
+        // GcPtr variants.
+        Value::BigInt(p) => p.is_static_alloc(),
+        Value::BigDecimal(p) => p.is_static_alloc(),
+        Value::Ratio(p) => p.is_static_alloc(),
+        Value::Str(p) => p.is_static_alloc(),
+        Value::Pattern(p) => p.is_static_alloc(),
+        Value::Matcher(p) => p.is_static_alloc(),
+        Value::Symbol(p) => p.is_static_alloc(),
+        Value::Keyword(p) => p.is_static_alloc(),
+        Value::List(p) => p.is_static_alloc(),
+        Value::Vector(p) => p.is_static_alloc(),
+        Value::Queue(p) => p.is_static_alloc(),
+        Value::Map(m) => match m {
+            MapValue::Array(p) => p.is_static_alloc(),
+            MapValue::Hash(p) => p.is_static_alloc(),
+            MapValue::Sorted(p) => p.is_static_alloc(),
+        },
+        Value::Set(s) => match s {
+            SetValue::Hash(p) => p.is_static_alloc(),
+            SetValue::Sorted(p) => p.is_static_alloc(),
+        },
+        Value::NativeFunction(p) => p.is_static_alloc(),
+        Value::Fn(p) | Value::Macro(p) => p.is_static_alloc(),
+        Value::BoundFn(p) => p.is_static_alloc(),
+        Value::Var(p) => p.is_static_alloc(),
+        Value::Atom(p) => p.is_static_alloc(),
+        Value::Namespace(p) => p.is_static_alloc(),
+        Value::LazySeq(p) => p.is_static_alloc(),
+        Value::Cons(p) => p.is_static_alloc(),
+        Value::Protocol(p) => p.is_static_alloc(),
+        Value::ProtocolFn(p) => p.is_static_alloc(),
+        Value::MultiFn(p) => p.is_static_alloc(),
+        Value::Volatile(p) => p.is_static_alloc(),
+        Value::Delay(p) => p.is_static_alloc(),
+        Value::Promise(p) => p.is_static_alloc(),
+        Value::Future(p) => p.is_static_alloc(),
+        Value::Agent(p) => p.is_static_alloc(),
+        Value::TypeInstance(p) => p.is_static_alloc(),
+        Value::ObjectArray(p) => p.is_static_alloc(),
+        Value::NativeObject(p) => p.is_static_alloc(),
+        Value::Error(p) => p.is_static_alloc(),
+        Value::TransientMap(p) => p.is_static_alloc(),
+        Value::TransientVector(p) => p.is_static_alloc(),
+        Value::TransientSet(p) => p.is_static_alloc(),
+        // Primitive arrays — no meaningful pointer check needed.
+        Value::BooleanArray(_)
+        | Value::ByteArray(_)
+        | Value::ShortArray(_)
+        | Value::IntArray(_)
+        | Value::LongArray(_)
+        | Value::FloatArray(_)
+        | Value::DoubleArray(_)
+        | Value::CharArray(_) => true,
+        // Wrapper variants.
+        Value::Reduced(inner) | Value::WithMeta(inner, _) => value_gcptr_is_static(inner),
+    }
+}
+
 // ── Protocol ──────────────────────────────────────────────────────────────────
 
 /// Inner map type for protocol implementations: method_name → impl fn.
@@ -154,6 +240,16 @@ impl Var {
     }
 
     pub fn bind(&self, v: Value) {
+        // In no-gc debug builds: assert the value being stored in this
+        // program-lifetime Var came from the StaticArena, not a scratch region.
+        // A region-local pointer would dangle after the function returns.
+        #[cfg(all(feature = "no-gc", debug_assertions))]
+        debug_assert!(
+            value_gcptr_is_static(&v),
+            "no-gc: Var::bind({}/{}) received a region-local value — store violations \
+             indicate a missing StaticCtxGuard around the value expression",
+            self.namespace, self.name
+        );
         *self.value.lock().unwrap() = Some(v);
     }
 
@@ -220,6 +316,14 @@ impl Atom {
     }
 
     pub fn reset(&self, v: Value) -> Value {
+        // In no-gc debug builds: assert the new value came from the StaticArena.
+        #[cfg(all(feature = "no-gc", debug_assertions))]
+        debug_assert!(
+            value_gcptr_is_static(&v),
+            "no-gc: Atom::reset() received a region-local value — the new-value \
+             expression must be computed inside a StaticCtxGuard (i.e. inside \
+             the swap! / reset! call) so it is allocated in the static arena"
+        );
         let mut guard = self.value.lock().unwrap();
         *guard = v.clone();
         v
@@ -595,6 +699,13 @@ impl Volatile {
     }
 
     pub fn reset(&self, v: Value) -> Value {
+        // In no-gc debug builds: assert the new value came from the StaticArena.
+        #[cfg(all(feature = "no-gc", debug_assertions))]
+        debug_assert!(
+            value_gcptr_is_static(&v),
+            "no-gc: Volatile::reset() received a region-local value — ensure the \
+             new-value expression is inside a StaticCtxGuard (vreset! handles this)"
+        );
         *self.value.lock().unwrap() = v.clone();
         v
     }


### PR DESCRIPTION
## Summary

This PR implements **Phase 6–7 of the no-gc plan**: a compile-time blacklist analysis that rejects unsafe memory patterns, plus runtime debug provenance assertions to catch violations early.

## Key Changes

### Blacklist Analysis (`escape.rs`)
- New module that analyzes IR functions to detect four unsafe patterns in no-gc mode:
  1. **Interior-pointer return**: returning an allocation from the function's scratch region (would dangle after region reset)
  2. **Region → static store**: storing a scratch-region allocation in a `Var` or via `set!` (would corrupt program-lifetime containers)
  3. **Lazy-sequence escape**: returning an unrealized lazy sequence that was used as an intermediate binding (captured thunk references would dangle)
  4. **Escaping closure**: storing a closure in a static container when it captures region-local values (would access freed memory when called)

- Implements transitive analysis through phi nodes to track allocation provenance
- Counts variable uses to distinguish intermediate bindings from direct tail expressions
- Integrates into the AOT compilation pipeline: violations are collected and reported as `AotError::NoGcBlacklist`

### Debug Provenance Tracking
- **`StaticArena`** (`static_arena.rs`): added `contains_addr()` to track which memory ranges belong to the static arena (O(chunks) scan, typically 1–2 chunks)
- **`GcPtr`** (`lib.rs`): added `is_static_alloc()` method to check if a pointer came from the static arena
- **Write-site assertions** (`types.rs`):
  - `Var::bind()`: asserts the stored value came from the static arena
  - `Atom::reset()`: asserts the new value came from the static arena
  - `Volatile::reset()`: asserts the new value came from the static arena
  - Helper function `value_gcptr_is_static()` recursively checks all GcPtr variants in a value (shallow check only — if top-level is static, contents are guaranteed static due to `StaticCtxGuard`)

### Integration
- AOT driver (`aot.rs`) now runs blacklist analysis after IR conversion and rejects programs with violations
- All new code is gated behind `#[cfg(feature = "no-gc")]` or `#[cfg(all(feature = "no-gc", debug_assertions))]`
- Updated README files to reflect Phase 7 completion

## Implementation Details

- Blacklist analysis is **compile-time only** and runs on the Rust-level `IrFunction` after Clojure-level optimization
- Debug provenance checks are **runtime assertions** that only fire in debug builds, catching violations that slip through the static analysis
- The shallow pointer check in `value_gcptr_is_static()` is sound because `StaticCtxGuard` ensures all allocations during an expression evaluation go to the static arena
- Comprehensive test suite for all four violation patterns included in `escape.rs`

https://claude.ai/code/session_01Mb2oMjAEY9Y5n49j62Vg8J