### PR TITLE
fix(deps): add version requirements to workspace dependencies for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,21 +24,21 @@ license = "EPL-1.0"
 repository = "https://github.com/csm/clojurust"
 
 [workspace.dependencies]
-cljrs-types    = { path = "crates/cljrs-types" }
-cljrs-gc       = { path = "crates/cljrs-gc" }
-cljrs-value    = { path = "crates/cljrs-value" }
-cljrs-reader   = { path = "crates/cljrs-reader" }
-cljrs-eval     = { path = "crates/cljrs-eval" }
-cljrs-stdlib   = { path = "crates/cljrs-stdlib" }
-cljrs-runtime  = { path = "crates/cljrs-runtime" }
-cljrs-ir       = { path = "crates/cljrs-ir" }
-cljrs-compiler = { path = "crates/cljrs-compiler" }
-cljrs-interop  = { path = "crates/cljrs-interop" }
-cljrs-logging  = { path = "crates/cljrs-logging" }
-cljrs-env      = { path = "crates/cljrs-env" }
-cljrs-builtins = { path = "crates/cljrs-builtins" }
-cljrs-interp   = { path = "crates/cljrs-interp" }
-cljrs-ir-prebuild = { path = "crates/cljrs-ir-prebuild" }
+cljrs-types    = { path = "crates/cljrs-types",    version = "0.1.0" }
+cljrs-gc       = { path = "crates/cljrs-gc",       version = "0.1.0" }
+cljrs-value    = { path = "crates/cljrs-value",    version = "0.1.0" }
+cljrs-reader   = { path = "crates/cljrs-reader",   version = "0.1.0" }
+cljrs-eval     = { path = "crates/cljrs-eval",     version = "0.1.0" }
+cljrs-stdlib   = { path = "crates/cljrs-stdlib",   version = "0.1.0" }
+cljrs-runtime  = { path = "crates/cljrs-runtime",  version = "0.1.0" }
+cljrs-ir       = { path = "crates/cljrs-ir",       version = "0.1.0" }
+cljrs-compiler = { path = "crates/cljrs-compiler", version = "0.1.0" }
+cljrs-interop  = { path = "crates/cljrs-interop",  version = "0.1.0" }
+cljrs-logging  = { path = "crates/cljrs-logging",  version = "0.1.0" }
+cljrs-env      = { path = "crates/cljrs-env",      version = "0.1.0" }
+cljrs-builtins = { path = "crates/cljrs-builtins", version = "0.1.0" }
+cljrs-interp   = { path = "crates/cljrs-interp",   version = "0.1.0" }
+cljrs-ir-prebuild = { path = "crates/cljrs-ir-prebuild", version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/crates/cljrs-ir/Cargo.toml
+++ b/crates/cljrs-ir/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 
 [dependencies]
 cljrs-types  = { workspace = true }
-cljrs-reader = { path = "../cljrs-reader" }
+cljrs-reader = { workspace = true }
 serde        = { workspace = true, features = ["rc"] }
 postcard     = { workspace = true, features = ["alloc"] }
 


### PR DESCRIPTION
All internal crate entries in [workspace.dependencies] now carry
version = "0.1.0" so cargo publish can resolve them when the path
specifier is stripped. Also switches cljrs-ir's cljrs-reader dep
from a bare path to workspace = true for consistency.

https://claude.ai/code/session_01HUoEdyHvYLQs7ukRTp6VM7