### PR TITLE
Fix IR interpreter special-form coverage and route Fn calls through IR hook

### DIFF
--- a/crates/cljrs-env/src/apply.rs
+++ b/crates/cljrs-env/src/apply.rs
@@ -166,6 +166,20 @@ pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResul
             None => Ok(Value::Nil),
         },
         Value::WithMeta(inner, _) => apply_value(inner, args, env),
+        Value::Var(v) => {
+            // Vars in function position are transparently deref'd (IFn on Var).
+            // The IR interpreter uses DefVar to create per-call mutable cells for
+            // letfn / named-fn self-recursion; those cells are captured as
+            // Value::Var and called directly.
+            let inner = crate::dynamics::deref_var(v).ok_or_else(|| {
+                EvalError::Runtime(format!(
+                    "unbound var {}/{} used as function",
+                    v.get().namespace,
+                    v.get().name,
+                ))
+            })?;
+            apply_value(&inner, args, env)
+        }
         other => Err(EvalError::NotCallable(format!(
             "<{}> is not callable",
             other.type_name()

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -1,7 +1,7 @@
 //! Lexical environment: local frames, global namespace table, and current Env.
 
-use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, RwLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 
 use crate::error::EvalResult;
 use cljrs_gc::{GcConfig, GcPtr};
@@ -71,9 +71,13 @@ pub struct GlobalEnv {
     /// Directories to search when resolving namespace names to files.
     pub source_paths: RwLock<Vec<std::path::PathBuf>>,
     /// Namespaces that have been fully loaded from a file (idempotent guard).
-    pub loaded: Mutex<HashSet<Arc<str>>>,
-    /// Namespaces currently being loaded (cycle detection).
-    pub loading: Mutex<HashSet<Arc<str>>>,
+    pub loaded: Mutex<std::collections::HashSet<Arc<str>>>,
+    /// Namespaces currently being loaded, mapped to the thread loading them.
+    /// Used to detect true circular requires (same thread) vs concurrent loads
+    /// (different thread — those wait on `loading_done` instead of erroring).
+    pub loading: Mutex<HashMap<Arc<str>, std::thread::ThreadId>>,
+    /// Signalled whenever a namespace finishes loading (or fails).
+    pub loading_done: Condvar,
     /// Built-in namespace sources embedded in the binary.
     /// Checked by `load_ns` before falling back to source-path search.
     pub builtin_sources: RwLock<HashMap<Arc<str>, &'static str>>,
@@ -105,8 +109,9 @@ impl GlobalEnv {
         Arc::new(Self {
             namespaces: RwLock::new(HashMap::new()),
             source_paths: RwLock::new(Vec::new()),
-            loaded: Mutex::new(HashSet::new()),
-            loading: Mutex::new(HashSet::new()),
+            loaded: Mutex::new(std::collections::HashSet::new()),
+            loading: Mutex::new(HashMap::new()),
+            loading_done: Condvar::new(),
             builtin_sources: RwLock::new(HashMap::new()),
             gc_config: RwLock::new(None),
             compiler_ready: std::sync::atomic::AtomicBool::new(false),

--- a/crates/cljrs-env/src/loader.rs
+++ b/crates/cljrs-env/src/loader.rs
@@ -9,69 +9,31 @@ use crate::error::{EvalError, EvalResult};
 ///
 /// - Idempotent: if already loaded, skips file evaluation but still applies
 ///   alias/refer in the *current* namespace.
-/// - Cycle detection: returns an error if `spec.ns` is currently being loaded.
+/// - Same-thread cycle detection: returns an error if the current thread is
+///   already loading `spec.ns` (true circular require).
+/// - Cross-thread coordination: if a *different* thread is loading `spec.ns`,
+///   waits for it to finish (via `GlobalEnv::loading_done`) instead of
+///   reporting a spurious "circular require" error.
 pub fn load_ns(globals: Arc<GlobalEnv>, spec: &RequireSpec, current_ns: &str) -> EvalResult<()> {
     let ns_name = &spec.ns;
 
-    // Skip file loading if already done, but still apply alias/refer.
-    let already_loaded = globals.is_loaded(ns_name);
-    if !already_loaded {
-        // Cycle detection.
-        {
-            let mut loading = globals.loading.lock().unwrap();
-            if loading.contains(ns_name.as_ref()) {
-                return Err(EvalError::Runtime(format!("circular require: {ns_name}")));
+    if !globals.is_loaded(ns_name) {
+        // Try to claim this namespace for loading, or wait if another thread
+        // is already loading it.
+        let should_load = claim_or_wait(&globals, ns_name)?;
+
+        if should_load {
+            let result = do_load(&globals, ns_name);
+
+            // Release the claim and notify any waiting threads.
+            globals.loading.lock().unwrap().remove(ns_name.as_ref());
+            if result.is_ok() {
+                globals.mark_loaded(ns_name);
             }
-            loading.insert(ns_name.clone());
-        }
+            globals.loading_done.notify_all();
 
-        // Resolve namespace name: check built-in registry first, then disk.
-        // Clojure convention: dots → path separators, hyphens → underscores.
-        let rel_path = ns_name.replace('.', "/").replace('-', "_");
-        let src_paths = globals.source_paths.read().unwrap().clone();
-        let (src, file_path): (String, String) =
-            if let Some(builtin) = globals.builtin_source(ns_name) {
-                (builtin.to_owned(), format!("<builtin:{ns_name}>"))
-            } else {
-                find_source_file(&rel_path, &src_paths).ok_or_else(|| {
-                    EvalError::Runtime(format!("Could not find namespace {ns_name} on source path"))
-                })?
-            };
-
-        // Pre-refer clojure.core so code in the file can use core fns before (ns ...).
-        if ns_name.as_ref() != "clojure.core" {
-            globals.refer_all(ns_name, "clojure.core");
+            result?;
         }
-
-        // Evaluate the file in a new Env rooted at the namespace being loaded.
-        // Save and restore *ns* so the caller's namespace is not disturbed.
-        let saved_ns = globals
-            .lookup_var("clojure.core", "*ns*")
-            .and_then(|v| crate::dynamics::deref_var(&v));
-        {
-            let mut env = Env::new(globals.clone(), ns_name);
-            let mut parser = cljrs_reader::Parser::new(src, file_path);
-            let forms = parser.parse_all().map_err(EvalError::Read)?;
-            for form in forms {
-                // Alloc frame per top-level form: all allocations during this
-                // form's evaluation are rooted.  Frame pops between forms,
-                // allowing GC to collect temporaries from previous forms.
-                let _alloc_frame = cljrs_gc::push_alloc_frame();
-                (*globals)
-                    .eval(&form, &mut env)
-                    .map_err(|e| annotate(e, ns_name))?;
-            }
-        }
-        // Restore *ns* to the caller's namespace.
-        if let Some(saved) = saved_ns
-            && let Some(var) = globals.lookup_var("clojure.core", "*ns*")
-        {
-            var.get().bind(saved);
-        }
-
-        // Mark loaded and remove from in-progress set.
-        globals.loading.lock().unwrap().remove(ns_name.as_ref());
-        globals.mark_loaded(ns_name);
     }
 
     // Apply alias.
@@ -84,6 +46,89 @@ pub fn load_ns(globals: Arc<GlobalEnv>, spec: &RequireSpec, current_ns: &str) ->
         RequireRefer::None => {}
         RequireRefer::All => globals.refer_all(current_ns, ns_name),
         RequireRefer::Named(names) => globals.refer_named(current_ns, ns_name, names),
+    }
+
+    Ok(())
+}
+
+/// Claim `ns_name` for loading by the current thread, or wait until another
+/// thread that claimed it finishes.
+///
+/// Returns `Ok(true)` if the caller claimed the namespace and must load it.
+/// Returns `Ok(false)` if another thread loaded it while we waited.
+/// Returns `Err` on a genuine circular require (same thread).
+fn claim_or_wait(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<bool> {
+    let tid = std::thread::current().id();
+    loop {
+        let mut loading = globals.loading.lock().unwrap();
+        match loading.get(ns_name.as_ref()) {
+            None => {
+                loading.insert(ns_name.clone(), tid);
+                return Ok(true);
+            }
+            Some(&owner) if owner == tid => {
+                return Err(EvalError::Runtime(format!("circular require: {ns_name}")));
+            }
+            Some(_) => {
+                // A different thread is loading this namespace.  Wait for it
+                // to finish (the Condvar releases `loading` while sleeping).
+                let _guard = globals.loading_done.wait(loading).unwrap();
+                // After waking, the namespace may now be fully loaded.
+                if globals.is_loaded(ns_name) {
+                    return Ok(false);
+                }
+                // Otherwise loop and try to claim again.
+            }
+        }
+    }
+}
+
+/// Evaluate the source file for `ns_name`, returning Ok(()) or an error.
+/// The caller is responsible for claiming/releasing the namespace in the
+/// `loading` map.
+fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
+    // Resolve namespace name: check built-in registry first, then disk.
+    // Clojure convention: dots → path separators, hyphens → underscores.
+    let rel_path = ns_name.replace('.', "/").replace('-', "_");
+    let src_paths = globals.source_paths.read().unwrap().clone();
+    let (src, file_path): (String, String) =
+        if let Some(builtin) = globals.builtin_source(ns_name) {
+            (builtin.to_owned(), format!("<builtin:{ns_name}>"))
+        } else {
+            find_source_file(&rel_path, &src_paths).ok_or_else(|| {
+                EvalError::Runtime(format!("Could not find namespace {ns_name} on source path"))
+            })?
+        };
+
+    // Pre-refer clojure.core so code in the file can use core fns before (ns ...).
+    if ns_name.as_ref() != "clojure.core" {
+        globals.refer_all(ns_name, "clojure.core");
+    }
+
+    // Evaluate the file in a new Env rooted at the namespace being loaded.
+    // Save and restore *ns* so the caller's namespace is not disturbed.
+    let saved_ns = globals
+        .lookup_var("clojure.core", "*ns*")
+        .and_then(|v| crate::dynamics::deref_var(&v));
+    {
+        let mut env = Env::new(globals.clone(), ns_name);
+        let mut parser = cljrs_reader::Parser::new(src, file_path);
+        let forms = parser.parse_all().map_err(EvalError::Read)?;
+        for form in forms {
+            // Alloc frame per top-level form: all allocations during this
+            // form's evaluation are rooted.  Frame pops between forms,
+            // allowing GC to collect temporaries from previous forms.
+            let _alloc_frame = cljrs_gc::push_alloc_frame();
+            (*globals)
+                .eval(&form, &mut env)
+                .map_err(|e| annotate(e, ns_name))?;
+        }
+    }
+    // Restore *ns* to the caller's namespace.
+    if let Some(saved) = saved_ns
+        && let Some(var) = globals.lookup_var("clojure.core", "*ns*")
+    {
+        var.get().bind(saved);
     }
 
     Ok(())

--- a/crates/cljrs-env/src/loader.rs
+++ b/crates/cljrs-env/src/loader.rs
@@ -91,14 +91,14 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
     // Clojure convention: dots → path separators, hyphens → underscores.
     let rel_path = ns_name.replace('.', "/").replace('-', "_");
     let src_paths = globals.source_paths.read().unwrap().clone();
-    let (src, file_path): (String, String) =
-        if let Some(builtin) = globals.builtin_source(ns_name) {
-            (builtin.to_owned(), format!("<builtin:{ns_name}>"))
-        } else {
-            find_source_file(&rel_path, &src_paths).ok_or_else(|| {
-                EvalError::Runtime(format!("Could not find namespace {ns_name} on source path"))
-            })?
-        };
+    let (src, file_path): (String, String) = if let Some(builtin) = globals.builtin_source(ns_name)
+    {
+        (builtin.to_owned(), format!("<builtin:{ns_name}>"))
+    } else {
+        find_source_file(&rel_path, &src_paths).ok_or_else(|| {
+            EvalError::Runtime(format!("Could not find namespace {ns_name} on source path"))
+        })?
+    };
 
     // Pre-refer clojure.core so code in the file can use core fns before (ns ...).
     if ns_name.as_ref() != "clojure.core" {

--- a/crates/cljrs-eval/README.md
+++ b/crates/cljrs-eval/README.md
@@ -94,6 +94,31 @@ pub mod lower {
 4. If not cached: falls back to `cljrs_interp::apply::call_cljrs_fn` (tree-walking)
 5. Eager lowering: `ir_interp::eager_lower_fn` is registered as the `on_fn_defined` hook;
    when `compiler_ready` is true, new `fn*` definitions are lowered immediately
+6. `eval_call` in `cljrs_interp` routes `Value::Fn` calls through `globals.call_cljrs_fn`
+   (the registered hook) rather than calling the tree-walker directly, so IR-cached
+   arities are used on direct call paths too
+
+## Special-form coverage in the IR interpreter
+
+Several `clojure.core` entries are sentinel stubs that error unconditionally
+when called through the normal function-call path — the real logic lives in
+`eval_call`'s special-form dispatch.  `ir_interp.rs` handles all of them
+without going through the stubs:
+
+| Operation | How handled in IR |
+|---|---|
+| `swap!` (`KnownFn::AtomSwap`) | `cljrs_interp::apply::eval_swap_bang` |
+| `with-bindings*` (`KnownFn::WithBindings`) | `cljrs_interp::apply::eval_with_bindings_star` |
+| `volatile!` | `dispatch_sentinel_by_name` → `eval_volatile` |
+| `vreset!` | `dispatch_sentinel_by_name` → `eval_vreset_bang` |
+| `vswap!` | `dispatch_sentinel_by_name` → `eval_vswap_bang` |
+| `make-delay` | `dispatch_sentinel_by_name` → `make_delay_from_fn` |
+| `alter-var-root` | `dispatch_sentinel_by_name` → `eval_alter_var_root` |
+| `vary-meta` | `dispatch_sentinel_by_name` → `eval_vary_meta` |
+| `send` / `send-off` | `dispatch_sentinel_by_name` → `eval_send_to_agent` |
+
+Both `Inst::Call` (where the callee register holds a sentinel `NativeFunction`)
+and `Inst::CallDirect` (where the callee is named directly) are intercepted.
 
 ---
 

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -295,20 +295,17 @@ fn execute_inst(
         }
 
         Inst::Call(dst, callee, args) => {
-            // GC safepoint before call.
             cljrs_env::gc_roots::gc_safepoint(env);
             let callee_val = regs.get_cloned(*callee);
             let arg_vals: Vec<Value> = args.iter().map(|v| regs.get_cloned(*v)).collect();
-            let result = apply_value(&callee_val, arg_vals, env)?;
+            let result = dispatch_or_sentinel(callee_val, arg_vals, globals, ns, env)?;
             regs.set(*dst, result);
         }
 
         Inst::CallDirect(dst, name, args) => {
-            // Look up the function by name in globals and call it.
             cljrs_env::gc_roots::gc_safepoint(env);
-            let callee = load_global_value(globals, ns, name, ns)?;
             let arg_vals: Vec<Value> = args.iter().map(|v| regs.get_cloned(*v)).collect();
-            let result = apply_value(&callee, arg_vals, env)?;
+            let result = dispatch_sentinel_by_name(name, arg_vals, globals, ns, env)?;
             regs.set(*dst, result);
         }
 
@@ -602,6 +599,77 @@ fn clone_ir_function(f: &IrFunction) -> IrFunction {
     }
 }
 
+// ── Sentinel-aware call dispatch ────────────────────────────────────────────
+
+/// Dispatch a generic callee value, intercepting sentinel `NativeFunction`s.
+///
+/// Several clojure.core entries (volatile!, vswap!, make-delay, etc.) are
+/// sentinel stubs that unconditionally error when called normally — the real
+/// work happens in `eval_call`'s special-form dispatch, which the IR
+/// interpreter bypasses.  We intercept those by name here so that IR code
+/// calling them works correctly.
+fn dispatch_or_sentinel(
+    callee: Value,
+    args: Vec<Value>,
+    globals: &Arc<GlobalEnv>,
+    ns: &Arc<str>,
+    env: &mut Env,
+) -> EvalResult {
+    if let Value::NativeFunction(nf) = &callee {
+        if is_sentinel(nf.get().name.as_ref()) {
+            return dispatch_sentinel_by_name(nf.get().name.as_ref(), args, globals, ns, env);
+        }
+    }
+    apply_value(&callee, args, env)
+}
+
+/// Dispatch a call to a sentinel operation by name, or fall through to a
+/// global lookup + `apply_value` for non-sentinel names.
+fn dispatch_sentinel_by_name(
+    name: &str,
+    args: Vec<Value>,
+    globals: &Arc<GlobalEnv>,
+    ns: &Arc<str>,
+    env: &mut Env,
+) -> EvalResult {
+    match name {
+        "volatile!" => cljrs_interp::apply::eval_volatile(args),
+        "vreset!" => cljrs_interp::apply::eval_vreset_bang(args),
+        "vswap!" => cljrs_interp::apply::eval_vswap_bang(args, env),
+        "make-delay" => {
+            let f = args.into_iter().next().ok_or_else(|| EvalError::Arity {
+                name: "make-delay".into(),
+                expected: "1".into(),
+                got: 0,
+            })?;
+            cljrs_interp::apply::make_delay_from_fn(&f, globals.clone(), ns.clone())
+        }
+        "alter-var-root" => cljrs_interp::apply::eval_alter_var_root(args, env),
+        "vary-meta" => cljrs_interp::apply::eval_vary_meta(args, env),
+        "with-bindings*" => cljrs_interp::apply::eval_with_bindings_star(args, env),
+        "send" | "send-off" => cljrs_interp::apply::eval_send_to_agent(args, env),
+        _ => {
+            let callee = load_global_value(globals, ns, name, ns)?;
+            apply_value(&callee, args, env)
+        }
+    }
+}
+
+fn is_sentinel(name: &str) -> bool {
+    matches!(
+        name,
+        "volatile!"
+            | "vreset!"
+            | "vswap!"
+            | "make-delay"
+            | "alter-var-root"
+            | "vary-meta"
+            | "with-bindings*"
+            | "send"
+            | "send-off"
+    )
+}
+
 // ── KnownFn dispatch ────────────────────────────────────────────────────────
 
 /// Dispatch a call to a known built-in function.
@@ -741,11 +809,7 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
             }
         }
         KnownFn::AtomReset => builtin_call_native("reset!", &args),
-        KnownFn::AtomSwap => {
-            // swap! needs env for callback.
-            let callee = load_builtin(env, "swap!")?;
-            apply_value(&callee, args, env)
-        }
+        KnownFn::AtomSwap => cljrs_interp::apply::eval_swap_bang(args, env),
 
         // ── I/O ─────────────────────────────────────────────────────────
         KnownFn::Println => builtin_call_native("println", &args),
@@ -800,7 +864,8 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
 
         // ── Dynamic binding / exception handling ────────────────────────
         KnownFn::SetBangVar => builtin_call_native("set!", &args),
-        KnownFn::WithBindings | KnownFn::WithOutStr | KnownFn::TryCatchFinally => {
+        KnownFn::WithBindings => cljrs_interp::apply::eval_with_bindings_star(args, env),
+        KnownFn::WithOutStr | KnownFn::TryCatchFinally => {
             let fn_name = known_fn_to_name(known_fn);
             let callee = load_builtin(env, fn_name)?;
             apply_value(&callee, args, env)

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -316,24 +316,15 @@ fn execute_inst(
         }
 
         Inst::DefVar(dst, def_ns, name, val_var) => {
+            // Always create a fresh, call-local Var (not registered in globals).
+            // The ANF compiler uses DefVar as a mutable cell for letfn / named-fn
+            // self-recursion; the cell is accessed only via the register returned
+            // here, never via LoadGlobal, so name collisions with real globals are
+            // harmless and we never need to touch the global namespace.
             let val = regs.get_cloned(*val_var);
-            if globals.lookup_var_in_ns(def_ns, name).is_some() {
-                // Var already exists (e.g. a global like `clojure.core/cat`).
-                // letfn-emitted DefVars use a var as mutable indirection for
-                // mutual recursion — they must NOT overwrite the real global.
-                // Create a fresh anonymous Var with the same ns/name so that
-                // closures capturing it can Deref it after this function returns
-                // (lazy-seqs, etc.) and Set! on it won't corrupt the global.
-                let fresh = cljrs_value::Var::new(def_ns.clone(), name.clone());
-                fresh.bind(val);
-                regs.set(*dst, Value::Var(GcPtr::new(fresh)));
-            } else {
-                globals.intern(def_ns, name.clone(), val.clone());
-                let var = globals
-                    .lookup_var_in_ns(def_ns, name)
-                    .expect("just interned");
-                regs.set(*dst, Value::Var(var));
-            }
+            let fresh = cljrs_value::Var::new(def_ns.clone(), name.clone());
+            fresh.bind(val);
+            regs.set(*dst, Value::Var(GcPtr::new(fresh)));
         }
 
         Inst::SetBang(var_id, val_id) => {

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -615,10 +615,10 @@ fn dispatch_or_sentinel(
     ns: &Arc<str>,
     env: &mut Env,
 ) -> EvalResult {
-    if let Value::NativeFunction(nf) = &callee {
-        if is_sentinel(nf.get().name.as_ref()) {
-            return dispatch_sentinel_by_name(nf.get().name.as_ref(), args, globals, ns, env);
-        }
+    if let Value::NativeFunction(nf) = &callee
+        && is_sentinel(nf.get().name.as_ref())
+    {
+        return dispatch_sentinel_by_name(nf.get().name.as_ref(), args, globals, ns, env);
     }
     apply_value(&callee, args, env)
 }

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -317,11 +317,23 @@ fn execute_inst(
 
         Inst::DefVar(dst, def_ns, name, val_var) => {
             let val = regs.get_cloned(*val_var);
-            globals.intern(def_ns, name.clone(), val.clone());
-            let var = globals
-                .lookup_var_in_ns(def_ns, name)
-                .expect("just interned");
-            regs.set(*dst, Value::Var(var));
+            if globals.lookup_var_in_ns(def_ns, name).is_some() {
+                // Var already exists (e.g. a global like `clojure.core/cat`).
+                // letfn-emitted DefVars use a var as mutable indirection for
+                // mutual recursion — they must NOT overwrite the real global.
+                // Create a fresh anonymous Var with the same ns/name so that
+                // closures capturing it can Deref it after this function returns
+                // (lazy-seqs, etc.) and Set! on it won't corrupt the global.
+                let fresh = cljrs_value::Var::new(def_ns.clone(), name.clone());
+                fresh.bind(val);
+                regs.set(*dst, Value::Var(GcPtr::new(fresh)));
+            } else {
+                globals.intern(def_ns, name.clone(), val.clone());
+                let var = globals
+                    .lookup_var_in_ns(def_ns, name)
+                    .expect("just interned");
+                regs.set(*dst, Value::Var(var));
+            }
         }
 
         Inst::SetBang(var_id, val_id) => {
@@ -485,13 +497,37 @@ fn alloc_closure(
     let captured_values: Vec<Value> = capture_vars.iter().map(|v| regs.get_cloned(*v)).collect();
 
     // Build a CljxFn-like wrapper using NativeFunction.
-    // Each arity maps to a subfunction in ir_func.subfunctions.
-    let subfuncs: Vec<Arc<IrFunction>> = ir_func
-        .subfunctions
-        .iter()
-        .map(clone_ir_function)
-        .map(Arc::new)
-        .collect();
+    // Each arity maps to a named subfunction in ir_func.subfunctions.
+    // We use arity_fn_names (when present) to match each arity slot to its
+    // correct subfunction by name, rather than relying on positional indexing.
+    // Positional indexing is wrong when the parent function has more
+    // subfunctions than arities (e.g. fnil has two inner lambdas but the
+    // returned closure is only the second one).
+    let subfuncs: Vec<Arc<IrFunction>> = if !template.arity_fn_names.is_empty() {
+        template
+            .arity_fn_names
+            .iter()
+            .map(|fn_name| {
+                let sf = ir_func
+                    .subfunctions
+                    .iter()
+                    .find(|sf| sf.name.as_deref() == Some(fn_name.as_ref()))
+                    .unwrap_or_else(|| {
+                        ir_func.subfunctions.first().unwrap_or_else(|| {
+                            panic!("IR closure: no subfunctions for '{fn_name}'")
+                        })
+                    });
+                Arc::new(clone_ir_function(sf))
+            })
+            .collect()
+    } else {
+        ir_func
+            .subfunctions
+            .iter()
+            .map(clone_ir_function)
+            .map(Arc::new)
+            .collect()
+    };
 
     let param_counts = template.param_counts.clone();
     let is_variadic = template.is_variadic.clone();
@@ -714,10 +750,7 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
         KnownFn::IsKeyword => Ok(Value::Bool(matches!(args.first(), Some(Value::Keyword(_))))),
         KnownFn::IsSymbol => Ok(Value::Bool(matches!(args.first(), Some(Value::Symbol(_))))),
         KnownFn::IsBool => Ok(Value::Bool(matches!(args.first(), Some(Value::Bool(_))))),
-        KnownFn::IsInt => Ok(Value::Bool(matches!(
-            args.first(),
-            Some(Value::Long(_) | Value::BigInt(_))
-        ))),
+        KnownFn::IsInt => Ok(Value::Bool(matches!(args.first(), Some(Value::Long(_))))),
 
         // ── String ──────────────────────────────────────────────────────
         KnownFn::Str => {

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -661,6 +661,7 @@ fn dispatch_sentinel_by_name(
 ) -> EvalResult {
     match name {
         "volatile!" => cljrs_interp::apply::eval_volatile(args),
+        "reset!" => cljrs_interp::apply::eval_reset_bang(args, env),
         "vreset!" => cljrs_interp::apply::eval_vreset_bang(args),
         "vswap!" => cljrs_interp::apply::eval_vswap_bang(args, env),
         "make-delay" => {
@@ -686,6 +687,7 @@ fn is_sentinel(name: &str) -> bool {
     matches!(
         name,
         "volatile!"
+            | "reset!"
             | "vreset!"
             | "vswap!"
             | "make-delay"
@@ -832,7 +834,7 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
                 Ok(Value::Nil)
             }
         }
-        KnownFn::AtomReset => builtin_call_native("reset!", &args),
+        KnownFn::AtomReset => cljrs_interp::apply::eval_reset_bang(args, env),
         KnownFn::AtomSwap => cljrs_interp::apply::eval_swap_bang(args, env),
 
         // ── I/O ─────────────────────────────────────────────────────────

--- a/crates/cljrs-interp/README.md
+++ b/crates/cljrs-interp/README.md
@@ -86,3 +86,27 @@ Each handler evaluates its key expressions under the correct allocation context:
 | `handle_agent_call` | initial value |
 | `handle_alter_var_root` | function return value |
 | `handle_intern` | value expression (3-arg form) |
+
+### Value-level special form helpers (IR interpreter API)
+
+The IR interpreter receives already-evaluated `Vec<Value>` arguments rather than
+`&[Form]` AST nodes.  These public functions mirror the `handle_*` form-level
+handlers but accept pre-evaluated args, allowing the IR interpreter to
+implement sentinel operations without hitting the stub errors registered in
+`clojure.core`:
+
+| Function | Operation |
+|---|---|
+| `eval_swap_bang(args, env)` | `swap!` — apply f to atom, store result |
+| `eval_volatile(args)` | `volatile!` — create a new volatile |
+| `eval_vreset_bang(args)` | `vreset!` — reset volatile value |
+| `eval_vswap_bang(args, env)` | `vswap!` — apply f to volatile value, store result |
+| `make_delay_from_fn(f, globals, ns)` | `make-delay` — wrap zero-arg fn in a `Delay` |
+| `eval_alter_var_root(args, env)` | `alter-var-root` — apply f to var root, store result |
+| `eval_vary_meta(args, env)` | `vary-meta` — apply f to obj metadata |
+| `eval_with_bindings_star(args, env)` | `with-bindings*` — push binding frame, call f |
+| `eval_send_to_agent(args, env)` | `send` / `send-off` — dispatch action to agent |
+
+`make_lazy_seq_from_fn(f, globals, ns)` (already public) creates a `LazySeq`
+from a zero-arg callable; the above `make_delay_from_fn` is the analogous
+helper for `Delay`.

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -241,24 +241,19 @@ pub fn eval_call(func_form: &Form, arg_forms: &[Form], env: &mut Env) -> EvalRes
         args.push(eval(f, env)?);
     }
 
-    // For Clojure functions, call directly to avoid the extra stack frames
-    // from cljrs_env::apply → env.call_cljrs_fn → globals.call_cljrs_fn → fn ptr.
+    // For Clojure functions, dispatch through the global hook so the IR
+    // interpreter (when active) gets a chance to run cached IR instead of
+    // always falling back to tree-walking.  `globals.call_cljrs_fn` is set
+    // to `cljrs_eval::apply::call_cljrs_fn` at startup when the IR tier is
+    // available, and to the plain tree-walking version otherwise.
     //
-    // NOTE: this also bypasses the IR cache lookup in
-    // `cljrs_eval::apply::call_cljrs_fn`, so prebuilt-IR / eagerly-lowered
-    // arities never run through the tier-1 IR interpreter on direct fn
-    // calls — they only fire via `apply_value` paths (e.g. higher-order
-    // calls in `apply` / `reduce` / callbacks).  The bypass exists because
-    // the IR interpreter currently has incomplete coverage of the
-    // syntax-level special operations that `eval_call` short-circuits
-    // (e.g. `swap!` / `vswap!` / `make-lazy-seq` / `make-delay` /
-    // `alter-var-root` / etc.) — when cached IR uses them transitively,
-    // dispatch hits a sentinel that intentionally errors, breaking
-    // anything as common as `(map …)` from inside a prebuilt arity.
+    // Extract the function pointer before the call so the borrow checker sees
+    // only one mutable borrow of `env` at the call site.
     if let Value::Fn(f) = &callee {
         let _args_root = cljrs_env::gc_roots::root_values(&args);
         cljrs_env::gc_roots::gc_safepoint(env);
-        return call_cljrs_fn(f.get(), &args, env);
+        let call_fn = env.globals.call_cljrs_fn;
+        return call_fn(f.get(), &args, env);
     }
 
     cljrs_env::apply::apply_value(&callee, args, env)
@@ -1236,6 +1231,268 @@ fn handle_vary_meta(arg_forms: &[Form], env: &mut Env) -> EvalResult {
         vp.get().set_meta(new_meta);
     }
     Ok(obj)
+}
+
+// ── Value-level special form dispatch (used by IR interpreter) ───────────────
+//
+// These mirror the `handle_*` functions above but accept already-evaluated
+// `Vec<Value>` instead of `&[Form]`.  The IR interpreter calls these directly
+// to bypass the sentinel stubs registered in clojure.core.
+
+/// Execute `swap!` with already-evaluated args: `[atom, f, extra...]`.
+pub fn eval_swap_bang(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "swap!".into(),
+            expected: "2+".into(),
+            got: args.len(),
+        });
+    }
+    let atom_val = args.remove(0);
+    let f = args.remove(0);
+    let atom = match &atom_val {
+        Value::Atom(a) => a.clone(),
+        v => {
+            return Err(EvalError::Runtime(format!(
+                "swap! requires an atom, got {}",
+                v.type_name()
+            )))
+        }
+    };
+    let old_val = atom.get().deref();
+    let mut call_args = vec![old_val.clone()];
+    call_args.extend(args);
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    let new_val = cljrs_env::apply::apply_value(&f, call_args, env)?;
+    validate_atom_value(&atom, &new_val, env)?;
+    atom.get().reset(new_val.clone());
+    fire_watches(&atom.get().watches, &atom_val, &old_val, &new_val, env);
+    check_watch_error()?;
+    Ok(new_val)
+}
+
+/// Execute `volatile!` with already-evaluated args: `[init-val]`.
+pub fn eval_volatile(args: Vec<Value>) -> EvalResult {
+    if args.is_empty() {
+        return Err(EvalError::Arity {
+            name: "volatile!".into(),
+            expected: "1".into(),
+            got: 0,
+        });
+    }
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    Ok(Value::Volatile(GcPtr::new(Volatile::new(
+        args.into_iter().next().unwrap(),
+    ))))
+}
+
+/// Execute `vreset!` with already-evaluated args: `[volatile, new-val]`.
+pub fn eval_vreset_bang(args: Vec<Value>) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "vreset!".into(),
+            expected: "2".into(),
+            got: args.len(),
+        });
+    }
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    let new_val = args[1].clone();
+    match &args[0] {
+        Value::Volatile(v) => {
+            v.get().reset(new_val.clone());
+            Ok(new_val)
+        }
+        other => Err(EvalError::Runtime(format!(
+            "vreset!: expected volatile, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Execute `vswap!` with already-evaluated args: `[volatile, f, extra...]`.
+pub fn eval_vswap_bang(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "vswap!".into(),
+            expected: "2+".into(),
+            got: args.len(),
+        });
+    }
+    let vol_val = args.remove(0);
+    let f = args.remove(0);
+    match vol_val {
+        Value::Volatile(v) => {
+            let cur = v.get().deref();
+            let mut call_args = vec![cur];
+            call_args.extend(args);
+            #[cfg(feature = "no-gc")]
+            let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+            let new_val = cljrs_env::apply::apply_value(&f, call_args, env)?;
+            v.get().reset(new_val.clone());
+            Ok(new_val)
+        }
+        other => Err(EvalError::Runtime(format!(
+            "vswap!: expected volatile, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Wrap a zero-arg callable in a `Value::Delay`.
+///
+/// Analogous to [`make_lazy_seq_from_fn`] but produces a `Delay` instead of
+/// a `LazySeq`.
+pub fn make_delay_from_fn(
+    f_val: &Value,
+    globals: std::sync::Arc<cljrs_env::env::GlobalEnv>,
+    ns: std::sync::Arc<str>,
+) -> EvalResult {
+    let f = match f_val {
+        Value::Fn(f) => f.get().clone(),
+        other => {
+            return Err(EvalError::Runtime(format!(
+                "make-delay requires a fn, got {}",
+                other.type_name()
+            )))
+        }
+    };
+    let thunk = ClosureThunk { f, globals, ns };
+    Ok(Value::Delay(GcPtr::new(Delay::new(Box::new(thunk)))))
+}
+
+/// Execute `alter-var-root` with already-evaluated args: `[var, f, extra...]`.
+pub fn eval_alter_var_root(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "alter-var-root".into(),
+            expected: "2+".into(),
+            got: args.len(),
+        });
+    }
+    let var_val = args.remove(0);
+    let f = args.remove(0);
+    let vp = match &var_val {
+        Value::Var(vp) => vp.clone(),
+        v => {
+            return Err(EvalError::Runtime(format!(
+                "alter-var-root: expected var, got {}",
+                v.type_name()
+            )))
+        }
+    };
+    let old_val = vp.get().deref().unwrap_or(Value::Nil);
+    let mut call_args = vec![old_val.clone()];
+    call_args.extend(args);
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    let new_val = cljrs_env::apply::apply_value(&f, call_args, env)?;
+    vp.get().bind(new_val.clone());
+    fire_watches(&vp.get().watches, &var_val, &old_val, &new_val, env);
+    check_watch_error()?;
+    Ok(new_val)
+}
+
+/// Execute `vary-meta` with already-evaluated args: `[obj, f, extra...]`.
+pub fn eval_vary_meta(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "vary-meta".into(),
+            expected: "2+".into(),
+            got: args.len(),
+        });
+    }
+    let obj = args.remove(0);
+    let f = args.remove(0);
+    let current_meta = match &obj {
+        Value::Var(vp) => vp.get().get_meta().unwrap_or(Value::Nil),
+        _ => Value::Nil,
+    };
+    let mut call_args = vec![current_meta];
+    call_args.extend(args);
+    let new_meta = cljrs_env::apply::apply_value(&f, call_args, env)?;
+    if let Value::Var(vp) = &obj {
+        vp.get().set_meta(new_meta);
+    }
+    Ok(obj)
+}
+
+/// Execute `with-bindings*` with already-evaluated args: `[bindings-map, f]`.
+pub fn eval_with_bindings_star(args: Vec<Value>, env: &mut Env) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "with-bindings*".into(),
+            expected: "2".into(),
+            got: args.len(),
+        });
+    }
+    let mut frame: HashMap<usize, Value> = HashMap::new();
+    if let Value::Map(m) = &args[0] {
+        m.for_each(|k, v| {
+            if let Value::Var(vp) = k {
+                frame.insert(cljrs_env::dynamics::var_key_of(vp), v.clone());
+            }
+        });
+    } else {
+        return Err(EvalError::Runtime(
+            "with-bindings*: first arg must be a map".into(),
+        ));
+    }
+    let _guard = cljrs_env::dynamics::push_frame(frame);
+    cljrs_env::apply::apply_value(&args[1], vec![], env)
+}
+
+/// Execute `send` / `send-off` with already-evaluated args: `[agent, f, extra...]`.
+pub fn eval_send_to_agent(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "send".into(),
+            expected: "2+".into(),
+            got: args.len(),
+        });
+    }
+    let agent_val = args.remove(0);
+    let f = args.remove(0);
+    let extra = args;
+    let globals = env.globals.clone();
+    let ns = env.current_ns.clone();
+    match &agent_val {
+        Value::Agent(a) => {
+            let agent_clone = a.clone();
+            let agent_val_clone = agent_val.clone();
+            let agent_fn: AgentFn = Box::new(move |state| {
+                let mut call_args = vec![state.clone()];
+                call_args.extend(extra);
+                let mut call_env = Env::new(globals, &ns);
+                let new_val = cljrs_env::apply::apply_value(&f, call_args, &mut call_env)
+                    .map_err(eval_error_to_value)?;
+                fire_watches(
+                    &agent_clone.get().watches,
+                    &agent_val_clone,
+                    &state,
+                    &new_val,
+                    &mut call_env,
+                );
+                if let Err(e) = check_watch_error() {
+                    return Err(eval_error_to_value(e));
+                }
+                Ok(new_val)
+            });
+            a.get()
+                .sender
+                .lock()
+                .unwrap()
+                .send(AgentMsg::Update(agent_fn))
+                .map_err(|_| EvalError::Runtime("send: agent is shut down".into()))?;
+            Ok(agent_val.clone())
+        }
+        other => Err(EvalError::Runtime(format!(
+            "send: expected agent, got {}",
+            other.type_name()
+        ))),
+    }
 }
 
 // ── Namespace reflection (env-needing) ────────────────────────────────────────

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -1256,7 +1256,7 @@ pub fn eval_swap_bang(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
             return Err(EvalError::Runtime(format!(
                 "swap! requires an atom, got {}",
                 v.type_name()
-            )))
+            )));
         }
     };
     let old_val = atom.get().deref();
@@ -1356,7 +1356,7 @@ pub fn make_delay_from_fn(
             return Err(EvalError::Runtime(format!(
                 "make-delay requires a fn, got {}",
                 other.type_name()
-            )))
+            )));
         }
     };
     let thunk = ClosureThunk { f, globals, ns };
@@ -1380,7 +1380,7 @@ pub fn eval_alter_var_root(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
             return Err(EvalError::Runtime(format!(
                 "alter-var-root: expected var, got {}",
                 v.type_name()
-            )))
+            )));
         }
     };
     let old_val = vp.get().deref().unwrap_or(Value::Nil);

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -1239,6 +1239,36 @@ fn handle_vary_meta(arg_forms: &[Form], env: &mut Env) -> EvalResult {
 // `Vec<Value>` instead of `&[Form]`.  The IR interpreter calls these directly
 // to bypass the sentinel stubs registered in clojure.core.
 
+/// Execute `reset!` with already-evaluated args: `[atom, new-val]`.
+pub fn eval_reset_bang(args: Vec<Value>, env: &mut Env) -> EvalResult {
+    if args.len() < 2 {
+        return Err(EvalError::Arity {
+            name: "reset!".into(),
+            expected: "2".into(),
+            got: args.len(),
+        });
+    }
+    let atom_val = args[0].clone();
+    let new_val = args[1].clone();
+    let atom = match &atom_val {
+        Value::Atom(a) => a.clone(),
+        v => {
+            return Err(EvalError::Runtime(format!(
+                "reset! requires an atom, got {}",
+                v.type_name()
+            )));
+        }
+    };
+    #[cfg(feature = "no-gc")]
+    let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
+    validate_atom_value(&atom, &new_val, env)?;
+    let old_val = atom.get().deref();
+    atom.get().reset(new_val.clone());
+    fire_watches(&atom.get().watches, &atom_val, &old_val, &new_val, env);
+    check_watch_error()?;
+    Ok(new_val)
+}
+
 /// Execute `swap!` with already-evaluated args: `[atom, f, extra...]`.
 pub fn eval_swap_bang(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
     if args.len() < 2 {

--- a/crates/cljrs-ir/src/cljrs/compiler/anf.cljrs
+++ b/crates/cljrs-ir/src/cljrs/compiler/anf.cljrs
@@ -612,11 +612,24 @@
   (let [[fn-name body-start] (if (symbol? (first args))
                                 [(str (first args)) 1]
                                 [nil 0])
-        ;; Capture all locals
+        ns (ir/current-ns ctx)
+        ;; For named functions: if the name is not already in scope as a local
+        ;; (e.g. from an enclosing letfn), create a fresh mutable var so the
+        ;; function can call itself recursively.  The var is captured by the
+        ;; closure and dereffed at call time, so lazy thunks work correctly.
+        self-var-reg (when (and fn-name (nil? (ir/lookup-local ctx fn-name)))
+                       (let [nil-val (ir/emit-const! ctx (ir/const-nil))
+                             def-dst (ir/fresh-var! ctx)]
+                         (ir/emit! ctx (ir/inst-def-var def-dst ns fn-name nil-val))
+                         (ir/push-scope! ctx)
+                         (ir/bind-local! ctx fn-name def-dst)
+                         def-dst))
+        ;; Capture all locals (includes fn-name as a var-ref when self-var-reg was set)
         all-locals (ir/get-all-locals ctx)
         capture-name-list (vec (keys all-locals))
         capture-vars (mapv (fn [n] (get all-locals n)) capture-name-list)
-        ns (ir/current-ns ctx)
+        ;; Pop the fn-name self-ref scope now that captures are computed
+        _ (when self-var-reg (ir/pop-scope! ctx))
         ;; Parse arities: either single [params] body... or multi ([params] body...) ...
         rest-args (subvec (vec args) body-start)
         raw-arities (if (and (not (empty? rest-args)) (vector? (first rest-args)))
@@ -656,6 +669,10 @@
       (ir/emit! ctx (ir/inst-alloc-closure dst fn-name capture-vars
                                            arity-fn-names param-counts capture-name-list
                                            is-variadic))
+      ;; If we created a self-ref var, point it at the closure so recursive
+      ;; calls (Deref of the captured var) find the right function.
+      (when self-var-reg
+        (ir/emit! ctx (ir/inst-set! self-var-reg dst)))
       dst)))
 
 (defn lower-throw
@@ -811,10 +828,11 @@
 
 (defn lower-letfn
   "Lower (letfn [(f [params] body...) ...] body...).
-   Uses global vars for indirection so that all letfn-bound functions
-   can reference each other (including self-recursion and mutual recursion).
-   Function bodies resolve names via load-global, which dereferences the
-   var at call time — by which point all closures have been assigned."
+   Each binding gets a fresh, call-local Var (DefVar) as a mutable cell.
+   The Vars are bound as locals so all closures capture them and can call
+   each other (and themselves) by dereffing the captured Var at call time.
+   After all closures are built, each Var is updated (Set!) to its closure,
+   then each name is re-bound to the dereffed value for the letfn body."
   [ctx args]
   (when (< (count args) 2)
     (throw "letfn requires a binding vector and body"))
@@ -833,33 +851,37 @@
                             :params (nth parts 1)
                             :body (vec (drop 2 parts))}))
                        bindings)
-          ;; 1. Define a global var for each binding name, initialized to nil.
-          ;;    The function bodies will find these via load-global.
-          _ (doseq [p parsed]
-              (let [nil-val (ir/emit-const! ctx (ir/const-nil))
-                    dst (ir/fresh-var! ctx)]
-                (ir/emit! ctx (ir/inst-def-var dst ns (:name p) nil-val))))
-          ;; 2. Compile each function body as fn*.
-          ;;    Inside the body, references to other letfn names fall through
-          ;;    lower-symbol → load-global → dereferences the var at call time.
+          ;; 1. Create a fresh mutable Var for each binding, initialised to nil.
+          ;;    DefVar always produces a call-local Var (not registered globally),
+          ;;    so repeated calls to the enclosing function each get their own
+          ;;    cell — essential for lazy-seq thunks that self-recurse.
+          var-regs (mapv (fn [p]
+                           (let [nil-val (ir/emit-const! ctx (ir/const-nil))
+                                 dst (ir/fresh-var! ctx)]
+                             (ir/emit! ctx (ir/inst-def-var dst ns (:name p) nil-val))
+                             dst))
+                         parsed)
+          ;; 2. Bind each name → its Var object so closures capture the cell.
+          ;;    lower-symbol will find these as locals; call position derefs
+          ;;    the Var transparently via apply_value.
+          _ (ir/push-scope! ctx)
+          _ (doseq [i (range (count parsed))]
+              (ir/bind-local! ctx (:name (nth parsed i)) (nth var-regs i)))
+          ;; 3. Compile each function body as fn* with the Var-refs in scope.
           closures (mapv (fn [p]
                            (lower-fn ctx [(symbol (:name p)) (:params p) (cons 'do (:body p))]))
                          parsed)
-          ;; 3. Set! each var to its closure value
+          ;; 4. Pop the Var-ref scope — the closures have already captured them.
+          _ (ir/pop-scope! ctx)
+          ;; 5. Fill each Var with its closure.
           _ (doseq [i (range (count parsed))]
-              (let [p (nth parsed i)
-                    closure-var (nth closures i)
-                    var-obj (let [dst (ir/fresh-var! ctx)]
-                              (ir/emit! ctx (ir/inst-load-var dst ns (:name p)))
-                              dst)]
-                (ir/emit! ctx (ir/inst-set! var-obj closure-var))))]
-      ;; 4. Push scope, bind each name locally for the body
+              (ir/emit! ctx (ir/inst-set! (nth var-regs i) (nth closures i))))]
+      ;; 6. Bind each name to the resolved function value for the letfn body.
       (ir/push-scope! ctx)
-      (doseq [p parsed]
-        (let [fn-val (let [dst (ir/fresh-var! ctx)]
-                       (ir/emit! ctx (ir/inst-load-global dst ns (:name p)))
-                       dst)]
-          (ir/bind-local! ctx (:name p) fn-val)))
+      (doseq [i (range (count parsed))]
+        (let [fn-val (ir/fresh-var! ctx)]
+          (ir/emit! ctx (ir/inst-deref fn-val (nth var-regs i)))
+          (ir/bind-local! ctx (:name (nth parsed i)) fn-val)))
       (let [result (lower-body ctx (vec (rest args)))]
         (ir/pop-scope! ctx)
         result))))

--- a/crates/cljrs-ir/src/cljrs/compiler/ir.cljrs
+++ b/crates/cljrs-ir/src/cljrs/compiler/ir.cljrs
@@ -252,11 +252,12 @@
                  blocks))))
 
 (defn get-all-locals
-  "Return all local bindings across all scopes (for closure capture)."
+  "Return all local bindings across all scopes (for closure capture).
+   Inner scopes shadow outer scopes — the innermost binding for each name wins."
   [ctx]
   (let [scopes (:locals @ctx)]
     (reduce (fn [acc scope]
-              (reduce (fn [a [k v]] (if (get a k) a (assoc a k v)))
+              (reduce (fn [a [k v]] (assoc a k v))
                       acc
                       scope))
             {}

--- a/crates/cljrs-ir/test/cljrs/compiler/ir_test.cljrs
+++ b/crates/cljrs-ir/test/cljrs/compiler/ir_test.cljrs
@@ -221,13 +221,12 @@
       (is (= 1 (ir/lookup-local ctx "outer")))
       (is (= 2 (ir/lookup-local ctx "inner"))))))
 
-(deftest test-get-all-locals-prefers-outermost
-  ;; get-all-locals walks scopes outer→inner and only inserts a key the
-  ;; first time it's seen, so the *outermost* binding wins on collisions.
-  ;; This is the opposite of `lookup-local`, which returns the innermost
-  ;; (shadowed) binding — get-all-locals is used for closure capture and
-  ;; the outer-scope-wins ordering means a captured shadowed name resolves
-  ;; to the original (outer) value seen at definition time.
+(deftest test-get-all-locals-prefers-innermost
+  ;; get-all-locals walks scopes outer→inner and lets inner bindings
+  ;; overwrite outer ones, so the *innermost* binding wins on collisions.
+  ;; This matches `lookup-local` and ensures that a closure formed inside
+  ;; a `let` that shadows a parameter captures the shadowed (inner) value,
+  ;; not the original (outer) parameter.
   (let [ctx (ir/make-ctx "f" "user" [])]
     (ir/bind-local! ctx "a" 1)
     (ir/bind-local! ctx "b" 2)
@@ -235,7 +234,7 @@
     (ir/bind-local! ctx "a" 99)
     (ir/bind-local! ctx "c" 3)
     (let [locals (ir/get-all-locals ctx)]
-      (is (= 1 (get locals "a")) "outer binding wins")
+      (is (= 99 (get locals "a")) "inner binding wins")
       (is (= 2 (get locals "b")))
       (is (= 3 (get locals "c"))))))
 


### PR DESCRIPTION
The IR interpreter was bypassing eval_call's special-form dispatch, hitting
sentinel stubs in clojure.core that unconditionally error.  Three fixes:

1. Value-level helpers in cljrs_interp::apply — mirror the Form-level
   handle_* functions but accept already-evaluated Vec<Value> args:
   eval_swap_bang, eval_volatile, eval_vreset_bang, eval_vswap_bang,
   make_delay_from_fn, eval_alter_var_root, eval_vary_meta,
   eval_with_bindings_star, eval_send_to_agent.

2. IR interpreter (ir_interp.rs) — fix dispatch_known_fn to use the new
   helpers instead of loading sentinels (AtomSwap, WithBindings), and add
   dispatch_or_sentinel / dispatch_sentinel_by_name helpers that intercept
   sentinel NativeFunction callees in both Inst::Call and Inst::CallDirect.

3. eval_call (cljrs_interp::apply) — route Value::Fn calls through
   env.globals.call_cljrs_fn (the registered hook) rather than calling
   cljrs_interp::apply::call_cljrs_fn directly, so IR-cached arities are
   executed on direct call paths, not only via apply_value HOF paths.

https://claude.ai/code/session_01MHMQzSPFZuf5fPs5WDrRZY