### PR TITLE
Simplify SetValue trace implementation using GcVisitor

### DIFF
--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -337,9 +337,10 @@ impl SetValue {
 
 impl cljrs_gc::Trace for SetValue {
     fn trace(&self, visitor: &mut cljrs_gc::MarkVisitor) {
+        use cljrs_gc::GcVisitor as _;
         match self {
-            SetValue::Hash(s) => s.get().trace(visitor),
-            SetValue::Sorted(s) => s.get().trace(visitor),
+            SetValue::Hash(s) => visitor.visit(s),
+            SetValue::Sorted(s) => visitor.visit(s),
         }
     }
 }


### PR DESCRIPTION
## Summary
Refactored the `Trace` implementation for `SetValue` to use the `GcVisitor` trait directly instead of calling `trace()` on dereferenced values.

## Key Changes
- Added `use cljrs_gc::GcVisitor as _` import to bring the trait into scope
- Replaced `s.get().trace(visitor)` calls with `visitor.visit(s)` for both `Hash` and `Sorted` variants
- This change applies to both `SetValue::Hash` and `SetValue::Sorted` cases

## Implementation Details
The refactoring leverages the `GcVisitor` trait's `visit()` method, which likely handles the dereferencing and tracing internally. This is a cleaner API that reduces boilerplate and makes the code more consistent with the garbage collection framework's intended usage patterns.

https://claude.ai/code/session_01N1toG7Pu43nPT3HiVifq1U