### PR TITLE
Drop unused `cc = "1"` build-dep from AOT harness Cargo.toml

### DIFF
--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -714,9 +714,6 @@ cljrs-env      = {{ path = "{ws}/crates/cljrs-env" }}
 cljrs-eval     = {{ path = "{ws}/crates/cljrs-eval" }}
 cljrs-stdlib   = {{ path = "{ws}/crates/cljrs-stdlib" }}
 cljrs-compiler = {{ path = "{ws}/crates/cljrs-compiler" }}
-
-[build-dependencies]
-cc = "1"
 "#,
         ws = workspace_root.display()
     );


### PR DESCRIPTION
The generated build.rs only emits a `cargo:rustc-link-arg=…` instruction to feed the AOT-compiled object into the linker — it doesn't import or invoke the `cc` crate at all.  The build-dep has been silently dead for a while.

Removing it fixes offline builds: with `--offline` (which is how the harness link step is already invoked, see `link_with_cargo`), Cargo needs every dep to be present in the local registry/lockfile.  `cc` isn't in this workspace's dependency graph, so cargo would fail with `no matching package named 'cc' found`.

Sample run that used to fail at the harness link stage:

    cljrs compile samples/graph.cljrs -o /tmp/graph

Now succeeds, and `CLJRS_GC_STATS=/dev/stdout /tmp/graph` reports the expected `Region (bump) allocs: 100` from the optimizer's promotions.