### PR TITLE
Add versioned symbol resolution and cljrs.edn dependency config (phases 1-7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,14 +312,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cljrs-deps"
+version = "0.1.0"
+dependencies = [
+ "cljrs-gc",
+ "cljrs-reader",
+ "cljrs-types",
+ "thiserror",
+]
+
+[[package]]
 name = "cljrs-env"
 version = "0.1.0"
 dependencies = [
+ "cljrs-deps",
  "cljrs-gc",
  "cljrs-logging",
  "cljrs-reader",
  "cljrs-types",
  "cljrs-value",
+ "cljrs-vcs",
  "log",
  "thiserror",
 ]
@@ -371,6 +383,7 @@ dependencies = [
  "cljrs-reader",
  "cljrs-types",
  "cljrs-value",
+ "cljrs-vcs",
  "regex",
  "uuid",
 ]
@@ -476,6 +489,13 @@ dependencies = [
  "rpds",
  "thiserror",
  "uuid",
+]
+
+[[package]]
+name = "cljrs-vcs"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ members = [
     "crates/cljrs-builtins",
     "crates/cljrs-interp",
     "crates/cljrs-ir-prebuild",
-    "crates/cljrs-ir-viz"]
+    "crates/cljrs-ir-viz",
+    "crates/cljrs-deps",
+    "crates/cljrs-vcs"]
 resolver = "2"
 
 [workspace.package]
@@ -41,6 +43,8 @@ cljrs-builtins = { path = "crates/cljrs-builtins", version = "0.1.0" }
 cljrs-interp   = { path = "crates/cljrs-interp",   version = "0.1.0" }
 cljrs-ir-prebuild = { path = "crates/cljrs-ir-prebuild", version = "0.1.0" }
 cljrs-ir-viz  = { path = "crates/cljrs-ir-viz",  version = "0.1.0" }
+cljrs-deps    = { path = "crates/cljrs-deps",    version = "0.1.0" }
+cljrs-vcs     = { path = "crates/cljrs-vcs",     version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,190 @@
+# Versioned Function Resolution
+
+This document tracks the design and implementation progress of two related
+features: **versioned symbol resolution** and the **`cljrs.edn` dependency
+configuration file**.
+
+## Overview
+
+Symbols in ClojuRust source can carry a git-commit suffix:
+
+```clojure
+my-fn@abc1234          ; unqualified versioned symbol
+my.ns/my-fn@abc1234    ; namespace-qualified versioned symbol
+```
+
+Whole namespaces can also be required at a specific commit:
+
+```clojure
+(require '[my.lib@abc1234 :as lib-v1])
+(require '[my.lib         :as lib   ])   ; HEAD
+
+(lib/some-fn x)      ; current version
+(lib-v1/some-fn x)   ; pinned version
+```
+
+This lets callers pin to a historical implementation without the defining
+codebase needing to maintain the old code alongside the new.
+
+---
+
+## `cljrs.edn` — project configuration
+
+Discovered by walking up the directory tree from the working directory.  Format
+is valid ClojuRust EDN:
+
+```clojure
+{:paths ["src" "resources"]
+
+ :deps
+ {my.lib {:git/url "https://github.com/user/my-lib"
+           :git/sha "abc1234ef"}
+  vendor.utils {:local/root "../vendor/utils"}}
+
+ :aliases
+ {:dev  {:extra-paths ["dev"]}
+  :test {:extra-paths ["test"]
+         :extra-deps  {test-tools {:git/url "..." :git/sha "..."}}}}}
+```
+
+Git dependencies are cached locally in `~/.cljrs/cache/git/`.  No implicit
+network access: the user must run `cljrs deps fetch` before git deps are
+usable.
+
+---
+
+## Propagation semantics
+
+When a function body is evaluated in a versioned context (commit `C`):
+
+| Symbol form                        | Resolved at          |
+|------------------------------------|----------------------|
+| Unqualified / same-namespace, no `@` | Commit `C` (inherited) |
+| Explicitly versioned `foo@D`       | Commit `D`           |
+| External / cross-namespace, no `@` | HEAD (current)       |
+
+This means a versioned call is a logical "snapshot": internal helpers are also
+drawn from the same commit, but the standard library and cross-namespace
+dependencies use their current values unless explicitly pinned.
+
+---
+
+## Architecture
+
+### New crates
+
+| Crate        | Responsibility |
+|--------------|----------------|
+| `cljrs-deps` | Parse `cljrs.edn`, `DepsConfig` / `Dependency` types, config discovery |
+| `cljrs-vcs`  | Git subprocess helpers: `find_repo_root`, `get_file_at_commit`, commit-hash validation, cache layout |
+
+### Modified crates
+
+| Crate            | Changes |
+|------------------|---------|
+| `cljrs-value`    | `Symbol` gains `version: Option<Arc<str>>`; `Symbol::parse` splits on `@`; `Namespace` gains `source_file`, `git_repo_root`, `is_versioned` |
+| `cljrs-reader`   | `lex_symbol` peeks for `@<hex>` suffix and embeds it in the symbol string |
+| `cljrs-env`      | `RequireSpec` gains `version`; `GlobalEnv` gains `version_cache` and `deps_config`; `Env` gains `versioned_eval_commit` and `lookup_local_frames`; `loader.rs` gains `load_versioned_ns` |
+| `cljrs-interp`   | `eval_symbol` dispatches versioned symbols; `resolve_versioned_symbol` function added |
+| `cljrs-builtins` / `cljrs-interp special.rs` | `parse_require_spec_val` / `parse_require_spec_form` extract version from namespace symbol |
+| `cljrs` (CLI)    | Load `cljrs.edn` at startup; `cljrs deps fetch/status` subcommands |
+
+---
+
+## Implementation phases and status
+
+| # | Phase | Crate(s) touched | Status |
+|---|-------|------------------|--------|
+| 1 | `cljrs-deps` crate — config types and `cljrs.edn` parser | `cljrs-deps` (new) | ✅ Done |
+| 2 | `cljrs-vcs` crate — git subprocess helpers | `cljrs-vcs` (new) | ✅ Done |
+| 3 | `Symbol.version`, `Namespace` git fields | `cljrs-value` | ✅ Done |
+| 4 | Lexer `@hash` recognition | `cljrs-reader` | ✅ Done |
+| 5 | `RequireSpec.version`, `GlobalEnv` version cache, `Env.versioned_eval_commit` | `cljrs-env` | ✅ Done |
+| 6 | `eval_symbol` versioned dispatch, `resolve_versioned_symbol`, `load_versioned_ns` | `cljrs-interp` | ✅ Done |
+| 7 | `parse_require_spec_*` version extraction | `cljrs-interp` special forms | ✅ Done |
+| 8 | CLI: startup config load, `deps fetch/status` | `cljrs` | 🔲 Todo |
+
+---
+
+## Key data structures (as implemented)
+
+### `Symbol` (cljrs-value)
+```rust
+pub struct Symbol {
+    pub namespace: Option<Arc<str>>,
+    pub name: Arc<str>,
+    pub version: Option<Arc<str>>,   // e.g. "abc1234"
+}
+```
+`Symbol::parse("ns/my-fn@abc1234")` → `{ namespace: Some("ns"), name: "my-fn", version: Some("abc1234") }`
+
+### `Namespace` (cljrs-value)
+```rust
+pub struct Namespace {
+    pub name: Arc<str>,
+    pub interns: Mutex<HashMap<Arc<str>, GcPtr<Var>>>,
+    pub refers:  Mutex<HashMap<Arc<str>, GcPtr<Var>>>,
+    pub aliases: Mutex<HashMap<Arc<str>, Arc<str>>>,
+    pub source_file:   Mutex<Option<Arc<str>>>,
+    pub git_repo_root: Mutex<Option<Arc<str>>>,
+    pub is_versioned:  bool,
+}
+```
+
+### `RequireSpec` (cljrs-env)
+```rust
+pub struct RequireSpec {
+    pub ns:      Arc<str>,
+    pub version: Option<Arc<str>>,   // present for `my.ns@abc1234`
+    pub alias:   Option<Arc<str>>,
+    pub refer:   RequireRefer,
+}
+```
+
+### `Env` (cljrs-env)
+```rust
+pub struct Env {
+    pub frames:                Vec<Frame>,
+    pub current_ns:            Arc<str>,
+    pub globals:               Arc<GlobalEnv>,
+    pub versioned_eval_commit: Option<Arc<str>>,
+}
+```
+
+### `GlobalEnv` additions (cljrs-env)
+```rust
+pub version_cache: Mutex<HashMap<Arc<str>, Value>>,
+// key: "<ns>/<name>@<commit>"
+pub deps_config: RwLock<Option<Arc<DepsConfig>>>,
+```
+
+### `DepsConfig` (cljrs-deps)
+```rust
+pub struct DepsConfig {
+    pub paths:   Vec<PathBuf>,
+    pub deps:    Vec<(String, Dependency)>,
+    pub aliases: Vec<(String, Alias)>,
+}
+pub enum Dependency {
+    Git   { url: String, sha: String },
+    Local { root: PathBuf },
+}
+```
+
+---
+
+## CLI commands (phase 8)
+
+```
+cljrs deps fetch              # clone/update all git deps
+cljrs deps fetch <dep-name>   # fetch one dep by name
+cljrs deps status             # show cached vs missing deps
+```
+
+Network access is always opt-in.  If a versioned symbol or namespace requires a
+git dep that is not cached, the runtime returns a clear error:
+
+```
+error: dependency 'my.lib' is not cached locally.
+       run `cljrs deps fetch` to download it.
+```

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -6833,10 +6833,7 @@ fn builtin_namespace_q(args: &[Value]) -> ValueResult<Value> {
 fn builtin_ns_name(args: &[Value]) -> ValueResult<Value> {
     let ns = ns_from_arg(&args[0])?;
     let name = ns.get().name.clone();
-    Ok(Value::Symbol(cljrs_gc::GcPtr::new(Symbol {
-        namespace: None,
-        name,
-    })))
+    Ok(Value::symbol(Symbol::simple(name)))
 }
 
 /// `(ns-interns ns)` — map of unqualified Symbol → Var for all interned vars.
@@ -6845,10 +6842,7 @@ fn builtin_ns_interns(args: &[Value]) -> ValueResult<Value> {
     let interns = ns.get().interns.lock().unwrap();
     let mut m = MapValue::empty();
     for (name, var) in interns.iter() {
-        let sym = Value::Symbol(cljrs_gc::GcPtr::new(Symbol {
-            namespace: None,
-            name: name.clone(),
-        }));
+        let sym = Value::symbol(Symbol::simple(name.clone()));
         m = m.assoc(sym, Value::Var(var.clone()));
     }
     Ok(Value::Map(m))
@@ -6860,10 +6854,7 @@ fn builtin_ns_refers(args: &[Value]) -> ValueResult<Value> {
     let refers = ns.get().refers.lock().unwrap();
     let mut m = MapValue::empty();
     for (name, var) in refers.iter() {
-        let sym = Value::Symbol(cljrs_gc::GcPtr::new(Symbol {
-            namespace: None,
-            name: name.clone(),
-        }));
+        let sym = Value::symbol(Symbol::simple(name.clone()));
         m = m.assoc(sym, Value::Var(var.clone()));
     }
     Ok(Value::Map(m))
@@ -6878,10 +6869,7 @@ fn builtin_ns_map(args: &[Value]) -> ValueResult<Value> {
     {
         let refers = ns.get().refers.lock().unwrap();
         for (name, var) in refers.iter() {
-            let sym = Value::Symbol(cljrs_gc::GcPtr::new(Symbol {
-                namespace: None,
-                name: name.clone(),
-            }));
+            let sym = Value::symbol(Symbol::simple(name.clone()));
             m = m.assoc(sym, Value::Var(var.clone()));
         }
     }
@@ -6889,10 +6877,7 @@ fn builtin_ns_map(args: &[Value]) -> ValueResult<Value> {
     {
         let interns = ns.get().interns.lock().unwrap();
         for (name, var) in interns.iter() {
-            let sym = Value::Symbol(cljrs_gc::GcPtr::new(Symbol {
-                namespace: None,
-                name: name.clone(),
-            }));
+            let sym = Value::symbol(Symbol::simple(name.clone()));
             m = m.assoc(sym, Value::Var(var.clone()));
         }
     }

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -242,10 +242,7 @@ pub unsafe extern "C" fn rt_const_keyword(ptr: *const u8, len: u64) -> *const Va
 pub unsafe extern "C" fn rt_const_symbol(ptr: *const u8, len: u64) -> *const Value {
     let bytes = unsafe { std::slice::from_raw_parts(ptr, len as *const () as usize) };
     let name = std::str::from_utf8(bytes).unwrap_or("??");
-    box_val(Value::Symbol(GcPtr::new(Symbol {
-        namespace: None,
-        name: Arc::from(name),
-    })))
+    box_val(Value::symbol(Symbol::simple(name)))
 }
 
 // ── Truthiness ──────────────────────────────────────────────────────────────

--- a/crates/cljrs-deps/Cargo.toml
+++ b/crates/cljrs-deps/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cljrs-deps"
+version = "0.1.0"
+edition = "2024"
+description = "cljrs.edn project configuration parser and dependency model"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cljrs-types  = { workspace = true }
+cljrs-gc     = { workspace = true }
+cljrs-reader = { workspace = true }
+thiserror    = { workspace = true }

--- a/crates/cljrs-deps/README.md
+++ b/crates/cljrs-deps/README.md
@@ -1,0 +1,49 @@
+# cljrs-deps
+
+## Purpose
+
+Parses `cljrs.edn` project configuration files and provides the `DepsConfig`
+type used throughout the runtime to locate git-hosted and local dependencies.
+
+## Status
+
+Phase 1 (implemented).  Config parsing is complete.  Integration with the CLI
+(`cljrs deps fetch/status`) is Phase 8 (todo).
+
+## File layout
+
+| File | Description |
+|------|-------------|
+| `src/lib.rs` | Public types (`DepsConfig`, `Dependency`, `Alias`, `GitDep`), `find_config_file`, `load_config` |
+| `src/parse.rs` | Walk the `cljrs-reader` Form tree from a `cljrs.edn` source into `DepsConfig` |
+
+## Public API
+
+```rust
+/// Find the nearest `cljrs.edn` by walking up from `start`.
+pub fn find_config_file(start: &Path) -> Option<PathBuf>
+
+/// Load and parse the nearest `cljrs.edn`, returning None if absent.
+pub fn load_config(start: &Path) -> DepsResult<Option<DepsConfig>>
+
+/// Parse `cljrs.edn` source text directly (used in tests / CLI).
+pub fn parse_config(src: &str, config_path: &Path) -> Result<DepsConfig, String>
+
+pub struct DepsConfig {
+    pub paths:   Vec<PathBuf>,
+    pub deps:    Vec<(Arc<str>, Dependency)>,
+    pub aliases: Vec<(Arc<str>, Alias)>,
+}
+
+pub enum Dependency {
+    Git(GitDep),
+    Local { root: PathBuf },
+}
+
+pub struct GitDep { pub url: Arc<str>, pub sha: Arc<str> }
+
+pub struct Alias {
+    pub extra_paths: Vec<PathBuf>,
+    pub extra_deps:  Vec<(Arc<str>, Dependency)>,
+}
+```

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -49,7 +49,9 @@ pub struct GitDep {
 pub enum Dependency {
     Git(GitDep),
     /// A local directory on disk, resolved relative to the `cljrs.edn` file.
-    Local { root: PathBuf },
+    Local {
+        root: PathBuf,
+    },
 }
 
 /// A single alias entry from the `:aliases` map.
@@ -106,8 +108,7 @@ pub fn load_config(start: &Path) -> DepsResult<Option<DepsConfig>> {
         None => Ok(None),
         Some(path) => {
             let src = std::fs::read_to_string(&path)?;
-            let config = parse_config(&src, &path)
-                .map_err(DepsError::Parse)?;
+            let config = parse_config(&src, &path).map_err(DepsError::Parse)?;
             Ok(Some(config))
         }
     }

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -1,0 +1,114 @@
+//! `cljrs.edn` project configuration: types, parser, and discovery.
+//!
+//! # Format
+//!
+//! ```edn
+//! {:paths ["src" "resources"]
+//!
+//!  :deps
+//!  {my.lib      {:git/url "https://github.com/user/my-lib" :git/sha "abc1234ef"}
+//!   local.utils {:local/root "../local-utils"}}
+//!
+//!  :aliases
+//!  {:dev  {:extra-paths ["dev"]}
+//!   :test {:extra-paths ["test"]
+//!          :extra-deps  {test-tools {:git/url "..." :git/sha "..."}}}}}
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use thiserror::Error;
+
+mod parse;
+pub use parse::parse_config;
+
+// ── Error ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Error)]
+pub enum DepsError {
+    #[error("could not read cljrs.edn: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("parse error in cljrs.edn: {0}")]
+    Parse(String),
+}
+
+pub type DepsResult<T> = Result<T, DepsError>;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// A git-hosted dependency with a pinned commit SHA.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitDep {
+    pub url: Arc<str>,
+    pub sha: Arc<str>,
+}
+
+/// A dependency declared in `:deps` or `:extra-deps`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Dependency {
+    Git(GitDep),
+    /// A local directory on disk, resolved relative to the `cljrs.edn` file.
+    Local { root: PathBuf },
+}
+
+/// A single alias entry from the `:aliases` map.
+#[derive(Debug, Clone, Default)]
+pub struct Alias {
+    pub extra_paths: Vec<PathBuf>,
+    pub extra_deps: Vec<(Arc<str>, Dependency)>,
+}
+
+/// The fully parsed contents of a `cljrs.edn` file.
+#[derive(Debug, Clone, Default)]
+pub struct DepsConfig {
+    /// Source/resource paths relative to the `cljrs.edn` file.
+    pub paths: Vec<PathBuf>,
+    /// Project-level dependency declarations.
+    pub deps: Vec<(Arc<str>, Dependency)>,
+    /// Named aliases (e.g. `:dev`, `:test`).
+    pub aliases: Vec<(Arc<str>, Alias)>,
+}
+
+impl DepsConfig {
+    /// Find a dependency by namespace-prefix name.
+    pub fn find_dep(&self, name: &str) -> Option<&Dependency> {
+        self.deps
+            .iter()
+            .find(|(n, _)| n.as_ref() == name)
+            .map(|(_, d)| d)
+    }
+}
+
+// ── Discovery ─────────────────────────────────────────────────────────────────
+
+/// Walk up the directory tree from `start`, returning the path of the first
+/// `cljrs.edn` file found, or `None` if no config exists in any ancestor.
+pub fn find_config_file(start: &Path) -> Option<PathBuf> {
+    let mut dir: &Path = if start.is_file() {
+        start.parent()?
+    } else {
+        start
+    };
+    loop {
+        let candidate = dir.join("cljrs.edn");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// Load and parse the `cljrs.edn` closest to `start`, returning `None` if
+/// no config file is found.
+pub fn load_config(start: &Path) -> DepsResult<Option<DepsConfig>> {
+    match find_config_file(start) {
+        None => Ok(None),
+        Some(path) => {
+            let src = std::fs::read_to_string(&path)?;
+            let config = parse_config(&src, &path)
+                .map_err(DepsError::Parse)?;
+            Ok(Some(config))
+        }
+    }
+}

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -1,0 +1,211 @@
+//! Walk the `cljrs-reader` Form tree produced from a `cljrs.edn` source
+//! and construct a `DepsConfig`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cljrs_reader::{Form, FormKind, Parser};
+
+use crate::{Alias, Dependency, DepsConfig, GitDep};
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Parse `src` (the text of a `cljrs.edn` file located at `config_path`) into
+/// a `DepsConfig`.  `config_path` is used only for resolving `:local/root`
+/// paths relative to the config directory.
+pub fn parse_config(src: &str, config_path: &Path) -> Result<DepsConfig, String> {
+    let config_dir = config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+
+    let mut parser = Parser::new(src.to_owned(), config_path.display().to_string());
+    let forms = parser.parse_all().map_err(|e| e.to_string())?;
+
+    // The file must contain exactly one top-level form: a map.
+    if forms.len() != 1 {
+        return Err(format!(
+            "cljrs.edn must contain exactly one top-level map; found {} forms",
+            forms.len()
+        ));
+    }
+
+    extract_config(&forms[0], config_dir)
+}
+
+// ── Top-level map ─────────────────────────────────────────────────────────────
+
+fn extract_config(form: &Form, config_dir: &Path) -> Result<DepsConfig, String> {
+    let pairs = require_map(form, "top-level cljrs.edn")?;
+    let mut config = DepsConfig::default();
+
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        let key = &pairs[i];
+        let val = &pairs[i + 1];
+        i += 2;
+
+        match keyword_name(key) {
+            Some("paths") => {
+                config.paths = extract_path_vec(val, ":paths", config_dir)?;
+            }
+            Some("deps") => {
+                config.deps = extract_deps_map(val, config_dir)?;
+            }
+            Some("aliases") => {
+                config.aliases = extract_aliases_map(val, config_dir)?;
+            }
+            _ => {} // ignore unknown keys
+        }
+    }
+
+    Ok(config)
+}
+
+// ── :paths ────────────────────────────────────────────────────────────────────
+
+fn extract_path_vec(form: &Form, ctx: &str, base: &Path) -> Result<Vec<PathBuf>, String> {
+    let items = require_vec(form, ctx)?;
+    items
+        .iter()
+        .map(|f| {
+            let s = require_str(f, ctx)?;
+            Ok(base.join(s))
+        })
+        .collect()
+}
+
+// ── :deps ─────────────────────────────────────────────────────────────────────
+
+fn extract_deps_map(
+    form: &Form,
+    config_dir: &Path,
+) -> Result<Vec<(Arc<str>, Dependency)>, String> {
+    let pairs = require_map(form, ":deps")?;
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        let name = sym_or_kw_name(&pairs[i])
+            .ok_or_else(|| format!(":deps key must be a symbol, got {:?}", pairs[i].kind))?;
+        let dep = extract_dependency(&pairs[i + 1], config_dir, &name)?;
+        out.push((Arc::from(name), dep));
+        i += 2;
+    }
+    Ok(out)
+}
+
+fn extract_dependency(
+    form: &Form,
+    config_dir: &Path,
+    name: &str,
+) -> Result<Dependency, String> {
+    let pairs = require_map(form, &format!("dep {name}"))?;
+    let mut git_url: Option<Arc<str>> = None;
+    let mut git_sha: Option<Arc<str>> = None;
+    let mut local_root: Option<PathBuf> = None;
+
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        match keyword_name(&pairs[i]) {
+            Some("git/url") => {
+                git_url = Some(Arc::from(require_str(&pairs[i + 1], "git/url")?));
+            }
+            Some("git/sha") => {
+                git_sha = Some(Arc::from(require_str(&pairs[i + 1], "git/sha")?));
+            }
+            Some("local/root") => {
+                let rel = require_str(&pairs[i + 1], "local/root")?;
+                local_root = Some(config_dir.join(rel));
+            }
+            _ => {}
+        }
+        i += 2;
+    }
+
+    match (git_url, git_sha, local_root) {
+        (Some(url), Some(sha), _) => Ok(Dependency::Git(GitDep { url, sha })),
+        (_, _, Some(root)) => Ok(Dependency::Local { root }),
+        _ => Err(format!(
+            "dep {name}: must specify either :git/url + :git/sha or :local/root"
+        )),
+    }
+}
+
+// ── :aliases ──────────────────────────────────────────────────────────────────
+
+fn extract_aliases_map(
+    form: &Form,
+    config_dir: &Path,
+) -> Result<Vec<(Arc<str>, Alias)>, String> {
+    let pairs = require_map(form, ":aliases")?;
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        let name = keyword_name(&pairs[i])
+            .ok_or_else(|| ":aliases key must be a keyword".to_string())?
+            .to_owned();
+        let alias = extract_alias(&pairs[i + 1], config_dir, &name)?;
+        out.push((Arc::from(name), alias));
+        i += 2;
+    }
+    Ok(out)
+}
+
+fn extract_alias(form: &Form, config_dir: &Path, name: &str) -> Result<Alias, String> {
+    let pairs = require_map(form, &format!("alias :{name}"))?;
+    let mut alias = Alias::default();
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        match keyword_name(&pairs[i]) {
+            Some("extra-paths") => {
+                alias.extra_paths =
+                    extract_path_vec(&pairs[i + 1], ":extra-paths", config_dir)?;
+            }
+            Some("extra-deps") => {
+                alias.extra_deps = extract_deps_map(&pairs[i + 1], config_dir)?;
+            }
+            _ => {}
+        }
+        i += 2;
+    }
+    Ok(alias)
+}
+
+// ── Form helpers ──────────────────────────────────────────────────────────────
+
+fn require_map<'a>(form: &'a Form, ctx: &str) -> Result<&'a Vec<Form>, String> {
+    match &form.kind {
+        FormKind::Map(pairs) => Ok(pairs),
+        _ => Err(format!("{ctx}: expected a map, got {:?}", form.kind)),
+    }
+}
+
+fn require_vec<'a>(form: &'a Form, ctx: &str) -> Result<&'a Vec<Form>, String> {
+    match &form.kind {
+        FormKind::Vector(items) => Ok(items),
+        _ => Err(format!("{ctx}: expected a vector, got {:?}", form.kind)),
+    }
+}
+
+fn require_str<'a>(form: &'a Form, ctx: &str) -> Result<&'a str, String> {
+    match &form.kind {
+        FormKind::Str(s) => Ok(s.as_str()),
+        _ => Err(format!("{ctx}: expected a string, got {:?}", form.kind)),
+    }
+}
+
+/// Extract the name from a `:keyword` form (without the leading colon).
+fn keyword_name(form: &Form) -> Option<&str> {
+    match &form.kind {
+        FormKind::Keyword(k) => Some(k.as_str()),
+        _ => None,
+    }
+}
+
+/// Extract the string content from either a `Symbol` or `Keyword` form.
+fn sym_or_kw_name(form: &Form) -> Option<String> {
+    match &form.kind {
+        FormKind::Symbol(s) => Some(s.clone()),
+        FormKind::Keyword(k) => Some(k.clone()),
+        _ => None,
+    }
+}

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -14,9 +14,7 @@ use crate::{Alias, Dependency, DepsConfig, GitDep};
 /// a `DepsConfig`.  `config_path` is used only for resolving `:local/root`
 /// paths relative to the config directory.
 pub fn parse_config(src: &str, config_path: &Path) -> Result<DepsConfig, String> {
-    let config_dir = config_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."));
+    let config_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
 
     let mut parser = Parser::new(src.to_owned(), config_path.display().to_string());
     let forms = parser.parse_all().map_err(|e| e.to_string())?;
@@ -76,10 +74,7 @@ fn extract_path_vec(form: &Form, ctx: &str, base: &Path) -> Result<Vec<PathBuf>,
 
 // ── :deps ─────────────────────────────────────────────────────────────────────
 
-fn extract_deps_map(
-    form: &Form,
-    config_dir: &Path,
-) -> Result<Vec<(Arc<str>, Dependency)>, String> {
+fn extract_deps_map(form: &Form, config_dir: &Path) -> Result<Vec<(Arc<str>, Dependency)>, String> {
     let pairs = require_map(form, ":deps")?;
     let mut out = Vec::new();
     let mut i = 0;
@@ -93,11 +88,7 @@ fn extract_deps_map(
     Ok(out)
 }
 
-fn extract_dependency(
-    form: &Form,
-    config_dir: &Path,
-    name: &str,
-) -> Result<Dependency, String> {
+fn extract_dependency(form: &Form, config_dir: &Path, name: &str) -> Result<Dependency, String> {
     let pairs = require_map(form, &format!("dep {name}"))?;
     let mut git_url: Option<Arc<str>> = None;
     let mut git_sha: Option<Arc<str>> = None;
@@ -132,10 +123,7 @@ fn extract_dependency(
 
 // ── :aliases ──────────────────────────────────────────────────────────────────
 
-fn extract_aliases_map(
-    form: &Form,
-    config_dir: &Path,
-) -> Result<Vec<(Arc<str>, Alias)>, String> {
+fn extract_aliases_map(form: &Form, config_dir: &Path) -> Result<Vec<(Arc<str>, Alias)>, String> {
     let pairs = require_map(form, ":aliases")?;
     let mut out = Vec::new();
     let mut i = 0;
@@ -157,8 +145,7 @@ fn extract_alias(form: &Form, config_dir: &Path, name: &str) -> Result<Alias, St
     while i + 1 < pairs.len() {
         match keyword_name(&pairs[i]) {
             Some("extra-paths") => {
-                alias.extra_paths =
-                    extract_path_vec(&pairs[i + 1], ":extra-paths", config_dir)?;
+                alias.extra_paths = extract_path_vec(&pairs[i + 1], ":extra-paths", config_dir)?;
             }
             Some("extra-deps") => {
                 alias.extra_deps = extract_deps_map(&pairs[i + 1], config_dir)?;

--- a/crates/cljrs-env/Cargo.toml
+++ b/crates/cljrs-env/Cargo.toml
@@ -15,5 +15,7 @@ cljrs-gc      = { workspace = true }
 cljrs-reader  = { workspace = true }
 cljrs-value   = { workspace = true }
 cljrs-logging = { workspace = true }
+cljrs-deps    = { workspace = true }
+cljrs-vcs     = { workspace = true }
 log = "0.4.29"
 thiserror = "2.0.18"

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -22,6 +22,8 @@ pub enum RequireRefer {
 #[derive(Debug, Clone)]
 pub struct RequireSpec {
     pub ns: Arc<str>,
+    /// Present when the namespace symbol carried a `@<hash>` version suffix.
+    pub version: Option<Arc<str>>,
     pub alias: Option<Arc<str>>,
     pub refer: RequireRefer,
 }
@@ -92,6 +94,12 @@ pub struct GlobalEnv {
     pub call_cljrs_fn: fn(&CljxFn, &[Value], &mut Env) -> EvalResult,
     /// Hook for customization when a new fn* is defined.
     on_fn_defined: Option<fn(&CljxFn, &mut Env)>,
+    /// Cache of values resolved at a specific commit.
+    /// Key format: `"<ns>/<name>@<commit>"` for individual vars,
+    /// or `"<ns>@<commit>"` for whole versioned namespaces.
+    pub version_cache: Mutex<HashMap<Arc<str>, Value>>,
+    /// Parsed `cljrs.edn` config, loaded once at startup.
+    pub deps_config: RwLock<Option<Arc<cljrs_deps::DepsConfig>>>,
 }
 
 impl std::fmt::Debug for GlobalEnv {
@@ -118,6 +126,8 @@ impl GlobalEnv {
             eval_fn,
             call_cljrs_fn,
             on_fn_defined,
+            version_cache: Mutex::new(HashMap::new()),
+            deps_config: RwLock::new(None),
         })
     }
 
@@ -324,6 +334,36 @@ impl GlobalEnv {
     pub fn set_on_fn_defined(&mut self, hook: fn(&CljxFn, &mut Env)) {
         self.on_fn_defined = Some(hook);
     }
+
+    /// Return `(source_file, git_repo_root)` for the named namespace, if
+    /// both have been populated by the loader.
+    pub fn get_ns_git_context(&self, ns_name: &str) -> Option<(Arc<str>, Arc<str>)> {
+        let map = self.namespaces.read().unwrap();
+        let ns = map.get(ns_name)?;
+        let ns_ref = ns.get();
+        let file = ns_ref.source_file.lock().unwrap().clone()?;
+        let repo = ns_ref.git_repo_root.lock().unwrap().clone()?;
+        Some((file, repo))
+    }
+
+    /// Store a resolved versioned value in the cache.
+    /// Key: `"<ns>/<name>@<commit>"`.
+    pub fn cache_versioned(&self, ns: &str, name: &str, commit: &str, val: Value) {
+        let key: Arc<str> = Arc::from(format!("{ns}/{name}@{commit}"));
+        self.version_cache.lock().unwrap().insert(key, val);
+    }
+
+    /// Retrieve a previously resolved versioned value, if cached.
+    pub fn get_cached_versioned(&self, ns: &str, name: &str, commit: &str) -> Option<Value> {
+        let key = format!("{ns}/{name}@{commit}");
+        self.version_cache.lock().unwrap().get(key.as_str()).cloned()
+    }
+
+    /// Mark namespace `name@commit` as loaded in the standard loaded set.
+    pub fn cache_versioned_ns(&self, ns: &str, commit: &str) {
+        let key: Arc<str> = Arc::from(format!("{ns}@{commit}"));
+        self.version_cache.lock().unwrap().insert(key, Value::Nil);
+    }
 }
 
 // ── Env ───────────────────────────────────────────────────────────────────────
@@ -333,6 +373,10 @@ pub struct Env {
     pub frames: Vec<Frame>,
     pub current_ns: Arc<str>,
     pub globals: Arc<GlobalEnv>,
+    /// When set, unversioned same-namespace symbol lookups implicitly resolve
+    /// at this commit hash instead of HEAD.  Set by the versioned resolver when
+    /// evaluating a function body fetched from git history.
+    pub versioned_eval_commit: Option<Arc<str>>,
 }
 
 impl Env {
@@ -341,6 +385,15 @@ impl Env {
             frames: Vec::new(),
             current_ns: Arc::from(ns),
             globals,
+            versioned_eval_commit: None,
+        }
+    }
+
+    /// Create an Env for evaluating source at a specific commit.
+    pub fn new_versioned(globals: Arc<GlobalEnv>, ns: &str, commit: &str) -> Self {
+        Self {
+            versioned_eval_commit: Some(Arc::from(commit)),
+            ..Self::new(globals, ns)
         }
     }
 
@@ -382,6 +435,18 @@ impl Env {
             }
         }
         self.globals.lookup_in_ns(&self.current_ns, name)
+    }
+
+    /// Look up `name` in local frames only — does **not** fall back to the
+    /// global namespace.  Used by the versioned resolver to check for local
+    /// bindings before applying commit inheritance.
+    pub fn lookup_local_frames(&self, name: &str) -> Option<Value> {
+        for frame in self.frames.iter().rev() {
+            if let Some(v) = frame.lookup(name) {
+                return Some(v.clone());
+            }
+        }
+        None
     }
 
     /// Look up the Var object for `name` in the current namespace.

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -356,7 +356,11 @@ impl GlobalEnv {
     /// Retrieve a previously resolved versioned value, if cached.
     pub fn get_cached_versioned(&self, ns: &str, name: &str, commit: &str) -> Option<Value> {
         let key = format!("{ns}/{name}@{commit}");
-        self.version_cache.lock().unwrap().get(key.as_str()).cloned()
+        self.version_cache
+            .lock()
+            .unwrap()
+            .get(key.as_str())
+            .cloned()
     }
 
     /// Mark namespace `name@commit` as loaded in the standard loaded set.

--- a/crates/cljrs-env/src/loader.rs
+++ b/crates/cljrs-env/src/loader.rs
@@ -1,5 +1,6 @@
 //! Namespace file loader: resolves `require` to source files and evaluates them.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::env::{Env, GlobalEnv, RequireRefer, RequireSpec};
@@ -14,7 +15,14 @@ use crate::error::{EvalError, EvalResult};
 /// - Cross-thread coordination: if a *different* thread is loading `spec.ns`,
 ///   waits for it to finish (via `GlobalEnv::loading_done`) instead of
 ///   reporting a spurious "circular require" error.
+/// - Versioned require: if `spec.version` is set, delegates to
+///   `load_versioned_ns` which fetches source at the given commit.
 pub fn load_ns(globals: Arc<GlobalEnv>, spec: &RequireSpec, current_ns: &str) -> EvalResult<()> {
+    // Versioned require: delegate entirely to the versioned loader.
+    if let Some(ref commit) = spec.version {
+        return load_versioned_ns(globals, spec, commit, current_ns);
+    }
+
     let ns_name = &spec.ns;
 
     if !globals.is_loaded(ns_name) {
@@ -100,6 +108,17 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
         })?
     };
 
+    // Record source location on the namespace for versioned resolution.
+    // Only meaningful for real files (not builtins).
+    if !file_path.starts_with("<builtin:") {
+        let repo_root = cljrs_vcs::find_repo_root(Path::new(&file_path))
+            .map(|p| p.display().to_string());
+        let ns_ptr = globals.get_or_create_ns(ns_name);
+        ns_ptr
+            .get()
+            .set_source_location(&file_path, repo_root.as_deref());
+    }
+
     // Pre-refer clojure.core so code in the file can use core fns before (ns ...).
     if ns_name.as_ref() != "clojure.core" {
         globals.refer_all(ns_name, "clojure.core");
@@ -132,6 +151,121 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
     }
 
     Ok(())
+}
+
+// ── Versioned namespace loading ───────────────────────────────────────────────
+
+/// Load `spec.ns` at `commit`, registering the result as the namespace
+/// `"<spec.ns>@<commit>"` in the global namespace table.
+///
+/// Idempotent: if the versioned namespace is already loaded, only applies the
+/// alias/refer from `spec` in `current_ns`.
+pub fn load_versioned_ns(
+    globals: Arc<GlobalEnv>,
+    spec: &RequireSpec,
+    commit: &str,
+    current_ns: &str,
+) -> EvalResult<()> {
+    let base_ns = &spec.ns;
+    let versioned_ns_name: Arc<str> = Arc::from(format!("{base_ns}@{commit}"));
+
+    if globals.is_loaded(&versioned_ns_name) {
+        apply_alias_refer(&globals, &versioned_ns_name, current_ns, spec);
+        return Ok(());
+    }
+
+    // Locate the source file for the base namespace.
+    let rel_path = base_ns.replace('.', "/").replace('-', "_");
+    let src_paths = globals.source_paths.read().unwrap().clone();
+    let (_, file_path) = find_source_file(&rel_path, &src_paths).ok_or_else(|| {
+        EvalError::Runtime(format!(
+            "Cannot find source for namespace {base_ns} (needed for {base_ns}@{commit})"
+        ))
+    })?;
+
+    // Locate the git repository.
+    let repo_root = cljrs_vcs::find_repo_root(Path::new(&file_path)).ok_or_else(|| {
+        EvalError::Runtime(format!(
+            "Namespace {base_ns} (file {file_path}) is not in a git repository; \
+             cannot resolve {base_ns}@{commit}"
+        ))
+    })?;
+
+    // Compute the path relative to the repo root.
+    let abs_file = std::path::Path::new(&file_path);
+    let rel_file = abs_file.strip_prefix(&repo_root).map_err(|_| {
+        EvalError::Runtime(format!(
+            "Cannot compute relative path for {file_path} within {}",
+            repo_root.display()
+        ))
+    })?;
+    let rel_file_str = rel_file.to_string_lossy();
+
+    // Fetch the source at the requested commit.
+    let src = cljrs_vcs::get_file_at_commit(&repo_root, &rel_file_str, commit)
+        .map_err(|e| EvalError::Runtime(format!("{e}")))?;
+
+    // Create the versioned namespace (immutable).
+    {
+        use cljrs_value::Namespace;
+        let ns = cljrs_gc::GcPtr::new(Namespace::new_versioned(versioned_ns_name.as_ref()));
+        ns.get().set_source_location(
+            &file_path,
+            Some(&repo_root.display().to_string()),
+        );
+        let mut map = globals.namespaces.write().unwrap();
+        map.entry(versioned_ns_name.clone())
+            .or_insert(ns);
+    }
+
+    // Pre-refer clojure.core.
+    globals.refer_all(&versioned_ns_name, "clojure.core");
+
+    // Evaluate all forms with a versioned commit context so that
+    // same-namespace calls inside the historical source also resolve at
+    // `commit` rather than HEAD.
+    let saved_ns = globals
+        .lookup_var("clojure.core", "*ns*")
+        .and_then(|v| crate::dynamics::deref_var(&v));
+    {
+        let mut env = Env::new_versioned(globals.clone(), &versioned_ns_name, commit);
+        let file_label = format!("<{base_ns}@{commit}>");
+        let mut parser = cljrs_reader::Parser::new(src, file_label);
+        let forms = parser.parse_all().map_err(EvalError::Read)?;
+        for form in forms {
+            let _alloc_frame = cljrs_gc::push_alloc_frame();
+            globals
+                .eval(&form, &mut env)
+                .map_err(|e| annotate(e, &versioned_ns_name))?;
+        }
+    }
+    if let Some(saved) = saved_ns
+        && let Some(var) = globals.lookup_var("clojure.core", "*ns*")
+    {
+        var.get().bind(saved);
+    }
+
+    globals.mark_loaded(&versioned_ns_name);
+    apply_alias_refer(&globals, &versioned_ns_name, current_ns, spec);
+    Ok(())
+}
+
+/// Apply the alias and refer clauses from `spec` into `current_ns`, using
+/// `effective_ns` as the source namespace (which may be `"base@commit"`).
+fn apply_alias_refer(
+    globals: &GlobalEnv,
+    effective_ns: &Arc<str>,
+    current_ns: &str,
+    spec: &RequireSpec,
+) {
+    if let Some(alias) = &spec.alias {
+        globals.add_alias(current_ns, alias, effective_ns);
+    }
+    match &spec.refer {
+        RequireRefer::None => {}
+        RequireRefer::All => globals.refer_all(current_ns, effective_ns),
+        RequireRefer::Named(names) => globals.refer_named(current_ns, effective_ns, names),
+    }
 }
 
 fn find_source_file(rel: &str, src_paths: &[std::path::PathBuf]) -> Option<(String, String)> {

--- a/crates/cljrs-env/src/loader.rs
+++ b/crates/cljrs-env/src/loader.rs
@@ -111,8 +111,8 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
     // Record source location on the namespace for versioned resolution.
     // Only meaningful for real files (not builtins).
     if !file_path.starts_with("<builtin:") {
-        let repo_root = cljrs_vcs::find_repo_root(Path::new(&file_path))
-            .map(|p| p.display().to_string());
+        let repo_root =
+            cljrs_vcs::find_repo_root(Path::new(&file_path)).map(|p| p.display().to_string());
         let ns_ptr = globals.get_or_create_ns(ns_name);
         ns_ptr
             .get()
@@ -209,13 +209,10 @@ pub fn load_versioned_ns(
     {
         use cljrs_value::Namespace;
         let ns = cljrs_gc::GcPtr::new(Namespace::new_versioned(versioned_ns_name.as_ref()));
-        ns.get().set_source_location(
-            &file_path,
-            Some(&repo_root.display().to_string()),
-        );
+        ns.get()
+            .set_source_location(&file_path, Some(&repo_root.display().to_string()));
         let mut map = globals.namespaces.write().unwrap();
-        map.entry(versioned_ns_name.clone())
-            .or_insert(ns);
+        map.entry(versioned_ns_name.clone()).or_insert(ns);
     }
 
     // Pre-refer clojure.core.

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -426,10 +426,7 @@ fn const_to_value(c: &Const) -> Value {
         Const::Double(d) => Value::Double(*d),
         Const::Str(s) => Value::Str(GcPtr::new(s.to_string())),
         Const::Keyword(k) => Value::Keyword(GcPtr::new(cljrs_value::keyword::Keyword::parse(k))),
-        Const::Symbol(s) => Value::Symbol(GcPtr::new(cljrs_value::Symbol {
-            namespace: None,
-            name: s.clone(),
-        })),
+        Const::Symbol(s) => Value::symbol(cljrs_value::Symbol::simple(s.clone())),
         Const::Char(c) => Value::Char(*c),
     }
 }
@@ -452,10 +449,7 @@ fn load_global_value(globals: &GlobalEnv, ns: &str, name: &str, defining_ns: &st
     }
     // JVM class names resolve to themselves as symbols, mirroring eval_symbol.
     if cljrs_interp::eval::is_jvm_class_name(name) {
-        return Ok(Value::Symbol(GcPtr::new(cljrs_value::Symbol {
-            namespace: None,
-            name: Arc::from(name),
-        })));
+        return Ok(Value::symbol(cljrs_value::Symbol::simple(name)));
     }
     Err(EvalError::Runtime(format!(
         "IR interpreter: var not found {resolved_ns}/{name}"

--- a/crates/cljrs-interp/Cargo.toml
+++ b/crates/cljrs-interp/Cargo.toml
@@ -16,5 +16,6 @@ cljrs-builtins = { workspace = true }
 cljrs-value = { workspace = true }
 cljrs-gc = { workspace = true }
 cljrs-reader = { workspace = true }
+cljrs-vcs = { workspace = true }
 regex = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -1609,10 +1609,7 @@ fn handle_ns_aliases(arg_forms: &[Form], env: &mut Env) -> EvalResult {
     drop(map);
     let mut m = cljrs_value::MapValue::empty();
     for (alias, full_ns_name) in &aliases {
-        let sym = Value::Symbol(cljrs_gc::GcPtr::new(cljrs_value::Symbol {
-            namespace: None,
-            name: alias.clone(),
-        }));
+        let sym = Value::symbol(cljrs_value::Symbol::simple(alias.clone()));
         let nsmap = env.globals.namespaces.read().unwrap();
         if let Some(target_ns) = nsmap.get(full_ns_name.as_ref()) {
             m = m.assoc(sym, Value::Namespace(target_ns.clone()));

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -194,7 +194,8 @@ fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
     }
 
     // Namespace-qualified external symbol: `ns/name`
-    if s.contains('/') && !s.starts_with('/')
+    if s.contains('/')
+        && !s.starts_with('/')
         && let Some(ns_part) = &sym.namespace
     {
         let resolved: Arc<str> = env

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -181,8 +181,8 @@ fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
     // function body, unversioned same-namespace symbols resolve at the inherited
     // commit rather than HEAD.
     if let Some(commit) = env.versioned_eval_commit.clone() {
-        let is_same_ns = sym.namespace.is_none()
-            || sym.namespace.as_deref() == Some(env.current_ns.as_ref());
+        let is_same_ns =
+            sym.namespace.is_none() || sym.namespace.as_deref() == Some(env.current_ns.as_ref());
         if is_same_ns {
             return crate::versioned::resolve_versioned_symbol(&sym, &commit, env);
         }
@@ -194,17 +194,17 @@ fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
     }
 
     // Namespace-qualified external symbol: `ns/name`
-    if s.contains('/') && !s.starts_with('/') {
-        if let Some(ns_part) = &sym.namespace {
-            let resolved: Arc<str> = env
-                .globals
-                .resolve_alias(&env.current_ns, ns_part)
-                .unwrap_or_else(|| Arc::from(ns_part.as_ref()));
-            return env
-                .globals
-                .lookup_in_ns(&resolved, &sym.name)
-                .ok_or_else(|| EvalError::UnboundSymbol(s.to_string()));
-        }
+    if s.contains('/') && !s.starts_with('/')
+        && let Some(ns_part) = &sym.namespace
+    {
+        let resolved: Arc<str> = env
+            .globals
+            .resolve_alias(&env.current_ns, ns_part)
+            .unwrap_or_else(|| Arc::from(ns_part.as_ref()));
+        return env
+            .globals
+            .lookup_in_ns(&resolved, &sym.name)
+            .ok_or_else(|| EvalError::UnboundSymbol(s.to_string()));
     }
 
     // JVM class names resolve to themselves as symbols (for instance?, catch, etc.)

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -163,16 +163,39 @@ fn eval_list(forms: &[Form], env: &mut Env) -> EvalResult {
 // ── Symbol resolution ─────────────────────────────────────────────────────────
 
 fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
-    // Local frames (including closed-over).
-    if let Some(v) = env.lookup(s) {
+    let sym = Symbol::parse(s);
+
+    // Explicit version suffix (`name@hash` or `ns/name@hash`): always a
+    // namespace-level lookup — no local-frame fallback.
+    if let Some(ref commit) = sym.version.clone() {
+        return crate::versioned::resolve_versioned_symbol(&sym, commit, env);
+    }
+
+    // Local frames (params, let-bindings, closed-over vars) take priority for
+    // unversioned symbols.
+    if let Some(v) = env.lookup_local_frames(s) {
         return Ok(v);
     }
 
-    // Namespace-qualified: `ns/name`
+    // Inherited versioned context: if we are evaluating inside a versioned
+    // function body, unversioned same-namespace symbols resolve at the inherited
+    // commit rather than HEAD.
+    if let Some(commit) = env.versioned_eval_commit.clone() {
+        let is_same_ns = sym.namespace.is_none()
+            || sym.namespace.as_deref() == Some(env.current_ns.as_ref());
+        if is_same_ns {
+            return crate::versioned::resolve_versioned_symbol(&sym, &commit, env);
+        }
+    }
+
+    // Fall through to normal global namespace lookup.
+    if let Some(v) = env.globals.lookup_in_ns(&env.current_ns, s) {
+        return Ok(v);
+    }
+
+    // Namespace-qualified external symbol: `ns/name`
     if s.contains('/') && !s.starts_with('/') {
-        let sym = Symbol::parse(s);
         if let Some(ns_part) = &sym.namespace {
-            // Resolve alias first, fall back to literal namespace name.
             let resolved: Arc<str> = env
                 .globals
                 .resolve_alias(&env.current_ns, ns_part)
@@ -1444,10 +1467,7 @@ mod tests {
             panic!("expected map")
         };
         // The map should contain 'my-test-var
-        let sym = Value::Symbol(cljrs_gc::GcPtr::new(cljrs_value::Symbol {
-            namespace: None,
-            name: Arc::from("my-test-var"),
-        }));
+        let sym = Value::symbol(cljrs_value::Symbol::simple("my-test-var"));
         assert!(m.get(&sym).is_some());
     }
 

--- a/crates/cljrs-interp/src/lib.rs
+++ b/crates/cljrs-interp/src/lib.rs
@@ -15,8 +15,8 @@ pub mod eval;
 pub mod macros;
 pub mod special;
 pub mod syntax_quote;
-mod virtualize;
 pub mod versioned;
+mod virtualize;
 
 /// Create a minimal `GlobalEnv` with `clojure.core` builtins and bootstrap
 /// HOFs, but without any stdlib namespaces pre-loaded.

--- a/crates/cljrs-interp/src/lib.rs
+++ b/crates/cljrs-interp/src/lib.rs
@@ -16,6 +16,7 @@ pub mod macros;
 pub mod special;
 pub mod syntax_quote;
 mod virtualize;
+pub mod versioned;
 
 /// Create a minimal `GlobalEnv` with `clojure.core` builtins and bootstrap
 /// HOFs, but without any stdlib namespaces pre-loaded.

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1013,7 +1013,12 @@ fn parse_require_spec_val(val: Value) -> Result<RequireSpec, String> {
                 }
                 i += 1;
             }
-            Ok(RequireSpec { ns, version, alias, refer })
+            Ok(RequireSpec {
+                ns,
+                version,
+                alias,
+                refer,
+            })
         }
         other => Err(format!(
             "require expects a symbol or vector, got {}",
@@ -1092,7 +1097,12 @@ fn parse_require_spec_form(form: &Form) -> Result<RequireSpec, String> {
                 }
                 i += 1;
             }
-            Ok(RequireSpec { ns, version, alias, refer })
+            Ok(RequireSpec {
+                ns,
+                version,
+                alias,
+                refer,
+            })
         }
         _ => Err("require spec must be a symbol or vector".into()),
     }

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -935,21 +935,29 @@ fn eval_require(args: &[Form], env: &mut Env) -> EvalResult {
 
 /// Parse a `RequireSpec` from an already-evaluated `Value`.
 /// Accepts: `'some.ns`, `['some.ns :as alias]`, `['some.ns :refer [syms]]`,
-/// `['some.ns :refer :all]`.
+/// `['some.ns :refer :all]`, and versioned forms like `'some.ns@abc1234` or
+/// `['some.ns@abc1234 :as alias]`.
 fn parse_require_spec_val(val: Value) -> Result<RequireSpec, String> {
     match val {
-        Value::Symbol(s) => Ok(RequireSpec {
-            ns: s.get().name.clone(),
-            alias: None,
-            refer: RequireRefer::None,
-        }),
+        Value::Symbol(s) => {
+            let sym = s.get();
+            Ok(RequireSpec {
+                ns: sym.name.clone(),
+                version: sym.version.clone(),
+                alias: None,
+                refer: RequireRefer::None,
+            })
+        }
         Value::Vector(v) => {
             let items: Vec<Value> = v.get().iter().cloned().collect();
             if items.is_empty() {
                 return Err("require spec vector must not be empty".into());
             }
-            let ns = match &items[0] {
-                Value::Symbol(s) => s.get().name.clone(),
+            let (ns, version) = match &items[0] {
+                Value::Symbol(s) => {
+                    let sym = s.get();
+                    (sym.name.clone(), sym.version.clone())
+                }
                 other => {
                     return Err(format!(
                         "require spec: first element must be a symbol, got {}",
@@ -1005,7 +1013,7 @@ fn parse_require_spec_val(val: Value) -> Result<RequireSpec, String> {
                 }
                 i += 1;
             }
-            Ok(RequireSpec { ns, alias, refer })
+            Ok(RequireSpec { ns, version, alias, refer })
         }
         other => Err(format!(
             "require expects a symbol or vector, got {}",
@@ -1015,19 +1023,27 @@ fn parse_require_spec_val(val: Value) -> Result<RequireSpec, String> {
 }
 
 /// Parse a `RequireSpec` from a raw `Form` (unevaluated, used in `ns` macro).
+/// Also handles versioned namespace symbols such as `my.ns@abc1234`.
 fn parse_require_spec_form(form: &Form) -> Result<RequireSpec, String> {
     match &form.kind {
-        FormKind::Symbol(s) => Ok(RequireSpec {
-            ns: Arc::from(s.as_str()),
-            alias: None,
-            refer: RequireRefer::None,
-        }),
+        FormKind::Symbol(s) => {
+            let sym = cljrs_value::Symbol::parse(s);
+            Ok(RequireSpec {
+                ns: sym.name.clone(),
+                version: sym.version.clone(),
+                alias: None,
+                refer: RequireRefer::None,
+            })
+        }
         FormKind::Vector(items) => {
             if items.is_empty() {
                 return Err("require spec vector must not be empty".into());
             }
-            let ns = match &items[0].kind {
-                FormKind::Symbol(s) => Arc::from(s.as_str()),
+            let (ns, version) = match &items[0].kind {
+                FormKind::Symbol(s) => {
+                    let sym = cljrs_value::Symbol::parse(s);
+                    (sym.name.clone(), sym.version.clone())
+                }
                 _ => return Err("require spec: first element must be a symbol".into()),
             };
             let mut alias = None;
@@ -1076,7 +1092,7 @@ fn parse_require_spec_form(form: &Form) -> Result<RequireSpec, String> {
                 }
                 i += 1;
             }
-            Ok(RequireSpec { ns, alias, refer })
+            Ok(RequireSpec { ns, version, alias, refer })
         }
         _ => Err("require spec must be a symbol or vector".into()),
     }

--- a/crates/cljrs-interp/src/versioned.rs
+++ b/crates/cljrs-interp/src/versioned.rs
@@ -1,0 +1,163 @@
+//! Versioned symbol and namespace resolution.
+//!
+//! When a symbol carries an `@<commit>` suffix — or when evaluation is
+//! happening inside a versioned namespace body — this module fetches the
+//! historical source from git and evaluates the relevant definition in a
+//! snapshot environment.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use cljrs_env::env::Env;
+use cljrs_env::error::{EvalError, EvalResult};
+use cljrs_reader::form::FormKind;
+use cljrs_reader::Form;
+use cljrs_value::{Symbol, Value};
+
+// ── Public entry points ───────────────────────────────────────────────────────
+
+/// Resolve `sym` (which may or may not carry a version) at `commit` within
+/// `env`.
+///
+/// Resolution order:
+/// 1. Version cache hit → return immediately.
+/// 2. Determine the owning namespace for the symbol.
+/// 3. Fetch the source file at `commit` via `cljrs-vcs`.
+/// 4. Scan forms for `(def name …)` / `(defn name …)` / `(defmacro name …)`.
+/// 5. Evaluate the found form in a snapshot env with `versioned_eval_commit`
+///    set to `commit`, so that same-namespace helpers also resolve historically.
+/// 6. Cache the result.
+pub fn resolve_versioned_symbol(sym: &Symbol, commit: &str, env: &mut Env) -> EvalResult {
+    // Determine the owning namespace.
+    let ns_name: Arc<str> = match &sym.namespace {
+        Some(ns_part) => env
+            .globals
+            .resolve_alias(&env.current_ns, ns_part)
+            .unwrap_or_else(|| Arc::clone(ns_part)),
+        None => Arc::clone(&env.current_ns),
+    };
+
+    let name = sym.name.as_ref();
+
+    // Cache check.
+    if let Some(cached) = env.globals.get_cached_versioned(&ns_name, name, commit) {
+        return Ok(cached);
+    }
+
+    // Get git context for the owning namespace.  If the namespace hasn't been
+    // loaded yet, try to load it so the context gets populated.
+    let (source_file, repo_root) = git_context_for_ns(&ns_name, env)?;
+
+    // Compute repo-relative path.
+    let abs_file = Path::new(source_file.as_ref());
+    let repo_path = Path::new(repo_root.as_ref());
+    let rel_file = abs_file.strip_prefix(repo_path).map_err(|_| {
+        EvalError::Runtime(format!(
+            "Cannot compute relative path for {source_file} within {repo_root}"
+        ))
+    })?;
+    let rel_file_str = rel_file.to_string_lossy();
+
+    // Fetch source at commit.
+    let src = cljrs_vcs::get_file_at_commit(repo_path, &rel_file_str, commit)
+        .map_err(|e| EvalError::Runtime(format!("{e}")))?;
+
+    // Parse.
+    let file_label = format!("<{ns_name}@{commit}>");
+    let mut parser = cljrs_reader::Parser::new(src, file_label);
+    let forms = parser.parse_all().map_err(EvalError::Read)?;
+
+    // Find the definition of `name`.
+    let def_form = find_def_form(&forms, name).ok_or_else(|| {
+        EvalError::Runtime(format!(
+            "Cannot find definition of `{name}` in `{ns_name}@{commit}`"
+        ))
+    })?;
+
+    // Evaluate in a snapshot env: same namespace, versioned commit.
+    let val = eval_in_snapshot(def_form, &ns_name, commit, env)?;
+
+    // Cache and return.
+    env.globals
+        .cache_versioned(&ns_name, name, commit, val.clone());
+    Ok(val)
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Return `(source_file, git_repo_root)` for `ns_name`, triggering a load of
+/// the namespace if it has not yet been loaded (so the loader can populate the
+/// git context fields).
+fn git_context_for_ns(ns_name: &Arc<str>, env: &mut Env) -> EvalResult<(Arc<str>, Arc<str>)> {
+    // Fast path: already populated.
+    if let Some(ctx) = env.globals.get_ns_git_context(ns_name) {
+        return Ok(ctx);
+    }
+
+    // Try loading the namespace (idempotent if already loaded).
+    let spec = cljrs_env::env::RequireSpec {
+        ns: Arc::clone(ns_name),
+        version: None,
+        alias: None,
+        refer: cljrs_env::env::RequireRefer::None,
+    };
+    cljrs_env::loader::load_ns(Arc::clone(&env.globals), &spec, &env.current_ns)?;
+
+    // Try again after load.
+    env.globals.get_ns_git_context(ns_name).ok_or_else(|| {
+        EvalError::Runtime(format!(
+            "Namespace `{ns_name}` has no git context (built-in or not in a git repo); \
+             cannot resolve versioned symbols from it"
+        ))
+    })
+}
+
+/// Evaluate `form` inside a snapshot environment: the current namespace is set
+/// to `ns_name` and `versioned_eval_commit` is set to `commit`.
+fn eval_in_snapshot(form: &Form, ns_name: &str, commit: &str, env: &mut Env) -> EvalResult {
+    let mut snap = Env::new_versioned(Arc::clone(&env.globals), ns_name, commit);
+    (env.globals.eval_fn)(form, &mut snap)
+}
+
+/// Scan `forms` for the first top-level `def`-like form that binds `name`.
+///
+/// Recognises: `(def name …)`, `(defn name …)`, `(defmacro name …)`,
+/// `(defn- name …)`, `(def- name …)`.
+fn find_def_form<'a>(forms: &'a [Form], name: &str) -> Option<&'a Form> {
+    for form in forms {
+        if let FormKind::List(items) = &form.kind {
+            if items.len() < 2 {
+                continue;
+            }
+            let head = match &items[0].kind {
+                FormKind::Symbol(s) => s.as_str(),
+                _ => continue,
+            };
+            let is_def_like = matches!(
+                head,
+                "def" | "defn" | "defn-" | "def-" | "defmacro" | "defmulti"
+            );
+            if !is_def_like {
+                continue;
+            }
+            // The name is the second element, possibly wrapped in metadata.
+            let name_form = &items[1];
+            let actual_name = def_form_name(name_form);
+            if actual_name.as_deref() == Some(name) {
+                return Some(form);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the symbol name from the second element of a `def`-like form.
+/// Handles `^metadata name` wrapping.
+fn def_form_name(form: &Form) -> Option<String> {
+    match &form.kind {
+        FormKind::Symbol(s) => Some(s.clone()),
+        // `^{:doc "…"} name`  or  `^:private name`
+        FormKind::Meta(_, inner) => def_form_name(inner),
+        _ => None,
+    }
+}

--- a/crates/cljrs-interp/src/versioned.rs
+++ b/crates/cljrs-interp/src/versioned.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 
 use cljrs_env::env::Env;
 use cljrs_env::error::{EvalError, EvalResult};
-use cljrs_reader::form::FormKind;
 use cljrs_reader::Form;
-use cljrs_value::{Symbol, Value};
+use cljrs_reader::form::FormKind;
+use cljrs_value::Symbol;
 
 // ── Public entry points ───────────────────────────────────────────────────────
 

--- a/crates/cljrs-reader/src/lexer.rs
+++ b/crates/cljrs-reader/src/lexer.rs
@@ -536,7 +536,25 @@ impl Lexer {
         start_line: u32,
         start_col: u32,
     ) -> CljxResult<(Token, Span)> {
-        let name = self.read_symbol_chars();
+        let mut name = self.read_symbol_chars();
+
+        // Peek for a version suffix: `@<commit-hash>`.  We only consume the `@`
+        // when it is immediately followed by 7–40 hex characters so that a
+        // standalone `@expr` (deref reader macro) is never affected — deref
+        // always starts a *new* form where `@` is the first character, not a
+        // mid-symbol suffix.
+        if self.peek() == Some('@') {
+            let version_candidate = self.peek_version_hash();
+            if let Some(hash) = version_candidate {
+                self.advance(); // consume '@'
+                for _ in 0..hash.len() {
+                    self.advance();
+                }
+                name.push('@');
+                name.push_str(&hash);
+            }
+        }
+
         let tok = match name.as_str() {
             "nil" => Token::Nil,
             "true" => Token::Bool(true),
@@ -544,6 +562,31 @@ impl Lexer {
             _ => Token::Symbol(name),
         };
         Ok((tok, self.span_from(start_pos, start_line, start_col)))
+    }
+
+    /// Look ahead past the `@` that `peek()` just returned and collect
+    /// characters as long as they are ASCII hex digits, up to 40.  Returns
+    /// `Some(hash)` if the candidate is 7–40 hex chars followed by a
+    /// non-hex-digit (or EOF), `None` otherwise.  Does **not** advance the
+    /// cursor.
+    fn peek_version_hash(&self) -> Option<String> {
+        // Start one byte past the current `@`.
+        let at_byte = self.pos + 1; // '@' is single-byte ASCII
+        let rest = &self.source[at_byte..];
+        let hash: String = rest
+            .chars()
+            .take(40)
+            .take_while(|c| c.is_ascii_hexdigit())
+            .collect();
+        if hash.len() >= 7 {
+            // Make sure the character after the hash is a delimiter (or EOF).
+            let after = rest[hash.len()..].chars().next();
+            let is_delimited = after.map_or(true, |c| !c.is_ascii_hexdigit());
+            if is_delimited {
+                return Some(hash);
+            }
+        }
+        None
     }
 
     // ── Number ────────────────────────────────────────────────────────────

--- a/crates/cljrs-reader/src/lexer.rs
+++ b/crates/cljrs-reader/src/lexer.rs
@@ -581,7 +581,7 @@ impl Lexer {
         if hash.len() >= 7 {
             // Make sure the character after the hash is a delimiter (or EOF).
             let after = rest[hash.len()..].chars().next();
-            let is_delimited = after.map_or(true, |c| !c.is_ascii_hexdigit());
+            let is_delimited = after.is_none_or(|c| !c.is_ascii_hexdigit());
             if is_delimited {
                 return Some(hash);
             }

--- a/crates/cljrs-value/src/symbol.rs
+++ b/crates/cljrs-value/src/symbol.rs
@@ -1,55 +1,105 @@
 use std::sync::Arc;
 
-/// An interned Clojure symbol, optionally namespace-qualified.
+/// An interned Clojure symbol, optionally namespace-qualified, optionally
+/// pinned to a git commit via the `@<hash>` suffix syntax.
 ///
-/// `"foo"` → `Symbol { namespace: None, name: "foo" }`
-/// `"clojure.core/map"` → `Symbol { namespace: Some("clojure.core"), name: "map" }`
+/// `"foo"`              → `Symbol { namespace: None,              name: "foo", version: None }`
+/// `"ns/name"`          → `Symbol { namespace: Some("ns"),        name: "name", version: None }`
+/// `"my-fn@abc1234"`    → `Symbol { namespace: None,              name: "my-fn", version: Some("abc1234") }`
+/// `"ns/fn@abc1234"`    → `Symbol { namespace: Some("ns"),        name: "fn", version: Some("abc1234") }`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Symbol {
     pub namespace: Option<Arc<str>>,
     pub name: Arc<str>,
+    /// Git commit hash suffix, present when the symbol was written as `name@hash`.
+    pub version: Option<Arc<str>>,
 }
 
 impl Symbol {
-    /// Unqualified symbol.
+    /// Unqualified, unversioned symbol.
     pub fn simple(name: impl Into<Arc<str>>) -> Self {
         Self {
             namespace: None,
             name: name.into(),
+            version: None,
         }
     }
 
-    /// Namespace-qualified symbol.
+    /// Namespace-qualified, unversioned symbol.
     pub fn qualified(ns: impl Into<Arc<str>>, name: impl Into<Arc<str>>) -> Self {
         Self {
             namespace: Some(ns.into()),
             name: name.into(),
+            version: None,
         }
     }
 
-    /// Parse a symbol from a string of the form `"ns/name"` or `"name"`.
+    /// Parse a symbol from a string of the form `"ns/name"`, `"name"`,
+    /// `"name@hash"`, or `"ns/name@hash"`.
+    ///
+    /// The `@` version suffix is detected in the *name* portion (after any `/`
+    /// split).  A bare `"/"` remains an unqualified symbol as before.
     pub fn parse(s: &str) -> Self {
-        match s.find('/') {
-            Some(idx) if idx > 0 && idx < s.len() - 1 => Self::qualified(&s[..idx], &s[idx + 1..]),
-            _ => Self::simple(s),
+        // Split namespace qualifier on the first `/`.
+        let (ns_part, name_part) = match s.find('/') {
+            Some(idx) if idx > 0 && idx < s.len() - 1 => {
+                (Some(&s[..idx]), &s[idx + 1..])
+            }
+            _ => (None, s),
+        };
+
+        // Split version suffix on the last `@` in the name portion, accepting
+        // only valid commit hashes (7–40 hex characters).
+        let (base_name, version) = split_version(name_part);
+
+        Symbol {
+            namespace: ns_part.map(Arc::from),
+            name: Arc::from(base_name),
+            version: version.map(Arc::from),
         }
     }
 
-    /// The fully-qualified string, e.g. `"clojure.core/map"` or `"foo"`.
+    /// The unversioned, fully-qualified string: `"ns/name"` or `"name"`.
     pub fn full_name(&self) -> String {
         match &self.namespace {
             Some(ns) => format!("{}/{}", ns, self.name),
             None => self.name.to_string(),
         }
     }
+
+    /// The display string including the version suffix if present:
+    /// `"ns/name@hash"` or `"name@hash"` or `"name"`.
+    pub fn versioned_name(&self) -> String {
+        match (&self.namespace, &self.version) {
+            (Some(ns), Some(v)) => format!("{}/{}@{}", ns, self.name, v),
+            (Some(ns), None)    => format!("{}/{}", ns, self.name),
+            (None,     Some(v)) => format!("{}@{}", self.name, v),
+            (None,     None)    => self.name.to_string(),
+        }
+    }
+}
+
+/// Split `name_part` into `(base, Some(hash))` if the last `@` is followed by
+/// a valid commit hash (7–40 hex chars), otherwise return `(name_part, None)`.
+fn split_version(name_part: &str) -> (&str, Option<&str>) {
+    if let Some(at_pos) = name_part.rfind('@') {
+        let candidate = &name_part[at_pos + 1..];
+        if is_commit_hash(candidate) {
+            return (&name_part[..at_pos], Some(candidate));
+        }
+    }
+    (name_part, None)
+}
+
+/// Returns `true` if `s` could be an abbreviated or full git commit hash
+/// (7–40 lowercase or uppercase hex characters).
+pub fn is_commit_hash(s: &str) -> bool {
+    (7..=40).contains(&s.len()) && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 impl std::fmt::Display for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.namespace {
-            Some(ns) => write!(f, "{}/{}", ns, self.name),
-            None => write!(f, "{}", self.name),
-        }
+        write!(f, "{}", self.versioned_name())
     }
 }
 
@@ -66,6 +116,7 @@ mod tests {
         let s = Symbol::simple("foo");
         assert_eq!(s.name.as_ref(), "foo");
         assert!(s.namespace.is_none());
+        assert!(s.version.is_none());
         assert_eq!(s.full_name(), "foo");
     }
 
@@ -73,13 +124,45 @@ mod tests {
     fn test_qualified() {
         let s = Symbol::qualified("clojure.core", "map");
         assert_eq!(s.full_name(), "clojure.core/map");
+        assert!(s.version.is_none());
     }
 
     #[test]
-    fn test_parse() {
+    fn test_parse_unversioned() {
         assert_eq!(Symbol::parse("foo"), Symbol::simple("foo"));
         assert_eq!(Symbol::parse("a/b"), Symbol::qualified("a", "b"));
-        // bare "/" is unqualified
         assert_eq!(Symbol::parse("/").namespace, None);
+    }
+
+    #[test]
+    fn test_parse_versioned_simple() {
+        let s = Symbol::parse("my-fn@abc1234");
+        assert_eq!(s.name.as_ref(), "my-fn");
+        assert!(s.namespace.is_none());
+        assert_eq!(s.version.as_deref(), Some("abc1234"));
+        assert_eq!(s.versioned_name(), "my-fn@abc1234");
+    }
+
+    #[test]
+    fn test_parse_versioned_qualified() {
+        let s = Symbol::parse("my.ns/my-fn@abc1234");
+        assert_eq!(s.namespace.as_deref(), Some("my.ns"));
+        assert_eq!(s.name.as_ref(), "my-fn");
+        assert_eq!(s.version.as_deref(), Some("abc1234"));
+    }
+
+    #[test]
+    fn test_at_without_valid_hash_is_part_of_name() {
+        // "@" followed by fewer than 7 hex chars is not a version.
+        let s = Symbol::parse("my-fn@abc");
+        assert_eq!(s.name.as_ref(), "my-fn@abc");
+        assert!(s.version.is_none());
+    }
+
+    #[test]
+    fn test_at_followed_by_non_hex_is_part_of_name() {
+        let s = Symbol::parse("my-fn@not-hex");
+        assert_eq!(s.name.as_ref(), "my-fn@not-hex");
+        assert!(s.version.is_none());
     }
 }

--- a/crates/cljrs-value/src/symbol.rs
+++ b/crates/cljrs-value/src/symbol.rs
@@ -42,9 +42,7 @@ impl Symbol {
     pub fn parse(s: &str) -> Self {
         // Split namespace qualifier on the first `/`.
         let (ns_part, name_part) = match s.find('/') {
-            Some(idx) if idx > 0 && idx < s.len() - 1 => {
-                (Some(&s[..idx]), &s[idx + 1..])
-            }
+            Some(idx) if idx > 0 && idx < s.len() - 1 => (Some(&s[..idx]), &s[idx + 1..]),
             _ => (None, s),
         };
 
@@ -72,9 +70,9 @@ impl Symbol {
     pub fn versioned_name(&self) -> String {
         match (&self.namespace, &self.version) {
             (Some(ns), Some(v)) => format!("{}/{}@{}", ns, self.name, v),
-            (Some(ns), None)    => format!("{}/{}", ns, self.name),
-            (None,     Some(v)) => format!("{}@{}", self.name, v),
-            (None,     None)    => self.name.to_string(),
+            (Some(ns), None) => format!("{}/{}", ns, self.name),
+            (None, Some(v)) => format!("{}@{}", self.name, v),
+            (None, None) => self.name.to_string(),
         }
     }
 }

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -387,6 +387,15 @@ pub struct Namespace {
     pub refers: Mutex<HashMap<Arc<str>, GcPtr<Var>>>,
     /// Namespace aliases: short-name → full namespace name.
     pub aliases: Mutex<HashMap<Arc<str>, Arc<str>>>,
+    /// Absolute path of the source file this namespace was loaded from,
+    /// populated by the loader.  Used by the versioned resolver to locate the
+    /// file for `git show`.
+    pub source_file: Mutex<Option<Arc<str>>>,
+    /// Absolute path of the git repository root that contains `source_file`.
+    pub git_repo_root: Mutex<Option<Arc<str>>>,
+    /// `true` for namespaces loaded from a specific commit (`name@hash`).
+    /// Versioned namespaces are immutable: `intern()` will refuse new bindings.
+    pub is_versioned: bool,
 }
 
 impl Namespace {
@@ -396,7 +405,24 @@ impl Namespace {
             interns: Mutex::new(HashMap::new()),
             refers: Mutex::new(HashMap::new()),
             aliases: Mutex::new(HashMap::new()),
+            source_file: Mutex::new(None),
+            git_repo_root: Mutex::new(None),
+            is_versioned: false,
         }
+    }
+
+    /// Create a versioned (immutable) namespace for `name@commit`.
+    pub fn new_versioned(name: impl Into<Arc<str>>) -> Self {
+        Self {
+            is_versioned: true,
+            ..Self::new(name)
+        }
+    }
+
+    /// Record the source file path and its git repo root (if in a repo).
+    pub fn set_source_location(&self, file: &str, repo_root: Option<&str>) {
+        *self.source_file.lock().unwrap() = Some(Arc::from(file));
+        *self.git_repo_root.lock().unwrap() = repo_root.map(Arc::from);
     }
 }
 

--- a/crates/cljrs-vcs/Cargo.toml
+++ b/crates/cljrs-vcs/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cljrs-vcs"
+version = "0.1.0"
+edition = "2024"
+description = "Git subprocess helpers for versioned symbol resolution"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }

--- a/crates/cljrs-vcs/README.md
+++ b/crates/cljrs-vcs/README.md
@@ -1,0 +1,48 @@
+# cljrs-vcs
+
+## Purpose
+
+Thin wrapper around the `git` CLI for versioned symbol resolution: locating
+repository roots, fetching file content at a specific commit, validating commit
+hashes, and managing the local dependency cache at `~/.cljrs/cache/git/`.
+
+## Status
+
+Phase 2 (implemented).  All git operations shell out to the `git` binary; no
+libgit2 dependency.  Remote fetching (`fetch_remote`) is wired up but the CLI
+command that calls it (`cljrs deps fetch`) is Phase 8 (todo).
+
+## File layout
+
+| File | Description |
+|------|-------------|
+| `src/lib.rs` | All public functions and `VcsError` type |
+
+## Public API
+
+```rust
+/// True if `s` is a valid abbreviated or full git commit hash (7–40 hex chars).
+pub fn is_valid_commit_hash(s: &str) -> bool
+
+/// Walk up from `start` to find the git repo root (dir containing `.git`).
+pub fn find_repo_root(start: &Path) -> Option<PathBuf>
+
+/// Return file contents at `rel_path` (relative to repo root) at `commit`.
+pub fn get_file_at_commit(repo_root: &Path, rel_path: &str, commit: &str) -> VcsResult<String>
+
+/// Path to the local git-dep cache: `~/.cljrs/cache/git/`.
+pub fn cache_root() -> PathBuf
+
+/// Clone or fetch `url`, ensuring `sha` is present locally.
+/// Returns the path to the bare repo in the cache.
+pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf>
+
+pub enum VcsError {
+    InvalidCommit(String),
+    CommitNotFound(String),
+    PathNotFound(String, String),
+    Io(std::io::Error),
+    Utf8,
+    NoRepo(PathBuf),
+}
+```

--- a/crates/cljrs-vcs/src/lib.rs
+++ b/crates/cljrs-vcs/src/lib.rs
@@ -80,7 +80,10 @@ pub fn get_file_at_commit(repo_root: &Path, rel_path: &str, commit: &str) -> Vcs
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if stderr.contains("does not exist") || stderr.contains("exists on disk") {
-            Err(VcsError::PathNotFound(rel_path.to_string(), commit.to_string()))
+            Err(VcsError::PathNotFound(
+                rel_path.to_string(),
+                commit.to_string(),
+            ))
         } else {
             Err(VcsError::CommitNotFound(commit.to_string()))
         }
@@ -110,7 +113,13 @@ pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
     // Stable cache directory derived from the URL (replace non-alphanum with _).
     let slug: String = url
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '_' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     let repo_dir = cache_root().join(&slug);
 
@@ -127,8 +136,7 @@ pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
             return Err(VcsError::Io(std::io::Error::other("git fetch failed")));
         }
     } else {
-        std::fs::create_dir_all(&repo_dir)
-            .map_err(VcsError::Io)?;
+        std::fs::create_dir_all(&repo_dir).map_err(VcsError::Io)?;
         let status = std::process::Command::new("git")
             .arg("clone")
             .arg("--bare")
@@ -163,9 +171,11 @@ mod tests {
     #[test]
     fn valid_hashes() {
         assert!(is_valid_commit_hash("abc1234"));
-        assert!(is_valid_commit_hash("abc1234ef5678901234567890123456789012345"));
-        assert!(!is_valid_commit_hash("abc123"));   // too short
-        assert!(!is_valid_commit_hash("xyz1234"));  // non-hex
+        assert!(is_valid_commit_hash(
+            "abc1234ef5678901234567890123456789012345"
+        ));
+        assert!(!is_valid_commit_hash("abc123")); // too short
+        assert!(!is_valid_commit_hash("xyz1234")); // non-hex
         assert!(!is_valid_commit_hash(""));
     }
 }

--- a/crates/cljrs-vcs/src/lib.rs
+++ b/crates/cljrs-vcs/src/lib.rs
@@ -1,0 +1,171 @@
+//! Git subprocess helpers for versioned symbol resolution.
+//!
+//! All git operations are performed by shelling out to the `git` binary.
+//! No network access happens here; callers are responsible for ensuring
+//! that required commits are present locally before calling these functions.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VcsError {
+    #[error("invalid commit hash {0:?} (must be 7-40 hex characters)")]
+    InvalidCommit(String),
+    #[error("commit {0:?} not found in repository (run `cljrs deps fetch`)")]
+    CommitNotFound(String),
+    #[error("path {0:?} not found at commit {1:?}")]
+    PathNotFound(String, String),
+    #[error("git subprocess error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("git output is not valid UTF-8")]
+    Utf8,
+    #[error("no git repository found at or above {0:?}")]
+    NoRepo(PathBuf),
+}
+
+pub type VcsResult<T> = Result<T, VcsError>;
+
+/// Returns `true` if `s` looks like a valid (abbreviated or full) commit hash:
+/// 7–40 lowercase or uppercase hex characters.
+pub fn is_valid_commit_hash(s: &str) -> bool {
+    (7..=40).contains(&s.len()) && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Walk upward from `start` (a file or directory) to find the root of the
+/// enclosing git repository, i.e. the directory that contains `.git`.
+pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
+    // Normalise: if `start` is a file, begin from its parent directory.
+    let dir: &Path = if start.is_file() {
+        start.parent()?
+    } else {
+        start
+    };
+
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let s = String::from_utf8(output.stdout).ok()?;
+        Some(PathBuf::from(s.trim()))
+    } else {
+        None
+    }
+}
+
+/// Return the contents of `rel_path` (relative to the repo root) at `commit`.
+///
+/// Errors if the commit hash is malformed, the commit is not present locally,
+/// or the path does not exist at that commit.
+pub fn get_file_at_commit(repo_root: &Path, rel_path: &str, commit: &str) -> VcsResult<String> {
+    if !is_valid_commit_hash(commit) {
+        return Err(VcsError::InvalidCommit(commit.to_string()));
+    }
+
+    let spec = format!("{commit}:{rel_path}");
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("show")
+        .arg(&spec)
+        .output()?;
+
+    if output.status.success() {
+        String::from_utf8(output.stdout).map_err(|_| VcsError::Utf8)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("does not exist") || stderr.contains("exists on disk") {
+            Err(VcsError::PathNotFound(rel_path.to_string(), commit.to_string()))
+        } else {
+            Err(VcsError::CommitNotFound(commit.to_string()))
+        }
+    }
+}
+
+/// Returns the path to the local git-dep cache root: `~/.cljrs/cache/git/`.
+pub fn cache_root() -> PathBuf {
+    // Prefer $HOME; fall back to the current directory if HOME is unset.
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    home.join(".cljrs").join("cache").join("git")
+}
+
+/// Clone or fetch a remote git repository into the local cache.
+///
+/// `url`  — remote URL (https or ssh)
+/// `sha`  — the commit SHA that must be reachable after the operation
+///
+/// Returns the path to the bare repository in the cache.
+pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
+    if !is_valid_commit_hash(sha) {
+        return Err(VcsError::InvalidCommit(sha.to_string()));
+    }
+
+    // Stable cache directory derived from the URL (replace non-alphanum with _).
+    let slug: String = url
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '_' })
+        .collect();
+    let repo_dir = cache_root().join(&slug);
+
+    if repo_dir.exists() {
+        // Already cloned — fetch to make sure we have the requested commit.
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo_dir)
+            .arg("fetch")
+            .arg("--quiet")
+            .arg("origin")
+            .status()?;
+        if !status.success() {
+            return Err(VcsError::Io(std::io::Error::other("git fetch failed")));
+        }
+    } else {
+        std::fs::create_dir_all(&repo_dir)
+            .map_err(VcsError::Io)?;
+        let status = std::process::Command::new("git")
+            .arg("clone")
+            .arg("--bare")
+            .arg("--quiet")
+            .arg(url)
+            .arg(&repo_dir)
+            .status()?;
+        if !status.success() {
+            return Err(VcsError::Io(std::io::Error::other("git clone failed")));
+        }
+    }
+
+    // Verify that the requested commit is now present.
+    let check = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_dir)
+        .arg("cat-file")
+        .arg("-e")
+        .arg(sha)
+        .status()?;
+    if !check.success() {
+        return Err(VcsError::CommitNotFound(sha.to_string()));
+    }
+
+    Ok(repo_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_hashes() {
+        assert!(is_valid_commit_hash("abc1234"));
+        assert!(is_valid_commit_hash("abc1234ef5678901234567890123456789012345"));
+        assert!(!is_valid_commit_hash("abc123"));   // too short
+        assert!(!is_valid_commit_hash("xyz1234"));  // non-hex
+        assert!(!is_valid_commit_hash(""));
+    }
+}


### PR DESCRIPTION
New crates:
- cljrs-deps: parse cljrs.edn project config (DepsConfig, Dependency, Alias)
- cljrs-vcs: git subprocess helpers (find_repo_root, get_file_at_commit, fetch_remote)

cljrs-value:
- Symbol gains `version: Option<Arc<str>>` and `Symbol::parse` splits on `@hash`
- Namespace gains `source_file`, `git_repo_root`, `is_versioned`, `set_source_location`

cljrs-reader:
- `lex_symbol` peeks for `@<7-40 hex chars>` suffix and embeds it in the token,
  leaving standalone `@expr` (deref) unaffected

cljrs-env:
- RequireSpec gains `version` field for versioned require forms
- GlobalEnv gains `version_cache`, `deps_config`, git-context helpers
- Env gains `versioned_eval_commit` and `lookup_local_frames`
- loader: populates namespace git context on load; `load_versioned_ns` fetches
  source at a commit and evaluates it with versioned commit propagation

cljrs-interp:
- eval_symbol dispatches explicit `@hash` symbols and inherits commit context
  for same-namespace symbols when inside a versioned eval
- versioned.rs: `resolve_versioned_symbol` — cache, git fetch, form scan, eval
- special.rs: parse_require_spec_{val,form} extract version from namespace symbol

Tracking doc: VERSIONING.md

https://claude.ai/code/session_014s1Nj3g43VM9R5w14H5fEV