### PR TITLE
Add nanotime builtin.

### DIFF
--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -11,6 +11,7 @@ use crate::new::{builtin_exception_dot, builtin_new};
 use crate::regex::{
     builtin_re_find, builtin_re_groups, builtin_re_matcher, builtin_re_matches, builtin_re_pattern,
 };
+use crate::time::builtin_nanotime;
 use crate::transients::{
     builtin_assoc_bang, builtin_conj_bang, builtin_disj_bang, builtin_dissoc_bang,
     builtin_persistent_bang, builtin_pop_bang, builtin_transient,
@@ -41,7 +42,6 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::sleep;
 use std::time::Duration;
-use crate::time::builtin_nanotime;
 // ── Output capture (for with-out-str) ─────────────────────────────────────────
 
 thread_local! {
@@ -676,7 +676,6 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
             Arity::Variadic { min: 1 },
             builtin_exception_dot,
         ),
-
         // time utils
         ("nanotime", Arity::Fixed(0), builtin_nanotime),
     ];

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -41,6 +41,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::sleep;
 use std::time::Duration;
+use crate::time::builtin_nanotime;
 // ── Output capture (for with-out-str) ─────────────────────────────────────────
 
 thread_local! {
@@ -675,6 +676,9 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
             Arity::Variadic { min: 1 },
             builtin_exception_dot,
         ),
+
+        // time utils
+        ("nanotime", Arity::Fixed(0), builtin_nanotime),
     ];
 
     for (name, arity, func) in fns {

--- a/crates/cljrs-builtins/src/lib.rs
+++ b/crates/cljrs-builtins/src/lib.rs
@@ -11,6 +11,7 @@ pub mod special;
 mod taps;
 pub mod transients;
 pub mod util;
+mod time;
 
 pub use special::*;
 pub use util::*;

--- a/crates/cljrs-builtins/src/lib.rs
+++ b/crates/cljrs-builtins/src/lib.rs
@@ -9,9 +9,9 @@ mod new;
 mod regex;
 pub mod special;
 mod taps;
+mod time;
 pub mod transients;
 pub mod util;
-mod time;
 
 pub use special::*;
 pub use util::*;

--- a/crates/cljrs-builtins/src/time.rs
+++ b/crates/cljrs-builtins/src/time.rs
@@ -1,12 +1,15 @@
-use std::time::SystemTime;
-use num_traits::ToPrimitive;
 use cljrs_value::{Value, ValueError, ValueResult};
+use num_traits::ToPrimitive;
+use std::time::SystemTime;
 
 pub(crate) fn builtin_nanotime(_args: &[Value]) -> ValueResult<Value> {
     match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(nanos ) => Ok(Value::Long(nanos.as_nanos().to_i64().ok_or_else(
-            || ValueError::OutOfRange,
-        )?)),
-        Err(e) => Err(ValueError::Other(format!("{}", e)))
+        Ok(nanos) => Ok(Value::Long(
+            nanos
+                .as_nanos()
+                .to_i64()
+                .ok_or_else(|| ValueError::OutOfRange)?,
+        )),
+        Err(e) => Err(ValueError::Other(format!("{}", e))),
     }
 }

--- a/crates/cljrs-builtins/src/time.rs
+++ b/crates/cljrs-builtins/src/time.rs
@@ -1,0 +1,12 @@
+use std::time::SystemTime;
+use num_traits::ToPrimitive;
+use cljrs_value::{Value, ValueError, ValueResult};
+
+pub(crate) fn builtin_nanotime(_args: &[Value]) -> ValueResult<Value> {
+    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(nanos ) => Ok(Value::Long(nanos.as_nanos().to_i64().ok_or_else(
+            || ValueError::OutOfRange,
+        )?)),
+        Err(e) => Err(ValueError::Other(format!("{}", e)))
+    }
+}


### PR DESCRIPTION
Adds a `nanotime` function that returns a long with the current system time in nanoseconds since the epoch. 