### PR TITLE
fix(release): remove invalid [workspace] section from release.toml

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
-[workspace]
 # Keep all workspace crate versions in lock-step when bumping.
 dependent-version = "upgrade"
 


### PR DESCRIPTION
cargo-release does not recognise a [workspace] table — all config keys
must be top-level. The stray section header caused the publish step to
abort with "Failed to parse release.toml".

https://claude.ai/code/session_01Gwn4Pbm23giQoBdYxaaUWg