### PR TITLE
fix(publish): allow dirty working tree when publishing crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Publish crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo release publish --execute --no-confirm
+        run: cargo release publish --execute --no-confirm --allow-dirty


### PR DESCRIPTION
cargo release version modifies Cargo.toml files on disk without committing
them, so the subsequent cargo release publish step correctly detects
uncommitted changes and aborts. Adding --allow-dirty skips that guard.

https://claude.ai/code/session_01UBHsTVAqf2bBZ3MGMk1MPE