### PR TITLE
escape: stage-3 caller-context propagation (cross_fn_no_escape)

### DIFF
--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -141,9 +141,12 @@ pub fn inline(ir: IrFunction) -> IrFunction;
    small, non-capturing, non-variadic `defn` in the same compilation unit and
    splices the callee body into the caller.  Runs up to 8 rounds per function,
    bottom-up.  Threshold: ≤ 20 instructions across all callee blocks.
-2. **Escape analysis** (`lower::escape`) — classifies each allocation as
-   `NoEscape`, `ArgEscape`, `Returns`, or `Escapes`.  Inter-procedural via
-   `EscapeContext`.
+2. **Escape analysis** (`lower::escape`) — two-pass analysis.  Pass 1
+   classifies each allocation as `NoEscape`, `ArgEscape`, `Returns`, or
+   `Escapes` (inter-procedural via `EscapeContext`).  Pass 2 (stage-3
+   caller-context propagation) identifies callee allocations that are
+   transitively `NoEscape` at a specific call site and records them in
+   `AnalysisResult::cross_fn_no_escape`, keyed by callee arity-fn-name.
 3. **Region promotion** (`lower::optimize`) — rewrites `NoEscape` allocations
    to `RegionStart` / `RegionAlloc` / `RegionEnd` over the minimal CFG
    subgraph that covers the allocation and all its uses.
@@ -160,9 +163,12 @@ pub enum UseKind { Return, DefVar, SetBang, ClosureCapture, Throw,
                    StoredInHeap, Recur, KnownCallArg{..}, UnknownCallArg{..},
                    PhiInput, BranchCond, Deref, CallCallee }
 pub struct AnalysisResult {
-    pub states:       HashMap<VarId, EscapeState>,
-    pub uses:         HashMap<VarId, Vec<UseInfo>>,
-    pub alloc_blocks: HashMap<VarId, BlockId>,
+    pub states:            HashMap<VarId, EscapeState>,
+    // Stage-3: callee arity-fn-name → callee alloc VarIds that are
+    // transitively NoEscape because the call result is NoEscape here.
+    pub cross_fn_no_escape: HashMap<Arc<str>, HashSet<VarId>>,
+    pub uses:              HashMap<VarId, Vec<UseInfo>>,
+    pub alloc_blocks:      HashMap<VarId, BlockId>,
 }
 ```
 

--- a/crates/cljrs-ir/src/lower/escape.rs
+++ b/crates/cljrs-ir/src/lower/escape.rs
@@ -770,12 +770,11 @@ pub fn analyze(ir_func: &IrFunction, ctx: Option<&EscapeContext>) -> AnalysisRes
                 let Some(callee_fn) = ectx.registry.get(&callee_name) else {
                     continue;
                 };
-                let returns_allocs: HashSet<VarId> =
-                    compute_return_alloc_summary(callee_fn, ectx)
-                        .into_iter()
-                        .filter(|(_, s)| *s == EscapeState::Returns)
-                        .map(|(v, _)| v)
-                        .collect();
+                let returns_allocs: HashSet<VarId> = compute_return_alloc_summary(callee_fn, ectx)
+                    .into_iter()
+                    .filter(|(_, s)| *s == EscapeState::Returns)
+                    .map(|(v, _)| v)
+                    .collect();
                 if !returns_allocs.is_empty() {
                     cross_fn_no_escape
                         .entry(callee_name)

--- a/crates/cljrs-ir/src/lower/escape.rs
+++ b/crates/cljrs-ir/src/lower/escape.rs
@@ -655,14 +655,34 @@ pub(crate) fn classify_escape_with_ctx(
 /// the optimizer (and downstream tooling such as `cljrs-ir-viz`).
 pub struct AnalysisResult {
     pub states: HashMap<VarId, EscapeState>,
+    /// Callee arity-fn-name → set of alloc `VarId`s that are transitively
+    /// `NoEscape` from this caller because the call's return value is
+    /// `NoEscape` here.  Populated only when `ctx` is `Some`.
+    ///
+    /// Produced by the stage-3 caller-context propagation pass.  The VarIds
+    /// live in the *callee's* scope, not the caller's.  Stage 4 uses this
+    /// map to decide which callee variants to clone and region-parameterise.
+    pub cross_fn_no_escape: HashMap<Arc<str>, HashSet<VarId>>,
     pub uses: HashMap<VarId, Vec<UseInfo>>,
     pub alloc_blocks: HashMap<VarId, BlockId>,
 }
 
-/// Run escape analysis on `ir_func`.  When `ctx` is `Some`, inter-procedural
-/// closure-call resolution is enabled (build the context with
-/// [`crate::lower::make_analysis_context`]).
-pub fn analyze(ir_func: &IrFunction, ctx: Option<&EscapeContext>) -> AnalysisResult {
+// ── Pass-1: intra-procedural escape states ───────────────────────────────────
+
+type Pass1Result<'f> = (
+    HashMap<VarId, EscapeState>,
+    HashMap<VarId, Vec<UseInfo>>,
+    HashMap<VarId, BlockId>,
+    HashMap<VarId, &'f Inst>,
+);
+
+/// Compute per-alloc escape states for `ir_func` without cross-function
+/// propagation (pass 1 only).
+///
+/// Returns `(states, uses, alloc_blocks, var_defs)`.  `var_defs` borrows
+/// from `ir_func` and is returned so the caller can reuse it in pass 2
+/// without rebuilding.
+fn analyze_states<'f>(ir_func: &'f IrFunction, ctx: Option<&EscapeContext>) -> Pass1Result<'f> {
     let alloc_blocks = collect_allocs(ir_func);
     let uses = build_use_chains(ir_func);
     let var_defs = build_var_defs(ir_func);
@@ -682,12 +702,10 @@ pub fn analyze(ir_func: &IrFunction, ctx: Option<&EscapeContext>) -> AnalysisRes
         })
         .collect();
 
-    AnalysisResult {
-        states,
-        uses,
-        alloc_blocks,
-    }
+    (states, uses, alloc_blocks, var_defs)
 }
+
+// ── Per-allocation return summary ─────────────────────────────────────────────
 
 /// Per-allocation return summary for a function.
 ///
@@ -695,10 +713,83 @@ pub fn analyze(ir_func: &IrFunction, ctx: Option<&EscapeContext>) -> AnalysisRes
 /// Allocations whose only escape path is a `Return` terminator are classified
 /// as [`EscapeState::Returns`] rather than [`EscapeState::Escapes`], making
 /// it possible for callers to decide whether the value truly escapes.
-#[allow(dead_code)] // used by stage-3 caller-context propagation (not yet implemented)
+///
+/// Calls [`analyze_states`] (pass 1 only) to avoid infinite recursion when
+/// invoked from [`analyze`]'s pass-2 loop.
 pub(crate) fn compute_return_alloc_summary(
     ir_func: &IrFunction,
     ctx: &EscapeContext,
 ) -> HashMap<VarId, EscapeState> {
-    analyze(ir_func, Some(ctx)).states
+    analyze_states(ir_func, Some(ctx)).0
+}
+
+// ── Pass-2: caller-context propagation ───────────────────────────────────────
+
+/// Run escape analysis on `ir_func`.  When `ctx` is `Some`, inter-procedural
+/// closure-call resolution is enabled (build the context with
+/// [`crate::lower::make_analysis_context`]).
+///
+/// Two-pass algorithm:
+/// * **Pass 1** (`analyze_states`) — classify every allocation in the current
+///   function using the worklist-based `classify_escape_with_ctx`.
+/// * **Pass 2** — for every `Call(dst, callee, args)` where `dst` is
+///   `NoEscape` in this function, look up the callee's return-alloc summary
+///   (via `compute_return_alloc_summary`) and record any `Returns`-tagged
+///   allocations in `cross_fn_no_escape`.  This information is consumed by
+///   stage 4's region-parameter-passing transform.
+pub fn analyze(ir_func: &IrFunction, ctx: Option<&EscapeContext>) -> AnalysisResult {
+    let (states, uses, alloc_blocks, var_defs) = analyze_states(ir_func, ctx);
+
+    // Pass 2: caller-context propagation.
+    let mut cross_fn_no_escape: HashMap<Arc<str>, HashSet<VarId>> = HashMap::new();
+    if let Some(ectx) = ctx {
+        for block in &ir_func.blocks {
+            for inst in &block.insts {
+                let Inst::Call(dst, callee, args) = inst else {
+                    continue;
+                };
+                // `states` only contains allocation VarIds, not call-result
+                // VarIds, so classify the call result explicitly.  We reuse
+                // the `uses` chain built in pass 1.
+                let dst_state = classify_escape_with_ctx(
+                    *dst,
+                    &uses,
+                    ir_func,
+                    Some(ectx),
+                    Some(&var_defs),
+                    EscapeMode::Alloc,
+                );
+                if dst_state != EscapeState::NoEscape {
+                    continue;
+                }
+                let Some(callee_name) =
+                    resolve_call_target(*callee, args.len(), &var_defs, &ectx.defn_map)
+                else {
+                    continue;
+                };
+                let Some(callee_fn) = ectx.registry.get(&callee_name) else {
+                    continue;
+                };
+                let returns_allocs: HashSet<VarId> =
+                    compute_return_alloc_summary(callee_fn, ectx)
+                        .into_iter()
+                        .filter(|(_, s)| *s == EscapeState::Returns)
+                        .map(|(v, _)| v)
+                        .collect();
+                if !returns_allocs.is_empty() {
+                    cross_fn_no_escape
+                        .entry(callee_name)
+                        .or_default()
+                        .extend(returns_allocs);
+                }
+            }
+        }
+    }
+
+    AnalysisResult {
+        states,
+        cross_fn_no_escape,
+        uses,
+        alloc_blocks,
+    }
 }

--- a/crates/cljrs-ir/tests/escape_regression.rs
+++ b/crates/cljrs-ir/tests/escape_regression.rs
@@ -12,7 +12,9 @@
 //! These tests use the public Rust ANF lowerer + analyzer, so they run
 //! quickly and don't depend on the embedded Clojure compiler.
 
-use cljrs_ir::lower::{EscapeContext, EscapeState, analyze, lower_fn_body, make_analysis_context, optimize};
+use cljrs_ir::lower::{
+    EscapeContext, EscapeState, analyze, lower_fn_body, make_analysis_context, optimize,
+};
 use cljrs_ir::{Inst, IrFunction};
 use cljrs_reader::Parser;
 use std::sync::Arc;

--- a/crates/cljrs-ir/tests/escape_regression.rs
+++ b/crates/cljrs-ir/tests/escape_regression.rs
@@ -12,7 +12,7 @@
 //! These tests use the public Rust ANF lowerer + analyzer, so they run
 //! quickly and don't depend on the embedded Clojure compiler.
 
-use cljrs_ir::lower::{EscapeState, analyze, lower_fn_body, make_analysis_context, optimize};
+use cljrs_ir::lower::{EscapeContext, EscapeState, analyze, lower_fn_body, make_analysis_context, optimize};
 use cljrs_ir::{Inst, IrFunction};
 use cljrs_reader::Parser;
 use std::sync::Arc;
@@ -174,6 +174,73 @@ fn non_escaping_inline_result_stays_no_escape() {
     assert!(
         region_alloc_count(&optimized) >= 1,
         "inlined triple alloc should be region-promoted; IR:\n{optimized}"
+    );
+}
+
+// ── Stage-3: caller-context propagation tests ────────────────────────────────
+
+/// Walk `ir` and every subfunction recursively; return true if any function's
+/// `analyze` result has a non-empty `cross_fn_no_escape` map.
+fn any_has_cross_fn_no_escape(ir: &cljrs_ir::IrFunction, ctx: &EscapeContext) -> bool {
+    if !analyze(ir, Some(ctx)).cross_fn_no_escape.is_empty() {
+        return true;
+    }
+    ir.subfunctions
+        .iter()
+        .any(|sub| any_has_cross_fn_no_escape(sub, ctx))
+}
+
+#[test]
+fn cross_fn_no_escape_populated_when_return_value_is_local() {
+    // The top-level expression calls make-pair and passes the result straight
+    // to `count` — only an inspection use, so call_dst is NoEscape.
+    // make-pair's AllocVector is classified Returns in isolation (stage 2).
+    // Stage-3 pass-2 should record it in cross_fn_no_escape.
+    //
+    // Note: we do NOT go through `optimize` here so the Call instruction is
+    // still present (inlining would replace it and pass-2 would see nothing).
+    let ir = lower(
+        "(do
+           (defn make-pair [a b] [a b])
+           (count (make-pair 1 2)))",
+    );
+    let ctx = make_analysis_context(&ir);
+    assert!(
+        any_has_cross_fn_no_escape(&ir, &ctx),
+        "make-pair's AllocVector should appear in cross_fn_no_escape; IR:\n{ir}"
+    );
+}
+
+#[test]
+fn cross_fn_no_escape_empty_when_return_value_escapes() {
+    // The top-level returns make-pair's result directly — call_dst is Returns,
+    // not NoEscape, so pass-2 should not record anything.
+    let ir = lower(
+        "(do
+           (defn make-pair [a b] [a b])
+           (make-pair 1 2))",
+    );
+    let ctx = make_analysis_context(&ir);
+    assert!(
+        !any_has_cross_fn_no_escape(&ir, &ctx),
+        "when the call result itself escapes, cross_fn_no_escape must be empty; IR:\n{ir}"
+    );
+}
+
+#[test]
+fn cross_fn_no_escape_covers_all_returns_allocs() {
+    // make-triple returns a 3-element vector; use-triple passes it to count.
+    // All Returns-tagged allocs in make-triple should be captured.
+    let ir = lower(
+        "(do
+           (defn make-triple [a b c] [a b c])
+           (count (make-triple 1 2 3)))",
+    );
+    let ctx = make_analysis_context(&ir);
+    // Check that the analysis (across the tree) picks up make-triple's alloc.
+    assert!(
+        any_has_cross_fn_no_escape(&ir, &ctx),
+        "make-triple's AllocVector should appear in cross_fn_no_escape; IR:\n{ir}"
     );
 }
 


### PR DESCRIPTION
Pass 1 (analyze_states) now returns the var-def map so pass 2 can
reuse it without a second build_var_defs call.

Pass 2 iterates every Call(dst, callee, args) in the caller.  When
classify_escape_with_ctx classifies dst as NoEscape, it fetches the
callee's return-alloc summary via compute_return_alloc_summary (which
calls analyze_states — not analyze — to avoid infinite recursion) and
records any Returns-tagged allocs in
AnalysisResult::cross_fn_no_escape keyed by callee arity-fn-name.

AnalysisResult gains the new cross_fn_no_escape field
(HashMap<Arc<str>, HashSet<VarId>>).  Pass1Result<'f> type alias
silences the clippy::type_complexity warning on analyze_states.

Three new regression tests verify:
- cross_fn_no_escape is populated when the call result is only used by
  an inspection-only known-fn (count).
- cross_fn_no_escape is empty when the call result itself escapes.
- The analysis captures all Returns allocs for a 3-arg callee.

ESCAPE_OPT_PLAN.md stages 1 and 2 were already done; stage 3 is now
complete.  Stage 4 (region-parameter passing) remains.

https://claude.ai/code/session_01ENjvUa9FcobniBRKaHck2W