### PR TITLE
Fix crates.io publish: add version to cljrs-stdlib build-dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,12 @@ jobs:
           echo "Publishing version: $VERSION"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-          # Update workspace dependency versions so inter-crate deps use the new version
+          # Update workspace dependency versions so inter-crate deps use the new version.
+          # The /g flag and lack of ^ anchor are intentional: this must also rewrite
+          # inline version = "0.1.0" inside [build-dependencies] entries (e.g. cljrs-stdlib),
+          # not just the top-level [package] version line.
           for toml in crates/*/Cargo.toml; do
-            sed -i "s/^version.*=.*\"0\.1\.0\"/version = \"$VERSION\"/" "$toml"
+            sed -i "s/version = \"0\.1\.0\"/version = \"$VERSION\"/g" "$toml"
           done
 
           # Update workspace dependency table to use the new version

--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -32,10 +32,10 @@ tokio        = { workspace = true, features = ["rt", "sync", "rt-multi-thread"] 
 lazy_static = "1.5.0"
 
 [build-dependencies]
-cljrs-ir-bd     = { path = "../cljrs-ir",     package = "cljrs-ir",     optional = true }
-cljrs-eval-bd   = { path = "../cljrs-eval",   package = "cljrs-eval",   optional = true }
-cljrs-interp-bd = { path = "../cljrs-interp", package = "cljrs-interp", optional = true }
-cljrs-value-bd  = { path = "../cljrs-value",  package = "cljrs-value",  optional = true }
-cljrs-env-bd    = { path = "../cljrs-env",    package = "cljrs-env",    optional = true }
-cljrs-reader-bd = { path = "../cljrs-reader", package = "cljrs-reader", optional = true }
-cljrs-types-bd  = { path = "../cljrs-types",  package = "cljrs-types",  optional = true }
+cljrs-ir-bd     = { path = "../cljrs-ir",     package = "cljrs-ir",     version = "0.1.0", optional = true }
+cljrs-eval-bd   = { path = "../cljrs-eval",   package = "cljrs-eval",   version = "0.1.0", optional = true }
+cljrs-interp-bd = { path = "../cljrs-interp", package = "cljrs-interp", version = "0.1.0", optional = true }
+cljrs-value-bd  = { path = "../cljrs-value",  package = "cljrs-value",  version = "0.1.0", optional = true }
+cljrs-env-bd    = { path = "../cljrs-env",    package = "cljrs-env",    version = "0.1.0", optional = true }
+cljrs-reader-bd = { path = "../cljrs-reader", package = "cljrs-reader", version = "0.1.0", optional = true }
+cljrs-types-bd  = { path = "../cljrs-types",  package = "cljrs-types",  version = "0.1.0", optional = true }


### PR DESCRIPTION
crates.io requires all path dependencies to also specify a version.
The [build-dependencies] added for the prebuild-ir feature specified
only path = "..." without version = "...", causing publish to fail
with "dependency X does not specify a version requirement".

https://claude.ai/code/session_01KYsWLrm8kJpeUb7X446osJ