### PR TITLE
feat(builtins): implement re-seq using re-matcher, re-find, and take-while

### DIFF
--- a/crates/cljrs-builtins/src/bootstrap.cljrs
+++ b/crates/cljrs-builtins/src/bootstrap.cljrs
@@ -1053,4 +1053,4 @@
 (defn re-seq
   [re s]
   (let [matcher (re-matcher re s)]
-    ))
+    (take-while identity (repeatedly #(re-find matcher)))))


### PR DESCRIPTION
Replaces the stub body with the standard Clojure idiom: create a
matcher with re-matcher, then lazily pull successive matches with
(take-while identity (repeatedly #(re-find matcher))).