### PR TITLE
Add GC statistics tracking and --gc-stats CLI flag

### DIFF
--- a/crates/cljrs-gc/README.md
+++ b/crates/cljrs-gc/README.md
@@ -49,6 +49,8 @@ src/
   region.rs       — Region bump allocator, RegionGuard, thread-local region stack
   cancellation.rs — (GC mode) STW coordination, MutatorGuard, safepoints
   config.rs       — (GC mode) GcConfig, GcCancellation, GcParked
+  stats.rs        — process-global GcStats counters: GC allocations,
+                    region (bump) allocations, GC pauses + freed bytes/objects
 tests/
   no_gc_alloc.rs  — (no-gc mode) integration tests for the allocation context stack:
                     ScratchGuard, StaticCtxGuard, pop_for_return protocol,
@@ -169,6 +171,30 @@ Destructors run on `reset()` or `drop`.
 
 RAII guard that pushes a `Region` onto the thread-local stack. Use with
 `try_alloc_in_region()` for opportunistic region allocation.
+
+### `stats::GcStats` and `GC_STATS`
+
+```rust
+pub struct GcStats { /* AtomicU64 counters */ }
+
+impl GcStats {
+    pub const fn new() -> Self
+    pub fn record_gc_alloc(&self, bytes: usize)
+    pub fn record_region_alloc(&self, bytes: usize)
+    pub fn record_gc_pause(&self, pause: Duration, freed_objects: u64, freed_bytes: u64)
+    pub fn snapshot(&self) -> GcStatsSnapshot
+}
+
+pub struct GcStatsSnapshot { /* immutable view of counters */ }
+impl GcStatsSnapshot { pub fn total_pause(&self) -> Duration }
+impl std::fmt::Display for GcStatsSnapshot { /* multi-line summary */ }
+
+pub static GC_STATS: GcStats;
+```
+
+Process-global counters updated automatically by `GcHeap::alloc`,
+`GcHeap::collect`, and `Region::alloc`.  The `cljrs --gc-stats [FILE]` CLI
+flag prints a snapshot of these counters at program exit.
 
 ---
 

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -6,6 +6,7 @@
 use std::ptr::NonNull;
 
 pub mod region;
+pub mod stats;
 
 #[cfg(not(feature = "no-gc"))]
 pub mod cancellation;
@@ -16,6 +17,8 @@ pub mod config;
 pub mod alloc_ctx;
 #[cfg(feature = "no-gc")]
 pub mod static_arena;
+
+pub use stats::{GC_STATS, GcStats, GcStatsSnapshot};
 
 // ── Re-exports from active implementation ─────────────────────────────────────
 
@@ -463,6 +466,7 @@ mod gc_full {
             }
             self.total_allocated_bytes
                 .fetch_add(ESTIMATED_OBJECT_SIZE, Ordering::Relaxed);
+            crate::stats::GC_STATS.record_gc_alloc(ESTIMATED_OBJECT_SIZE);
             let current_usage = self
                 .memory_in_use
                 .fetch_add(ESTIMATED_OBJECT_SIZE, Ordering::Relaxed)
@@ -543,6 +547,11 @@ mod gc_full {
             let freed_bytes = freed_count * ESTIMATED_OBJECT_SIZE;
             self.memory_in_use.fetch_sub(freed_bytes, Ordering::Relaxed);
             let sweep_elapsed = sweep_start.elapsed();
+            crate::stats::GC_STATS.record_gc_pause(
+                mark_elapsed + sweep_elapsed,
+                freed_count as u64,
+                freed_bytes as u64,
+            );
             let post_memory = self.memory_in_use.load(Ordering::Relaxed);
             cljrs_logging::feat_debug!(
                 "gc",

--- a/crates/cljrs-gc/src/region.rs
+++ b/crates/cljrs-gc/src/region.rs
@@ -134,6 +134,7 @@ impl Region {
             drop_fn: drop_gcbox_in_place::<T>,
         });
         self.object_count += 1;
+        crate::stats::GC_STATS.record_region_alloc(layout.size());
 
         // SAFETY: `gc_box` is non-null (from bump_alloc).
         GcPtr(unsafe { NonNull::new_unchecked(gc_box) })

--- a/crates/cljrs-gc/src/stats.rs
+++ b/crates/cljrs-gc/src/stats.rs
@@ -70,7 +70,8 @@ impl GcStats {
             .fetch_add(pause.as_nanos() as u64, Ordering::Relaxed);
         self.gc_objects_freed
             .fetch_add(freed_objects, Ordering::Relaxed);
-        self.gc_bytes_freed.fetch_add(freed_bytes, Ordering::Relaxed);
+        self.gc_bytes_freed
+            .fetch_add(freed_bytes, Ordering::Relaxed);
     }
 
     /// Take a point-in-time snapshot of all counters.
@@ -128,11 +129,7 @@ impl fmt::Display for GcStatsSnapshot {
             self.region_allocations, self.region_alloc_bytes
         )?;
         writeln!(f, "  GC collections:        {}", self.gc_collections)?;
-        writeln!(
-            f,
-            "  Total GC pause time:   {:.3?}",
-            self.total_pause()
-        )?;
+        writeln!(f, "  Total GC pause time:   {:.3?}", self.total_pause())?;
         writeln!(f, "  Objects freed by GC:   {}", self.gc_objects_freed)?;
         write!(f, "  Bytes freed by GC:     {}", self.gc_bytes_freed)
     }

--- a/crates/cljrs-gc/src/stats.rs
+++ b/crates/cljrs-gc/src/stats.rs
@@ -1,0 +1,210 @@
+//! Process-global GC statistics counters.
+//!
+//! Tracks three classes of events:
+//!
+//! 1. **GC heap allocations** — every object allocated through `GcHeap::alloc`
+//!    (default build) bumps `gc_allocations` and `gc_alloc_bytes`.
+//! 2. **Region (bump) allocations** — every object allocated through
+//!    [`crate::region::Region::alloc`] bumps `region_allocations` and
+//!    `region_alloc_bytes`.  These represent cases where the bump allocator
+//!    was used instead of the GC heap.
+//! 3. **Stop-the-world collections** — every completed `GcHeap::collect`
+//!    bumps `gc_collections` and accumulates pause time, freed object count,
+//!    and freed bytes.
+//!
+//! Counters are process-global ([`GC_STATS`]) and thread-safe via atomics.
+//! Reset is not supported — the counters live for the lifetime of the process.
+
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+/// Process-global GC statistics counters.
+pub struct GcStats {
+    gc_allocations: AtomicU64,
+    gc_alloc_bytes: AtomicU64,
+    region_allocations: AtomicU64,
+    region_alloc_bytes: AtomicU64,
+    gc_collections: AtomicU64,
+    gc_pause_total_nanos: AtomicU64,
+    gc_objects_freed: AtomicU64,
+    gc_bytes_freed: AtomicU64,
+}
+
+impl GcStats {
+    pub const fn new() -> Self {
+        Self {
+            gc_allocations: AtomicU64::new(0),
+            gc_alloc_bytes: AtomicU64::new(0),
+            region_allocations: AtomicU64::new(0),
+            region_alloc_bytes: AtomicU64::new(0),
+            gc_collections: AtomicU64::new(0),
+            gc_pause_total_nanos: AtomicU64::new(0),
+            gc_objects_freed: AtomicU64::new(0),
+            gc_bytes_freed: AtomicU64::new(0),
+        }
+    }
+
+    /// Record one allocation through the GC heap (`bytes` is the estimated
+    /// or actual allocated size).
+    #[inline]
+    pub fn record_gc_alloc(&self, bytes: usize) {
+        self.gc_allocations.fetch_add(1, Ordering::Relaxed);
+        self.gc_alloc_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Record one allocation through a bump region (instead of the GC heap).
+    #[inline]
+    pub fn record_region_alloc(&self, bytes: usize) {
+        self.region_allocations.fetch_add(1, Ordering::Relaxed);
+        self.region_alloc_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Record a completed stop-the-world collection.
+    #[inline]
+    pub fn record_gc_pause(&self, pause: Duration, freed_objects: u64, freed_bytes: u64) {
+        self.gc_collections.fetch_add(1, Ordering::Relaxed);
+        self.gc_pause_total_nanos
+            .fetch_add(pause.as_nanos() as u64, Ordering::Relaxed);
+        self.gc_objects_freed
+            .fetch_add(freed_objects, Ordering::Relaxed);
+        self.gc_bytes_freed.fetch_add(freed_bytes, Ordering::Relaxed);
+    }
+
+    /// Take a point-in-time snapshot of all counters.
+    pub fn snapshot(&self) -> GcStatsSnapshot {
+        GcStatsSnapshot {
+            gc_allocations: self.gc_allocations.load(Ordering::Relaxed),
+            gc_alloc_bytes: self.gc_alloc_bytes.load(Ordering::Relaxed),
+            region_allocations: self.region_allocations.load(Ordering::Relaxed),
+            region_alloc_bytes: self.region_alloc_bytes.load(Ordering::Relaxed),
+            gc_collections: self.gc_collections.load(Ordering::Relaxed),
+            gc_pause_total_nanos: self.gc_pause_total_nanos.load(Ordering::Relaxed),
+            gc_objects_freed: self.gc_objects_freed.load(Ordering::Relaxed),
+            gc_bytes_freed: self.gc_bytes_freed.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for GcStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Immutable point-in-time view of [`GcStats`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GcStatsSnapshot {
+    pub gc_allocations: u64,
+    pub gc_alloc_bytes: u64,
+    pub region_allocations: u64,
+    pub region_alloc_bytes: u64,
+    pub gc_collections: u64,
+    pub gc_pause_total_nanos: u64,
+    pub gc_objects_freed: u64,
+    pub gc_bytes_freed: u64,
+}
+
+impl GcStatsSnapshot {
+    /// Total cumulative GC pause time.
+    pub fn total_pause(&self) -> Duration {
+        Duration::from_nanos(self.gc_pause_total_nanos)
+    }
+}
+
+impl fmt::Display for GcStatsSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "GC stats:")?;
+        writeln!(
+            f,
+            "  GC allocations:        {} ({} bytes)",
+            self.gc_allocations, self.gc_alloc_bytes
+        )?;
+        writeln!(
+            f,
+            "  Region (bump) allocs:  {} ({} bytes)",
+            self.region_allocations, self.region_alloc_bytes
+        )?;
+        writeln!(f, "  GC collections:        {}", self.gc_collections)?;
+        writeln!(
+            f,
+            "  Total GC pause time:   {:.3?}",
+            self.total_pause()
+        )?;
+        writeln!(f, "  Objects freed by GC:   {}", self.gc_objects_freed)?;
+        write!(f, "  Bytes freed by GC:     {}", self.gc_bytes_freed)
+    }
+}
+
+/// Process-global GC statistics counters.
+pub static GC_STATS: GcStats = GcStats::new();
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_zero_by_default() {
+        let stats = GcStats::new();
+        let snap = stats.snapshot();
+        assert_eq!(snap.gc_allocations, 0);
+        assert_eq!(snap.region_allocations, 0);
+        assert_eq!(snap.gc_collections, 0);
+        assert_eq!(snap.total_pause(), Duration::ZERO);
+    }
+
+    #[test]
+    fn record_gc_alloc_updates_counters() {
+        let stats = GcStats::new();
+        stats.record_gc_alloc(48);
+        stats.record_gc_alloc(48);
+        let snap = stats.snapshot();
+        assert_eq!(snap.gc_allocations, 2);
+        assert_eq!(snap.gc_alloc_bytes, 96);
+    }
+
+    #[test]
+    fn record_region_alloc_updates_counters() {
+        let stats = GcStats::new();
+        stats.record_region_alloc(16);
+        stats.record_region_alloc(32);
+        let snap = stats.snapshot();
+        assert_eq!(snap.region_allocations, 2);
+        assert_eq!(snap.region_alloc_bytes, 48);
+    }
+
+    #[test]
+    fn record_gc_pause_updates_counters() {
+        let stats = GcStats::new();
+        stats.record_gc_pause(Duration::from_micros(500), 7, 336);
+        stats.record_gc_pause(Duration::from_micros(250), 3, 144);
+        let snap = stats.snapshot();
+        assert_eq!(snap.gc_collections, 2);
+        assert_eq!(snap.gc_objects_freed, 10);
+        assert_eq!(snap.gc_bytes_freed, 480);
+        assert_eq!(snap.total_pause(), Duration::from_micros(750));
+    }
+
+    #[test]
+    fn display_renders_all_fields() {
+        let snap = GcStatsSnapshot {
+            gc_allocations: 5,
+            gc_alloc_bytes: 240,
+            region_allocations: 3,
+            region_alloc_bytes: 96,
+            gc_collections: 1,
+            gc_pause_total_nanos: 1_000_000,
+            gc_objects_freed: 2,
+            gc_bytes_freed: 96,
+        };
+        let s = format!("{snap}");
+        assert!(s.contains("GC allocations:"));
+        assert!(s.contains("Region (bump) allocs:"));
+        assert!(s.contains("GC collections:"));
+        assert!(s.contains("Total GC pause time:"));
+        assert!(s.contains("Objects freed by GC:"));
+        assert!(s.contains("Bytes freed by GC:"));
+    }
+}

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -29,6 +29,12 @@ Subcommands:
 `--src-path` may be repeated to add multiple source directories searched by
 `require` when resolving namespace names to files.
 
+`--gc-stats [FILE]` is a global flag honoured by the `run`, `eval`, and `test`
+subcommands.  At program exit, it prints a snapshot of `cljrs_gc::GC_STATS`
+(GC heap allocations, region/bump allocations, GC pause count and total
+duration, freed objects/bytes).  With no value the report goes to stdout;
+with a path it is written to that file.
+
 ### Examples
 
 ```bash
@@ -38,6 +44,11 @@ cljrs repl --src-path src
 cljrs compile app.cljrs -o app
 cljrs eval '(+ 1 2)'
 cljrs test --src-path src/ --src-path test/ my-ns.my-tests
+
+# GC stats:
+cljrs run main.cljrs --gc-stats              # → stdout
+cljrs eval '(reduce + (range 1e6))' --gc-stats stats.txt
+cljrs test --src-path test/ --gc-stats /tmp/test-gc.log
 ```
 
 ---

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -41,6 +41,18 @@ struct Cli {
     #[arg(short = 'X', global = true, value_name = "LEVEL:FEATURES")]
     x_flags: Vec<String>,
 
+    /// Print GC statistics on exit. Pass a path to write them to a file;
+    /// pass the flag without a value to write them to stdout. Only the
+    /// `run`, `eval`, and `test` subcommands honour this flag.
+    #[arg(
+        long = "gc-stats",
+        global = true,
+        value_name = "FILE",
+        num_args = 0..=1,
+        default_missing_value = "",
+    )]
+    gc_stats: Option<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -171,18 +183,42 @@ fn main() -> miette::Result<()> {
         .name("cljrs-main".into())
         .stack_size(stack_size);
     let handle = builder.spawn(move || run(cli)).into_diagnostic()?;
-    handle.join().unwrap_or_else(|e| {
+    let result: miette::Result<i32> = handle.join().unwrap_or_else(|e| {
         eprintln!("cljrs: thread panicked: {e:?}");
         std::process::exit(1);
-    })
+    });
+    match result {
+        Ok(0) => Ok(()),
+        Ok(code) => std::process::exit(code),
+        Err(e) => Err(e),
+    }
 }
 
-fn run(cli: Cli) -> miette::Result<()> {
+fn run(cli: Cli) -> miette::Result<i32> {
     // Register the main thread as a GC mutator so the collector knows
     // how many threads to wait for during stop-the-world collection.
     let _mutator = cljrs_gc::register_mutator();
 
-    match cli.command {
+    let gc_stats_target = cli.gc_stats.clone();
+    let supports_gc_stats = matches!(
+        &cli.command,
+        Commands::Run { .. } | Commands::Eval { .. } | Commands::Test { .. },
+    );
+
+    let result = run_command(cli.command);
+
+    if supports_gc_stats
+        && let Some(target) = gc_stats_target.as_deref()
+        && let Err(e) = write_gc_stats(target)
+    {
+        eprintln!("cljrs: failed to write GC stats: {e}");
+    }
+
+    result
+}
+
+fn run_command(command: Commands) -> miette::Result<i32> {
+    match command {
         Commands::Run {
             file,
             src_paths,
@@ -194,6 +230,7 @@ fn run(cli: Cli) -> miette::Result<()> {
             let filename = file.display().to_string();
             let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
             run_source(&src, &filename, src_paths, gc_config)?;
+            Ok(0)
         }
         Commands::Repl {
             src_paths,
@@ -202,6 +239,7 @@ fn run(cli: Cli) -> miette::Result<()> {
         } => {
             let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
             run_repl(src_paths, gc_config);
+            Ok(0)
         }
         Commands::Compile {
             file,
@@ -221,6 +259,7 @@ fn run(cli: Cli) -> miette::Result<()> {
                 cljrs_compiler::aot::compile_file(&file, &out, &src_paths)
                     .map_err(|e| miette::miette!("{e}"))?;
             }
+            Ok(0)
         }
         Commands::Eval { expr } => {
             // Eval uses default GC config
@@ -229,6 +268,7 @@ fn run(cli: Cli) -> miette::Result<()> {
             if result != Value::Nil {
                 println!("{}", result);
             }
+            Ok(0)
         }
         Commands::Test {
             namespaces,
@@ -236,17 +276,28 @@ fn run(cli: Cli) -> miette::Result<()> {
             verbose,
             gc_soft_limit_mb,
             gc_hard_limit_mb,
-        } => {
-            run_tests_command(
-                namespaces,
-                src_paths,
-                verbose,
-                gc_soft_limit_mb,
-                gc_hard_limit_mb,
-            )?;
-        }
+        } => run_tests_command(
+            namespaces,
+            src_paths,
+            verbose,
+            gc_soft_limit_mb,
+            gc_hard_limit_mb,
+        ),
     }
-    Ok(())
+}
+
+/// Write a snapshot of `cljrs_gc::GC_STATS` to `target`.
+///
+/// An empty target (the flag was passed without a value) writes to stdout;
+/// any other value is treated as a filesystem path.
+fn write_gc_stats(target: &str) -> std::io::Result<()> {
+    let snapshot = cljrs_gc::GC_STATS.snapshot();
+    if target.is_empty() {
+        println!("{snapshot}");
+        Ok(())
+    } else {
+        std::fs::write(target, format!("{snapshot}\n"))
+    }
 }
 
 // ── Source evaluation ─────────────────────────────────────────────────────────
@@ -319,12 +370,12 @@ fn run_tests_command(
     verbose: bool,
     gc_soft_limit_mb: Option<usize>,
     gc_hard_limit_mb: Option<usize>,
-) -> miette::Result<()> {
+) -> miette::Result<i32> {
     let namespaces = if namespaces.is_empty() {
         let discovered = discover_namespaces(&src_paths);
         if discovered.is_empty() {
             eprintln!("cljrs test: no test namespaces found in source paths");
-            std::process::exit(2);
+            return Ok(2);
         }
         eprintln!("Discovered {} test namespace(s).\n", discovered.len());
         discovered
@@ -364,9 +415,10 @@ fn run_tests_command(
     let total_load_errors: usize = results.iter().filter(|r| r.load_error.is_some()).count();
 
     if total_fail > 0 || total_load_errors > 0 {
-        std::process::exit(1);
+        Ok(1)
+    } else {
+        Ok(0)
     }
-    Ok(())
 }
 
 fn run_single_ns_tests(env: &mut Env, ns: &str) -> NsTestResult {


### PR DESCRIPTION
## Summary

This PR adds process-global GC statistics tracking to `cljrs-gc` and exposes it via a new `--gc-stats` CLI flag in the main `cljrs` binary. Users can now collect and inspect detailed metrics about garbage collection behavior, including allocation counts, pause times, and freed memory.

## Key Changes

- **New `stats` module** (`cljrs-gc/src/stats.rs`):
  - `GcStats`: Thread-safe atomic counters for GC heap allocations, region (bump) allocations, collection pauses, and freed objects/bytes
  - `GcStatsSnapshot`: Immutable point-in-time view of counters with a human-readable `Display` implementation
  - `GC_STATS`: Process-global static instance automatically updated by the allocator and collector
  - Comprehensive unit tests covering all counter operations

- **Automatic counter updates**:
  - `GcHeap::alloc()` calls `GC_STATS.record_gc_alloc()` to track heap allocations
  - `GcHeap::collect()` calls `GC_STATS.record_gc_pause()` to record pause duration and freed memory
  - `Region::alloc()` calls `GC_STATS.record_region_alloc()` to track bump allocations

- **CLI integration** (`cljrs/src/main.rs`):
  - New global `--gc-stats [FILE]` flag supported by `run`, `eval`, and `test` subcommands
  - Flag accepts optional path argument: empty/no value writes to stdout, path writes to file
  - `write_gc_stats()` helper function handles output formatting
  - Refactored `run()` to return exit code and properly handle GC stats output at program exit

- **Documentation updates**:
  - Updated `cljrs-gc/README.md` with `stats` module description and API reference
  - Updated `cljrs/README.md` with `--gc-stats` flag usage and examples

## Implementation Details

- Uses `Ordering::Relaxed` atomics for performance (no synchronization needed for stats)
- Counters are monotonically increasing and never reset (live for process lifetime)
- Snapshot mechanism allows safe concurrent reads without blocking writers
- Exit code handling refactored to support deferred GC stats output while preserving command exit codes

https://claude.ai/code/session_01CeZ5A22ba7cQMLKSDFR1ub