### PR TITLE
fix(cljrs-stdlib): remove duplicate cljrs-eval build-dep alias that b…

### DIFF
--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -9,13 +9,13 @@ repository.workspace = true
 [features]
 default = []
 prebuild-ir = [
-    "dep:cljrs-ir-bd",
-    "dep:cljrs-eval-bd",
-    "dep:cljrs-interp-bd",
-    "dep:cljrs-value-bd",
-    "dep:cljrs-env-bd",
-    "dep:cljrs-reader-bd",
-    "dep:cljrs-types-bd",
+    "dep:cljrs-ir",
+    "dep:cljrs-eval",
+    "dep:cljrs-interp",
+    "dep:cljrs-value",
+    "dep:cljrs-env",
+    "dep:cljrs-reader",
+    "dep:cljrs-types",
 ]
 no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc", "cljrs-eval/no-gc", "cljrs-interp/no-gc", "cljrs-builtins/no-gc"]
 
@@ -32,10 +32,10 @@ tokio        = { workspace = true, features = ["rt", "sync", "rt-multi-thread"] 
 lazy_static = "1.5.0"
 
 [build-dependencies]
-cljrs-ir-bd     = { path = "../cljrs-ir",     package = "cljrs-ir",     version = "0.1.0", optional = true }
-cljrs-eval-bd   = { path = "../cljrs-eval",   package = "cljrs-eval",   version = "0.1.0", optional = true }
-cljrs-interp-bd = { path = "../cljrs-interp", package = "cljrs-interp", version = "0.1.0", optional = true }
-cljrs-value-bd  = { path = "../cljrs-value",  package = "cljrs-value",  version = "0.1.0", optional = true }
-cljrs-env-bd    = { path = "../cljrs-env",    package = "cljrs-env",    version = "0.1.0", optional = true }
-cljrs-reader-bd = { path = "../cljrs-reader", package = "cljrs-reader", version = "0.1.0", optional = true }
-cljrs-types-bd  = { path = "../cljrs-types",  package = "cljrs-types",  version = "0.1.0", optional = true }
+cljrs-ir     = { path = "../cljrs-ir",     version = "0.1.0", optional = true }
+cljrs-eval   = { path = "../cljrs-eval",   version = "0.1.0", optional = true }
+cljrs-interp = { path = "../cljrs-interp", version = "0.1.0", optional = true }
+cljrs-value  = { path = "../cljrs-value",  version = "0.1.0", optional = true }
+cljrs-env    = { path = "../cljrs-env",    version = "0.1.0", optional = true }
+cljrs-reader = { path = "../cljrs-reader", version = "0.1.0", optional = true }
+cljrs-types  = { path = "../cljrs-types",  version = "0.1.0", optional = true }

--- a/crates/cljrs-stdlib/build.rs
+++ b/crates/cljrs-stdlib/build.rs
@@ -4,18 +4,6 @@
 //!
 //! Only runs when the `prebuild-ir` feature is enabled.
 
-// The build-deps are optional (activated by the `prebuild-ir` feature) and
-// carry a `-bd` local alias to avoid collisions with the regular [dependencies]
-// table.  Extern-crate aliases restore the short names for all call sites below.
-#[cfg(feature = "prebuild-ir")]
-extern crate cljrs_eval_bd as cljrs_eval;
-#[cfg(feature = "prebuild-ir")]
-extern crate cljrs_interp_bd as cljrs_interp;
-#[cfg(feature = "prebuild-ir")]
-extern crate cljrs_ir_bd as cljrs_ir;
-#[cfg(feature = "prebuild-ir")]
-extern crate cljrs_value_bd as cljrs_value;
-
 #[cfg(feature = "prebuild-ir")]
 fn main() {
     use std::path::PathBuf;


### PR DESCRIPTION
…roke cargo publish

Cargo rejects publishing when the same package appears in [dependencies] and [build-dependencies] under different local names. The -bd suffix + `package = "cljrs-eval"` pattern caused exactly this: cljrs-eval appeared as "cljrs-eval" (regular dep) and "cljrs-eval-bd" (build dep), triggering the "depends on crate multiple times with different names" error from `cargo metadata`.

Fix: drop the -bd local aliases and `package =` fields from all seven build-dependencies, update the prebuild-ir feature list to match, and remove the now-unnecessary `extern crate X_bd as X` lines from build.rs.

https://claude.ai/code/session_01PSz5hp2H6ixthscFzkpRka