### PR TITLE
ir: stage 2 — classify returning allocs as Returns, not Escapes

### DIFF
--- a/crates/cljrs-ir/ESCAPE_OPT_PLAN.md
+++ b/crates/cljrs-ir/ESCAPE_OPT_PLAN.md
@@ -40,53 +40,23 @@ self/closure param (`params[0]`), then the user params.  `do_inline` maps
 
 ---
 
-## Stage 2 — `Returns` state for allocations
+## Stage 2 — `Returns` state for allocations  ✅ DONE  (`lower/escape.rs`)
 
-**Goal.** Instead of immediately classifying a returning allocation as
-`Escapes`, classify it as `Returns` — the same state parameters already use.
-This lets the caller decide whether the allocation actually escapes.
+**What it does.**  `classify_escape_with_ctx` no longer short-circuits to
+`Escapes` when an allocation reaches a `Return` terminator.  Both
+`EscapeMode::Alloc` and `EscapeMode::Param` now join `EscapeState::Returns`,
+so the caller can decide whether the value truly escapes.
 
-**Exact change.**  `escape.rs:538–543`:
-```rust
-// CURRENT
-UseKind::Return => {
-    if mode == EscapeMode::Param {
-        result = EscapeState::join(result, EscapeState::Returns);
-    } else {
-        result = EscapeState::Escapes;   // ← change this
-        break 'outer;
-    }
-}
+`compute_return_alloc_summary(ir_func, ctx)` was added as a thin wrapper over
+`analyze()` that surfaces the `states` map with the finer-grained
+classification.  It is annotated `#[allow(dead_code)]` pending stage-3 usage.
 
-// AFTER
-UseKind::Return => {
-    result = EscapeState::join(result, EscapeState::Returns);
-    // same for both Alloc and Param modes
-}
-```
+The `returned_vector_escapes` regression test was updated to assert `Returns`
+(previously `Escapes`).
 
-**New function.** Add to `escape.rs`:
-```rust
-/// Per-allocation return summary for a function.
-/// Maps each allocation VarId to its EscapeState, using `Returns` for
-/// allocations whose only escape path is via Return.
-pub(crate) fn compute_return_alloc_summary(
-    ir_func: &IrFunction,
-    ctx: &EscapeContext,
-) -> HashMap<VarId, EscapeState> { ... }
-```
-
-This is a thin wrapper over `analyze()` that returns the `states` map
-(which will now contain `Returns` entries instead of `Escapes` for
-returning allocations).
-
-**Impact on existing tests.**  The existing test `returned_vector_escapes`
-(escape_regression.rs:70) currently asserts `Escapes`.  After this change it
-will assert `Returns` — update the assertion and the comment.
-
-**Impact on the optimizer.**  `optimize_regions` filters for `NoEscape` only
-(`optimize.rs:432–433`), so `Returns` allocations are still skipped — no
-region promotion yet.  That is correct: without stage 4 we can't promote them.
+**Impact on the optimizer.**  `optimize_regions` filters for `NoEscape` only,
+so `Returns` allocations are still skipped — no region promotion yet.  That is
+correct: without stage 4 we can't promote them.
 
 ---
 

--- a/crates/cljrs-ir/src/lower/escape.rs
+++ b/crates/cljrs-ir/src/lower/escape.rs
@@ -536,12 +536,7 @@ pub(crate) fn classify_escape_with_ctx(
         for use_info in use_list {
             match &use_info.kind {
                 UseKind::Return => {
-                    if mode == EscapeMode::Param {
-                        result = EscapeState::join(result, EscapeState::Returns);
-                    } else {
-                        result = EscapeState::Escapes;
-                        break 'outer;
-                    }
+                    result = EscapeState::join(result, EscapeState::Returns);
                 }
                 UseKind::DefVar
                 | UseKind::SetBang
@@ -692,4 +687,17 @@ pub fn analyze(ir_func: &IrFunction, ctx: Option<&EscapeContext>) -> AnalysisRes
         uses,
         alloc_blocks,
     }
+}
+
+/// Per-allocation return summary for a function.
+///
+/// Returns `{alloc_var → EscapeState}` for every allocation in `ir_func`.
+/// Allocations whose only escape path is a `Return` terminator are classified
+/// as [`EscapeState::Returns`] rather than [`EscapeState::Escapes`], making
+/// it possible for callers to decide whether the value truly escapes.
+pub(crate) fn compute_return_alloc_summary(
+    ir_func: &IrFunction,
+    ctx: &EscapeContext,
+) -> HashMap<VarId, EscapeState> {
+    analyze(ir_func, Some(ctx)).states
 }

--- a/crates/cljrs-ir/src/lower/escape.rs
+++ b/crates/cljrs-ir/src/lower/escape.rs
@@ -695,6 +695,7 @@ pub fn analyze(ir_func: &IrFunction, ctx: Option<&EscapeContext>) -> AnalysisRes
 /// Allocations whose only escape path is a `Return` terminator are classified
 /// as [`EscapeState::Returns`] rather than [`EscapeState::Escapes`], making
 /// it possible for callers to decide whether the value truly escapes.
+#[allow(dead_code)] // used by stage-3 caller-context propagation (not yet implemented)
 pub(crate) fn compute_return_alloc_summary(
     ir_func: &IrFunction,
     ctx: &EscapeContext,

--- a/crates/cljrs-ir/tests/escape_regression.rs
+++ b/crates/cljrs-ir/tests/escape_regression.rs
@@ -68,15 +68,16 @@ fn loop_local_empty_vec_is_no_escape_through_recur() {
 
 #[test]
 fn returned_vector_escapes() {
-    // The vec is the function's return value — must be classified as
-    // Escapes regardless of analyser improvements.
+    // The vec is the function's return value.  After stage 2 the analyser
+    // classifies it as `Returns` (not `Escapes`) — the caller decides whether
+    // it truly escapes.
     let ir = lower("[1 2 3]");
     let dst = first_alloc_vec(&ir).expect("alloc-vec");
     let ctx = make_analysis_context(&ir);
     let analysis = analyze(&ir, Some(&ctx));
     assert_eq!(
         analysis.states.get(&dst).copied(),
-        Some(EscapeState::Escapes),
+        Some(EscapeState::Returns),
     );
 }
 


### PR DESCRIPTION
`UseKind::Return` in `EscapeMode::Alloc` previously short-circuited to
`Escapes`.  Now it joins `Returns`, identical to the `Param` path.  This
lets the caller decide whether the returned allocation truly escapes its
own scope, enabling stage-3 caller-context propagation.

`compute_return_alloc_summary` is added as a thin wrapper over `analyze`
that surfaces the `states` map (now with `Returns` entries) for use by
the upcoming cross-function propagation pass.

The `returned_vector_escapes` regression test is updated to assert
`Returns` to match the new, more precise classification.

https://claude.ai/code/session_01QKmrNR28njYfPvi1itApok