### PR TITLE
fix(stdlib): normalize Cargo.toml package field spacing

### DIFF
--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name        = "cljrs-stdlib"
-version     = "0.1.0"
-edition     = "2024"
+name = "cljrs-stdlib"
+version = "0.1.0"
+edition = "2024"
 description = "Built-in standard library namespaces for clojurust (clojure.string, clojure.set, clojure.test, …)"
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
The publish workflow uses sed to bump version strings matching exactly
`version = "0.1.0"`. The extra spaces in `name        =` and
`version     =` caused the regex to miss cljrs-stdlib, leaving it at
0.1.0 while dependents were bumped to the release version.

https://claude.ai/code/session_014S6xR5oZLsLAWbgVgsE84q