### PR TITLE
feat(interop): add #[export] proc-macro for automatic function registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cljrs-export-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cljrs-gc"
 version = "0.1.0"
 dependencies = [
@@ -372,9 +381,11 @@ name = "cljrs-interop"
 version = "0.1.0"
 dependencies = [
  "cljrs-env",
+ "cljrs-export-macro",
  "cljrs-gc",
  "cljrs-types",
  "cljrs-value",
+ "inventory",
  "num-bigint",
 ]
 
@@ -863,6 +874,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/cljrs-ir",
     "crates/cljrs-compiler",
     "crates/cljrs-interop",
+    "crates/cljrs-export-macro",
     "crates/cljrs-logging",
     "crates/cljrs",
     "examples/rust-interop",
@@ -27,27 +28,29 @@ license = "EPL-1.0"
 repository = "https://github.com/csm/clojurust"
 
 [workspace.dependencies]
-cljrs-types    = { path = "crates/cljrs-types",    version = "0.1.0" }
-cljrs-gc       = { path = "crates/cljrs-gc",       version = "0.1.0" }
-cljrs-value    = { path = "crates/cljrs-value",    version = "0.1.0" }
-cljrs-reader   = { path = "crates/cljrs-reader",   version = "0.1.0" }
-cljrs-eval     = { path = "crates/cljrs-eval",     version = "0.1.0" }
-cljrs-stdlib   = { path = "crates/cljrs-stdlib",   version = "0.1.0" }
-cljrs-runtime  = { path = "crates/cljrs-runtime",  version = "0.1.0" }
-cljrs-ir       = { path = "crates/cljrs-ir",       version = "0.1.0" }
-cljrs-compiler = { path = "crates/cljrs-compiler", version = "0.1.0" }
-cljrs-interop  = { path = "crates/cljrs-interop",  version = "0.1.0" }
-cljrs-logging  = { path = "crates/cljrs-logging",  version = "0.1.0" }
-cljrs-env      = { path = "crates/cljrs-env",      version = "0.1.0" }
-cljrs-builtins = { path = "crates/cljrs-builtins", version = "0.1.0" }
-cljrs-interp   = { path = "crates/cljrs-interp",   version = "0.1.0" }
-cljrs-ir-prebuild = { path = "crates/cljrs-ir-prebuild", version = "0.1.0" }
-cljrs-ir-viz  = { path = "crates/cljrs-ir-viz",  version = "0.1.0" }
-cljrs-deps    = { path = "crates/cljrs-deps",    version = "0.1.0" }
-cljrs-vcs     = { path = "crates/cljrs-vcs",     version = "0.1.0" }
+cljrs-types        = { path = "crates/cljrs-types",        version = "0.1.0" }
+cljrs-gc           = { path = "crates/cljrs-gc",           version = "0.1.0" }
+cljrs-value        = { path = "crates/cljrs-value",        version = "0.1.0" }
+cljrs-reader       = { path = "crates/cljrs-reader",       version = "0.1.0" }
+cljrs-eval         = { path = "crates/cljrs-eval",         version = "0.1.0" }
+cljrs-stdlib       = { path = "crates/cljrs-stdlib",       version = "0.1.0" }
+cljrs-runtime      = { path = "crates/cljrs-runtime",      version = "0.1.0" }
+cljrs-ir           = { path = "crates/cljrs-ir",           version = "0.1.0" }
+cljrs-compiler     = { path = "crates/cljrs-compiler",     version = "0.1.0" }
+cljrs-interop      = { path = "crates/cljrs-interop",      version = "0.1.0" }
+cljrs-export-macro = { path = "crates/cljrs-export-macro", version = "0.1.0" }
+cljrs-logging      = { path = "crates/cljrs-logging",      version = "0.1.0" }
+cljrs-env          = { path = "crates/cljrs-env",          version = "0.1.0" }
+cljrs-builtins     = { path = "crates/cljrs-builtins",     version = "0.1.0" }
+cljrs-interp       = { path = "crates/cljrs-interp",       version = "0.1.0" }
+cljrs-ir-prebuild  = { path = "crates/cljrs-ir-prebuild",  version = "0.1.0" }
+cljrs-ir-viz       = { path = "crates/cljrs-ir-viz",       version = "0.1.0" }
+cljrs-deps         = { path = "crates/cljrs-deps",         version = "0.1.0" }
+cljrs-vcs          = { path = "crates/cljrs-vcs",          version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"
+inventory    = "0.3"
 clap         = { version = "4", features = ["derive"] }
 num-bigint   = "0.4"
 num-rational = "0.4"

--- a/TODO.md
+++ b/TODO.md
@@ -355,7 +355,7 @@ Pattern: `(map f (map g xs))`, lower to single loop.
 ## Phase 9 — Rust Interop
 
 - [x] Define calling conventions: how Clojure code invokes Rust functions
-- [ ] Macro or annotation to expose a Rust `fn` as a clojurust native function (e.g. `#[cljx::export]`)
+- [x] Macro or annotation to expose a Rust `fn` as a clojurust native function (`#[cljrs_interop::export]` in `cljrs-export-macro`)
 - [x] Type marshalling: Clojure `Value` ↔ Rust primitive / struct conversions (`FromValue`/`IntoValue` traits in `cljrs-interop`)
 - [x] Error/exception bridging: Rust `Result`/`panic` → Clojure exception (`wrap_result` in `cljrs-interop`)
 - [x] Access to Rust structs as opaque objects (`NativeObject` variant in `Value`)

--- a/crates/cljrs-export-macro/Cargo.toml
+++ b/crates/cljrs-export-macro/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cljrs-export-macro"
+version = "0.1.0"
+edition = "2024"
+description = "Proc-macro: #[export] for automatic registration of Rust functions as Clojurust native functions"
+license.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn         = { version = "2", features = ["full"] }
+quote       = "1"
+proc-macro2 = "1"

--- a/crates/cljrs-export-macro/README.md
+++ b/crates/cljrs-export-macro/README.md
@@ -1,0 +1,122 @@
+# cljrs-export-macro
+
+Proc-macro crate backing `#[cljrs_interop::export]`. Exposes Rust functions as
+Clojurust native functions with zero hand-written registration boilerplate.
+
+**Do not depend on this crate directly.** Add `cljrs-interop` instead, which
+re-exports the macro.
+
+**Phase:** 9 — Rust Interop (implemented).
+
+---
+
+## File layout
+
+```
+src/
+  lib.rs  — #[export] proc-macro attribute implementation
+```
+
+---
+
+## Public API
+
+### `#[export]`
+
+```rust
+#[proc_macro_attribute]
+pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream
+```
+
+Attribute macro that:
+1. Leaves the original function unchanged.
+2. Generates an [`inventory`] submission so the function is collected at link time.
+3. Inlines `FromValue` / `IntoValue` marshalling for each parameter and the
+   return value — no `wrap_fn*` calls required.
+
+### Attribute arguments
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `ns` | string literal | **yes** | Clojure namespace, e.g. `"math"` |
+| `name` | string literal | no | Override the Clojure symbol name (default: fn name with `_` → `-`) |
+| `variadic_min` | integer | no | Minimum arity for variadic functions (default 0) |
+
+### Supported signatures
+
+**Fixed arity** — each parameter must implement `FromValue`:
+```rust
+#[export(ns = "math")]
+pub fn add(a: i64, b: i64) -> Result<i64, String> { Ok(a + b) }
+```
+
+**Plain return value** — any type implementing `IntoValue` (wrapped in `Ok` automatically):
+```rust
+#[export(ns = "math")]
+pub fn pi() -> f64 { std::f64::consts::PI }
+```
+
+**No return value** — maps to `Value::Nil`:
+```rust
+#[export(ns = "log")]
+pub fn log_info(msg: String) { println!("{msg}"); }
+```
+
+**Variadic** — single `&[Value]` parameter:
+```rust
+#[export(ns = "math", variadic_min = 1)]
+pub fn sum(args: &[Value]) -> Result<Value, String> {
+    let total: i64 = args.iter()
+        .map(|v| i64::from_value(v).map_err(|e| e.to_string()))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter().sum();
+    Ok(total.into_value())
+}
+```
+
+### Name conversion
+
+Rust `fn my_cool_fn` becomes Clojure `my-cool-fn` by default.
+Override with `name = "..."`.
+
+---
+
+## Generated code (example)
+
+```rust
+#[export(ns = "math")]
+pub fn add(a: i64, b: i64) -> Result<i64, String> { Ok(a + b) }
+```
+
+Expands to (approximately):
+
+```rust
+pub fn add(a: i64, b: i64) -> Result<i64, String> { Ok(a + b) }
+
+::cljrs_interop::inventory::submit!(::cljrs_interop::ExportEntry {
+    qualified: "math/add",
+    make_fn: || {
+        ::cljrs_interop::NativeFn::with_closure(
+            "math/add",
+            ::cljrs_interop::Arity::Fixed(2),
+            move |args| {
+                let __a0 = <i64 as ::cljrs_interop::FromValue>::from_value(&args[0])?;
+                let __a1 = <i64 as ::cljrs_interop::FromValue>::from_value(&args[1])?;
+                add(__a0, __a1)
+                    .map(<i64 as ::cljrs_interop::IntoValue>::into_value)
+                    .map_err(|e| ::cljrs_interop::ValueError::Other(e.to_string()))
+            }
+        )
+    },
+});
+```
+
+---
+
+## Dependencies
+
+| Crate | Role |
+|-------|------|
+| `syn 2` | Parse Rust function signatures |
+| `quote 1` | Generate token streams |
+| `proc-macro2 1` | Span-aware token manipulation |

--- a/crates/cljrs-export-macro/src/lib.rs
+++ b/crates/cljrs-export-macro/src/lib.rs
@@ -59,7 +59,11 @@ impl Parse for ExportArgs {
             }
         }
 
-        Ok(Self { ns, name, variadic_min })
+        Ok(Self {
+            ns,
+            name,
+            variadic_min,
+        })
     }
 }
 
@@ -162,13 +166,12 @@ fn export_impl(args: ExportArgs, func: ItemFn) -> syn::Result<TokenStream2> {
             None => 0,
         };
         build_variadic(&qualified, fn_ident, &func.sig.output, min)?
+    } else if args.variadic_min.is_some() {
+        return Err(syn::Error::new_spanned(
+            fn_ident,
+            "`variadic_min` is only valid when the function takes `&[Value]`",
+        ));
     } else {
-        if args.variadic_min.is_some() {
-            return Err(syn::Error::new_spanned(
-                fn_ident,
-                "`variadic_min` is only valid when the function takes `&[Value]`",
-            ));
-        }
         build_fixed(&qualified, fn_ident, &params, &func.sig.output)?
     };
 
@@ -266,14 +269,12 @@ fn build_result_expr(call: TokenStream2, ret: &ReturnType) -> syn::Result<TokenS
 
 /// Returns true for `&[Value]` (a reference to a slice of `Value`).
 fn is_slice_of_value(ty: &Type) -> bool {
-    if let Type::Reference(tr) = ty {
-        if let Type::Slice(ts) = tr.elem.as_ref() {
-            if let Type::Path(tp) = ts.elem.as_ref() {
-                if let Some(seg) = tp.path.segments.last() {
-                    return seg.ident == "Value";
-                }
-            }
-        }
+    if let Type::Reference(tr) = ty
+        && let Type::Slice(ts) = tr.elem.as_ref()
+        && let Type::Path(tp) = ts.elem.as_ref()
+        && let Some(seg) = tp.path.segments.last()
+    {
+        return seg.ident == "Value";
     }
     false
 }
@@ -281,30 +282,25 @@ fn is_slice_of_value(ty: &Type) -> bool {
 /// Returns true if `ty` is a path whose last segment is `Result` with ≥ 2
 /// generic arguments (covers `Result<T, E>`, `std::result::Result<T, E>`, etc.).
 fn is_result_type(ty: &Type) -> bool {
-    if let Type::Path(tp) = ty {
-        if let Some(seg) = tp.path.segments.last() {
-            if seg.ident == "Result" {
-                if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
-                    return ab.args.len() >= 2;
-                }
-            }
-        }
+    if let Type::Path(tp) = ty
+        && let Some(seg) = tp.path.segments.last()
+        && seg.ident == "Result"
+        && let syn::PathArguments::AngleBracketed(ab) = &seg.arguments
+    {
+        return ab.args.len() >= 2;
     }
     false
 }
 
 /// Extract the `T` from `Result<T, E>`.
 fn result_ok_type(ty: &Type) -> Option<&Type> {
-    if let Type::Path(tp) = ty {
-        if let Some(seg) = tp.path.segments.last() {
-            if seg.ident == "Result" {
-                if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
-                    if let Some(syn::GenericArgument::Type(t)) = ab.args.first() {
-                        return Some(t);
-                    }
-                }
-            }
-        }
+    if let Type::Path(tp) = ty
+        && let Some(seg) = tp.path.segments.last()
+        && seg.ident == "Result"
+        && let syn::PathArguments::AngleBracketed(ab) = &seg.arguments
+        && let Some(syn::GenericArgument::Type(t)) = ab.args.first()
+    {
+        return Some(t);
     }
     None
 }

--- a/crates/cljrs-export-macro/src/lib.rs
+++ b/crates/cljrs-export-macro/src/lib.rs
@@ -1,0 +1,315 @@
+//! Proc-macro crate backing `#[cljrs_interop::export]`.
+//!
+//! Do not depend on this crate directly. Use `cljrs_interop` instead:
+//!
+//! ```rust,ignore
+//! use cljrs_interop::export;
+//!
+//! #[export(ns = "math")]
+//! pub fn add(a: i64, b: i64) -> Result<i64, String> {
+//!     Ok(a + b)
+//! }
+//! ```
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{
+    FnArg, ItemFn, LitInt, LitStr, PatType, ReturnType, Token, Type,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+};
+
+// ── Attribute argument parsing ────────────────────────────────────────────────
+
+struct ExportArgs {
+    ns: Option<LitStr>,
+    name: Option<LitStr>,
+    /// Minimum arity for variadic functions (default 0).
+    variadic_min: Option<LitInt>,
+}
+
+impl Parse for ExportArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut ns: Option<LitStr> = None;
+        let mut name: Option<LitStr> = None;
+        let mut variadic_min: Option<LitInt> = None;
+
+        while !input.is_empty() {
+            let key: syn::Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            match key.to_string().as_str() {
+                "ns" => ns = Some(input.parse::<LitStr>()?),
+                "name" => name = Some(input.parse::<LitStr>()?),
+                "variadic_min" => variadic_min = Some(input.parse::<LitInt>()?),
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!(
+                            "unknown attribute key `{other}`; \
+                             expected `ns`, `name`, or `variadic_min`"
+                        ),
+                    ));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(Self { ns, name, variadic_min })
+    }
+}
+
+// ── Public proc-macro ─────────────────────────────────────────────────────────
+
+/// Expose a Rust function as a Clojurust native function.
+///
+/// The macro keeps the original function intact and generates an
+/// [`inventory`] submission that registers the function when
+/// [`cljrs_interop::register_exports`] is called.
+///
+/// # Required attribute
+///
+/// - `ns = "my.namespace"` — the Clojure namespace the function is interned into.
+///
+/// # Optional attributes
+///
+/// - `name = "clojure-name"` — override the Clojure symbol name
+///   (default: Rust function name with `_` replaced by `-`).
+/// - `variadic_min = N` — for variadic functions, set the minimum arity
+///   (default 0). Only meaningful when the function takes `&[Value]`.
+///
+/// # Supported signatures
+///
+/// **Fixed arity** — each parameter must implement [`FromValue`]:
+/// ```rust,ignore
+/// #[export(ns = "math")]
+/// pub fn add(a: i64, b: i64) -> Result<i64, String> { Ok(a + b) }
+/// ```
+///
+/// **Returning a plain value** — any type that implements [`IntoValue`]:
+/// ```rust,ignore
+/// #[export(ns = "math")]
+/// pub fn pi() -> f64 { std::f64::consts::PI }
+/// ```
+///
+/// **Variadic** — single `&[Value]` parameter:
+/// ```rust,ignore
+/// #[export(ns = "math", variadic_min = 1)]
+/// pub fn sum(args: &[Value]) -> Result<Value, String> { ... }
+/// ```
+///
+/// [`FromValue`]: cljrs_interop::FromValue
+/// [`IntoValue`]: cljrs_interop::IntoValue
+/// [`inventory`]: https://docs.rs/inventory
+/// [`cljrs_interop::register_exports`]: cljrs_interop::register_exports
+#[proc_macro_attribute]
+pub fn export(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as ExportArgs);
+    let func = parse_macro_input!(item as ItemFn);
+
+    match export_impl(args, func) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+// ── Implementation ────────────────────────────────────────────────────────────
+
+fn export_impl(args: ExportArgs, func: ItemFn) -> syn::Result<TokenStream2> {
+    let fn_ident = &func.sig.ident;
+
+    // Clojure symbol name: Rust snake_case → kebab-case unless overridden.
+    let clj_sym = match &args.name {
+        Some(lit) => lit.value(),
+        None => fn_ident.to_string().replace('_', "-"),
+    };
+
+    // Namespace is required.
+    let ns_str = match &args.ns {
+        Some(lit) => lit.value(),
+        None => {
+            return Err(syn::Error::new_spanned(
+                fn_ident,
+                "#[export] requires `ns = \"...\"`,  e.g.  #[export(ns = \"my.ns\")]",
+            ));
+        }
+    };
+
+    let qualified = format!("{ns_str}/{clj_sym}");
+
+    // Collect typed parameters (skip `self`, which is not valid in free fns
+    // but guard against it anyway).
+    let params: Vec<&PatType> = func
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|a| match a {
+            FnArg::Typed(pt) => Some(pt),
+            FnArg::Receiver(_) => None,
+        })
+        .collect();
+
+    // Detect variadic: exactly one parameter whose type is `&[Value]`.
+    let variadic = params.len() == 1 && is_slice_of_value(&params[0].ty);
+
+    let native_fn_expr = if variadic {
+        let min: usize = match &args.variadic_min {
+            Some(lit) => lit.base10_parse()?,
+            None => 0,
+        };
+        build_variadic(&qualified, fn_ident, &func.sig.output, min)?
+    } else {
+        if args.variadic_min.is_some() {
+            return Err(syn::Error::new_spanned(
+                fn_ident,
+                "`variadic_min` is only valid when the function takes `&[Value]`",
+            ));
+        }
+        build_fixed(&qualified, fn_ident, &params, &func.sig.output)?
+    };
+
+    Ok(quote! {
+        #func
+
+        ::cljrs_interop::inventory::submit!(::cljrs_interop::ExportEntry {
+            qualified: #qualified,
+            make_fn: || { #native_fn_expr },
+        });
+    })
+}
+
+// ── NativeFn builders ─────────────────────────────────────────────────────────
+
+fn build_fixed(
+    qualified: &str,
+    fn_ident: &syn::Ident,
+    params: &[&PatType],
+    ret: &ReturnType,
+) -> syn::Result<TokenStream2> {
+    let n = params.len();
+    let indices: Vec<usize> = (0..n).collect();
+    let arg_idents: Vec<syn::Ident> = (0..n).map(|i| format_ident!("__a{i}")).collect();
+    let param_tys: Vec<&Type> = params.iter().map(|pt| pt.ty.as_ref()).collect();
+
+    let result_expr = build_result_expr(quote! { #fn_ident(#(#arg_idents),*) }, ret)?;
+
+    Ok(quote! {
+        ::cljrs_interop::NativeFn::with_closure(
+            #qualified,
+            ::cljrs_interop::Arity::Fixed(#n),
+            move |args| {
+                #(
+                    let #arg_idents =
+                        <#param_tys as ::cljrs_interop::FromValue>::from_value(&args[#indices])?;
+                )*
+                #result_expr
+            }
+        )
+    })
+}
+
+fn build_variadic(
+    qualified: &str,
+    fn_ident: &syn::Ident,
+    ret: &ReturnType,
+    min: usize,
+) -> syn::Result<TokenStream2> {
+    let result_expr = build_result_expr(quote! { #fn_ident(args) }, ret)?;
+
+    Ok(quote! {
+        ::cljrs_interop::NativeFn::with_closure(
+            #qualified,
+            ::cljrs_interop::Arity::Variadic { min: #min },
+            move |args| { #result_expr }
+        )
+    })
+}
+
+/// Wrap a call expression in the appropriate result-mapping code depending on
+/// whether the return type is `Result<T, E>`, plain `T`, or `()`.
+fn build_result_expr(call: TokenStream2, ret: &ReturnType) -> syn::Result<TokenStream2> {
+    match ret {
+        // `fn f() { ... }` — no declared return, treat as `()`
+        ReturnType::Default => Ok(quote! { { #call; Ok(::cljrs_interop::Value::Nil) } }),
+
+        ReturnType::Type(_, ty) => {
+            if is_unit_type(ty) {
+                Ok(quote! { { #call; Ok(::cljrs_interop::Value::Nil) } })
+            } else if is_result_type(ty) {
+                // Result<T, E> — forward the error as ValueError::Other
+                match result_ok_type(ty) {
+                    Some(ok_ty) => Ok(quote! {
+                        #call
+                            .map(<#ok_ty as ::cljrs_interop::IntoValue>::into_value)
+                            .map_err(|e| ::cljrs_interop::ValueError::Other(e.to_string()))
+                    }),
+                    // Fallback: can't statically determine T (unusual)
+                    None => Ok(quote! {
+                        #call
+                            .map(::cljrs_interop::IntoValue::into_value)
+                            .map_err(|e| ::cljrs_interop::ValueError::Other(e.to_string()))
+                    }),
+                }
+            } else {
+                // Plain T: wrap in Ok
+                Ok(quote! { Ok(<#ty as ::cljrs_interop::IntoValue>::into_value(#call)) })
+            }
+        }
+    }
+}
+
+// ── Type inspection helpers ───────────────────────────────────────────────────
+
+/// Returns true for `&[Value]` (a reference to a slice of `Value`).
+fn is_slice_of_value(ty: &Type) -> bool {
+    if let Type::Reference(tr) = ty {
+        if let Type::Slice(ts) = tr.elem.as_ref() {
+            if let Type::Path(tp) = ts.elem.as_ref() {
+                if let Some(seg) = tp.path.segments.last() {
+                    return seg.ident == "Value";
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Returns true if `ty` is a path whose last segment is `Result` with ≥ 2
+/// generic arguments (covers `Result<T, E>`, `std::result::Result<T, E>`, etc.).
+fn is_result_type(ty: &Type) -> bool {
+    if let Type::Path(tp) = ty {
+        if let Some(seg) = tp.path.segments.last() {
+            if seg.ident == "Result" {
+                if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
+                    return ab.args.len() >= 2;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Extract the `T` from `Result<T, E>`.
+fn result_ok_type(ty: &Type) -> Option<&Type> {
+    if let Type::Path(tp) = ty {
+        if let Some(seg) = tp.path.segments.last() {
+            if seg.ident == "Result" {
+                if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(t)) = ab.args.first() {
+                        return Some(t);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Returns true for the unit type `()`.
+fn is_unit_type(ty: &Type) -> bool {
+    matches!(ty, Type::Tuple(t) if t.elems.is_empty())
+}

--- a/crates/cljrs-interop/Cargo.toml
+++ b/crates/cljrs-interop/Cargo.toml
@@ -7,8 +7,10 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cljrs-types = { workspace = true }
-cljrs-gc    = { workspace = true }
-cljrs-value = { workspace = true }
-cljrs-env   = { workspace = true }
-num-bigint  = { workspace = true }
+cljrs-types        = { workspace = true }
+cljrs-gc           = { workspace = true }
+cljrs-value        = { workspace = true }
+cljrs-env          = { workspace = true }
+cljrs-export-macro = { workspace = true }
+num-bigint         = { workspace = true }
+inventory          = { workspace = true }

--- a/crates/cljrs-interop/README.md
+++ b/crates/cljrs-interop/README.md
@@ -4,7 +4,8 @@ Rust ↔ Clojure interoperability layer. Exposes Rust functions to Clojure code,
 marshals values across the boundary, and wraps opaque Rust structs as
 GC-managed `NativeObject` values.
 
-**Phase:** 9 — partially implemented (NativeObject, marshalling, error bridging, registration helpers, Registry).
+**Phase:** 9 — partially implemented (NativeObject, marshalling, error bridging,
+registration helpers, Registry, `#[export]` proc-macro).
 
 ---
 
@@ -14,6 +15,7 @@ GC-managed `NativeObject` values.
 src/
   lib.rs       — re-exports, crate entry point
   error.rs     — wrap_result: Rust Result → ValueResult<Value>
+  exports.rs   — ExportEntry, inventory::collect!, register_exports
   marshal.rs   — FromValue / IntoValue traits with impls for common Rust types
   register.rs  — wrap_fn0..wrap_fn3, wrap_fn_variadic: auto-marshalling function wrappers
   registry.rs  — Registry struct and InitFn type alias for cljrs_init convention
@@ -21,6 +23,9 @@ src/
 
 The `NativeObject` trait and `NativeObjectBox` wrapper live in `cljrs-value::native_object`
 and are re-exported from this crate for convenience.
+
+The `#[export]` attribute macro is implemented in `cljrs-export-macro` and
+re-exported here for ergonomic use as `#[cljrs_interop::export(...)]`.
 
 ---
 
@@ -67,6 +72,37 @@ pub fn wrap_fn_variadic<R, E, F>(name: impl Into<Arc<str>>, min: usize, f: F) ->
 
 These accept closures (not just bare `fn` pointers) since `NativeFnFunc` is now
 `Arc<dyn Fn(&[Value]) -> ValueResult<Value> + Send + Sync>`.
+
+### `#[export]` proc-macro and `register_exports`
+
+Annotate any free Rust function with `#[export(ns = "...")]` to register it
+automatically. Then call `register_exports` once inside `cljrs_init`:
+
+```rust
+use cljrs_interop::{export, register_exports, Registry};
+
+#[export(ns = "math")]
+pub fn add(a: i64, b: i64) -> Result<i64, String> { Ok(a + b) }
+
+#[export(ns = "math")]
+pub fn pi() -> f64 { std::f64::consts::PI }
+
+pub fn cljrs_init(registry: &mut Registry) {
+    register_exports(registry);
+}
+```
+
+Supported signatures and attribute options are documented in the
+`cljrs-export-macro` crate README.
+
+```rust
+pub struct ExportEntry {
+    pub qualified: &'static str,  // "ns/name"
+    pub make_fn:   fn() -> NativeFn,
+}
+
+pub fn register_exports(registry: &mut Registry);
+```
 
 ### Registry and InitFn
 
@@ -119,7 +155,6 @@ pub fn cljrs_init(registry: &mut Registry) {
 
 ## Remaining work (Phase 9)
 
-- `#[cljrs::export]` proc-macro — syntactic sugar over manual registration
 - `cljrs.rust` namespace with intrinsics
 - Dynamic linking — load `.so`/`.dylib` Rust extensions at runtime via `cljrs build-native`
 
@@ -133,4 +168,6 @@ pub fn cljrs_init(registry: &mut Registry) {
 | `cljrs-gc` (workspace) | `GcPtr`, `Trace`, `MarkVisitor` |
 | `cljrs-value` (workspace) | `Value`, `NativeFn`, `NativeObject`, `NativeObjectBox` |
 | `cljrs-env` (workspace) | `GlobalEnv` — used by `Registry` to intern native functions |
+| `cljrs-export-macro` (workspace) | `#[export]` proc-macro |
+| `inventory` (workspace) | Link-time collection of `ExportEntry` items |
 | `num-bigint` (workspace) | `BigInt` marshalling |

--- a/crates/cljrs-interop/src/exports.rs
+++ b/crates/cljrs-interop/src/exports.rs
@@ -1,5 +1,5 @@
 //! Static export registry — collects every `#[export]`-annotated function and
-//! lets a `cljrs_init` implementation register them all in one call.
+//! registers them automatically when a [`Registry`] is created.
 
 use cljrs_value::NativeFn;
 
@@ -7,8 +7,10 @@ use crate::registry::Registry;
 
 /// A single entry produced by `#[export]`.
 ///
-/// The `inventory` crate collects all of these at link time; call
-/// [`register_exports`] to intern them into a [`Registry`].
+/// The `inventory` crate collects all of these at link time.  Every
+/// [`Registry`] calls [`register_exports`] in its constructor, so
+/// `#[export]`-annotated functions are available without any explicit
+/// registration call.
 pub struct ExportEntry {
     /// Fully-qualified Clojure name, e.g. `"math/add"`.
     pub qualified: &'static str,
@@ -18,17 +20,12 @@ pub struct ExportEntry {
 
 inventory::collect!(ExportEntry);
 
-/// Register every `#[export]`-annotated function into `registry`.
+/// Intern every `#[export]`-annotated function into `registry`.
 ///
-/// Call this inside your `cljrs_init` function to avoid listing each function
-/// individually:
-///
-/// ```rust,ignore
-/// pub fn cljrs_init(registry: &mut Registry) {
-///     cljrs_interop::register_exports(registry);
-/// }
-/// ```
-pub fn register_exports(registry: &mut Registry) {
+/// Called automatically by [`Registry::new`]; you only need this directly if
+/// you are constructing a `Registry` by other means or want to re-register
+/// into a second environment.
+pub fn register_exports(registry: &Registry) {
     for entry in inventory::iter::<ExportEntry> {
         registry.define(entry.qualified, (entry.make_fn)());
     }

--- a/crates/cljrs-interop/src/exports.rs
+++ b/crates/cljrs-interop/src/exports.rs
@@ -1,0 +1,35 @@
+//! Static export registry — collects every `#[export]`-annotated function and
+//! lets a `cljrs_init` implementation register them all in one call.
+
+use cljrs_value::NativeFn;
+
+use crate::registry::Registry;
+
+/// A single entry produced by `#[export]`.
+///
+/// The `inventory` crate collects all of these at link time; call
+/// [`register_exports`] to intern them into a [`Registry`].
+pub struct ExportEntry {
+    /// Fully-qualified Clojure name, e.g. `"math/add"`.
+    pub qualified: &'static str,
+    /// Factory that constructs the `NativeFn` (called once per registration).
+    pub make_fn: fn() -> NativeFn,
+}
+
+inventory::collect!(ExportEntry);
+
+/// Register every `#[export]`-annotated function into `registry`.
+///
+/// Call this inside your `cljrs_init` function to avoid listing each function
+/// individually:
+///
+/// ```rust,ignore
+/// pub fn cljrs_init(registry: &mut Registry) {
+///     cljrs_interop::register_exports(registry);
+/// }
+/// ```
+pub fn register_exports(registry: &mut Registry) {
+    for entry in inventory::iter::<ExportEntry> {
+        registry.define(entry.qualified, (entry.make_fn)());
+    }
+}

--- a/crates/cljrs-interop/src/lib.rs
+++ b/crates/cljrs-interop/src/lib.rs
@@ -8,10 +8,13 @@
 //! - **`FromValue` / `IntoValue`** — type-safe conversion between `Value` and
 //!   Rust types
 //! - **`wrap_result`** — convert `Result<T, E>` to `ValueResult<Value>`
-//! - **`wrap_native_fn`** — helpers to register Rust functions with automatic
+//! - **`wrap_fn*`** — helpers to register Rust functions with automatic
 //!   argument marshalling
+//! - **`#[export]`** — proc-macro for automatic function registration
+//! - **`register_exports`** — register all `#[export]`-annotated functions at once
 
 pub mod error;
+pub mod exports;
 pub mod marshal;
 pub mod register;
 pub mod registry;
@@ -23,6 +26,15 @@ pub use cljrs_value::native_object::{NativeObject, NativeObjectBox, gc_native_ob
 pub use cljrs_value::{Arity, NativeFn, Value, ValueError, ValueResult};
 
 pub use error::wrap_result;
+pub use exports::{ExportEntry, register_exports};
 pub use marshal::{FromValue, IntoValue};
 pub use register::{wrap_fn_variadic, wrap_fn0, wrap_fn1, wrap_fn2, wrap_fn3};
 pub use registry::{InitFn, Registry};
+
+// Re-export the proc-macro so users write `#[cljrs_interop::export(...)]`.
+pub use cljrs_export_macro::export;
+
+// Re-export inventory so the generated `::cljrs_interop::inventory::submit!`
+// path resolves correctly inside user crates.
+#[doc(hidden)]
+pub use inventory;

--- a/crates/cljrs-interop/src/registry.rs
+++ b/crates/cljrs-interop/src/registry.rs
@@ -26,6 +26,8 @@ use cljrs_env::env::GlobalEnv;
 use cljrs_gc::GcPtr;
 use cljrs_value::{NativeFn, Value};
 
+use crate::exports::register_exports;
+
 // ── InitFn ────────────────────────────────────────────────────────────────────
 
 /// The expected signature of a Rust-side hook-registration function.
@@ -54,10 +56,13 @@ pub struct Registry {
 impl Registry {
     /// Create a `Registry` backed by `env`.
     ///
-    /// Called by the generated `main.rs`; user code receives `&mut Registry`
-    /// and never constructs one directly.
+    /// Automatically registers every `#[export]`-annotated function found in
+    /// the binary (via `inventory`).  Called by the generated `main.rs`; user
+    /// code receives `&mut Registry` and never constructs one directly.
     pub fn new(env: Arc<GlobalEnv>) -> Self {
-        Self { env }
+        let r = Self { env };
+        register_exports(&r);
+        r
     }
 
     /// Register `f` under the fully-qualified Clojure name `"my.ns/my-fn"`.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -27,5 +27,6 @@
 - [Overview](rust-interop/index.md)
 - [Project setup](rust-interop/project-setup.md)
 - [Registry API](rust-interop/registry.md)
+- [The `#[export]` macro](rust-interop/export-macro.md)
 - [Interpreter mode](rust-interop/interpreter.md)
 - [AOT mode](rust-interop/aot.md)

--- a/docs/book/src/rust-interop/export-macro.md
+++ b/docs/book/src/rust-interop/export-macro.md
@@ -1,0 +1,219 @@
+# The `#[export]` Macro
+
+The `#[export]` attribute (from `cljrs_interop`) is the zero-boilerplate way to
+expose Rust functions to Clojure. Annotating a function with it causes the
+function to be registered automatically when a `Registry` is created — no
+explicit call required.
+
+## Basic usage
+
+```rust
+use cljrs_interop::export;
+
+#[export(ns = "math")]
+pub fn add(a: i64, b: i64) -> Result<i64, String> {
+    Ok(a + b)
+}
+```
+
+`add` is now visible in Clojure as `math/add` as soon as the shared library is
+loaded or the AOT binary starts. No `cljrs_init` is required unless you have
+other setup to perform (see [When `cljrs_init` is still needed](#when-cljrs_init-is-still-needed)).
+
+## Attribute options
+
+| Key | Required | Description |
+|---|---|---|
+| `ns` | **yes** | Clojure namespace, e.g. `"math"` or `"my.project"`. |
+| `name` | no | Override the Clojure symbol name. Default: Rust name with `_` replaced by `-`. |
+| `variadic_min` | no | Minimum arity for variadic functions (default `0`). Only valid when the function takes a single `&[Value]` parameter. |
+
+## Name mapping
+
+Rust function names are converted to Clojure-style kebab-case: every `_` becomes
+`-`. Use `name = "..."` to override:
+
+```rust
+#[export(ns = "str.util")]
+fn to_upper_case(s: String) -> String {        // → str.util/to-upper-case
+    s.to_uppercase()
+}
+
+#[export(ns = "str.util", name = "upper")]     // → str.util/upper
+fn to_upper_case_v2(s: String) -> String {
+    s.to_uppercase()
+}
+```
+
+## Supported signatures
+
+### Fixed arity
+
+Each parameter must implement `FromValue`. The parameter count sets the arity
+enforced by the runtime. There is no upper limit.
+
+**Plain return value** — any type implementing `IntoValue`; wrapped in `Ok`
+automatically:
+
+```rust
+#[export(ns = "math")]
+pub fn pi() -> f64 {
+    std::f64::consts::PI
+}
+```
+
+**`Result<T, E>` return** — `Err` becomes a Clojure exception via `E::to_string()`:
+
+```rust
+#[export(ns = "math")]
+pub fn safe_sqrt(x: f64) -> Result<f64, String> {
+    if x < 0.0 {
+        Err(format!("cannot take sqrt of {x}"))
+    } else {
+        Ok(x.sqrt())
+    }
+}
+```
+
+**No return value** — maps to `nil`:
+
+```rust
+#[export(ns = "log")]
+pub fn log_info(msg: String) {
+    eprintln!("[info] {msg}");
+}
+```
+
+**Four or more parameters** work identically to two or three:
+
+```rust
+#[export(ns = "geom")]
+pub fn rect_contains(rx: f64, ry: f64, rw: f64, rh: f64, px: f64, py: f64) -> bool {
+    px >= rx && px <= rx + rw && py >= ry && py <= ry + rh
+}
+```
+
+### Variadic
+
+For functions that take a variable number of arguments, use a single `&[Value]`
+parameter. Set `variadic_min` to enforce a minimum argument count:
+
+```rust
+use cljrs_interop::{FromValue, IntoValue, export};
+use cljrs_value::Value;
+
+#[export(ns = "math", variadic_min = 1)]
+pub fn sum(args: &[Value]) -> Result<Value, String> {
+    let total: i64 = args
+        .iter()
+        .map(|v| i64::from_value(v).map_err(|e| e.to_string()))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .sum();
+    Ok(total.into_value())
+}
+```
+
+```clojure
+(math/sum 1 2 3 4 5)   ; => 15
+```
+
+## When `cljrs_init` is still needed
+
+`#[export]` handles function registration. A `cljrs_init` is still required when
+you need to:
+
+- Call `mark_loaded` so `require` treats a namespace as built-in rather than
+  looking for a file on the source path.
+- Set namespace aliases or refer bindings via `Registry::env()`.
+- Perform any other startup work beyond defining Clojure-visible functions.
+
+```rust
+use cljrs_interop::Registry;
+
+#[no_mangle]
+pub extern "C" fn cljrs_init(registry: *mut Registry) {
+    let r = unsafe { &mut *registry };
+    // #[export] functions are already registered — Registry::new ran first.
+    r.env().mark_loaded("math");
+    r.env().mark_loaded("log");
+}
+```
+
+> **Note:** The `*mut Registry` passed to `cljrs_init` is the same `Registry`
+> created by the runtime before calling your function. All `#[export]` entries
+> are already interned when `cljrs_init` is invoked.
+
+## Mixing `#[export]` with manual `define`
+
+Both styles can coexist freely. Use `#[export]` for straightforward functions
+and `r.define` / `wrap_fn*` for cases that capture runtime state or need custom
+arity logic:
+
+```rust
+use cljrs_interop::{Registry, wrap_fn1, export};
+use std::sync::{Arc, Mutex};
+
+// Simple stateless function — use #[export].
+#[export(ns = "counter")]
+pub fn increment(n: i64) -> i64 {
+    n + 1
+}
+
+#[no_mangle]
+pub extern "C" fn cljrs_init(registry: *mut Registry) {
+    let r = unsafe { &mut *registry };
+
+    // Stateful closure that captures a value created at init time.
+    let total: Arc<Mutex<i64>> = Arc::new(Mutex::new(0));
+    let t = total.clone();
+    r.define(
+        "counter/running-total",
+        wrap_fn1("running-total", move |n: i64| {
+            let mut guard = t.lock().unwrap();
+            *guard += n;
+            Ok::<i64, String>(*guard)
+        }),
+    );
+}
+```
+
+## How it works
+
+`#[export]` is a proc-macro (in `cljrs-export-macro`) that leaves the original
+function intact and emits an [`inventory`](https://docs.rs/inventory) submission:
+
+```rust
+// What #[export(ns = "math")] generates alongside your function:
+::cljrs_interop::inventory::submit!(::cljrs_interop::ExportEntry {
+    qualified: "math/add",
+    make_fn: || {
+        ::cljrs_interop::NativeFn::with_closure(
+            "math/add",
+            ::cljrs_interop::Arity::Fixed(2),
+            move |args| {
+                let __a0 = <i64 as ::cljrs_interop::FromValue>::from_value(&args[0])?;
+                let __a1 = <i64 as ::cljrs_interop::FromValue>::from_value(&args[1])?;
+                add(__a0, __a1)
+                    .map(<i64 as ::cljrs_interop::IntoValue>::into_value)
+                    .map_err(|e| ::cljrs_interop::ValueError::Other(e.to_string()))
+            },
+        )
+    },
+});
+```
+
+`inventory` uses linker constructors to collect all submissions across the
+binary at link time. `Registry::new` then iterates them and calls
+`Registry::define` for each one.
+
+If you need to register exports into a `Registry` you constructed outside the
+normal runtime flow (e.g. in tests), call `register_exports` directly:
+
+```rust
+use cljrs_interop::{register_exports, Registry};
+
+let r = Registry::new(env.clone());  // already auto-registered
+// …or, if you have a registry from elsewhere:
+register_exports(&r);
+```

--- a/docs/book/src/rust-interop/index.md
+++ b/docs/book/src/rust-interop/index.md
@@ -27,6 +27,7 @@ names to Rust functions.
 |---|---|
 | [Project setup](project-setup.md) | `cljrs.edn` config, Cargo setup, crate layout |
 | [Registry API](registry.md) | `Registry`, `wrap_fn*`, type marshalling, `NativeObject` |
+| [The `#[export]` macro](export-macro.md) | Zero-boilerplate function registration |
 | [Interpreter mode](interpreter.md) | `cljrs build-native`, auto-loading, hot-reload workflow |
 | [AOT mode](aot.md) | How `cljrs compile` wires native init into the binary |
 

--- a/docs/book/src/rust-interop/registry.md
+++ b/docs/book/src/rust-interop/registry.md
@@ -190,3 +190,9 @@ impl Trace for Cache {
 
 If your struct holds no `GcPtr` fields (only plain Rust data), a no-op `Trace`
 impl is sufficient.
+
+---
+
+For simpler cases that don't need closures or custom `NativeObject` wiring,
+the [`#[export]` macro](export-macro.md) provides a zero-boilerplate alternative
+to manual `define` calls.

--- a/examples/rust-interop/src/main.rs
+++ b/examples/rust-interop/src/main.rs
@@ -5,14 +5,18 @@
 //! - Wrapping it as a `Value::NativeObject` and registering native functions
 //! - Using protocol dispatch from Clojure to call methods on the Rust object
 //! - Type marshalling with `FromValue` / `IntoValue`
+//! - Automatic registration with `#[export]` and `register_exports`
 
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use cljrs_eval::{Env, eval};
 use cljrs_gc::{GcPtr, MarkVisitor, Trace};
 use cljrs_interop::{
-    FromValue, IntoValue, NativeObject, gc_native_object, wrap_fn1, wrap_fn2, wrap_result,
+    FromValue, IntoValue, NativeObject, Registry, gc_native_object, register_exports, wrap_fn1,
+    wrap_fn2, wrap_result,
 };
+// Bring the `export` attribute into scope.
+use cljrs_interop::export;
 use cljrs_stdlib::standard_env;
 use cljrs_value::{Arity, NativeFn, Value, ValueError, ValueResult};
 
@@ -118,6 +122,51 @@ fn builtin_counter_name(args: &[Value]) -> ValueResult<Value> {
     wrap_result(Ok::<_, std::fmt::Error>(c.name.clone()))
 }
 
+// ── Step 3b: Auto-registered string utilities via #[export] ──────────────────
+//
+// Each function annotated with #[export] is picked up by `register_exports` at
+// runtime — no manual listing required.
+
+#[export(ns = "strutils")]
+fn str_length(s: String) -> i64 {
+    s.chars().count() as i64
+}
+
+#[export(ns = "strutils")]
+fn str_reverse(s: String) -> String {
+    s.chars().rev().collect()
+}
+
+#[export(ns = "strutils", name = "str-upper")]
+fn str_upper(s: String) -> String {
+    s.to_uppercase()
+}
+
+#[export(ns = "strutils")]
+fn str_repeat(s: String, n: i64) -> Result<String, String> {
+    if n < 0 {
+        Err(format!("repeat count must be non-negative, got {n}"))
+    } else {
+        Ok(s.repeat(n as usize))
+    }
+}
+
+#[export(ns = "strutils", variadic_min = 1)]
+fn str_join(args: &[Value]) -> Result<Value, String> {
+    let sep = String::from_value(&args[0]).map_err(|e| e.to_string())?;
+    let parts: Result<Vec<String>, _> = args[1..]
+        .iter()
+        .map(|v| String::from_value(v).map_err(|e| e.to_string()))
+        .collect();
+    Ok(Value::Str(cljrs_gc::GcPtr::new(parts?.join(&sep))))
+}
+
+fn register_auto_fns(env: &mut Env) {
+    let registry = &mut Registry::new(env.globals.clone());
+    register_exports(registry);
+    env.globals.mark_loaded("strutils");
+}
+
 // ── Step 4: Register everything and run Clojure code ─────────────────────────
 
 fn register_counter_fns(env: &mut Env) {
@@ -197,6 +246,9 @@ fn main() {
     // Register math functions using wrap_fn* helpers.
     register_math_fns(&mut env);
 
+    // Register string utilities using #[export] + register_exports.
+    register_auto_fns(&mut env);
+
     // Evaluate Clojure code that uses the Counter.
     let clojure_code = r#"
         ;; Require our native namespace
@@ -260,6 +312,24 @@ fn main() {
             (println "Caught error:" e)))
 
         (println "\nDone!")
+
+        ;; ── #[export] macro demo: auto-registered string utilities ──────────
+        (require '[strutils :as su])
+
+        (println "\n── #[export] macro ──")
+        (println "str-length:" (su/str-length "hello"))
+        (println "str-reverse:" (su/str-reverse "hello"))
+        (println "str-upper:" (su/str-upper "hello world"))
+        (println "str-repeat:" (su/str-repeat "ab" 3))
+        (println "str-join:" (su/str-join ", " "one" "two" "three"))
+
+        ;; Error from a #[export] function
+        (try
+          (su/str-repeat "x" -1)
+          (catch Exception e
+            (println "Caught error:" e)))
+
+        (println "\nAll done!")
     "#;
 
     let mut parser =

--- a/examples/rust-interop/src/main.rs
+++ b/examples/rust-interop/src/main.rs
@@ -11,12 +11,10 @@ use std::sync::atomic::{AtomicI64, Ordering};
 
 use cljrs_eval::{Env, eval};
 use cljrs_gc::{GcPtr, MarkVisitor, Trace};
-use cljrs_interop::{
-    FromValue, IntoValue, NativeObject, Registry, gc_native_object, register_exports, wrap_fn1,
-    wrap_fn2, wrap_result,
-};
-// Bring the `export` attribute into scope.
 use cljrs_interop::export;
+use cljrs_interop::{
+    FromValue, IntoValue, NativeObject, Registry, gc_native_object, wrap_fn1, wrap_fn2, wrap_result,
+};
 use cljrs_stdlib::standard_env;
 use cljrs_value::{Arity, NativeFn, Value, ValueError, ValueResult};
 
@@ -162,8 +160,8 @@ fn str_join(args: &[Value]) -> Result<Value, String> {
 }
 
 fn register_auto_fns(env: &mut Env) {
-    let registry = &mut Registry::new(env.globals.clone());
-    register_exports(registry);
+    // Registry::new automatically registers all #[export]-annotated functions.
+    Registry::new(env.globals.clone());
     env.globals.mark_loaded("strutils");
 }
 


### PR DESCRIPTION
Introduces cljrs-export-macro, a new proc-macro crate that provides the
#[export(ns = "...")] attribute. Annotating a Rust function with it
generates an inventory submission that registers a NativeFn automatically
when register_exports() is called, eliminating all manual wrap_fn*/
registry.define() boilerplate.

- cljrs-export-macro: new proc-macro crate with #[export] attribute
  - Supports fixed-arity (0..N params via FromValue) and variadic (&[Value])
  - Return types: Result<T, E>, plain T: IntoValue, and () → Nil
  - Optional `name = "..."` overrides the Clojure symbol; `_` → `-` by default
  - Optional `variadic_min = N` sets the minimum arity for variadic fns
  - Emits a compile error if `ns` is omitted
- cljrs-interop: add exports.rs with ExportEntry and register_exports()
  - Re-exports #[export] macro and inventory for generated code paths
- examples/rust-interop: add strutils demo using #[export] + register_exports
- TODO.md: mark export macro task complete

https://claude.ai/code/session_01NA8ZsxEWq8JcgAJs7xRoCB