### PR TITLE
feat(interop): add Registry, InitFn, and :rust cljrs.edn config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "cljrs-types",
  "cljrs-value",
  "cljrs-vcs",
+ "libloading",
  "miette",
  "rustyline",
  "tracing",
@@ -296,6 +297,7 @@ name = "cljrs-compiler"
 version = "0.1.0"
 dependencies = [
  "cljrs-builtins",
+ "cljrs-deps",
  "cljrs-env",
  "cljrs-eval",
  "cljrs-gc",
@@ -908,6 +910,16 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
 name = "cljrs-interop"
 version = "0.1.0"
 dependencies = [
+ "cljrs-env",
  "cljrs-gc",
  "cljrs-types",
  "cljrs-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ regex        = "1.12.3"
 serde        = "1.0.228"
 postcard     = "1.1.3"
 rustyline    = "18.0.0"
+libloading   = "0.8"
 
 # Cranelift compiler backend (all crates must be at the same version)
 cranelift-codegen  = "0.129.1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # clojurust
 
 [![crates.io](https://img.shields.io/crates/v/cljrs.svg)](https://crates.io/crates/cljrs)
-[![docs](https://img.shields.io/badge/docs-csm.github.io%2Fclojurust-blue)](https://csm.github.io/clojurust/)
+[![docs](https://img.shields.io/badge/docs-docs.clj.rs-blue)](https://docs.clj.rs)
 
 A Rust-hosted dialect of the Clojure programming language.
 

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -12,6 +12,7 @@ no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc", "cljrs-eval/no-gc", "cljrs-inter
 
 [dependencies]
 cljrs-builtins = { workspace = true }
+cljrs-deps     = { workspace = true }
 cljrs-types    = { workspace = true }
 cljrs-ir       = { workspace = true }
 cljrs-gc       = { workspace = true }

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -383,8 +383,15 @@ pub fn lower_file_to_ir(
 ///
 /// `src_path` is the input source file.  `out_path` is the desired output
 /// binary.  `src_dirs` are additional directories for `require` resolution
-/// during macro expansion.
-pub fn compile_file(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf]) -> AotResult<()> {
+/// during macro expansion.  `rust_config`, when present, causes the generated
+/// harness to depend on the user's Rust crate and call its `cljrs_init` hook
+/// before loading any Clojure code.
+pub fn compile_file(
+    src_path: &Path,
+    out_path: &Path,
+    src_dirs: &[PathBuf],
+    rust_config: Option<&cljrs_deps::RustConfig>,
+) -> AotResult<()> {
     eprintln!("[aot] reading {}", src_path.display());
     let source = std::fs::read_to_string(src_path)?;
     let filename = src_path.display().to_string();
@@ -521,7 +528,8 @@ pub fn compile_file(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf]) -> A
     eprintln!("[aot] generated {} bytes of object code", obj_bytes.len());
 
     // ── 5. Generate harness project & build ─────────────────────────────
-    let harness_dir = build_harness(out_path, &obj_bytes, &interpreted_source, &bundled_sources)?;
+    let harness_dir =
+        build_harness(out_path, &obj_bytes, &interpreted_source, &bundled_sources, rust_config)?;
     link_with_cargo(&harness_dir, out_path)?;
 
     eprintln!("[aot] wrote {}", out_path.display());
@@ -674,6 +682,7 @@ fn build_harness(
     obj_bytes: &[u8],
     interpreted_source: &str,
     bundled_sources: &[(Arc<str>, String)],
+    rust_config: Option<&cljrs_deps::RustConfig>,
 ) -> AotResult<PathBuf> {
     // Place the harness in a temp dir next to the output.
     let harness_dir = out_path
@@ -697,6 +706,19 @@ fn build_harness(
     // Write Cargo.toml.
     // The empty [workspace] table prevents Cargo from thinking this is
     // part of a parent workspace.
+    let ws = workspace_root.display();
+    let mut native_deps = String::new();
+    if let Some(rc) = rust_config {
+        native_deps.push_str(&format!(
+            "cljrs-interop  = {{ path = \"{ws}/crates/cljrs-interop\" }}\n"
+        ));
+        if let Some(crate_name) = rc.crate_name() {
+            let crate_dir = rc.crate_dir.display();
+            native_deps.push_str(&format!(
+                "{crate_name} = {{ path = \"{crate_dir}\" }}\n"
+            ));
+        }
+    }
     let cargo_toml = format!(
         r#"[package]
 name = "cljrs-aot-harness"
@@ -714,8 +736,7 @@ cljrs-env      = {{ path = "{ws}/crates/cljrs-env" }}
 cljrs-eval     = {{ path = "{ws}/crates/cljrs-eval" }}
 cljrs-stdlib   = {{ path = "{ws}/crates/cljrs-stdlib" }}
 cljrs-compiler = {{ path = "{ws}/crates/cljrs-compiler" }}
-"#,
-        ws = workspace_root.display()
+{native_deps}"#,
     );
     std::fs::write(harness_dir.join("Cargo.toml"), cargo_toml)?;
 
@@ -771,6 +792,19 @@ cljrs-compiler = {{ path = "{ws}/crates/cljrs-compiler" }}
         ""
     };
 
+    // Emit the native init call when :rust :init is configured.  The init
+    // function has the signature `fn cljrs_init(registry: &mut Registry)`
+    // and is called before the preamble so native functions are visible to
+    // macro-expanded code at startup.
+    let native_init_code = match rust_config.and_then(|rc| rc.init_fn.as_deref()) {
+        Some(init_fn) => format!(
+            "\n    // Register native Rust functions via the user crate's init hook.\n    \
+             let mut __registry = cljrs_interop::Registry::new(globals.clone());\n    \
+             {init_fn}(&mut __registry);\n"
+        ),
+        None => String::new(),
+    };
+
     let main_rs = format!(
         r#"//! Auto-generated AOT harness for clojurust.
 //!
@@ -794,7 +828,7 @@ fn main() {{
 
     // Register bundled dependency sources so require can find them
     // without needing source files on disk.
-{bundled}
+{bundled}{native_init}
     let mut env = cljrs_eval::Env::new(globals, "user");
 
     // Push an eval context so rt_call can dispatch through the interpreter.
@@ -811,7 +845,8 @@ fn main() {{
 }}
 "#,
         preamble = preamble_code,
-        bundled = bundled_registration
+        bundled = bundled_registration,
+        native_init = native_init_code,
     );
     std::fs::write(harness_dir.join("src/main.rs"), main_rs)?;
 

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -528,8 +528,13 @@ pub fn compile_file(
     eprintln!("[aot] generated {} bytes of object code", obj_bytes.len());
 
     // ── 5. Generate harness project & build ─────────────────────────────
-    let harness_dir =
-        build_harness(out_path, &obj_bytes, &interpreted_source, &bundled_sources, rust_config)?;
+    let harness_dir = build_harness(
+        out_path,
+        &obj_bytes,
+        &interpreted_source,
+        &bundled_sources,
+        rust_config,
+    )?;
     link_with_cargo(&harness_dir, out_path)?;
 
     eprintln!("[aot] wrote {}", out_path.display());
@@ -714,9 +719,7 @@ fn build_harness(
         ));
         if let Some(crate_name) = rc.crate_name() {
             let crate_dir = rc.crate_dir.display();
-            native_deps.push_str(&format!(
-                "{crate_name} = {{ path = \"{crate_dir}\" }}\n"
-            ));
+            native_deps.push_str(&format!("{crate_name} = {{ path = \"{crate_dir}\" }}\n"));
         }
     }
     let cargo_toml = format!(

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -37,7 +37,7 @@ fn compile_and_run(name: &str, source: &str) -> String {
         .spawn({
             let src = src_path.clone();
             let bin = bin_path.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[])
+            move || cljrs_compiler::aot::compile_file(&src, &bin, &[], None)
         })
         .unwrap()
         .join()
@@ -1038,7 +1038,7 @@ fn compile_and_run_multi(name: &str, main_source: &str, deps: &[(&str, &str)]) -
             let src = src_path.clone();
             let bin = bin_path.clone();
             let src_dir = src_dir.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir])
+            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None)
         })
         .unwrap()
         .join()

--- a/crates/cljrs-deps/README.md
+++ b/crates/cljrs-deps/README.md
@@ -3,7 +3,8 @@
 ## Purpose
 
 Parses `cljrs.edn` project configuration files and provides the `DepsConfig`
-type used throughout the runtime to locate git-hosted and local dependencies.
+type used throughout the runtime to locate git-hosted and local dependencies,
+and to discover the optional embedded Rust crate configuration.
 
 ## Status
 
@@ -14,7 +15,7 @@ Phase 1 (implemented).  Config parsing is complete.  Integration with the CLI
 
 | File | Description |
 |------|-------------|
-| `src/lib.rs` | Public types (`DepsConfig`, `Dependency`, `Alias`, `GitDep`), `find_config_file`, `load_config` |
+| `src/lib.rs` | Public types (`DepsConfig`, `RustConfig`, `Dependency`, `Alias`, `GitDep`), `find_config_file`, `load_config` |
 | `src/parse.rs` | Walk the `cljrs-reader` Form tree from a `cljrs.edn` source into `DepsConfig` |
 
 ## Public API
@@ -30,9 +31,20 @@ pub fn load_config(start: &Path) -> DepsResult<Option<DepsConfig>>
 pub fn parse_config(src: &str, config_path: &Path) -> Result<DepsConfig, String>
 
 pub struct DepsConfig {
-    pub paths:   Vec<PathBuf>,
-    pub deps:    Vec<(Arc<str>, Dependency)>,
-    pub aliases: Vec<(Arc<str>, Alias)>,
+    pub paths:                    Vec<PathBuf>,
+    pub deps:                     Vec<(Arc<str>, Dependency)>,
+    pub aliases:                  Vec<(Arc<str>, Alias)>,
+    pub verify_commit_signatures: bool,
+    pub rust:                     Option<RustConfig>,
+}
+
+/// Rust-crate configuration for mixed Rust/Clojure projects.
+/// Parsed from the `:rust` key in `cljrs.edn`.
+pub struct RustConfig {
+    /// Directory containing the user's Cargo.toml (resolved from cljrs.edn dir).
+    pub crate_dir: PathBuf,
+    /// Fully-qualified init fn, e.g. "my_project::cljrs_init". Optional.
+    pub init_fn:   Option<Arc<str>>,
 }
 
 pub enum Dependency {
@@ -46,4 +58,25 @@ pub struct Alias {
     pub extra_paths: Vec<PathBuf>,
     pub extra_deps:  Vec<(Arc<str>, Dependency)>,
 }
+```
+
+## cljrs.edn format
+
+```edn
+{:paths ["src"]
+
+ :deps
+ {my.lib {:git/url "https://github.com/user/my-lib" :git/sha "abc1234ef"}}
+
+ ;; Optional: embed a Rust crate in this project.
+ ;; :crate is the path (relative to cljrs.edn) to the directory holding Cargo.toml.
+ ;; :init  is the fully-qualified Rust path to a fn(registry: &mut Registry) called
+ ;;        at startup before any Clojure source is loaded.
+ :rust {:crate "."
+        :init  "my_project::cljrs_init"}
+
+ :aliases
+ {:dev  {:extra-paths ["dev"]}
+  :test {:extra-paths ["test"]
+         :extra-deps  {test-tools {:git/url "..." :git/sha "..."}}}}}
 ```

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -63,6 +63,10 @@ pub struct Alias {
 
 /// Rust-crate configuration for mixed Rust/Clojure projects.
 ///
+/// The `:init` value is a Rust path like `"my_project::cljrs_init"`. The
+/// first `::` segment is the crate name used in `Cargo.toml` and when
+/// looking for the compiled shared library on disk.
+///
 /// Parsed from the `:rust` key in `cljrs.edn`:
 ///
 /// ```edn
@@ -80,6 +84,18 @@ pub struct RustConfig {
     /// Clojure source.  Omit if you rely solely on `#[cljrs::export]`
     /// inventory-based registration (future feature).
     pub init_fn: Option<Arc<str>>,
+}
+
+impl RustConfig {
+    /// Derive the Rust crate name from the init function path.
+    ///
+    /// `"my_project::cljrs_init"` → `Some("my_project")`.
+    /// Returns `None` when `init_fn` is absent.
+    pub fn crate_name(&self) -> Option<&str> {
+        self.init_fn
+            .as_deref()
+            .map(|s| s.split("::").next().unwrap_or(s))
+    }
 }
 
 /// The fully parsed contents of a `cljrs.edn` file.

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -61,6 +61,27 @@ pub struct Alias {
     pub extra_deps: Vec<(Arc<str>, Dependency)>,
 }
 
+/// Rust-crate configuration for mixed Rust/Clojure projects.
+///
+/// Parsed from the `:rust` key in `cljrs.edn`:
+///
+/// ```edn
+/// :rust {:crate "."                        ; path to directory with Cargo.toml
+///        :init  "my_project::cljrs_init"}  ; optional hook-registration fn
+/// ```
+#[derive(Debug, Clone)]
+pub struct RustConfig {
+    /// Directory containing the user's `Cargo.toml`, resolved relative to the
+    /// `cljrs.edn` file.  Defaults to the `cljrs.edn` directory (`"."`).
+    pub crate_dir: PathBuf,
+    /// Fully-qualified Rust path to the init function, e.g.
+    /// `"my_project::cljrs_init"`.  When present, `cljrs compile` emits a
+    /// call to this function in the generated `main.rs` before loading any
+    /// Clojure source.  Omit if you rely solely on `#[cljrs::export]`
+    /// inventory-based registration (future feature).
+    pub init_fn: Option<Arc<str>>,
+}
+
 /// The fully parsed contents of a `cljrs.edn` file.
 #[derive(Debug, Clone, Default)]
 pub struct DepsConfig {
@@ -74,6 +95,8 @@ pub struct DepsConfig {
     /// must pass `git verify-commit` before historical code is executed.
     /// Equivalent to the `--verify-commit-signatures` CLI flag.
     pub verify_commit_signatures: bool,
+    /// Optional Rust-crate configuration for mixed Rust/Clojure projects.
+    pub rust: Option<RustConfig>,
 }
 
 impl DepsConfig {

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use cljrs_reader::{Form, FormKind, Parser};
 
-use crate::{Alias, Dependency, DepsConfig, GitDep};
+use crate::{Alias, Dependency, DepsConfig, GitDep, RustConfig};
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
@@ -56,6 +56,9 @@ fn extract_config(form: &Form, config_dir: &Path) -> Result<DepsConfig, String> 
                 FormKind::Bool(b) => config.verify_commit_signatures = *b,
                 _ => return Err(":verify-commit-signatures must be true or false".to_string()),
             },
+            Some("rust") => {
+                config.rust = Some(extract_rust_config(val, config_dir)?);
+            }
             _ => {} // ignore unknown keys
         }
     }
@@ -161,6 +164,32 @@ fn extract_alias(form: &Form, config_dir: &Path, name: &str) -> Result<Alias, St
     Ok(alias)
 }
 
+// ── :rust ─────────────────────────────────────────────────────────────────────
+
+fn extract_rust_config(form: &Form, config_dir: &Path) -> Result<RustConfig, String> {
+    let pairs = require_map(form, ":rust")?;
+    let mut crate_dir: PathBuf = config_dir.to_path_buf();
+    let mut init_fn: Option<Arc<str>> = None;
+
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        match keyword_name(&pairs[i]) {
+            Some("crate") => {
+                let rel = require_str(&pairs[i + 1], ":rust :crate")?;
+                crate_dir = config_dir.join(rel);
+            }
+            Some("init") => {
+                let s = require_str(&pairs[i + 1], ":rust :init")?;
+                init_fn = Some(Arc::from(s));
+            }
+            _ => {}
+        }
+        i += 2;
+    }
+
+    Ok(RustConfig { crate_dir, init_fn })
+}
+
 // ── Form helpers ──────────────────────────────────────────────────────────────
 
 fn require_map<'a>(form: &'a Form, ctx: &str) -> Result<&'a Vec<Form>, String> {
@@ -198,5 +227,57 @@ fn sym_or_kw_name(form: &Form) -> Option<String> {
         FormKind::Symbol(s) => Some(s.clone()),
         FormKind::Keyword(k) => Some(k.clone()),
         _ => None,
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn parse(src: &str) -> Result<DepsConfig, String> {
+        parse_config(src, Path::new("/proj/cljrs.edn"))
+    }
+
+    #[test]
+    fn rust_key_defaults() {
+        // :rust with only :crate; no :init
+        let cfg = parse(r#"{:rust {:crate "."}}"#).unwrap();
+        let rust = cfg.rust.unwrap();
+        assert_eq!(rust.crate_dir, Path::new("/proj"));
+        assert!(rust.init_fn.is_none());
+    }
+
+    #[test]
+    fn rust_key_with_init() {
+        let cfg = parse(r#"{:rust {:crate "." :init "my_crate::cljrs_init"}}"#).unwrap();
+        let rust = cfg.rust.unwrap();
+        assert_eq!(rust.init_fn.as_deref(), Some("my_crate::cljrs_init"));
+    }
+
+    #[test]
+    fn rust_key_subdirectory_crate() {
+        let cfg = parse(r#"{:rust {:crate "native"}}"#).unwrap();
+        let rust = cfg.rust.unwrap();
+        assert_eq!(rust.crate_dir, Path::new("/proj/native"));
+    }
+
+    #[test]
+    fn no_rust_key_is_none() {
+        let cfg = parse(r#"{:paths ["src"]}"#).unwrap();
+        assert!(cfg.rust.is_none());
+    }
+
+    #[test]
+    fn rust_alongside_other_keys() {
+        let cfg = parse(
+            r#"{:paths ["src"]
+                :rust  {:crate "." :init "lib::cljrs_init"}}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.paths.len(), 1);
+        assert!(cfg.rust.is_some());
     }
 }

--- a/crates/cljrs-interop/Cargo.toml
+++ b/crates/cljrs-interop/Cargo.toml
@@ -10,4 +10,5 @@ repository.workspace = true
 cljrs-types = { workspace = true }
 cljrs-gc    = { workspace = true }
 cljrs-value = { workspace = true }
+cljrs-env   = { workspace = true }
 num-bigint  = { workspace = true }

--- a/crates/cljrs-interop/README.md
+++ b/crates/cljrs-interop/README.md
@@ -4,7 +4,7 @@ Rust ↔ Clojure interoperability layer. Exposes Rust functions to Clojure code,
 marshals values across the boundary, and wraps opaque Rust structs as
 GC-managed `NativeObject` values.
 
-**Phase:** 9 — partially implemented (NativeObject, marshalling, error bridging, registration helpers).
+**Phase:** 9 — partially implemented (NativeObject, marshalling, error bridging, registration helpers, Registry).
 
 ---
 
@@ -16,6 +16,7 @@ src/
   error.rs     — wrap_result: Rust Result → ValueResult<Value>
   marshal.rs   — FromValue / IntoValue traits with impls for common Rust types
   register.rs  — wrap_fn0..wrap_fn3, wrap_fn_variadic: auto-marshalling function wrappers
+  registry.rs  — Registry struct and InitFn type alias for cljrs_init convention
 ```
 
 The `NativeObject` trait and `NativeObjectBox` wrapper live in `cljrs-value::native_object`
@@ -67,13 +68,60 @@ pub fn wrap_fn_variadic<R, E, F>(name: impl Into<Arc<str>>, min: usize, f: F) ->
 These accept closures (not just bare `fn` pointers) since `NativeFnFunc` is now
 `Arc<dyn Fn(&[Value]) -> ValueResult<Value> + Send + Sync>`.
 
+### Registry and InitFn
+
+The entry point for mixed Rust/Clojure projects.  User crates implement a
+`cljrs_init` function and list it under `:rust :init` in `cljrs.edn`; the
+build toolchain calls it before loading any Clojure source.
+
+```rust
+/// Signature of the hook-registration function.
+pub type InitFn = fn(&mut Registry);
+
+pub struct Registry { /* wraps Arc<GlobalEnv> */ }
+
+impl Registry {
+    pub fn new(env: Arc<GlobalEnv>) -> Self;
+
+    /// Register f under "my.ns/my-fn" (panics if no '/' present).
+    pub fn define(&self, qualified: &str, f: NativeFn);
+
+    /// Register f into an explicit namespace under a plain name.
+    pub fn define_in(&self, ns: &str, name: &str, f: NativeFn);
+
+    /// Access the underlying GlobalEnv for advanced operations.
+    pub fn env(&self) -> &Arc<GlobalEnv>;
+}
+```
+
+**Usage pattern:**
+
+```rust
+// user's lib.rs
+use cljrs_interop::{Registry, wrap_fn1, wrap_fn2};
+
+pub fn cljrs_init(registry: &mut Registry) {
+    registry.define("my.project/greet",
+        wrap_fn1("greet", |name: String| Ok::<String, String>(format!("Hello, {name}!"))));
+    registry.define("my.project/add",
+        wrap_fn2("add", |a: i64, b: i64| Ok::<i64, String>(a + b)));
+}
+```
+
+```edn
+;; cljrs.edn
+{:paths ["src"]
+ :rust  {:crate "."
+         :init  "my_project::cljrs_init"}}
+```
+
 ---
 
 ## Remaining work (Phase 9)
 
-- `#[cljx::export]` proc-macro — syntactic sugar over manual registration
-- `cljx.rust` namespace with intrinsics
-- Dynamic linking — load `.so`/`.dylib` Rust extensions at runtime
+- `#[cljrs::export]` proc-macro — syntactic sugar over manual registration
+- `cljrs.rust` namespace with intrinsics
+- Dynamic linking — load `.so`/`.dylib` Rust extensions at runtime via `cljrs build-native`
 
 ---
 
@@ -84,4 +132,5 @@ These accept closures (not just bare `fn` pointers) since `NativeFnFunc` is now
 | `cljrs-types` (workspace) | `CljxError`, `CljxResult` |
 | `cljrs-gc` (workspace) | `GcPtr`, `Trace`, `MarkVisitor` |
 | `cljrs-value` (workspace) | `Value`, `NativeFn`, `NativeObject`, `NativeObjectBox` |
+| `cljrs-env` (workspace) | `GlobalEnv` — used by `Registry` to intern native functions |
 | `num-bigint` (workspace) | `BigInt` marshalling |

--- a/crates/cljrs-interop/src/lib.rs
+++ b/crates/cljrs-interop/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod error;
 pub mod marshal;
 pub mod register;
+pub mod registry;
 
 // Re-export the core interop traits from cljrs-value so downstream crates
 // only need to depend on cljrs-interop.
@@ -24,3 +25,4 @@ pub use cljrs_value::{Arity, NativeFn, Value, ValueError, ValueResult};
 pub use error::wrap_result;
 pub use marshal::{FromValue, IntoValue};
 pub use register::{wrap_fn_variadic, wrap_fn0, wrap_fn1, wrap_fn2, wrap_fn3};
+pub use registry::{InitFn, Registry};

--- a/crates/cljrs-interop/src/registry.rs
+++ b/crates/cljrs-interop/src/registry.rs
@@ -1,0 +1,121 @@
+//! `Registry` — entry point for native Rust code to register Clojure-visible
+//! functions and values.
+//!
+//! # Usage
+//!
+//! User crates that embed Rust code alongside Clojure sources implement a
+//! `cljrs_init` function matching the [`InitFn`] signature:
+//!
+//! ```rust,ignore
+//! use cljrs_interop::{Registry, wrap_fn1};
+//!
+//! pub fn cljrs_init(registry: &mut Registry) {
+//!     registry.define("my.project/greet", wrap_fn1("greet", |name: String| {
+//!         Ok::<String, String>(format!("Hello, {name}!"))
+//!     }));
+//! }
+//! ```
+//!
+//! The `cljrs compile` toolchain reads the `:rust :init` key from `cljrs.edn`
+//! (e.g. `"my_project::cljrs_init"`) and emits a generated `main.rs` that calls
+//! it before loading any Clojure source.
+
+use std::sync::Arc;
+
+use cljrs_env::env::GlobalEnv;
+use cljrs_gc::GcPtr;
+use cljrs_value::{NativeFn, Value};
+
+// ── InitFn ────────────────────────────────────────────────────────────────────
+
+/// The expected signature of a Rust-side hook-registration function.
+///
+/// Name your function `cljrs_init` and list it under `:rust :init` in
+/// `cljrs.edn` so the build toolchain can wire it up automatically:
+///
+/// ```edn
+/// :rust {:crate "."
+///        :init  "my_crate::cljrs_init"}
+/// ```
+pub type InitFn = fn(&mut Registry);
+
+// ── Registry ──────────────────────────────────────────────────────────────────
+
+/// A handle passed to [`InitFn`] implementations so they can register native
+/// functions and values into the Clojure namespace table.
+///
+/// `Registry` wraps an `Arc<GlobalEnv>` and is intentionally thin: it exposes
+/// only the operations needed for safe interop, leaving advanced `GlobalEnv`
+/// access available via [`Registry::env`].
+pub struct Registry {
+    env: Arc<GlobalEnv>,
+}
+
+impl Registry {
+    /// Create a `Registry` backed by `env`.
+    ///
+    /// Called by the generated `main.rs`; user code receives `&mut Registry`
+    /// and never constructs one directly.
+    pub fn new(env: Arc<GlobalEnv>) -> Self {
+        Self { env }
+    }
+
+    /// Register `f` under the fully-qualified Clojure name `"my.ns/my-fn"`.
+    ///
+    /// The namespace is created if it does not yet exist. The unqualified
+    /// symbol after `/` becomes the var name visible to Clojure code.
+    ///
+    /// Panics if `qualified` contains no `/`; use [`define_in`][Self::define_in]
+    /// for plain names.
+    pub fn define(&self, qualified: &str, f: NativeFn) {
+        let (ns, sym) = split_qualified(qualified)
+            .unwrap_or_else(|| panic!("Registry::define: {qualified:?} has no '/' separator"));
+        self.env
+            .intern(ns, Arc::from(sym), Value::NativeFunction(GcPtr::new(f)));
+    }
+
+    /// Register `f` into an explicit namespace under a plain (unqualified) name.
+    ///
+    /// Equivalent to `define("ns/name", f)` but avoids string formatting when
+    /// the parts are already separate.
+    pub fn define_in(&self, ns: &str, name: &str, f: NativeFn) {
+        self.env
+            .intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(f)));
+    }
+
+    /// Access the underlying `GlobalEnv` for operations beyond simple `define`
+    /// (e.g. registering builtin namespace sources, setting aliases).
+    pub fn env(&self) -> &Arc<GlobalEnv> {
+        &self.env
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Split `"my.ns/sym"` into `Some(("my.ns", "sym"))`, or `None` if no `/`.
+fn split_qualified(s: &str) -> Option<(&str, &str)> {
+    s.rfind('/').map(|idx| (&s[..idx], &s[idx + 1..]))
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::split_qualified;
+
+    #[test]
+    fn split_simple() {
+        assert_eq!(split_qualified("my.ns/my-fn"), Some(("my.ns", "my-fn")));
+    }
+
+    #[test]
+    fn split_nested_slash() {
+        // rfind: last '/' wins — shouldn't arise in practice but must be deterministic.
+        assert_eq!(split_qualified("a/b/c"), Some(("a/b", "c")));
+    }
+
+    #[test]
+    fn split_no_slash() {
+        assert_eq!(split_qualified("plain"), None);
+    }
+}

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -40,4 +40,5 @@ clap          = { workspace = true }
 miette        = { workspace = true }
 tracing-subscriber = "0.3.23"
 tracing = "0.1.44"
-rustyline = { workspace = true, optional = true }
+rustyline  = { workspace = true, optional = true }
+libloading = { workspace = true }

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -3,7 +3,7 @@
 The `cljrs` binary — command-line interface for running, compiling, and
 interactively exploring clojurust programs.
 
-**[Full documentation →](https://csm.github.io/clojurust/)**
+**[Full documentation →](https://docs.clj.rs)**
 
 ---
 

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -328,13 +328,8 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
                 cljrs_compiler::aot::compile_test_harness(&file, &out, &src_paths)
                     .map_err(|e| miette::miette!("{e}"))?;
             } else {
-                cljrs_compiler::aot::compile_file(
-                    &file,
-                    &out,
-                    &src_paths,
-                    rust_config.as_ref(),
-                )
-                .map_err(|e| miette::miette!("{e}"))?;
+                cljrs_compiler::aot::compile_file(&file, &out, &src_paths, rust_config.as_ref())
+                    .map_err(|e| miette::miette!("{e}"))?;
             }
             Ok(0)
         }

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -164,6 +164,22 @@ enum Commands {
         #[command(subcommand)]
         command: DepsCommands,
     },
+    /// Build the project's native Rust crate as a shared library.
+    ///
+    /// Reads the `:rust` key from `cljrs.edn`, runs `cargo build` in the
+    /// declared crate directory, and prints the path of the resulting
+    /// `.so` / `.dylib` / `.dll`.  The library is loaded automatically by
+    /// `cljrs run` and `cljrs repl` to register native functions before any
+    /// Clojure code is evaluated.
+    ///
+    /// The user crate must declare `crate-type = ["cdylib"]` (or
+    /// `["cdylib", "rlib"]`) and export a `#[no_mangle] pub extern "C" fn
+    /// cljrs_init(registry: *mut cljrs_interop::Registry)` entry point.
+    BuildNative {
+        /// Build in release mode instead of debug.
+        #[arg(long)]
+        release: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -301,13 +317,24 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
         } => {
             // GC config is for the compiled binary, not the compilation process
             let _gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
+            // Load cljrs.edn :rust config so native init gets wired into the
+            // generated harness main.rs.
+            let rust_config = std::env::current_dir()
+                .ok()
+                .and_then(|cwd| cljrs_deps::load_config(&cwd).ok().flatten())
+                .and_then(|c| c.rust);
             if test {
                 // For test mode, the file is a directory containing test files
                 cljrs_compiler::aot::compile_test_harness(&file, &out, &src_paths)
                     .map_err(|e| miette::miette!("{e}"))?;
             } else {
-                cljrs_compiler::aot::compile_file(&file, &out, &src_paths)
-                    .map_err(|e| miette::miette!("{e}"))?;
+                cljrs_compiler::aot::compile_file(
+                    &file,
+                    &out,
+                    &src_paths,
+                    rust_config.as_ref(),
+                )
+                .map_err(|e| miette::miette!("{e}"))?;
             }
             Ok(0)
         }
@@ -344,6 +371,7 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
             DepsCommands::Fetch { name } => run_deps_fetch(name),
             DepsCommands::Status => run_deps_status(),
         },
+        Commands::BuildNative { release } => run_build_native(release),
     }
 }
 
@@ -443,6 +471,11 @@ fn apply_deps_config(globals: &Arc<GlobalEnv>, cwd: &Path) {
                     .verify_commit_signatures
                     .store(true, std::sync::atomic::Ordering::Relaxed);
             }
+            // Load the native shared library (if :rust is configured) so that
+            // native functions are registered before any Clojure code runs.
+            if let Some(rust_config) = &config.rust {
+                load_native_lib(rust_config, globals);
+            }
             *globals.deps_config.write().unwrap() = Some(Arc::new(config));
         }
         Ok(None) => {}
@@ -495,6 +528,128 @@ fn format_eval_error(e: EvalError) -> miette::Report {
             miette::miette!("commit {commit:?} failed signature verification: {reason}")
         }
     }
+}
+
+// ── Native library support ────────────────────────────────────────────────────
+
+/// Return the expected on-disk path for the shared library produced by
+/// `cargo build` inside `crate_dir`.
+fn native_lib_path(crate_dir: &Path, crate_name: &str, release: bool) -> PathBuf {
+    let profile = if release { "release" } else { "debug" };
+    let lib_file = if cfg!(target_os = "windows") {
+        format!("{crate_name}.dll")
+    } else if cfg!(target_os = "macos") {
+        format!("lib{crate_name}.dylib")
+    } else {
+        format!("lib{crate_name}.so")
+    };
+    crate_dir.join("target").join(profile).join(lib_file)
+}
+
+/// Load the shared library declared by `rust_config` and call its `cljrs_init`
+/// entry point to register native functions into `globals`.
+///
+/// A missing library emits a warning and returns — callers of unregistered
+/// functions will get a runtime error rather than a startup crash, which is
+/// friendlier during development.
+fn load_native_lib(rust_config: &cljrs_deps::RustConfig, globals: &Arc<GlobalEnv>) {
+    let Some(init_fn) = rust_config.init_fn.as_deref() else {
+        return;
+    };
+    let Some(crate_name) = rust_config.crate_name() else {
+        return;
+    };
+    // Symbol name is the last segment of the Rust path, e.g. "cljrs_init".
+    let sym_name = init_fn.rsplit("::").next().unwrap_or(init_fn);
+
+    let lib_path = native_lib_path(&rust_config.crate_dir, crate_name, false);
+    if !lib_path.exists() {
+        eprintln!(
+            "cljrs: native library not found at {} — run `cljrs build-native` first",
+            lib_path.display()
+        );
+        return;
+    }
+
+    // SAFETY: we own the process and are responsible for ensuring the library
+    // stays loaded (via mem::forget below) for the entire lifetime of globals.
+    unsafe {
+        let lib = match libloading::Library::new(&lib_path) {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("cljrs: could not load {}: {e}", lib_path.display());
+                return;
+            }
+        };
+
+        // The exported symbol has C linkage and takes a raw pointer so it is
+        // callable across the FFI boundary without ABI assumptions.
+        let sym_bytes: Vec<u8> = format!("{sym_name}\0").into_bytes();
+        let init: libloading::Symbol<unsafe extern "C" fn(*mut cljrs_interop::Registry)> =
+            match lib.get(&sym_bytes) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "cljrs: could not find symbol {sym_name} in {}: {e}",
+                        lib_path.display()
+                    );
+                    return;
+                }
+            };
+
+        let mut registry = cljrs_interop::Registry::new(globals.clone());
+        init(&mut registry as *mut _);
+
+        // Prevent the library from being unloaded — its code must remain
+        // reachable as long as any registered NativeFn closures exist.
+        std::mem::forget(lib);
+    }
+    eprintln!(
+        "[build-native] loaded {} ({})",
+        lib_path.display(),
+        sym_name
+    );
+}
+
+/// Build the native Rust crate declared in `cljrs.edn` as a shared library.
+fn run_build_native(release: bool) -> miette::Result<i32> {
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let config = cljrs_deps::load_config(&cwd)
+        .into_diagnostic()?
+        .ok_or_else(|| miette::miette!("no cljrs.edn found in or above the current directory"))?;
+
+    let rust_config = config
+        .rust
+        .as_ref()
+        .ok_or_else(|| miette::miette!("no :rust key found in cljrs.edn"))?;
+
+    let crate_name = rust_config
+        .crate_name()
+        .ok_or_else(|| miette::miette!(":rust has no :init function; cannot derive crate name"))?;
+
+    eprintln!(
+        "[build-native] building {} in {}",
+        crate_name,
+        rust_config.crate_dir.display()
+    );
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.arg("build");
+    if release {
+        cmd.arg("--release");
+    }
+    cmd.current_dir(&rust_config.crate_dir);
+
+    let status = cmd.status().into_diagnostic()?;
+    if !status.success() {
+        return Err(miette::miette!("cargo build failed"));
+    }
+
+    let lib_path = native_lib_path(&rust_config.crate_dir, crate_name, release);
+    eprintln!("[build-native] built {}", lib_path.display());
+    println!("{}", lib_path.display());
+
+    Ok(0)
 }
 
 // ── Deps subcommand ───────────────────────────────────────────────────────────

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [compile](cli/compile.md)
   - [test](cli/test.md)
   - [deps](cli/deps.md)
+  - [build-native](cli/build-native.md)
   - [ir-viz](cli/ir-viz.md)
 
 # The Language
@@ -20,3 +21,11 @@
 - [Versioned symbols](language/versioned-symbols.md)
 - [Differences from Clojure](language/differences.md)
 - [New built-in functions](language/builtins.md)
+
+# Rust Interop
+
+- [Overview](rust-interop/index.md)
+- [Project setup](rust-interop/project-setup.md)
+- [Registry API](rust-interop/registry.md)
+- [Interpreter mode](rust-interop/interpreter.md)
+- [AOT mode](rust-interop/aot.md)

--- a/docs/book/src/cli/build-native.md
+++ b/docs/book/src/cli/build-native.md
@@ -1,0 +1,51 @@
+# cljrs build-native
+
+Compile the project's embedded Rust crate to a shared library so that
+`cljrs run` and `cljrs repl` can load native functions at startup.
+
+```
+cljrs build-native [--release]
+```
+
+This command reads the `:rust` key from the nearest `cljrs.edn`, runs
+`cargo build` inside the declared crate directory, and prints the path of the
+resulting library to stdout.
+
+## Options
+
+### `--release`
+
+Build in release mode (`cargo build --release`) instead of the default debug
+mode. Use this when profiling or shipping.
+
+## What it does
+
+1. Locates `cljrs.edn` by walking up the directory tree.
+2. Reads `:rust :crate` (the directory containing the user's `Cargo.toml`)
+   and `:rust :init` (the fully-qualified Rust path to the init function).
+3. Derives the crate name from the first `::` segment of the init path —
+   e.g. `"my_project::cljrs_init"` → `my_project`.
+4. Runs `cargo build [--release]` in the crate directory.
+5. Prints the output library path on success:
+   - Linux: `target/debug/libmy_project.so`
+   - macOS: `target/debug/libmy_project.dylib`
+   - Windows: `target/debug/my_project.dll`
+
+## Auto-loading
+
+Once the library exists, `cljrs run` and `cljrs repl` load it automatically on
+startup — no flags required. If the library is absent (not yet built or
+deleted), a warning is printed but the interpreter continues; calls to
+unregistered native functions will produce a runtime error.
+
+## Example
+
+```
+# Build the native library
+cljrs build-native
+
+# Now run Clojure code that calls native functions
+cljrs run src/main.cljrs
+```
+
+See [Rust Interop](../rust-interop/index.md) for a complete walkthrough.

--- a/docs/book/src/cli/compile.md
+++ b/docs/book/src/cli/compile.md
@@ -59,3 +59,9 @@ cljrs compile --test test/ --out run-tests && ./run-tests
 AOT compilation is based on Cranelift. Not all language features are yet
 supported in AOT mode; in particular, features that rely on dynamic dispatch
 or late binding may fall back to interpreted execution within the compiled binary.
+
+## Native Rust code
+
+If `cljrs.edn` contains a `:rust` key, `cljrs compile` links the declared Rust
+crate into the binary and calls its `cljrs_init` function before any Clojure
+code runs. See [AOT mode](../rust-interop/aot.md) for details.

--- a/docs/book/src/cli/deps.md
+++ b/docs/book/src/cli/deps.md
@@ -86,7 +86,11 @@ valid clojurust EDN:
          :extra-deps  {test-tools {:git/url "..."
                                    :git/sha "..."}}}}
 
- :verify-commit-signatures true}
+ :verify-commit-signatures true
+
+ ; Optional: embed a Rust crate for native interop
+ :rust {:crate "."
+        :init  "my_project::cljrs_init"}}
 ```
 
 ### Keys
@@ -97,6 +101,23 @@ valid clojurust EDN:
 | `:deps` | map | Map from dependency name (symbol) to dependency descriptor. |
 | `:aliases` | map | Named alias maps with `:extra-paths` and `:extra-deps`. |
 | `:verify-commit-signatures` | boolean | If `true`, require GPG/SSH signatures on all versioned commits. |
+| `:rust` | map | Embedded Rust crate for native interop. See [Rust Interop](../rust-interop/index.md). |
+
+#### `:rust` key
+
+```clojure
+:rust {:crate "."                       ; path to Cargo.toml directory
+       :init  "my_project::cljrs_init"} ; Rust path to the init function
+```
+
+| Sub-key | Description |
+|---|---|
+| `:crate` | Directory containing the user's `Cargo.toml`, relative to `cljrs.edn`. |
+| `:init` | Fully-qualified Rust path to the init function. The first `::` segment is treated as the crate name. |
+
+When `:rust` is present, `cljrs run` and `cljrs repl` automatically load the
+compiled shared library from `<crate>/target/debug/lib<name>.so` (or
+equivalent). Build it first with `cljrs build-native`.
 
 ### Dependency descriptors
 

--- a/docs/book/src/rust-interop/aot.md
+++ b/docs/book/src/rust-interop/aot.md
@@ -1,0 +1,99 @@
+# AOT Mode
+
+When `cljrs compile` detects a `:rust` key in `cljrs.edn`, it statically links
+the user's Rust crate into the generated binary. The compiled binary is fully
+self-contained: no shared library or `cljrs` installation is needed at runtime.
+
+## How it works
+
+`cljrs compile` generates a temporary Cargo harness project that:
+
+1. Depends on the clojurust runtime crates (`cljrs-stdlib`, `cljrs-eval`, etc.)
+2. Also depends on the user's Rust crate (via `path = "<crate_dir>"`)
+3. Also depends on `cljrs-interop` (for `Registry`)
+4. Contains a generated `main.rs` that:
+   a. Initialises the standard environment
+   b. Creates a `Registry` and calls the user's init function
+   c. Evaluates the Clojure preamble (interpreted forms: `ns`, `require`, `defmacro`, …)
+   d. Calls the AOT-compiled `__cljrs_main` function
+
+The harness is compiled with `cargo build --release` and the resulting binary
+is copied to the output path.
+
+## Generated `main.rs` (simplified)
+
+```rust
+fn main() {
+    cljrs_compiler::rt_abi::anchor_rt_symbols();
+
+    let globals = cljrs_stdlib::standard_env();
+
+    // Native init — registered before any Clojure code runs
+    let mut registry = cljrs_interop::Registry::new(globals.clone());
+    my_project::cljrs_init(&mut registry);
+
+    let mut env = cljrs_eval::Env::new(globals, "user");
+    cljrs_env::callback::push_eval_context(&env);
+
+    // Interpreted preamble (ns, require, defmacro, …)
+    // …
+
+    // AOT-compiled body
+    unsafe { __cljrs_main() };
+}
+```
+
+## Crate type requirement
+
+For AOT static linking the user crate must produce an `rlib` (the default for
+library crates). If you also need interpreter-mode dynamic loading, declare
+both:
+
+```toml
+[lib]
+crate-type = ["cdylib", "rlib"]
+```
+
+If you only need AOT (no `cljrs run` native loading), `crate-type = ["rlib"]`
+is sufficient.
+
+## Building an AOT binary
+
+```
+# Build once (debug or release)
+cljrs build-native          # optional — only needed for cljrs run
+
+# Compile to a native binary
+cljrs compile src/main.cljrs --out myapp
+
+# Run anywhere — no cljrs required
+./myapp
+```
+
+The `cljrs compile` step does **not** require a pre-built `.so`; it statically
+links the Rust crate directly. You do not need to run `cljrs build-native`
+before `cljrs compile`.
+
+## Native functions in the preamble
+
+Because the native init call happens before the interpreted preamble is
+evaluated, native functions are visible to `ns`, `require`, macros, and
+`defprotocol`/`extend-type` forms that run at startup:
+
+```clojure
+(ns my.app
+  (:require [my.project]))   ; my.project namespace already populated
+
+(defprotocol IWidget
+  (render [w]))
+
+(extend-type my_project.Widget IWidget   ; native type tag
+  (render [w] (my.project/widget-render w)))
+```
+
+## Offline builds
+
+The AOT harness uses `cargo build --release --offline` by default. All
+dependencies (the clojurust crates and the user crate) must be resolvable
+without network access. Point to local paths in `Cargo.toml` as shown in
+[Project setup](project-setup.md).

--- a/docs/book/src/rust-interop/index.md
+++ b/docs/book/src/rust-interop/index.md
@@ -1,0 +1,75 @@
+# Rust Interop
+
+clojurust lets Clojure code call Rust functions with full type safety and GC
+integration. The interop layer has two modes that work together:
+
+- **Interpreter mode** — the Rust crate is compiled to a shared library
+  (`.so`/`.dylib`/`.dll`) and loaded by `cljrs run`/`cljrs repl` at startup via
+  `cljrs build-native`.
+- **AOT mode** — `cljrs compile` statically links the Rust crate into the
+  generated binary; the native init function is called before any Clojure code
+  runs.
+
+Both modes use the same API: a `Registry` object that maps Clojure-visible
+names to Rust functions.
+
+## When to use Rust interop
+
+- Wrapping an existing Rust library (e.g. a database driver, image codec, or
+  systems API) for use from Clojure.
+- Hot paths where Clojure performance is insufficient.
+- Exposing mutable or OS-level state (file descriptors, sockets, GPU buffers)
+  as opaque `NativeObject` values that participate in protocol dispatch.
+
+## Chapter overview
+
+| Page | Contents |
+|---|---|
+| [Project setup](project-setup.md) | `cljrs.edn` config, Cargo setup, crate layout |
+| [Registry API](registry.md) | `Registry`, `wrap_fn*`, type marshalling, `NativeObject` |
+| [Interpreter mode](interpreter.md) | `cljrs build-native`, auto-loading, hot-reload workflow |
+| [AOT mode](aot.md) | How `cljrs compile` wires native init into the binary |
+
+## Quick example
+
+**`cljrs.edn`:**
+```clojure
+{:paths ["src"]
+ :rust  {:crate "."
+         :init  "my_project::cljrs_init"}}
+```
+
+**`Cargo.toml` (user crate):**
+```toml
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cljrs-interop = { path = "/path/to/cljrs/crates/cljrs-interop" }
+```
+
+**`src/lib.rs`:**
+```rust
+use cljrs_interop::{Registry, wrap_fn2};
+
+#[no_mangle]
+pub extern "C" fn cljrs_init(registry: *mut Registry) {
+    let r = unsafe { &mut *registry };
+    r.define("my.project/add",
+        wrap_fn2("add", |a: i64, b: i64| Ok::<i64, String>(a + b)));
+}
+```
+
+**`src/main.cljrs`:**
+```clojure
+(ns my.project.core
+  (:require [my.project :as native]))
+
+(println (native/add 3 4))   ; => 7
+```
+
+**Workflow:**
+```
+cljrs build-native            # compile lib → target/debug/libmy_project.so
+cljrs run src/main.cljrs      # auto-loads the .so, then runs Clojure
+```

--- a/docs/book/src/rust-interop/interpreter.md
+++ b/docs/book/src/rust-interop/interpreter.md
@@ -1,0 +1,83 @@
+# Interpreter Mode
+
+In interpreter mode (`cljrs run` / `cljrs repl`), the Rust crate is compiled to
+a shared library and loaded at startup via `dlopen`. No recompilation of
+`cljrs` itself is required.
+
+## Workflow
+
+```
+# 1. Build the shared library (once, or after Rust changes)
+cljrs build-native
+
+# 2. Run Clojure code — the .so is loaded automatically
+cljrs run src/main.cljrs
+
+# 3. Start the REPL — also auto-loads
+cljrs repl
+```
+
+`cljrs build-native` is just `cargo build` run inside the crate directory
+declared by `:rust :crate` in `cljrs.edn`. It inherits your normal Rust
+toolchain, `RUSTFLAGS`, and `cargo` configuration.
+
+## How auto-loading works
+
+When `cljrs run` (or `repl`) starts:
+
+1. It locates `cljrs.edn` by walking up the directory tree.
+2. If `:rust` is present, it derives the library path from the crate name and
+   profile (`debug` by default):
+   - Linux: `<crate_dir>/target/debug/lib<crate_name>.so`
+   - macOS: `<crate_dir>/target/debug/lib<crate_name>.dylib`
+   - Windows: `<crate_dir>/target/debug/<crate_name>.dll`
+3. It opens the library with `dlopen` and looks up the symbol named after the
+   last `::` segment of `:rust :init` (e.g. `"cljrs_init"`).
+4. It calls the symbol with a `*mut Registry`, which registers all native
+   functions into the global namespace table.
+5. The library is kept loaded for the lifetime of the process.
+
+All of this happens before any Clojure source is evaluated, so native functions
+are visible to `ns`/`require` forms and to top-level code.
+
+## Missing library
+
+If the shared library does not exist yet, `cljrs` prints a warning and
+continues:
+
+```
+cljrs: native library not found at target/debug/libmy_project.so
+       — run `cljrs build-native` first
+```
+
+Clojure code that calls unregistered native functions will get a runtime error;
+code that doesn't call them runs normally. This is intentional: you can develop
+pure-Clojure parts of a mixed project without running `cljrs build-native` on
+every edit.
+
+## Release builds
+
+Pass `--release` to build an optimised library:
+
+```
+cljrs build-native --release
+```
+
+The release library is placed at `target/release/libmy_project.so` (and so on).
+Note that `cljrs run` always looks for the **debug** build; to use the release
+library you currently need to copy it to the debug path or symlink it. (A future
+`--release` flag on `run`/`repl` will automate this.)
+
+## Development tips
+
+- **Fast iteration:** `cljrs build-native` compiles only the Rust crate, not the
+  whole clojurust workspace. On a warm build cache it typically takes a few
+  seconds.
+- **Separate processes:** Because the library is opened once at startup,
+  changes to Rust code require restarting `cljrs run`. There is no hot-reload
+  of native code within a single process.
+- **Cargo features:** Pass `CARGO_FLAGS` or set `[profile.*]` in your
+  `Cargo.toml` as usual; `cljrs build-native` inherits the environment.
+- **Debugging:** Use `RUST_LOG`, `RUST_BACKTRACE=1`, and your normal Rust
+  debugging tools. The library is a standard shared object; `gdb`/`lldb`
+  can attach to the `cljrs` process and set breakpoints in native code.

--- a/docs/book/src/rust-interop/project-setup.md
+++ b/docs/book/src/rust-interop/project-setup.md
@@ -1,0 +1,104 @@
+# Project Setup
+
+A mixed Rust/Clojure project needs three things: a `cljrs.edn` that points to
+the Rust crate, a `Cargo.toml` with the right crate type, and a `cljrs_init`
+entry point.
+
+## Directory layout
+
+```
+my-project/
+├── cljrs.edn          # Clojure project config (source paths, :rust key)
+├── Cargo.toml         # Rust crate manifest
+├── src/
+│   ├── lib.rs         # Rust source — defines cljrs_init and native fns
+│   └── main.cljrs     # Clojure entry point
+```
+
+The Rust crate and the `cljrs.edn` file can live in the same directory (`:crate
+"."`) or in a subdirectory (`:crate "native"`).
+
+## `cljrs.edn`
+
+Add a `:rust` map to the top-level config:
+
+```clojure
+{:paths ["src"]
+
+ :rust {:crate "."                       ; path to Cargo.toml directory
+        :init  "my_project::cljrs_init"} ; Rust path to the init function
+}
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `:crate` | yes | Path to the directory containing the user's `Cargo.toml`. Relative to `cljrs.edn`. |
+| `:init` | yes | Fully-qualified Rust path to the init function, e.g. `"my_crate::cljrs_init"`. The first `::` segment is used as the crate name. |
+
+## `Cargo.toml`
+
+The user crate must be a library with `cdylib` output (for interpreter-mode
+dynamic loading) and, optionally, `rlib` output (for AOT static linking):
+
+```toml
+[package]
+name    = "my_project"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cljrs-interop = { path = "/path/to/cljrs/crates/cljrs-interop" }
+```
+
+> **Note:** `cdylib` produces the `.so`/`.dylib`/`.dll` loaded by `cljrs run`.
+> `rlib` allows `cljrs compile` to link the crate statically into the AOT
+> binary. Both can coexist in `crate-type`.
+
+## The `cljrs_init` entry point
+
+The init function receives a `*mut Registry` pointer and registers all native
+functions. It must have C linkage so the dynamic linker can find it by name:
+
+```rust
+use cljrs_interop::{Registry, wrap_fn1, wrap_fn2};
+
+#[no_mangle]
+pub extern "C" fn cljrs_init(registry: *mut Registry) {
+    let r = unsafe { &mut *registry };
+
+    r.define("my.project/greet",
+        wrap_fn1("greet", |name: String| {
+            Ok::<String, String>(format!("Hello, {name}!"))
+        }));
+
+    r.define("my.project/add",
+        wrap_fn2("add", |a: i64, b: i64| Ok::<i64, String>(a + b)));
+}
+```
+
+The function name in `:rust :init` (`"my_project::cljrs_init"`) must match the
+Rust function name used in `#[no_mangle]` (`cljrs_init`). The crate prefix
+(`my_project`) is used when generating the AOT harness; it must match the
+`[package] name` in `Cargo.toml` with hyphens replaced by underscores.
+
+## Calling native functions from Clojure
+
+Native functions registered under `"my.project/greet"` are visible in Clojure
+as `my.project/greet`. No `require` is needed unless you want a namespace alias:
+
+```clojure
+; Direct qualified call
+(my.project/greet "world")       ; => "Hello, world!"
+
+; With a require alias
+(ns my.app
+  (:require [my.project :as native]))
+
+(native/add 3 4)                 ; => 7
+```
+
+The namespace `my.project` is created automatically when `cljrs_init` is called;
+you do not need to create or load a Clojure file for it.

--- a/docs/book/src/rust-interop/registry.md
+++ b/docs/book/src/rust-interop/registry.md
@@ -1,0 +1,192 @@
+# Registry API
+
+The `Registry` type (from `cljrs_interop`) is the handle passed to `cljrs_init`
+for registering Rust functions as Clojure-visible values.
+
+## `Registry` methods
+
+```rust
+// Register f under "my.ns/my-fn".
+// Panics if `qualified` contains no '/'.
+pub fn define(&self, qualified: &str, f: NativeFn);
+
+// Register f into an explicit namespace with a plain name.
+// Equivalent to define("ns/name", f).
+pub fn define_in(&self, ns: &str, name: &str, f: NativeFn);
+
+// Access the underlying GlobalEnv for advanced operations
+// (registering builtin sources, setting namespace aliases, etc.).
+pub fn env(&self) -> &Arc<GlobalEnv>;
+```
+
+## Wrapping Rust functions
+
+The `wrap_fn*` family converts idiomatic Rust signatures into `NativeFn` values.
+Arguments and return values are marshalled automatically via the `FromValue` and
+`IntoValue` traits.
+
+```rust
+use cljrs_interop::{wrap_fn0, wrap_fn1, wrap_fn2, wrap_fn3, wrap_fn_variadic};
+
+// Zero arguments
+wrap_fn0("my.ns/timestamp", || Ok::<i64, String>(epoch_millis()))
+
+// One argument
+wrap_fn1("my.ns/double", |x: i64| Ok::<i64, String>(x * 2))
+
+// Two arguments
+wrap_fn2("my.ns/add", |a: i64, b: i64| Ok::<i64, String>(a + b))
+
+// Three arguments
+wrap_fn3("my.ns/clamp", |lo: i64, hi: i64, x: i64| Ok::<i64, String>(x.clamp(lo, hi)))
+
+// Variadic — receives &[Value] directly; minimum argument count enforced
+wrap_fn_variadic("my.ns/sum", 0, |args: &[Value]| {
+    let total: i64 = args.iter().filter_map(|v| i64::from_value(v).ok()).sum();
+    Ok::<i64, String>(total)
+})
+```
+
+All wrappers accept closures (not just bare `fn` pointers), so they can capture
+Rust state:
+
+```rust
+let multiplier = Arc::new(AtomicI64::new(3));
+let m = multiplier.clone();
+r.define("my.ns/scale",
+    wrap_fn1("scale", move |x: i64| {
+        Ok::<i64, String>(x * m.load(Ordering::Relaxed))
+    }));
+```
+
+## Type marshalling
+
+### Built-in conversions
+
+| Clojure type | Rust type |
+|---|---|
+| `nil` | `()` or `Option<T>` (`None`) |
+| `true` / `false` | `bool` |
+| Long | `i64` |
+| Double | `f64` (also accepts Long) |
+| String | `String` |
+| Any value | `Value` (pass-through) |
+| Nil or any | `Option<T>` |
+| BigInt | `num_bigint::BigInt` |
+
+Implement `FromValue` and/or `IntoValue` on your own types to add new
+conversions:
+
+```rust
+use cljrs_interop::{FromValue, IntoValue};
+use cljrs_value::{Value, ValueResult};
+
+struct Point { x: f64, y: f64 }
+
+impl IntoValue for Point {
+    fn into_value(self) -> Value {
+        // encode as a two-element vector
+        Value::vector(vec![self.x.into_value(), self.y.into_value()])
+    }
+}
+```
+
+### Error bridging
+
+All `wrap_fn*` closures return `Result<R, E>` where `E: Display`. Any `Err`
+value is converted to a Clojure exception and re-thrown; `Ok` values are
+marshalled via `IntoValue`.
+
+For explicit control, use `wrap_result`:
+
+```rust
+use cljrs_interop::wrap_result;
+
+fn my_fn(args: &[Value]) -> ValueResult<Value> {
+    let n = i64::from_value(&args[0])?;
+    wrap_result(std::fs::read_to_string(format!("/tmp/{n}.txt")))
+}
+```
+
+## Opaque Rust objects (`NativeObject`)
+
+Arbitrary Rust structs can be wrapped as Clojure values using the `NativeObject`
+trait. The value appears in Clojure as an opaque object that can be passed
+around, stored in collections, and dispatched on via protocols.
+
+```rust
+use cljrs_interop::{NativeObject, gc_native_object};
+use cljrs_gc::{MarkVisitor, Trace};
+use cljrs_value::Value;
+
+#[derive(Debug)]
+struct Connection { /* ... */ }
+
+impl NativeObject for Connection {
+    fn type_tag(&self) -> &str { "Connection" }
+    fn as_any(&self) -> &dyn std::any::Any { self }
+}
+
+// Connection holds no GcPtr fields, so Trace is a no-op.
+impl Trace for Connection {
+    fn trace(&self, _: &mut MarkVisitor) {}
+}
+
+// Create a Value::NativeObject wrapping a Connection.
+fn make_conn(_args: &[Value]) -> ValueResult<Value> {
+    let conn = Connection { /* ... */ };
+    Ok(Value::NativeObject(gc_native_object(conn)))
+}
+```
+
+To downcast back to the concrete type in a Rust function:
+
+```rust
+fn use_conn(args: &[Value]) -> ValueResult<Value> {
+    let Value::NativeObject(obj) = &args[0] else {
+        return Err(ValueError::WrongType { expected: "Connection", got: "…".into() });
+    };
+    let conn = obj.get().downcast_ref::<Connection>()
+        .ok_or_else(|| ValueError::WrongType { expected: "Connection", got: obj.get().type_tag().into() })?;
+    // use conn…
+    Ok(Value::Nil)
+}
+```
+
+### Protocol dispatch on native objects
+
+`extend-type` can be used in Clojure to implement protocols for native objects.
+The type tag (the string returned by `type_tag()`) is used for dispatch:
+
+```clojure
+(defprotocol IConn
+  (query [conn sql])
+  (close! [conn]))
+
+(extend-type Connection IConn
+  (query  [conn sql]  (native/db-query conn sql))
+  (close! [conn]      (native/db-close conn)))
+```
+
+### GC integration
+
+If your `NativeObject` contains `GcPtr<T>` fields, implement `Trace` properly
+so the GC can follow references:
+
+```rust
+use cljrs_gc::{GcPtr, MarkVisitor, Trace};
+use cljrs_value::Value;
+
+struct Cache { entries: Vec<GcPtr<Value>> }
+
+impl Trace for Cache {
+    fn trace(&self, visitor: &mut MarkVisitor) {
+        for entry in &self.entries {
+            entry.trace(visitor);
+        }
+    }
+}
+```
+
+If your struct holds no `GcPtr` fields (only plain Rust data), a no-op `Trace`
+impl is sufficient.


### PR DESCRIPTION
Implements the first step of mixed Rust/Clojure project support:

- cljrs-interop: add Registry struct (wraps Arc<GlobalEnv>) with
  define/define_in/env methods; add InitFn type alias (fn(&mut Registry))
  documenting the cljrs_init convention; re-export both from crate root.
  Adds cljrs-env as a dependency.

- cljrs-deps: add RustConfig struct with crate_dir + optional init_fn;
  add rust: Option<RustConfig> field to DepsConfig; parse :rust {:crate
  "..." :init "..."} from cljrs.edn. Five new parse tests.

https://claude.ai/code/session_01DA93YgpjSpG6iyEimGqkha