### PR TITLE
Add opt-in commit signature verification for versioned symbols

### DIFF
--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -70,6 +70,10 @@ pub struct DepsConfig {
     pub deps: Vec<(Arc<str>, Dependency)>,
     /// Named aliases (e.g. `:dev`, `:test`).
     pub aliases: Vec<(Arc<str>, Alias)>,
+    /// When true, every versioned-symbol or versioned-namespace resolution
+    /// must pass `git verify-commit` before historical code is executed.
+    /// Equivalent to the `--verify-commit-signatures` CLI flag.
+    pub verify_commit_signatures: bool,
 }
 
 impl DepsConfig {

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -54,11 +54,7 @@ fn extract_config(form: &Form, config_dir: &Path) -> Result<DepsConfig, String> 
             }
             Some("verify-commit-signatures") => match &val.kind {
                 FormKind::Bool(b) => config.verify_commit_signatures = *b,
-                _ => {
-                    return Err(
-                        ":verify-commit-signatures must be true or false".to_string()
-                    )
-                }
+                _ => return Err(":verify-commit-signatures must be true or false".to_string()),
             },
             _ => {} // ignore unknown keys
         }

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -52,6 +52,14 @@ fn extract_config(form: &Form, config_dir: &Path) -> Result<DepsConfig, String> 
             Some("aliases") => {
                 config.aliases = extract_aliases_map(val, config_dir)?;
             }
+            Some("verify-commit-signatures") => match &val.kind {
+                FormKind::Bool(b) => config.verify_commit_signatures = *b,
+                _ => {
+                    return Err(
+                        ":verify-commit-signatures must be true or false".to_string()
+                    )
+                }
+            },
             _ => {} // ignore unknown keys
         }
     }

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -1,6 +1,7 @@
 //! Lexical environment: local frames, global namespace table, and current Env.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 
 use crate::error::EvalResult;
@@ -100,6 +101,14 @@ pub struct GlobalEnv {
     pub version_cache: Mutex<HashMap<Arc<str>, Value>>,
     /// Parsed `cljrs.edn` config, loaded once at startup.
     pub deps_config: RwLock<Option<Arc<cljrs_deps::DepsConfig>>>,
+    /// When true, every versioned-symbol or versioned-namespace resolution
+    /// must pass `git verify-commit` before the historical code is executed.
+    /// Off by default; enabled via `--verify-commit-signatures` CLI flag or
+    /// `:verify-commit-signatures true` in `cljrs.edn`.
+    pub verify_commit_signatures: AtomicBool,
+    /// Session-scoped cache of commits that have already passed signature
+    /// verification this run, keyed by `(repo_root, commit_hash)`.
+    pub sig_verify_cache: Mutex<HashSet<(Arc<str>, Arc<str>)>>,
 }
 
 impl std::fmt::Debug for GlobalEnv {
@@ -128,6 +137,8 @@ impl GlobalEnv {
             on_fn_defined,
             version_cache: Mutex::new(HashMap::new()),
             deps_config: RwLock::new(None),
+            verify_commit_signatures: AtomicBool::new(false),
+            sig_verify_cache: Mutex::new(HashSet::new()),
         })
     }
 
@@ -367,6 +378,36 @@ impl GlobalEnv {
     pub fn cache_versioned_ns(&self, ns: &str, commit: &str) {
         let key: Arc<str> = Arc::from(format!("{ns}@{commit}"));
         self.version_cache.lock().unwrap().insert(key, Value::Nil);
+    }
+
+    /// If `:verify-commit-signatures` is enabled, verify that `commit` inside
+    /// `repo_root` carries a valid GPG or SSH signature.
+    ///
+    /// Returns `Ok(())` immediately when the feature is off.  On the happy
+    /// path the result is cached per `(repo_root, commit)` so each commit is
+    /// only verified once per session.  On failure returns
+    /// `EvalError::CommitSignatureVerificationFailed`.
+    pub fn check_commit_signature(&self, repo_root: &str, commit: &str) -> EvalResult<()> {
+        if !self.verify_commit_signatures.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        let key = (Arc::<str>::from(repo_root), Arc::<str>::from(commit));
+        if self.sig_verify_cache.lock().unwrap().contains(&key) {
+            return Ok(());
+        }
+        cljrs_vcs::verify_commit_signature(std::path::Path::new(repo_root), commit).map_err(
+            |e| match e {
+                cljrs_vcs::VcsError::SignatureVerificationFailed { commit: c, reason } => {
+                    crate::error::EvalError::CommitSignatureVerificationFailed {
+                        commit: c,
+                        reason,
+                    }
+                }
+                other => crate::error::EvalError::Runtime(format!("{other}")),
+            },
+        )?;
+        self.sig_verify_cache.lock().unwrap().insert(key);
+        Ok(())
     }
 }
 

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -398,10 +398,7 @@ impl GlobalEnv {
         cljrs_vcs::verify_commit_signature(std::path::Path::new(repo_root), commit).map_err(
             |e| match e {
                 cljrs_vcs::VcsError::SignatureVerificationFailed { commit: c, reason } => {
-                    crate::error::EvalError::CommitSignatureVerificationFailed {
-                        commit: c,
-                        reason,
-                    }
+                    crate::error::EvalError::CommitSignatureVerificationFailed { commit: c, reason }
                 }
                 other => crate::error::EvalError::Runtime(format!("{other}")),
             },

--- a/crates/cljrs-env/src/error.rs
+++ b/crates/cljrs-env/src/error.rs
@@ -32,6 +32,13 @@ pub enum EvalError {
     #[doc(hidden)]
     #[error("internal: recur outside loop or fn")]
     Recur(Vec<Value>),
+
+    #[error(
+        "commit {commit:?} failed signature verification — \
+         refusing to execute versioned symbol (enable GPG/SSH trust or disable \
+         :verify-commit-signatures): {reason}"
+    )]
+    CommitSignatureVerificationFailed { commit: String, reason: String },
 }
 
 pub type EvalResult<T = Value> = Result<T, EvalError>;

--- a/crates/cljrs-env/src/loader.rs
+++ b/crates/cljrs-env/src/loader.rs
@@ -191,6 +191,9 @@ pub fn load_versioned_ns(
         ))
     })?;
 
+    // Verify commit signature before loading any historical code.
+    globals.check_commit_signature(&repo_root.to_string_lossy(), commit)?;
+
     // Compute the path relative to the repo root.
     let abs_file = std::path::Path::new(&file_path);
     let rel_file = abs_file.strip_prefix(&repo_root).map_err(|_| {

--- a/crates/cljrs-interp/src/versioned.rs
+++ b/crates/cljrs-interp/src/versioned.rs
@@ -48,6 +48,9 @@ pub fn resolve_versioned_symbol(sym: &Symbol, commit: &str, env: &mut Env) -> Ev
     // loaded yet, try to load it so the context gets populated.
     let (source_file, repo_root) = git_context_for_ns(&ns_name, env)?;
 
+    // Verify commit signature before loading any historical code.
+    env.globals.check_commit_signature(&repo_root, commit)?;
+
     // Compute repo-relative path.
     let abs_file = Path::new(source_file.as_ref());
     let repo_path = Path::new(repo_root.as_ref());

--- a/crates/cljrs-vcs/src/lib.rs
+++ b/crates/cljrs-vcs/src/lib.rs
@@ -22,6 +22,8 @@ pub enum VcsError {
     Utf8,
     #[error("no git repository found at or above {0:?}")]
     NoRepo(PathBuf),
+    #[error("commit {commit:?} has no valid signature: {reason}")]
+    SignatureVerificationFailed { commit: String, reason: String },
 }
 
 pub type VcsResult<T> = Result<T, VcsError>;
@@ -180,6 +182,33 @@ pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
     }
 
     Ok(repo_dir)
+}
+
+/// Verify the GPG or SSH signature on `commit` inside `repo_root`.
+///
+/// Delegates entirely to `git verify-commit`; trust is determined by the
+/// caller's GPG keyring or `gpg.program` git config.  Returns `Ok(())` when
+/// the signature is present and valid, `Err(SignatureVerificationFailed)`
+/// otherwise (unsigned commit, expired key, key not in keyring, etc.).
+pub fn verify_commit_signature(repo_root: &Path, commit: &str) -> VcsResult<()> {
+    if !is_valid_commit_hash(commit) {
+        return Err(VcsError::InvalidCommit(commit.to_string()));
+    }
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("verify-commit")
+        .arg(commit)
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let reason = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(VcsError::SignatureVerificationFailed {
+            commit: commit.to_string(),
+            reason,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -34,6 +34,12 @@ struct Cli {
     #[arg(long, global = true, help = "Enable trace logging (implies --debug)")]
     trace: bool,
 
+    /// Require valid GPG or SSH signatures on every versioned commit before
+    /// executing historical code.  Off by default.  Can also be enabled
+    /// per-project via `:verify-commit-signatures true` in `cljrs.edn`.
+    #[arg(long, global = true)]
+    verify_commit_signatures: bool,
+
     /// Feature-level logging flags: -X debug:gc,jit or -X trace:reader
     ///
     /// Format: <level>:<feature1>,<feature2>,...
@@ -241,12 +247,13 @@ fn run(cli: Cli) -> miette::Result<i32> {
     let _mutator = cljrs_gc::register_mutator();
 
     let gc_stats_target = cli.gc_stats.clone();
+    let verify_commit_signatures = cli.verify_commit_signatures;
     let supports_gc_stats = matches!(
         &cli.command,
         Commands::Run { .. } | Commands::Eval { .. } | Commands::Test { .. },
     );
 
-    let result = run_command(cli.command);
+    let result = run_command(cli.command, verify_commit_signatures);
 
     if supports_gc_stats
         && let Some(target) = gc_stats_target.as_deref()
@@ -258,7 +265,7 @@ fn run(cli: Cli) -> miette::Result<i32> {
     result
 }
 
-fn run_command(command: Commands) -> miette::Result<i32> {
+fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Result<i32> {
     match command {
         Commands::Run {
             file,
@@ -270,7 +277,7 @@ fn run_command(command: Commands) -> miette::Result<i32> {
                 .map_err(|e| miette::miette!("{}: {}", file.display(), e))?;
             let filename = file.display().to_string();
             let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
-            let globals = setup_globals(src_paths, gc_config);
+            let globals = setup_globals(src_paths, gc_config, verify_commit_signatures);
             run_source(&src, &filename, globals)?;
             Ok(0)
         }
@@ -280,7 +287,7 @@ fn run_command(command: Commands) -> miette::Result<i32> {
             gc_hard_limit_mb,
         } => {
             let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
-            let globals = setup_globals(src_paths, gc_config);
+            let globals = setup_globals(src_paths, gc_config, verify_commit_signatures);
             run_repl(globals);
             Ok(0)
         }
@@ -306,7 +313,7 @@ fn run_command(command: Commands) -> miette::Result<i32> {
         }
         Commands::Eval { expr } => {
             let gc_config = Arc::new(GcConfig::new());
-            let globals = setup_globals(Vec::new(), gc_config);
+            let globals = setup_globals(Vec::new(), gc_config, verify_commit_signatures);
             let result = eval_source(&expr, "<eval>", globals)?;
             if result != Value::Nil {
                 println!("{}", result);
@@ -331,6 +338,7 @@ fn run_command(command: Commands) -> miette::Result<i32> {
             verbose,
             gc_soft_limit_mb,
             gc_hard_limit_mb,
+            verify_commit_signatures,
         ),
         Commands::Deps { command } => match command {
             DepsCommands::Fetch { name } => run_deps_fetch(name),
@@ -397,8 +405,17 @@ fn write_gc_stats(target: &str) -> std::io::Result<()> {
 /// flags take precedence).  The parsed `DepsConfig` is stored in
 /// `GlobalEnv.deps_config` so that versioned symbol resolution and the
 /// `deps fetch`/`deps status` commands share the same config object.
-fn setup_globals(src_paths: Vec<PathBuf>, gc_config: Arc<GcConfig>) -> Arc<GlobalEnv> {
+fn setup_globals(
+    src_paths: Vec<PathBuf>,
+    gc_config: Arc<GcConfig>,
+    verify_commit_signatures: bool,
+) -> Arc<GlobalEnv> {
     let globals = cljrs_stdlib::standard_env_with_paths_and_config(src_paths, gc_config);
+    if verify_commit_signatures {
+        globals
+            .verify_commit_signatures
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
     if let Ok(cwd) = std::env::current_dir() {
         apply_deps_config(&globals, &cwd);
     }
@@ -420,6 +437,11 @@ fn apply_deps_config(globals: &Arc<GlobalEnv>, cwd: &Path) {
                         paths.push(p.clone());
                     }
                 }
+            }
+            if config.verify_commit_signatures {
+                globals
+                    .verify_commit_signatures
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
             }
             *globals.deps_config.write().unwrap() = Some(Arc::new(config));
         }
@@ -469,6 +491,9 @@ fn format_eval_error(e: EvalError) -> miette::Report {
         EvalError::Runtime(msg) => miette::miette!("{}", msg),
         EvalError::Read(e) => miette::Report::from(e),
         EvalError::Recur(_) => miette::miette!("recur outside of loop/fn"),
+        EvalError::CommitSignatureVerificationFailed { commit, reason } => {
+            miette::miette!("commit {commit:?} failed signature verification: {reason}")
+        }
     }
 }
 
@@ -601,9 +626,10 @@ fn run_tests_command(
     verbose: bool,
     gc_soft_limit_mb: Option<usize>,
     gc_hard_limit_mb: Option<usize>,
+    verify_commit_signatures: bool,
 ) -> miette::Result<i32> {
     let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
-    let globals = setup_globals(src_paths, gc_config);
+    let globals = setup_globals(src_paths, gc_config, verify_commit_signatures);
 
     let namespaces = if namespaces.is_empty() {
         // Read the final source paths (which may include cljrs.edn :paths).


### PR DESCRIPTION
When --verify-commit-signatures (or :verify-commit-signatures true in
cljrs.edn) is enabled, every versioned-symbol or versioned-namespace
resolution calls `git verify-commit` before loading historical source.
Unsigned commits and invalid/untrusted signatures produce a distinct
EvalError::CommitSignatureVerificationFailed rather than silently
executing untrusted code.

Trust is delegated entirely to the caller's GPG keyring / git config;
no crypto is reimplemented here.  Successful verifications are cached
per (repo_root, commit) for the session so each commit is only checked
once.  The feature is off by default and has no cost when disabled.

https://claude.ai/code/session_01LzPDuJa64fUaEAHGUFxUKA