### PR TITLE
Fix publish step.

### DIFF
--- a/crates/cljrs-eval/Cargo.toml
+++ b/crates/cljrs-eval/Cargo.toml
@@ -20,4 +20,4 @@ cljrs-builtins = { workspace = true }
 cljrs-interp   = { workspace = true }
 
 [dev-dependencies]
-cljrs-stdlib   = { workspace = true }
+cljrs-stdlib   = { path = "../cljrs-stdlib" }


### PR DESCRIPTION
Make cljrs-eval's dev-dependencies path based, not workspace-based.