### PR TITLE
fix: commit version bump before cargo release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,8 +62,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add -A
-          git commit -m "chore: release $VERSION [skip ci]"
-          git push
+          git commit -m "chore: release $VERSION"
           git tag "v$VERSION"
           git push origin "v$VERSION"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,8 +55,12 @@ jobs:
           echo ""
           echo "--- Sample crate Cargo.toml ---"
           cat crates/cljrs-types/Cargo.toml
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add -A
+          git commit -m "chore: release $VERSION"
 
       - name: Publish crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo release publish --execute --no-confirm --allow-dirty
+        run: cargo release publish --execute --no-confirm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,12 @@ jobs:
     name: Publish to crates.io
     needs: ci
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -58,7 +62,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add -A
-          git commit -m "chore: release $VERSION"
+          git commit -m "chore: release $VERSION [skip ci]"
+          git push
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
 
       - name: Publish crates
         env:


### PR DESCRIPTION
cargo release publish does not accept --allow-dirty. After the version bump step modifies Cargo.toml files the working tree is dirty, so we commit those changes first to give publish a clean tree.

https://claude.ai/code/session_01HBh2YY7rwQ5hZFVaG6RNE5