### PR TITLE
Add cljrs-blake3 interop crate wrapping the blake3 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +174,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +201,16 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -271,6 +307,20 @@ dependencies = [
  "rustyline",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cljrs-blake3"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "cljrs-env",
+ "cljrs-eval",
+ "cljrs-gc",
+ "cljrs-interop",
+ "cljrs-reader",
+ "cljrs-stdlib",
+ "cljrs-value",
 ]
 
 [[package]]
@@ -531,6 +581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +816,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -1380,6 +1442,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ members = [
     "crates/cljrs-ir-prebuild",
     "crates/cljrs-ir-viz",
     "crates/cljrs-deps",
-    "crates/cljrs-vcs"]
+    "crates/cljrs-vcs",
+    "crates/cljrs-blake3"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/cljrs-blake3/Cargo.toml
+++ b/crates/cljrs-blake3/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cljrs-blake3"
+version = "0.1.0"
+edition = "2024"
+description = "BLAKE3 cryptographic hash functions exposed as Clojure native functions"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cljrs-interop = { workspace = true }
+cljrs-gc      = { workspace = true }
+cljrs-value   = { workspace = true }
+blake3        = "1"
+
+[dev-dependencies]
+cljrs-eval    = { workspace = true }
+cljrs-stdlib  = { workspace = true }
+cljrs-env     = { workspace = true }
+cljrs-gc      = { workspace = true }
+cljrs-interop = { workspace = true }
+cljrs-reader  = { workspace = true }

--- a/crates/cljrs-blake3/README.md
+++ b/crates/cljrs-blake3/README.md
@@ -1,0 +1,109 @@
+# cljrs-blake3
+
+BLAKE3 cryptographic hash functions exposed as Clojure native functions via
+the cljrs interop layer. Wraps the [`blake3`](https://crates.io/crates/blake3)
+crate and registers the `blake3` Clojure namespace.
+
+**Phase:** 9 (Rust Interop) — fully implemented.
+
+---
+
+## File layout
+
+```
+src/
+  lib.rs                          — NativeObject impl, helper fns, cljrs_init
+test/
+  cljrs/
+    blake3_test.cljrs             — clojure.test suite (known vectors + properties)
+tests/
+  clojure_tests.rs                — Rust harness that drives the Clojure test suite
+cljrs.edn                         — project descriptor (paths, Rust init hook)
+```
+
+---
+
+## Public API
+
+### Rust
+
+```rust
+/// Register all `blake3` Clojure functions. Call from an embedding `main.rs`
+/// or from another crate's `cljrs_init`.
+pub fn cljrs_init(registry: &mut cljrs_interop::Registry);
+```
+
+### Clojure namespace: `blake3`
+
+All `data` arguments accept either a `String` (hashed as UTF-8 bytes) or a
+Clojure vector of integers in 0–255.
+
+| Symbol | Signature | Returns | Description |
+|---|---|---|---|
+| `hash` | `(hash data)` | `String` | 64-char lowercase hex digest |
+| `hash-raw` | `(hash-raw data)` | `[Long …]` | 32-element byte vector |
+| `keyed-hash` | `(keyed-hash key data)` | `String` | BLAKE3 MAC; `key` must be a 32-byte vector |
+| `derive-key` | `(derive-key context material)` | `String` | Domain-separated KDF; `context` is a `String` |
+| `hasher-new` | `(hasher-new)` | `Blake3Hasher` | Create an incremental hasher |
+| `hasher-update!` | `(hasher-update! h data)` | `Blake3Hasher` | Feed bytes into `h`; returns `h` for chaining |
+| `hasher-finalize` | `(hasher-finalize h)` | `String` | Current digest as hex; `h` stays usable |
+| `hasher-finalize-raw` | `(hasher-finalize-raw h)` | `[Long …]` | Current digest as 32-byte vector |
+
+`Blake3Hasher` is an opaque `NativeObject`; its `type-tag` is `"Blake3Hasher"`.
+
+### Usage examples
+
+```clojure
+(require '[blake3 :as b])
+
+;; One-shot hash
+(b/hash "hello world")
+;=> "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24"
+
+;; Hash a byte vector
+(b/hash [0 1 2 3])
+
+;; Keyed hash (MAC)
+(b/keyed-hash (vec (repeat 32 0)) "message")
+
+;; Key derivation
+(b/derive-key "MyApp 2024-01-01 subkey" "master-secret")
+
+;; Incremental hasher
+(let [h (b/hasher-new)]
+  (b/hasher-update! h "chunk-one")
+  (b/hasher-update! h "chunk-two")
+  (b/hasher-finalize h))
+```
+
+---
+
+## Integration
+
+Add to your `cljrs.edn`:
+
+```edn
+{:paths ["src"]
+ :rust  {:crate "path/to/cljrs-blake3"
+         :init  "cljrs_blake3::cljrs_init"}}
+```
+
+Or call `cljrs_init` directly in your own `cljrs_init` function:
+
+```rust
+pub fn cljrs_init(registry: &mut Registry) {
+    cljrs_blake3::cljrs_init(registry);
+    // … your own registrations …
+}
+```
+
+---
+
+## Dependencies
+
+| Crate | Role |
+|---|---|
+| `blake3` (1.x) | BLAKE3 hash implementation |
+| `cljrs-interop` (workspace) | `Registry`, `wrap_fn*`, `NativeObject`, marshalling |
+| `cljrs-gc` (workspace) | `GcPtr`, `Trace`, `MarkVisitor` |
+| `cljrs-value` (workspace) | `Value`, `NativeFn`, `Arity` |

--- a/crates/cljrs-blake3/cljrs.edn
+++ b/crates/cljrs-blake3/cljrs.edn
@@ -1,0 +1,17 @@
+;; cljrs.edn — project descriptor for the cljrs-blake3 interop crate.
+;;
+;; The `cljrs compile` toolchain reads this file to locate Clojure sources
+;; and to wire up the Rust initialisation hook before loading them.
+;;
+;; :paths      — directories containing Clojure source files (.cljrs / .cljc)
+;; :test-paths — directories containing clojure.test namespaces
+;; :rust       — Rust integration settings
+;;   :crate    — path to the Cargo crate root (relative to this file)
+;;   :init     — fully-qualified Rust symbol for the cljrs_init hook
+
+{:name       "cljrs-blake3"
+ :version    "0.1.0"
+ :paths      ["src"]
+ :test-paths ["test"]
+ :rust       {:crate "."
+              :init  "cljrs_blake3::cljrs_init"}}

--- a/crates/cljrs-blake3/src/lib.rs
+++ b/crates/cljrs-blake3/src/lib.rs
@@ -1,0 +1,231 @@
+//! BLAKE3 cryptographic hash functions for clojurust.
+//!
+//! Registers the `blake3` Clojure namespace with the following functions:
+//!
+//! | Symbol | Signature | Description |
+//! |---|---|---|
+//! | `blake3/hash` | `(hash data)` | One-shot hash → 64-char hex string |
+//! | `blake3/hash-raw` | `(hash-raw data)` | One-shot hash → 32-element byte vector |
+//! | `blake3/keyed-hash` | `(keyed-hash key data)` | BLAKE3 MAC; key is 32-byte vector |
+//! | `blake3/derive-key` | `(derive-key context material)` | Domain-separated KDF → hex string |
+//! | `blake3/hasher-new` | `(hasher-new)` | Create incremental hasher (NativeObject) |
+//! | `blake3/hasher-update!` | `(hasher-update! h data)` | Feed data into hasher; returns `h` |
+//! | `blake3/hasher-finalize` | `(hasher-finalize h)` | Produce 64-char hex; hasher stays usable |
+//! | `blake3/hasher-finalize-raw` | `(hasher-finalize-raw h)` | Produce 32-element byte vector |
+//!
+//! `data` arguments accept either a `String` (hashed as UTF-8 bytes) or a
+//! Clojure vector of integers in the range 0–255.
+
+use std::sync::Mutex;
+
+use cljrs_gc::{MarkVisitor, Trace};
+use cljrs_interop::{
+    IntoValue, NativeObject, Registry, Value, ValueError, ValueResult, gc_native_object, wrap_fn0,
+    wrap_fn1, wrap_fn2,
+};
+use cljrs_value::{Arity, NativeFn};
+
+// ── Blake3Hasher NativeObject ─────────────────────────────────────────────────
+
+/// Incremental BLAKE3 hasher wrapped as an opaque Clojure value.
+///
+/// Thread-safe: the inner `blake3::Hasher` is guarded by a `Mutex` so the
+/// same hasher object can be updated from Clojure code without data races.
+pub struct Blake3Hasher {
+    inner: Mutex<blake3::Hasher>,
+}
+
+impl std::fmt::Debug for Blake3Hasher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Blake3Hasher").finish_non_exhaustive()
+    }
+}
+
+impl NativeObject for Blake3Hasher {
+    fn type_tag(&self) -> &str {
+        "Blake3Hasher"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// Blake3Hasher holds no GcPtr/Value fields, so Trace is a no-op.
+impl Trace for Blake3Hasher {
+    fn trace(&self, _: &mut MarkVisitor) {}
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn as_blake3_hasher(v: &Value) -> Result<&Blake3Hasher, String> {
+    match v {
+        Value::NativeObject(obj) => obj
+            .get()
+            .downcast_ref::<Blake3Hasher>()
+            .ok_or_else(|| format!("expected Blake3Hasher, got {}", obj.get().type_tag())),
+        other => Err(format!("expected Blake3Hasher, got {}", other.type_name())),
+    }
+}
+
+/// Convert a Clojure `Value` to raw bytes.
+///
+/// Accepts:
+/// - `String` — hashed as UTF-8
+/// - `Vector` of `Long` values in 0–255 — treated as a byte sequence
+fn to_bytes(v: &Value) -> Result<Vec<u8>, String> {
+    match v {
+        Value::Str(s) => Ok(s.get().as_bytes().to_vec()),
+        Value::Vector(vec) => {
+            let mut bytes = Vec::with_capacity(vec.get().count());
+            for elem in vec.get().iter() {
+                match elem {
+                    Value::Long(n) if (0..=255).contains(n) => bytes.push(*n as u8),
+                    Value::Long(n) => return Err(format!("byte out of range 0–255: {n}")),
+                    other => {
+                        return Err(format!(
+                            "byte vector must contain integers 0–255, got {}",
+                            other.type_name()
+                        ));
+                    }
+                }
+            }
+            Ok(bytes)
+        }
+        other => Err(format!(
+            "expected string or byte vector, got {}",
+            other.type_name()
+        )),
+    }
+}
+
+fn hash_to_hex(hash: &blake3::Hash) -> String {
+    hash.to_hex().to_string()
+}
+
+fn hash_to_byte_vec(hash: &blake3::Hash) -> Vec<Value> {
+    hash.as_bytes()
+        .iter()
+        .map(|b| Value::Long(*b as i64))
+        .collect()
+}
+
+// ── cljrs_init ────────────────────────────────────────────────────────────────
+
+/// Register all `blake3` namespace functions into the Clojure runtime.
+///
+/// The `cljrs compile` toolchain calls this automatically when the crate is
+/// listed under `:rust :init` in `cljrs.edn`:
+///
+/// ```edn
+/// {:rust {:crate "."
+///         :init  "cljrs_blake3::cljrs_init"}}
+/// ```
+pub fn cljrs_init(registry: &mut Registry) {
+    // blake3/hash — one-shot hash of a string or byte vector → 64-char hex
+    registry.define(
+        "blake3/hash",
+        wrap_fn1("blake3/hash", |data: Value| -> Result<String, String> {
+            let bytes = to_bytes(&data)?;
+            Ok(hash_to_hex(&blake3::hash(&bytes)))
+        }),
+    );
+
+    // blake3/hash-raw — one-shot hash → 32-element vector of byte integers
+    registry.define(
+        "blake3/hash-raw",
+        wrap_fn1(
+            "blake3/hash-raw",
+            |data: Value| -> Result<Vec<Value>, String> {
+                let bytes = to_bytes(&data)?;
+                Ok(hash_to_byte_vec(&blake3::hash(&bytes)))
+            },
+        ),
+    );
+
+    // blake3/keyed-hash — BLAKE3 MAC; key must be exactly 32 bytes → hex
+    registry.define(
+        "blake3/keyed-hash",
+        NativeFn::with_closure(
+            "blake3/keyed-hash",
+            Arity::Fixed(2),
+            |args| -> ValueResult<Value> {
+                let key_bytes = to_bytes(&args[0]).map_err(ValueError::Other)?;
+                if key_bytes.len() != 32 {
+                    return Err(ValueError::Other(format!(
+                        "keyed-hash key must be exactly 32 bytes, got {}",
+                        key_bytes.len()
+                    )));
+                }
+                let key: [u8; 32] = key_bytes.try_into().unwrap();
+                let data_bytes = to_bytes(&args[1]).map_err(ValueError::Other)?;
+                Ok(hash_to_hex(&blake3::keyed_hash(&key, &data_bytes)).into_value())
+            },
+        ),
+    );
+
+    // blake3/derive-key — domain-separated KDF → 64-char hex string
+    registry.define(
+        "blake3/derive-key",
+        wrap_fn2(
+            "blake3/derive-key",
+            |context: String, material: Value| -> Result<String, String> {
+                let bytes = to_bytes(&material)?;
+                let mut h = blake3::Hasher::new_derive_key(&context);
+                h.update(&bytes);
+                Ok(hash_to_hex(&h.finalize()))
+            },
+        ),
+    );
+
+    // blake3/hasher-new — create a new incremental hasher
+    registry.define(
+        "blake3/hasher-new",
+        wrap_fn0("blake3/hasher-new", || -> Result<Value, String> {
+            Ok(Value::NativeObject(gc_native_object(Blake3Hasher {
+                inner: Mutex::new(blake3::Hasher::new()),
+            })))
+        }),
+    );
+
+    // blake3/hasher-update! — feed data into hasher; returns the same hasher
+    registry.define(
+        "blake3/hasher-update!",
+        wrap_fn2(
+            "blake3/hasher-update!",
+            |h: Value, data: Value| -> Result<Value, String> {
+                let bytes = to_bytes(&data)?;
+                as_blake3_hasher(&h)?.inner.lock().unwrap().update(&bytes);
+                Ok(h)
+            },
+        ),
+    );
+
+    // blake3/hasher-finalize — produce hex digest; hasher stays usable
+    registry.define(
+        "blake3/hasher-finalize",
+        wrap_fn1(
+            "blake3/hasher-finalize",
+            |h: Value| -> Result<String, String> {
+                Ok(hash_to_hex(
+                    &as_blake3_hasher(&h)?.inner.lock().unwrap().finalize(),
+                ))
+            },
+        ),
+    );
+
+    // blake3/hasher-finalize-raw — produce 32-element byte vector
+    registry.define(
+        "blake3/hasher-finalize-raw",
+        wrap_fn1(
+            "blake3/hasher-finalize-raw",
+            |h: Value| -> Result<Vec<Value>, String> {
+                Ok(hash_to_byte_vec(
+                    &as_blake3_hasher(&h)?.inner.lock().unwrap().finalize(),
+                ))
+            },
+        ),
+    );
+
+    registry.env().mark_loaded("blake3");
+}

--- a/crates/cljrs-blake3/test/cljrs/blake3_test.cljrs
+++ b/crates/cljrs-blake3/test/cljrs/blake3_test.cljrs
@@ -1,0 +1,154 @@
+(ns cljrs.blake3-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [blake3 :as b]))
+
+;; ── Known test vectors ────────────────────────────────────────────────────────
+;;
+;; Official BLAKE3 test vector (input_len=0, from test_vectors.json in the
+;; BLAKE3 reference repository):
+;;   blake3("") = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+
+(def ^:private empty-hash
+  "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262")
+
+(deftest test-known-vector-empty
+  (testing "BLAKE3 hash of empty string matches official test vector"
+    (is (= empty-hash (b/hash "")))))
+
+(deftest test-known-vector-empty-bytes
+  (testing "BLAKE3 hash of empty byte vector matches empty-string hash"
+    (is (= empty-hash (b/hash [])))))
+
+;; ── Output format ─────────────────────────────────────────────────────────────
+
+(deftest test-hash-output-length
+  (testing "hash returns 64 hex characters (32 bytes)"
+    (is (= 64 (count (b/hash ""))))
+    (is (= 64 (count (b/hash "hello"))))
+    (is (= 64 (count (b/hash "the quick brown fox"))))))
+
+(deftest test-hash-raw-output-shape
+  (testing "hash-raw returns a 32-element vector"
+    (let [raw (b/hash-raw "hello")]
+      (is (= 32 (count raw)))))
+  (testing "every byte is an integer in 0..255"
+    (let [raw (b/hash-raw "hello")]
+      (is (every? integer? raw))
+      (is (every? #(and (>= % 0) (<= % 255)) raw)))))
+
+;; ── String vs byte-vector input consistency ───────────────────────────────────
+
+(deftest test-string-equals-byte-vector-input
+  (testing "hashing a string and the equivalent UTF-8 byte vector yields the same digest"
+    ;; "abc" = bytes [97 98 99]
+    (is (= (b/hash "abc")
+           (b/hash [97 98 99])))
+    (is (= (b/hash-raw "abc")
+           (b/hash-raw [97 98 99])))))
+
+;; ── Determinism ───────────────────────────────────────────────────────────────
+
+(deftest test-hash-is-deterministic
+  (testing "identical inputs always produce the same hash"
+    (is (= (b/hash "hello") (b/hash "hello")))
+    (is (= (b/hash [1 2 3]) (b/hash [1 2 3])))))
+
+(deftest test-different-inputs-differ
+  (testing "distinct inputs produce distinct hashes"
+    (is (not= (b/hash "hello") (b/hash "world")))
+    (is (not= (b/hash "") (b/hash "a")))))
+
+;; ── Incremental hasher ────────────────────────────────────────────────────────
+
+(deftest test-incremental-matches-single-pass
+  (testing "chunked update matches a single-pass hash of the concatenation"
+    (let [h (b/hasher-new)]
+      (b/hasher-update! h "hel")
+      (b/hasher-update! h "lo")
+      (is (= (b/hash "hello")
+             (b/hasher-finalize h))))))
+
+(deftest test-incremental-byte-vector-input
+  (testing "hasher-update! accepts byte vectors"
+    (let [h (b/hasher-new)]
+      (b/hasher-update! h [104 101])   ; "he"
+      (b/hasher-update! h [108 108 111]) ; "llo"
+      (is (= (b/hash "hello")
+             (b/hasher-finalize h))))))
+
+(deftest test-hasher-finalize-is-nondestructive
+  (testing "finalize can be called multiple times and returns the same digest"
+    (let [h (b/hasher-new)]
+      (b/hasher-update! h "data")
+      (let [first-result  (b/hasher-finalize h)
+            second-result (b/hasher-finalize h)]
+        (is (= first-result second-result))))))
+
+(deftest test-hasher-update-returns-hasher
+  (testing "hasher-update! returns the hasher for chaining"
+    (let [h  (b/hasher-new)
+          h2 (b/hasher-update! h "hello")]
+      (is (identical? h h2)))))
+
+(deftest test-hasher-finalize-raw
+  (testing "hasher-finalize-raw returns 32 bytes"
+    (let [h (b/hasher-new)
+          _ (b/hasher-update! h "test")]
+      (is (= 32 (count (b/hasher-finalize-raw h))))))
+  (testing "hasher-finalize-raw matches hash-raw for the same data"
+    (let [h (b/hasher-new)
+          _ (b/hasher-update! h "test")]
+      (is (= (b/hash-raw "test")
+             (b/hasher-finalize-raw h))))))
+
+;; ── Keyed hash ────────────────────────────────────────────────────────────────
+
+(deftest test-keyed-hash-output-length
+  (testing "keyed-hash produces a 64-char hex string"
+    (let [key (vec (repeat 32 0))]
+      (is (= 64 (count (b/keyed-hash key "hello")))))))
+
+(deftest test-keyed-hash-differs-from-plain-hash
+  (testing "keyed-hash with a non-zero key differs from plain hash"
+    (let [key (vec (repeat 32 1))]
+      (is (not= (b/hash "hello")
+                (b/keyed-hash key "hello"))))))
+
+(deftest test-keyed-hash-key-must-be-32-bytes
+  (testing "keyed-hash throws when key is not 32 bytes"
+    (is (thrown? Exception (b/keyed-hash (vec (repeat 16 0)) "hello")))
+    (is (thrown? Exception (b/keyed-hash (vec (repeat 33 0)) "hello")))))
+
+(deftest test-keyed-hash-same-key-same-result
+  (testing "identical key + data always give the same keyed hash"
+    (let [key (vec (range 32))]
+      (is (= (b/keyed-hash key "hello")
+             (b/keyed-hash key "hello"))))))
+
+(deftest test-keyed-hash-different-keys-differ
+  (testing "different keys with the same data give different keyed hashes"
+    (let [key1 (vec (repeat 32 0))
+          key2 (vec (repeat 32 1))]
+      (is (not= (b/keyed-hash key1 "hello")
+                (b/keyed-hash key2 "hello"))))))
+
+;; ── Key derivation ────────────────────────────────────────────────────────────
+
+(deftest test-derive-key-output-length
+  (testing "derive-key produces a 64-char hex string"
+    (is (= 64 (count (b/derive-key "test context" "key material"))))))
+
+(deftest test-derive-key-context-separates
+  (testing "different contexts with same material yield different keys"
+    (is (not= (b/derive-key "context-a" "material")
+              (b/derive-key "context-b" "material")))))
+
+(deftest test-derive-key-material-separates
+  (testing "same context with different material yields different keys"
+    (is (not= (b/derive-key "context" "material-a")
+              (b/derive-key "context" "material-b")))))
+
+(deftest test-derive-key-differs-from-plain-hash
+  (testing "derive-key is domain-separated from a plain hash"
+    (is (not= (b/hash "key material")
+              (b/derive-key "test context" "key material")))))

--- a/crates/cljrs-blake3/tests/clojure_tests.rs
+++ b/crates/cljrs-blake3/tests/clojure_tests.rs
@@ -1,0 +1,114 @@
+//! Runs the Clojure-side `clojure.test` suite for the `cljrs.blake3-test`
+//! namespace against the native `blake3` functions registered by this crate.
+//!
+//! The test:
+//! 1. Calls `cljrs_blake3::cljrs_init` to register the `blake3` namespace.
+//! 2. Loads the standard environment with the crate's `test/` directory on
+//!    the source path so `(require 'cljrs.blake3-test)` resolves.
+//! 3. Drives `clojure.test/run-tests` and fails if any assertion fails.
+
+use std::path::PathBuf;
+
+use cljrs_eval::{Env, eval};
+use cljrs_interop::Registry;
+use cljrs_value::Value;
+
+const TEST_NSES: &[&str] = &["cljrs.blake3-test"];
+
+fn parse_one(src: &str) -> cljrs_reader::Form {
+    let mut parser = cljrs_reader::Parser::new(src.to_string(), "<test-driver>".to_string());
+    let forms = parser.parse_all().expect("test driver: parse failed");
+    forms
+        .into_iter()
+        .next()
+        .expect("test driver: expected at least one form")
+}
+
+fn eval_str(env: &mut Env, src: &str) -> Value {
+    let form = parse_one(src);
+    eval(&form, env).unwrap_or_else(|e| panic!("eval `{src}` failed: {e:?}"))
+}
+
+fn extract_counter(map: &Value, key: &str) -> i64 {
+    let mut found = 0i64;
+    if let Value::Map(m) = map {
+        m.for_each(|k, v| {
+            if let (Value::Keyword(kw), Value::Long(n)) = (k, v)
+                && kw.get().name.as_ref() == key
+            {
+                found = *n;
+            }
+        });
+    }
+    found
+}
+
+#[test]
+fn run_clojure_blake3_tests() {
+    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test");
+    assert!(
+        test_dir.is_dir(),
+        "test dir not found: {}",
+        test_dir.display()
+    );
+
+    let _mutator = cljrs_gc::register_mutator();
+
+    let globals = cljrs_stdlib::standard_env_with_paths(vec![test_dir]);
+
+    // Wait for the background compiler-namespace loader to finish so that
+    // `require` doesn't race against it and trigger spurious circular-require errors.
+    while !globals
+        .compiler_ready
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // Register blake3 native functions before any Clojure code is evaluated.
+    let mut registry = Registry::new(globals.clone());
+    cljrs_blake3::cljrs_init(&mut registry);
+
+    let mut env = Env::new(globals, "user");
+
+    cljrs_env::callback::push_eval_context(&env);
+
+    eval_str(&mut env, "(require 'clojure.test)");
+
+    let mut total_pass = 0i64;
+    let mut total_fail = 0i64;
+    let mut total_error = 0i64;
+    let mut total_test = 0i64;
+    let mut failures: Vec<String> = Vec::new();
+
+    for ns in TEST_NSES {
+        eprintln!("[blake3-tests] running {ns}");
+        eval_str(&mut env, &format!("(require '{ns})"));
+        let result = eval_str(&mut env, &format!("(clojure.test/run-tests '{ns})"));
+        let pass = extract_counter(&result, "pass");
+        let fail = extract_counter(&result, "fail");
+        let error = extract_counter(&result, "error");
+        let test = extract_counter(&result, "test");
+        total_pass += pass;
+        total_fail += fail;
+        total_error += error;
+        total_test += test;
+        if fail > 0 || error > 0 {
+            failures.push(format!("{ns}: {fail} fail, {error} error"));
+        }
+    }
+
+    cljrs_env::callback::pop_eval_context();
+
+    eprintln!(
+        "[blake3-tests] totals: {total_test} tests, {total_pass} pass, \
+         {total_fail} fail, {total_error} error",
+    );
+
+    assert!(total_test > 0, "no tests ran");
+    assert!(
+        failures.is_empty(),
+        "Clojure-side test failures:\n  {}",
+        failures.join("\n  "),
+    );
+}


### PR DESCRIPTION
Exposes the BLAKE3 cryptographic hash API as Clojure native functions
in the `blake3` namespace via cljrs-interop:

  (blake3/hash data)              ; one-shot hex digest
  (blake3/hash-raw data)          ; one-shot 32-byte vector
  (blake3/keyed-hash key data)    ; BLAKE3 MAC (32-byte key)
  (blake3/derive-key context mat) ; domain-separated KDF
  (blake3/hasher-new)             ; incremental hasher (NativeObject)
  (blake3/hasher-update! h data)  ; feed bytes; returns h
  (blake3/hasher-finalize h)      ; hex digest; hasher stays usable
  (blake3/hasher-finalize-raw h)  ; 32-byte vector digest

Blake3Hasher wraps blake3::Hasher behind a Mutex<> so it is Send+Sync
and safe to use as a NativeObject.  All data arguments accept either a
String (UTF-8 bytes) or a Clojure vector of integers 0-255.

Includes:
- cljrs.edn project descriptor (:paths, :test-paths, :rust :init)
- 21 Clojure test assertions in test/cljrs/blake3_test.cljrs covering
  known vectors, output shape, string/byte-vec equivalence, incremental
  hasher consistency, keyed-hash, and derive-key
- Rust clojure.test harness in tests/clojure_tests.rs

https://claude.ai/code/session_012G9TcJJvwkR4LifWQcewp6