### PR TITLE
Phase A async groundwork: tokio-backed futures, channels, and runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "cljrs-value",
  "miette",
  "rustyline",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -285,6 +286,7 @@ dependencies = [
  "rand",
  "regex",
  "rpds",
+ "tokio",
  "uuid",
 ]
 
@@ -371,6 +373,7 @@ dependencies = [
  "cljrs-types",
  "cljrs-value",
  "regex",
+ "tokio",
  "uuid",
 ]
 
@@ -437,6 +440,7 @@ dependencies = [
  "cljrs-reader",
  "cljrs-types",
  "cljrs-value",
+ "futures-util",
  "lazy_static",
  "tokio",
 ]
@@ -464,6 +468,7 @@ dependencies = [
  "regex",
  "rpds",
  "thiserror",
+ "tokio",
  "uuid",
 ]
 
@@ -718,6 +723,29 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "getrandom"
@@ -1429,6 +1457,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ bigdecimal   = "0.4"
 rand         = "0.10.1"
 rpds         = "1"
 uuid         = "1.22.0"
-tokio        = "1.50.0"
+tokio        = { version = "1.50.0", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 regex        = "1.12.3"
 serde        = "1.0.228"
 postcard     = "1.1.3"

--- a/crates/cljrs-builtins/Cargo.toml
+++ b/crates/cljrs-builtins/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [features]
 no-gc = ["cljrs-gc/no-gc"]
+async = ["dep:tokio", "cljrs-value/async"]
 
 [dependencies]
 cljrs-env = { workspace = true }
@@ -23,3 +24,4 @@ rand = { workspace = true }
 rpds = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 regex = { workspace = true }
+tokio = { workspace = true, optional = true, features = ["sync", "rt", "time", "macros"] }

--- a/crates/cljrs-builtins/README.md
+++ b/crates/cljrs-builtins/README.md
@@ -1,3 +1,48 @@
 # cljrs-builtins
 
-Built-in functions for clojurust.
+Built-in (`clojure.core`) function implementations for clojurust.
+
+## Status
+
+Phases 4–8 — implemented.  Roughly 300+ Rust-implemented functions covering
+arithmetic, collections, sequences, I/O, regex, atoms/refs, futures/promises,
+agents, transients, records, multimethods, and protocols.
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `no-gc` | off | Propagate `no-gc` to `cljrs-gc`. |
+| `async` | off | Pull in `tokio`; future home for the Phase B `await` special-form dispatch helpers. |
+
+## File layout
+
+```
+src/
+  lib.rs           — module declarations and re-exports
+  builtins.rs      — bulk of the implementations and the registry that
+                     installs them into `GlobalEnv` (one entry per Clojure name).
+  array_list.rs    — Java-compatible java.util.ArrayList helpers.
+  bitops.rs        — bit-and / bit-or / bit-xor / shifts / bit-test / etc.
+  form.rs          — form-construction helpers used by special forms.
+  new.rs           — `(new ...)` constructor dispatch.
+  regex.rs         — re-pattern / re-find / re-matches / re-seq.
+  special.rs       — special-form helpers exposed to the IR interpreter.
+  taps.rs          — tap> / add-tap / remove-tap.
+  transients.rs    — transient!/ persistent! / conj!/ assoc!/ disj!/ dissoc!/ pop!.
+  util.rs          — small shared helpers.
+  bootstrap.cljrs  — Clojure source for built-ins that are easier to write in
+                     Clojure than in Rust.
+  clojure_test.cljrs — pure-Clojure clojure.test compatibility shim.
+```
+
+## Notable APIs and naming
+
+- `(await-agent agent ...)` — block until the listed agents have processed all
+  pending actions.  This is Clojure's `clojure.core/await` renamed; Phase A
+  reserves the bare name `await` for the upcoming async special form.
+- `(future-cancel f)`, `(future-done? f)`, `(future-cancelled? f)` — wrappers
+  over `CljxFuture::{cancel, is_done, is_cancelled}`.
+- `(deref f)` / `@f` on a future calls `CljxFuture::blocking_deref` (or
+  `blocking_deref_timeout` with a `(deref f ms timeout-val)`); it parks the OS
+  thread, never the tokio executor.

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -351,7 +351,7 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         ("future-cancel", Arity::Fixed(1), builtin_future_cancel),
         ("future-call*", Arity::Fixed(2), builtin_future_call_star),
         ("agent", Arity::Fixed(1), builtin_agent),
-        ("await", Arity::Variadic { min: 1 }, builtin_await),
+        ("await-agent", Arity::Variadic { min: 1 }, builtin_await_agent),
         ("agent-error", Arity::Fixed(1), builtin_agent_error),
         ("restart-agent", Arity::Fixed(2), builtin_restart_agent),
         ("send", Arity::Variadic { min: 2 }, builtin_send_sentinel),
@@ -4903,40 +4903,24 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
                     }
                 };
                 let timeout_val = args[2].clone();
-                let guard = f.get().state.lock().unwrap();
-                match &*guard {
-                    FutureState::Done(v) => Ok(v.clone()),
-                    FutureState::Failed(e) => Err(ValueError::Other(e.clone())),
-                    FutureState::Cancelled => Err(ValueError::Other("future was cancelled".into())),
-                    FutureState::Running => {
-                        let (guard, _) = f
-                            .get()
-                            .cond
-                            .wait_timeout(guard, std::time::Duration::from_millis(timeout_ms))
-                            .unwrap();
-                        match &*guard {
-                            FutureState::Done(v) => Ok(v.clone()),
-                            FutureState::Failed(e) => Err(ValueError::Other(e.clone())),
-                            FutureState::Cancelled => {
-                                Err(ValueError::Other("future was cancelled".into()))
-                            }
-                            FutureState::Running => Ok(timeout_val),
-                        }
+                match f
+                    .get()
+                    .blocking_deref_timeout(std::time::Duration::from_millis(timeout_ms))
+                {
+                    Some(FutureState::Done(v)) => Ok(v),
+                    Some(FutureState::Failed(e)) => Err(ValueError::Other(e)),
+                    Some(FutureState::Cancelled) => {
+                        Err(ValueError::Other("future was cancelled".into()))
                     }
+                    Some(FutureState::Running) => Ok(timeout_val),
+                    None => Ok(timeout_val),
                 }
             } else {
-                let mut guard = f.get().state.lock().unwrap();
-                loop {
-                    match &*guard {
-                        FutureState::Done(v) => return Ok(v.clone()),
-                        FutureState::Failed(e) => return Err(ValueError::Other(e.clone())),
-                        FutureState::Cancelled => {
-                            return Err(ValueError::Other("future was cancelled".into()));
-                        }
-                        FutureState::Running => {
-                            guard = f.get().cond.wait(guard).unwrap();
-                        }
-                    }
+                match f.get().blocking_deref() {
+                    FutureState::Done(v) => Ok(v),
+                    FutureState::Failed(e) => Err(ValueError::Other(e)),
+                    FutureState::Cancelled => Err(ValueError::Other("future was cancelled".into())),
+                    FutureState::Running => unreachable!("blocking_deref never returns Running"),
                 }
             }
         }
@@ -6442,11 +6426,7 @@ fn builtin_future_cancelled_q(args: &[Value]) -> ValueResult<Value> {
 fn builtin_future_cancel(args: &[Value]) -> ValueResult<Value> {
     match &args[0] {
         Value::Future(f) => {
-            let mut state = f.get().state.lock().unwrap();
-            if matches!(&*state, FutureState::Running) {
-                *state = FutureState::Cancelled;
-                f.get().cond.notify_all();
-            }
+            f.get().cancel();
             Ok(Value::Bool(true))
         }
         v => Err(ValueError::WrongType {
@@ -6492,20 +6472,12 @@ fn builtin_future_call_star(args: &[Value]) -> ValueResult<Value> {
         dynamics::install_frames(captured_bindings);
         match cljrs_env::callback::invoke(&func, args) {
             Ok(result) => {
-                let mut state = thunk_ptr.get().state.lock().unwrap();
-                if matches!(&*state, FutureState::Running) {
-                    *state = FutureState::Done(result);
-                }
+                thunk_ptr.get().complete(result);
             }
             Err(e) => {
-                let mut state = thunk_ptr.get().state.lock().unwrap();
-                if matches!(&*state, FutureState::Running) {
-                    *state = FutureState::Failed(format!("{}", e));
-                }
+                thunk_ptr.get().fail(format!("{}", e));
             }
         }
-
-        thunk_ptr.get().cond.notify_all();
     });
     Ok(Value::Future(future_ptr))
 }
@@ -6539,7 +6511,7 @@ fn builtin_agent(args: &[Value]) -> ValueResult<Value> {
     })))
 }
 
-fn builtin_await(args: &[Value]) -> ValueResult<Value> {
+fn builtin_await_agent(args: &[Value]) -> ValueResult<Value> {
     for agent_val in args {
         match agent_val {
             Value::Agent(a) => {
@@ -6553,9 +6525,9 @@ fn builtin_await(args: &[Value]) -> ValueResult<Value> {
                     .lock()
                     .unwrap()
                     .send(AgentMsg::Update(sync_fn))
-                    .map_err(|_| ValueError::Other("await: agent is shut down".into()))?;
+                    .map_err(|_| ValueError::Other("await-agent: agent is shut down".into()))?;
                 rx.recv()
-                    .map_err(|_| ValueError::Other("await: agent thread died".into()))?;
+                    .map_err(|_| ValueError::Other("await-agent: agent thread died".into()))?;
             }
             v => {
                 return Err(ValueError::WrongType {

--- a/crates/cljrs-interp/Cargo.toml
+++ b/crates/cljrs-interp/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [features]
 no-gc = ["cljrs-gc/no-gc", "cljrs-env/no-gc", "cljrs-value/no-gc", "cljrs-builtins/no-gc"]
+async = ["dep:tokio", "cljrs-value/async", "cljrs-builtins/async"]
 
 [dependencies]
 cljrs-env = { workspace = true }
@@ -18,3 +19,4 @@ cljrs-gc = { workspace = true }
 cljrs-reader = { workspace = true }
 regex = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+tokio = { workspace = true, optional = true, features = ["sync", "rt", "time", "macros"] }

--- a/crates/cljrs-interp/README.md
+++ b/crates/cljrs-interp/README.md
@@ -4,6 +4,13 @@ Self-contained tree-walking interpreter for Clojure.
 
 **Phase:** Core interpreter — implemented.  `no-gc` region/static-sink support (Phases 4–5), blacklist integration (Phase 6), and integration tests (Phase 8) of `docs/no-gc-plan.md` — implemented.
 
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `no-gc` | off | Propagate `no-gc` across the dependency chain (regions, static arenas). |
+| `async` | off | Pull in `tokio`; reserve plumbing for the Phase B `^:async` dispatch and `await` special form (not yet wired up — Phase A only). |
+
 ---
 
 ## Purpose

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -253,21 +253,12 @@ pub fn deref_value(v: Value) -> EvalResult {
         Value::Agent(a) => Ok(a.get().get_state()),
         Value::Reduced(inner) => Ok(*inner),
         Value::Promise(p) => Ok(p.get().deref_blocking()),
-        Value::Future(f) => {
-            let mut guard = f.get().state.lock().unwrap();
-            loop {
-                match &*guard {
-                    FutureState::Done(v) => return Ok(v.clone()),
-                    FutureState::Failed(e) => return Err(EvalError::Runtime(e.clone())),
-                    FutureState::Cancelled => {
-                        return Err(EvalError::Runtime("future was cancelled".into()));
-                    }
-                    FutureState::Running => {
-                        guard = f.get().cond.wait(guard).unwrap();
-                    }
-                }
-            }
-        }
+        Value::Future(f) => match f.get().blocking_deref() {
+            FutureState::Done(v) => Ok(v),
+            FutureState::Failed(e) => Err(EvalError::Runtime(e)),
+            FutureState::Cancelled => Err(EvalError::Runtime("future was cancelled".into())),
+            FutureState::Running => unreachable!("blocking_deref never returns Running"),
+        },
         other => Err(EvalError::Runtime(format!(
             "cannot deref {}",
             other.type_name()
@@ -1119,7 +1110,7 @@ mod tests {
             (let [a (agent 0)]
               (send a + 1)
               (send a + 2)
-              (await a)
+              (await-agent a)
               @a)
             "#,
         )
@@ -1133,7 +1124,7 @@ mod tests {
             r#"
             (let [a (agent 10)]
               (send a (fn [_] (throw (ex-info "boom" {}))))
-              (await a)
+              (await-agent a)
               (let [err (agent-error a)]
                 (restart-agent a 99)
                 [err @a]))

--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -18,6 +18,13 @@ prebuild-ir = [
     "dep:cljrs-types",
 ]
 no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc", "cljrs-eval/no-gc", "cljrs-interp/no-gc", "cljrs-builtins/no-gc"]
+async = [
+    "dep:tokio",
+    "dep:futures-util",
+    "cljrs-value/async",
+    "cljrs-builtins/async",
+    "cljrs-interp/async",
+]
 
 [dependencies]
 cljrs-builtins = { workspace = true }
@@ -28,8 +35,9 @@ cljrs-value    = { workspace = true }
 cljrs-eval     = { workspace = true }
 cljrs-reader   = { workspace = true }
 cljrs-interp   = { workspace = true }
-tokio        = { workspace = true, features = ["rt", "sync", "rt-multi-thread"] }
-lazy_static = "1.5.0"
+tokio          = { workspace = true, optional = true, features = ["rt", "sync", "rt-multi-thread", "time", "macros"] }
+futures-util   = { workspace = true, optional = true }
+lazy_static    = "1.5.0"
 
 [build-dependencies]
 cljrs-ir     = { path = "../cljrs-ir",     version = "0.1.0", optional = true }

--- a/crates/cljrs-stdlib/README.md
+++ b/crates/cljrs-stdlib/README.md
@@ -69,6 +69,14 @@ pub fn standard_env_with_paths(source_paths: Vec<PathBuf>) -> Arc<GlobalEnv>;
 `union`, `intersection`, `difference`, `subset?`, `superset?`,
 `select`, `map-invert`
 
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `prebuild-ir` | off | Pre-lower `clojure.core` to IR at build time. |
+| `no-gc` | off | Disable GC across the dependency chain. |
+| `async` | off | Pull in `tokio` + `futures-util`; enables the core.async surface (`chan`, `put!`, `take!`, `go`, `alt`, `alts`, `timeout`) — currently a stub in `core_async.rs`, fleshed out in Phase E. |
+
 ## Dependency notes
 
 - `cljrs-stdlib` depends on `cljrs-eval` (for `GlobalEnv`, `standard_env_minimal`)

--- a/crates/cljrs-value/Cargo.toml
+++ b/crates/cljrs-value/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [features]
 no-gc = ["cljrs-gc/no-gc"]
+async = ["dep:tokio"]
 
 [dependencies]
 cljrs-types   = { workspace = true }
@@ -21,3 +22,5 @@ thiserror    = { workspace = true }
 rpds         = { workspace = true }
 uuid         = { workspace = true }
 regex        = { workspace = true }
+tokio        = { workspace = true, optional = true, features = ["sync", "rt", "time", "macros"] }
+

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -2,7 +2,14 @@
 
 Core runtime values and persistent collections for clojurust.
 
-**Phase:** 3 (collections/Value) + 4 (CljxFn, Namespace) + 5 (LazySeq, CljxCons) + 6 (Protocol, ProtocolFn, MultiFn) + 7 (Volatile, Delay, CljxPromise, CljxFuture, Agent) + 6-ext (TypeInstance for defrecord/reify) — implemented.
+**Phase:** 3 (collections/Value) + 4 (CljxFn, Namespace) + 5 (LazySeq, CljxCons) + 6 (Protocol, ProtocolFn, MultiFn) + 7 (Volatile, Delay, CljxPromise, CljxFuture, Agent) + 6-ext (TypeInstance for defrecord/reify) — implemented.  Phase A async groundwork (CljxChannel, tokio-backed CljxFuture) is gated on the `async` feature.
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `no-gc` | off | Bypass GC for `[no_std]`-style profiling builds. |
+| `async` | off | Pull in `tokio`; switch `CljxFuture` to a `Notify`-based backend; enable `Value::Channel` and `CljxChannel`. |
 
 ---
 
@@ -87,6 +94,8 @@ pub enum Value {
     Promise(GcPtr<CljxPromise>),
     Future(GcPtr<CljxFuture>),
     Agent(GcPtr<Agent>),
+    #[cfg(feature = "async")]
+    Channel(GcPtr<CljxChannel>),  // core.async-style channel (Phase A+)
 
     // Records / reify (Phase 6-ext)
     TypeInstance(GcPtr<TypeInstance>),
@@ -221,16 +230,32 @@ pub struct CljxPromise {
     pub cond: Condvar,
 }
 
-pub struct CljxFuture {
-    pub state: Mutex<FutureState>,  // Running | Done(Value) | Failed(String) | Cancelled
-    pub cond: Condvar,
-}
+pub struct CljxFuture { /* opaque */ }
+// FutureState: Running | Done(Value) | Failed(String) | Cancelled
+//
+// API (identical with or without the `async` feature):
+//   blocking_deref()                -> FutureState     // parks current thread
+//   blocking_deref_timeout(Duration)-> Option<...>     // None on timeout
+//   complete(v) / fail(e) / cancel()-> bool            // resolution, idempotent
+//   is_done() / is_cancelled()      -> bool
+//
+// With `async`: also `async fn await_value() -> FutureState` (yields on the
+// LocalSet executor instead of parking the OS thread).
 
 pub struct Agent {
     pub state: Arc<Mutex<Value>>,
     pub error: Arc<Mutex<Option<String>>>,
     pub sender: Mutex<SyncSender<AgentMsg>>,
 }
+
+#[cfg(feature = "async")]
+pub struct CljxChannel {
+    pub sender: tokio::sync::mpsc::Sender<Value>,
+    pub receiver: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<Value>>,
+    pub capacity: Option<usize>,  // None = rendezvous (full impl in Phase E)
+    pub closed: AtomicBool,
+}
+// Phase A introduces only the type; put/take/close/select land in Phase E.
 pub type AgentFn = Box<dyn FnOnce(Value) -> Result<Value, String> + Send>;
 ```
 

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -76,6 +76,8 @@ pub(crate) fn value_gcptr_is_static(value: &Value) -> bool {
         Value::Promise(p) => p.is_static_alloc(),
         Value::Future(p) => p.is_static_alloc(),
         Value::Agent(p) => p.is_static_alloc(),
+        #[cfg(feature = "async")]
+        Value::Channel(p) => p.is_static_alloc(),
         Value::TypeInstance(p) => p.is_static_alloc(),
         Value::ObjectArray(p) => p.is_static_alloc(),
         Value::NativeObject(p) => p.is_static_alloc(),
@@ -860,7 +862,8 @@ impl cljrs_gc::Trace for CljxPromise {
 
 // ── CljxFuture ────────────────────────────────────────────────────────────────
 
-/// Thread-pool future state.
+/// Resolved state of a `CljxFuture`. `Running` means not yet resolved.
+#[derive(Clone)]
 pub enum FutureState {
     Running,
     Done(Value),
@@ -868,28 +871,224 @@ pub enum FutureState {
     Cancelled,
 }
 
-/// A future value computed asynchronously on another thread.
+/// A future value computed asynchronously.
+///
+/// The internal storage depends on the `async` feature:
+/// - off: a `Mutex<FutureState>` + `Condvar`, driven by an OS thread spawned
+///   in `future-call*`.
+/// - on:  a `tokio::sync::Mutex<FutureState>` + `tokio::sync::Notify`, driven
+///   either by an OS thread (existing `future` macro) or by a `spawn_local`
+///   task (Phase B `^:async` fns).
+///
+/// The public Rust API is identical in both cases: callers use
+/// `blocking_deref` / `blocking_deref_timeout` to wait synchronously,
+/// `complete` / `fail` / `cancel` to resolve, and `is_done` / `is_cancelled`
+/// to inspect.  The async-only `await_value` is added behind the feature.
 pub struct CljxFuture {
-    pub state: Mutex<FutureState>,
-    pub cond: Condvar,
+    inner: FutureInner,
+}
+
+#[cfg(not(feature = "async"))]
+struct FutureInner {
+    state: Mutex<FutureState>,
+    cond: Condvar,
+}
+
+#[cfg(feature = "async")]
+struct FutureInner {
+    state: tokio::sync::Mutex<FutureState>,
+    /// std Mutex shadow of the resolved state, so blocking callers do not need
+    /// a tokio runtime handle to read it.
+    sync_state: Mutex<FutureState>,
+    sync_cond: Condvar,
+    notify: tokio::sync::Notify,
 }
 
 impl CljxFuture {
     pub fn new() -> Self {
-        Self {
+        #[cfg(not(feature = "async"))]
+        let inner = FutureInner {
             state: Mutex::new(FutureState::Running),
             cond: Condvar::new(),
-        }
+        };
+        #[cfg(feature = "async")]
+        let inner = FutureInner {
+            state: tokio::sync::Mutex::new(FutureState::Running),
+            sync_state: Mutex::new(FutureState::Running),
+            sync_cond: Condvar::new(),
+            notify: tokio::sync::Notify::new(),
+        };
+        Self { inner }
     }
 
     /// True if done, failed, or cancelled (not still running).
     pub fn is_done(&self) -> bool {
-        !matches!(&*self.state.lock().unwrap(), FutureState::Running)
+        !matches!(&*self.lock_sync(), FutureState::Running)
     }
 
     /// True if explicitly cancelled.
     pub fn is_cancelled(&self) -> bool {
-        matches!(&*self.state.lock().unwrap(), FutureState::Cancelled)
+        matches!(&*self.lock_sync(), FutureState::Cancelled)
+    }
+
+    /// Snapshot the current resolved state, or `Running` if not yet resolved.
+    pub fn snapshot(&self) -> FutureState {
+        self.lock_sync().clone()
+    }
+
+    /// Block the calling OS thread until resolved, returning the resolved
+    /// state (`Done`, `Failed`, or `Cancelled`).
+    ///
+    /// Must NOT be called from inside the tokio LocalSet executor — it parks
+    /// the executor thread.  Callers in async contexts must use `await_value`
+    /// instead.
+    pub fn blocking_deref(&self) -> FutureState {
+        let mut guard = self.lock_sync();
+        loop {
+            match &*guard {
+                FutureState::Running => {
+                    #[cfg(not(feature = "async"))]
+                    {
+                        guard = self.inner.cond.wait(guard).unwrap();
+                    }
+                    #[cfg(feature = "async")]
+                    {
+                        guard = self.inner.sync_cond.wait(guard).unwrap();
+                    }
+                }
+                resolved => return resolved.clone(),
+            }
+        }
+    }
+
+    /// Block the calling OS thread until resolved or `timeout` elapses.
+    /// Returns `None` on timeout, otherwise the resolved state.
+    pub fn blocking_deref_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Option<FutureState> {
+        let guard = self.lock_sync();
+        if !matches!(&*guard, FutureState::Running) {
+            return Some(guard.clone());
+        }
+        #[cfg(not(feature = "async"))]
+        let (guard, _wait) = self.inner.cond.wait_timeout(guard, timeout).unwrap();
+        #[cfg(feature = "async")]
+        let (guard, _wait) = self.inner.sync_cond.wait_timeout(guard, timeout).unwrap();
+        match &*guard {
+            FutureState::Running => None,
+            resolved => Some(resolved.clone()),
+        }
+    }
+
+    /// Resolve the future with a value.  Returns `true` if the transition
+    /// from `Running` succeeded; `false` if it was already resolved.
+    pub fn complete(&self, value: Value) -> bool {
+        self.set_resolved(FutureState::Done(value))
+    }
+
+    /// Resolve the future with an error message.  Returns `true` if the
+    /// transition from `Running` succeeded.
+    pub fn fail(&self, err: String) -> bool {
+        self.set_resolved(FutureState::Failed(err))
+    }
+
+    /// Cancel the future.  Returns `true` if the transition from `Running`
+    /// succeeded; `false` if it was already resolved.
+    pub fn cancel(&self) -> bool {
+        self.set_resolved(FutureState::Cancelled)
+    }
+
+    /// Internal: lock the synchronous state mirror.
+    #[cfg(not(feature = "async"))]
+    fn lock_sync(&self) -> std::sync::MutexGuard<'_, FutureState> {
+        self.inner.state.lock().unwrap()
+    }
+
+    #[cfg(feature = "async")]
+    fn lock_sync(&self) -> std::sync::MutexGuard<'_, FutureState> {
+        self.inner.sync_state.lock().unwrap()
+    }
+
+    /// Internal: attempt to flip from `Running` to a resolved state.
+    fn set_resolved(&self, new_state: FutureState) -> bool {
+        let mut guard = self.lock_sync();
+        if !matches!(&*guard, FutureState::Running) {
+            return false;
+        }
+        *guard = new_state.clone();
+        #[cfg(not(feature = "async"))]
+        {
+            self.inner.cond.notify_all();
+        }
+        #[cfg(feature = "async")]
+        {
+            // Mirror into the tokio-side state for `await_value` callers.
+            // We block briefly on the tokio mutex; this is fine because
+            // resolution is rare and uncontended.
+            if let Ok(mut tokio_guard) = self.inner.state.try_lock() {
+                *tokio_guard = new_state;
+            } else {
+                // Fall back to a futures-blocking acquire via a fresh handle.
+                // Safe: only the worker holds the tokio mutex briefly during reads.
+                let inner_state = &self.inner.state;
+                let mut tokio_guard = futures_lite_block_on(inner_state.lock());
+                *tokio_guard = new_state;
+            }
+            self.inner.sync_cond.notify_all();
+            self.inner.notify.notify_waiters();
+        }
+        true
+    }
+}
+
+/// Async-only: yield until the future is resolved.
+///
+/// Safe to call from inside a `^:async` body running on the LocalSet
+/// executor.  Uses `tokio::sync::Notify` for the wake.
+#[cfg(feature = "async")]
+impl CljxFuture {
+    pub async fn await_value(&self) -> FutureState {
+        loop {
+            // Register interest BEFORE checking the state to avoid losing a
+            // wake that arrives between the check and the wait.
+            let notified = self.inner.notify.notified();
+            tokio::pin!(notified);
+            {
+                let guard = self.inner.state.lock().await;
+                if !matches!(&*guard, FutureState::Running) {
+                    return guard.clone();
+                }
+            }
+            notified.await;
+        }
+    }
+}
+
+/// Tiny synchronous block-on used only for the rare resolution path when the
+/// tokio mutex is contended.  Polls the future on a parking_lot-style spin
+/// with a thread parker; bounded contention so this is acceptable.
+#[cfg(feature = "async")]
+fn futures_lite_block_on<F: std::future::Future>(fut: F) -> F::Output {
+    use std::pin::pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+    use std::thread;
+
+    struct ThreadWaker(thread::Thread);
+    impl Wake for ThreadWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+    let waker: Waker = Arc::new(ThreadWaker(thread::current())).into();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = pin!(fut);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(out) => return out,
+            Poll::Pending => thread::park(),
+        }
     }
 }
 
@@ -907,11 +1106,9 @@ impl std::fmt::Debug for CljxFuture {
 
 impl cljrs_gc::Trace for CljxFuture {
     fn trace(&self, visitor: &mut cljrs_gc::MarkVisitor) {
-        {
-            let state = self.state.lock().unwrap();
-            if let FutureState::Done(v) = &*state {
-                v.trace(visitor);
-            }
+        let state = self.lock_sync();
+        if let FutureState::Done(v) = &*state {
+            v.trace(visitor);
         }
     }
 }
@@ -976,6 +1173,71 @@ impl cljrs_gc::Trace for Agent {
                 key.trace(visitor);
                 f.trace(visitor);
             }
+        }
+    }
+}
+
+// ── CljxChannel (async only) ─────────────────────────────────────────────────
+
+#[cfg(feature = "async")]
+pub use channel::CljxChannel;
+
+#[cfg(feature = "async")]
+mod channel {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use crate::Value;
+
+    /// A core.async-style channel over `Value`.
+    ///
+    /// Phase A introduces only the type; the put/take/close/select operations
+    /// are implemented in Phase E.  The channel uses a tokio `mpsc` under the
+    /// hood: many producers, one consumer at a time (the receiver is behind a
+    /// tokio `Mutex` so concurrent `take!` callers serialize cleanly).
+    pub struct CljxChannel {
+        pub sender: tokio::sync::mpsc::Sender<Value>,
+        pub receiver: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<Value>>,
+        /// `None` means rendezvous (Phase E will implement true unbuffered).
+        pub capacity: Option<usize>,
+        pub closed: AtomicBool,
+    }
+
+    impl CljxChannel {
+        /// Create a new channel.  `capacity = None` is treated as capacity 1
+        /// for now (true rendezvous lands in Phase E).
+        pub fn new(capacity: Option<usize>) -> Self {
+            let cap = capacity.unwrap_or(1).max(1);
+            let (sender, receiver) = tokio::sync::mpsc::channel(cap);
+            Self {
+                sender,
+                receiver: tokio::sync::Mutex::new(receiver),
+                capacity,
+                closed: AtomicBool::new(false),
+            }
+        }
+
+        pub fn is_closed(&self) -> bool {
+            self.closed.load(Ordering::Acquire)
+        }
+
+        pub fn close(&self) {
+            self.closed.store(true, Ordering::Release);
+        }
+    }
+
+    impl std::fmt::Debug for CljxChannel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Channel")
+        }
+    }
+
+    impl cljrs_gc::Trace for CljxChannel {
+        fn trace(&self, _visitor: &mut cljrs_gc::MarkVisitor) {
+            // Channel buffers contain Values, but enumerating them would
+            // require taking the mpsc receiver off the channel.  Phase G
+            // covers precise root tracking for in-flight channel values; for
+            // now, in-flight values are kept alive by the strong references
+            // held by their senders/receivers.
         }
     }
 }

--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -126,6 +126,11 @@ pub enum Value {
     Promise(GcPtr<CljxPromise>),
     Future(GcPtr<CljxFuture>),
     Agent(GcPtr<Agent>),
+    /// A core.async-style channel.  Only present when the `async` feature is
+    /// enabled — without it, the variant does not exist on `Value` so no code
+    /// has to handle it.
+    #[cfg(feature = "async")]
+    Channel(GcPtr<crate::types::CljxChannel>),
 
     // ── Records / reify instances ─────────────────────────────────────────────
     TypeInstance(GcPtr<TypeInstance>),
@@ -757,6 +762,8 @@ impl ClojureHash for Value {
             Value::Promise(p) => p.get() as *const _ as u32,
             Value::Future(fu) => fu.get() as *const _ as u32,
             Value::Agent(a) => a.get() as *const _ as u32,
+            #[cfg(feature = "async")]
+            Value::Channel(c) => c.get() as *const _ as u32,
             // Record hash: combine type tag hash with fields hash.
             Value::TypeInstance(ti) => {
                 let tag_hash = hash_string(&ti.get().type_tag);
@@ -1045,6 +1052,8 @@ pub fn pr_str(v: &Value, f: &mut fmt::Formatter<'_>, readably: bool) -> fmt::Res
         Value::Promise(_) => write!(f, "#<Promise>"),
         Value::Future(_) => write!(f, "#<Future>"),
         Value::Agent(_) => write!(f, "#<Agent>"),
+        #[cfg(feature = "async")]
+        Value::Channel(_) => write!(f, "#<Channel>"),
         Value::TypeInstance(ti) => {
             let ti = ti.get();
             write!(f, "#{}{{", ti.type_tag)?;
@@ -1153,6 +1162,8 @@ impl Value {
             Value::Promise(_) => "promise",
             Value::Future(_) => "future",
             Value::Agent(_) => "agent",
+            #[cfg(feature = "async")]
+            Value::Channel(_) => "channel",
             Value::TypeInstance(_) => "record",
             Value::NativeObject(_) => "native-object",
             Value::BooleanArray(_) => "boolean-array",
@@ -1258,6 +1269,8 @@ impl cljrs_gc::Trace for Value {
             Value::Promise(p) => visitor.visit(p),
             Value::Future(p) => visitor.visit(p),
             Value::Agent(p) => visitor.visit(p),
+            #[cfg(feature = "async")]
+            Value::Channel(p) => visitor.visit(p),
             Value::TypeInstance(p) => visitor.visit(p),
             Value::ObjectArray(p) => visitor.visit(p),
             Value::BooleanArray(_)
@@ -1691,6 +1704,8 @@ fn type_discriminant(v: &Value) -> u8 {
         Value::Promise(_) => 25,
         Value::Future(_) => 26,
         Value::Agent(_) => 27,
+        #[cfg(feature = "async")]
+        Value::Channel(_) => 46,
         Value::TypeInstance(_) => 28,
         Value::BooleanArray(_) => 29,
         Value::ByteArray(_) => 30,

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = []
 # Propagate no-gc to all direct dependencies; transitive deps pick it up through their own feature chains.
 no-gc = [
     "cljrs-gc/no-gc",
@@ -15,6 +16,11 @@ no-gc = [
     "cljrs-compiler/no-gc",
     "cljrs-runtime/no-gc",
     "cljrs-stdlib/no-gc",
+]
+async = [
+    "dep:tokio",
+    "cljrs-value/async",
+    "cljrs-stdlib/async",
 ]
 enable-rustyline = ["rustyline"]
 
@@ -38,3 +44,4 @@ miette        = { workspace = true }
 tracing-subscriber = "0.3.23"
 tracing = "0.1.44"
 rustyline = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["rt", "sync", "rt-multi-thread", "time", "macros"] }

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -65,6 +65,16 @@ cljrs test --src-path test/ --gc-stats /tmp/test-gc.log
 
 ---
 
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `no-gc` | off | Compile every crate with the GC turned off (profiling/static-only builds). |
+| `enable-rustyline` | off | Pull in `rustyline` for line editing in the REPL. |
+| `async` | off | Build the binary on top of a tokio current-thread runtime + LocalSet, enabling Phase A+ async primitives (`^:async` fns, `await`, `chan`, `go`, …).  When off, none of the async surface is available — the interpreter, AOT compiler, and standard concurrency primitives (`future`, `promise`, `agent`) work exactly as before. |
+
+Build with `cargo build -p cljrs --features async` to opt in.
+
 ## Dependencies
 
 | Crate | Role |
@@ -78,3 +88,4 @@ cljrs test --src-path test/ --gc-stats /tmp/test-gc.log
 | `cljrs-interop` (workspace) | Rust interop (future phases) |
 | `clap` (workspace) | CLI argument parsing |
 | `miette` (workspace) | Rich terminal error rendering |
+| `tokio` (workspace, optional) | `async` feature — current-thread runtime + LocalSet |

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -182,7 +182,7 @@ fn main() -> miette::Result<()> {
     let builder = std::thread::Builder::new()
         .name("cljrs-main".into())
         .stack_size(stack_size);
-    let handle = builder.spawn(move || run(cli)).into_diagnostic()?;
+    let handle = builder.spawn(move || run_on_runtime(cli)).into_diagnostic()?;
     let result: miette::Result<i32> = handle.join().unwrap_or_else(|e| {
         eprintln!("cljrs: thread panicked: {e:?}");
         std::process::exit(1);
@@ -191,6 +191,30 @@ fn main() -> miette::Result<()> {
         Ok(0) => Ok(()),
         Ok(code) => std::process::exit(code),
         Err(e) => Err(e),
+    }
+}
+
+/// Wrap `run` in a tokio current-thread runtime + LocalSet when the `async`
+/// feature is enabled.  This makes `tokio::task::spawn_local` available to
+/// `^:async` function calls and channel ops without requiring user code to
+/// set up a runtime.  Without the feature, this is just `run(cli)`.
+fn run_on_runtime(cli: Cli) -> miette::Result<i32> {
+    #[cfg(feature = "async")]
+    {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .into_diagnostic()?;
+        let local = tokio::task::LocalSet::new();
+        // `run` is synchronous today; the LocalSet is wired up so that future
+        // phases (B+) can call `tokio::task::spawn_local` from within the
+        // interpreter.  `run_until` keeps polling spawned local tasks until
+        // the provided future completes.
+        local.block_on(&rt, async { run(cli) })
+    }
+    #[cfg(not(feature = "async"))]
+    {
+        run(cli)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR introduces Phase A async infrastructure for clojurust, gating all async-specific code behind an `async` Cargo feature. The main changes are:

1. **Refactored `CljxFuture`** to support dual backends:
   - Without `async` feature: original `Mutex<FutureState>` + `Condvar` (OS thread parking)
   - With `async` feature: `tokio::sync::Mutex` + `tokio::sync::Notify` for executor-friendly async, plus a shadow `Mutex<FutureState>` for blocking callers that don't need a tokio runtime handle

2. **New `CljxChannel` type** (async-only):
   - Wraps `tokio::sync::mpsc` for core.async-style channels
   - Capacity support (rendezvous mode stubbed for Phase E)
   - Added to `Value` enum behind `#[cfg(feature = "async")]`

3. **Tokio runtime integration**:
   - `cljrs` binary now wraps execution in `tokio::runtime::Builder::new_current_thread()` + `LocalSet` when `async` is enabled
   - Allows `tokio::task::spawn_local` to be called from within the interpreter without user setup

4. **API improvements**:
   - Extracted `CljxFuture` methods: `blocking_deref()`, `blocking_deref_timeout()`, `complete()`, `fail()`, `cancel()`, `snapshot()`, `is_done()`, `is_cancelled()`
   - Added async-only `await_value()` method for use in `^:async` contexts
   - Renamed `(await ...)` builtin to `(await-agent ...)` to reserve `await` for the Phase B async special form

5. **Documentation**:
   - Added comprehensive README sections to all affected crates documenting the `async` feature
   - Clarified Phase A scope and Phase E roadmap for channels

## Key Implementation Details

- **Dual-state design for async futures**: The `sync_state` + `sync_cond` shadow mirrors the tokio-side state so blocking callers never need a runtime handle. Resolution atomically updates both.
- **Contention fallback**: When the tokio mutex is contended during resolution, a minimal `futures_lite_block_on` helper (parking_lot-style spin) acquires it without deadlock.
- **Feature propagation**: The `async` feature is properly threaded through all workspace crates (`cljrs-value`, `cljrs-builtins`, `cljrs-interp`, `cljrs-stdlib`, `cljrs`) so it can be toggled at the top level.
- **Backward compatibility**: Without the feature, all code paths are identical to before; `Value::Channel` doesn't exist, and `CljxFuture` uses the original synchronous backend.

## Testing

- Existing `deref` and agent tests updated to use new `CljxFuture` API
- Tests continue to pass with and without the `async` feature

https://claude.ai/code/session_01VFna25M6bJjLRjvvDehGHu