### PR TITLE
Fix native lib path resolution for workspace members

### DIFF
--- a/crates/cljrs-blake3/Cargo.toml
+++ b/crates/cljrs-blake3/Cargo.toml
@@ -6,6 +6,13 @@ description = "BLAKE3 cryptographic hash functions exposed as Clojure native fun
 license.workspace = true
 repository.workspace = true
 
+[lib]
+# `cdylib` produces the `.so`/`.dylib`/`.dll` loaded dynamically by
+# `cljrs run` / `cljrs repl` after `cljrs build-native`.
+# `rlib` keeps the crate usable as a normal Rust workspace member —
+# integration tests and AOT static linking both depend on it.
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 cljrs-interop = { workspace = true }
 cljrs-gc      = { workspace = true }

--- a/crates/cljrs-blake3/README.md
+++ b/crates/cljrs-blake3/README.md
@@ -28,9 +28,14 @@ cljrs.edn                         — project descriptor (paths, Rust init hook)
 ### Rust
 
 ```rust
-/// Register all `blake3` Clojure functions. Call from an embedding `main.rs`
-/// or from another crate's `cljrs_init`.
-pub fn cljrs_init(registry: &mut cljrs_interop::Registry);
+/// Register all `blake3` Clojure functions. Call from an embedding `main.rs`,
+/// from an integration test, or from another crate's init hook.
+pub fn register(registry: &mut cljrs_interop::Registry);
+
+/// C-ABI entry point looked up by `cljrs build-native` / `cljrs run`. Calls
+/// `register` internally.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cljrs_init(registry: *mut cljrs_interop::Registry);
 ```
 
 ### Clojure namespace: `blake3`
@@ -88,14 +93,20 @@ Add to your `cljrs.edn`:
          :init  "cljrs_blake3::cljrs_init"}}
 ```
 
-Or call `cljrs_init` directly in your own `cljrs_init` function:
+Or call `register` directly from your own init hook:
 
 ```rust
 pub fn cljrs_init(registry: &mut Registry) {
-    cljrs_blake3::cljrs_init(registry);
+    cljrs_blake3::register(registry);
     // … your own registrations …
 }
 ```
+
+> **Note on `Cargo.toml`:** this crate declares
+> `[lib] crate-type = ["cdylib", "rlib"]` — `cdylib` produces the
+> `.so`/`.dylib`/`.dll` loaded by `cljrs build-native`, while `rlib` keeps
+> the crate usable as a normal workspace dependency (integration tests, AOT
+> static linking). When wiring up your own interop crate, mirror this setup.
 
 ---
 

--- a/crates/cljrs-blake3/src/lib.rs
+++ b/crates/cljrs-blake3/src/lib.rs
@@ -114,14 +114,11 @@ fn hash_to_byte_vec(hash: &blake3::Hash) -> Vec<Value> {
 
 /// Register all `blake3` namespace functions into the Clojure runtime.
 ///
-/// The `cljrs compile` toolchain calls this automatically when the crate is
-/// listed under `:rust :init` in `cljrs.edn`:
-///
-/// ```edn
-/// {:rust {:crate "."
-///         :init  "cljrs_blake3::cljrs_init"}}
-/// ```
-pub fn cljrs_init(registry: &mut Registry) {
+/// Use this when calling from another Rust crate that holds a `Registry`
+/// directly (e.g. integration tests, AOT-compiled binaries). The dynamic
+/// `cljrs build-native` loader uses the `extern "C"` `cljrs_init` wrapper
+/// below instead.
+pub fn register(registry: &mut Registry) {
     // blake3/hash — one-shot hash of a string or byte vector → 64-char hex
     registry.define(
         "blake3/hash",
@@ -228,4 +225,22 @@ pub fn cljrs_init(registry: &mut Registry) {
     );
 
     registry.env().mark_loaded("blake3");
+}
+
+/// C-ABI entry point loaded dynamically by `cljrs build-native` / `cljrs run`.
+///
+/// `cljrs.edn`:
+/// ```edn
+/// {:rust {:crate "."
+///         :init  "cljrs_blake3::cljrs_init"}}
+/// ```
+///
+/// # Safety
+/// `registry` must be a valid, non-null `*mut Registry` and must remain
+/// uniquely borrowed for the duration of the call. The cljrs CLI satisfies
+/// both: it allocates the `Registry` on its stack and hands the only pointer
+/// to it across the FFI boundary.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cljrs_init(registry: *mut Registry) {
+    register(unsafe { &mut *registry });
 }

--- a/crates/cljrs-blake3/tests/clojure_tests.rs
+++ b/crates/cljrs-blake3/tests/clojure_tests.rs
@@ -2,7 +2,7 @@
 //! namespace against the native `blake3` functions registered by this crate.
 //!
 //! The test:
-//! 1. Calls `cljrs_blake3::cljrs_init` to register the `blake3` namespace.
+//! 1. Calls `cljrs_blake3::register` to register the `blake3` namespace.
 //! 2. Loads the standard environment with the crate's `test/` directory on
 //!    the source path so `(require 'cljrs.blake3-test)` resolves.
 //! 3. Drives `clojure.test/run-tests` and fails if any assertion fails.
@@ -67,7 +67,7 @@ fn run_clojure_blake3_tests() {
 
     // Register blake3 native functions before any Clojure code is evaluated.
     let mut registry = Registry::new(globals.clone());
-    cljrs_blake3::cljrs_init(&mut registry);
+    cljrs_blake3::register(&mut registry);
 
     let mut env = Env::new(globals, "user");
 

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -554,7 +554,13 @@ fn native_lib_path(crate_dir: &Path, crate_name: &str, release: bool) -> PathBuf
 /// is expected to fall back to `<crate_dir>/target`.
 fn cargo_target_dir(crate_dir: &Path) -> Option<PathBuf> {
     let output = std::process::Command::new("cargo")
-        .args(["metadata", "--format-version", "1", "--no-deps", "--offline"])
+        .args([
+            "metadata",
+            "--format-version",
+            "1",
+            "--no-deps",
+            "--offline",
+        ])
         .current_dir(crate_dir)
         .output()
         .ok()?;

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -529,6 +529,13 @@ fn format_eval_error(e: EvalError) -> miette::Report {
 
 /// Return the expected on-disk path for the shared library produced by
 /// `cargo build` inside `crate_dir`.
+///
+/// Respects cargo's workspace semantics: when `crate_dir` is a workspace
+/// member, cargo writes artifacts to `<workspace_root>/target/`, not
+/// `<crate_dir>/target/`. We ask cargo where its target directory is via
+/// `cargo metadata`. If that fails (no cargo on PATH, malformed manifest,
+/// etc.), we fall back to `<crate_dir>/target/` so the standalone-crate
+/// case still works.
 fn native_lib_path(crate_dir: &Path, crate_name: &str, release: bool) -> PathBuf {
     let profile = if release { "release" } else { "debug" };
     let lib_file = if cfg!(target_os = "windows") {
@@ -538,7 +545,70 @@ fn native_lib_path(crate_dir: &Path, crate_name: &str, release: bool) -> PathBuf
     } else {
         format!("lib{crate_name}.so")
     };
-    crate_dir.join("target").join(profile).join(lib_file)
+    let target_dir = cargo_target_dir(crate_dir).unwrap_or_else(|| crate_dir.join("target"));
+    target_dir.join(profile).join(lib_file)
+}
+
+/// Ask `cargo metadata` for the target directory that cargo will actually use
+/// when building inside `crate_dir`. Returns `None` on any failure; the caller
+/// is expected to fall back to `<crate_dir>/target`.
+fn cargo_target_dir(crate_dir: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps", "--offline"])
+        .current_dir(crate_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = std::str::from_utf8(&output.stdout).ok()?;
+    // Cargo's metadata JSON puts `target_directory` at the top level. We do
+    // a small targeted extract rather than pulling in a JSON dependency.
+    let key = r#""target_directory":""#;
+    let start = stdout.find(key)? + key.len();
+    let rest = &stdout[start..];
+    let mut end = None;
+    let bytes = rest.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if i + 1 < bytes.len() => i += 2,
+            b'"' => {
+                end = Some(i);
+                break;
+            }
+            _ => i += 1,
+        }
+    }
+    let raw = &rest[..end?];
+    Some(PathBuf::from(json_unescape(raw)))
+}
+
+/// Decode the small subset of JSON string escapes that can appear in a
+/// `target_directory` path emitted by `cargo metadata`.
+fn json_unescape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('\\') => out.push('\\'),
+            Some('"') => out.push('"'),
+            Some('/') => out.push('/'),
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 /// Load the shared library declared by `rust_config` and call its `cljrs_init`


### PR DESCRIPTION
## Summary

Fix `native_lib_path()` to respect Cargo's workspace semantics by querying `cargo metadata` for the actual target directory, rather than always assuming `<crate_dir>/target/`. This ensures the native library loader finds artifacts in the correct location when a crate is a workspace member.

## Changes

- **`crates/cljrs/src/main.rs`**
  - Enhanced `native_lib_path()` to call new `cargo_target_dir()` helper, falling back to `<crate_dir>/target/` if metadata lookup fails
  - Added `cargo_target_dir()` function that invokes `cargo metadata` and extracts the `target_directory` field from JSON output
  - Added `json_unescape()` helper to decode JSON string escapes in the metadata output
  - Updated doc comment to explain workspace semantics and fallback behavior

- **`crates/cljrs-blake3/src/lib.rs`**
  - Renamed `cljrs_init()` public function to `register()` to clarify its purpose for direct Rust callers
  - Created new `extern "C" cljrs_init()` wrapper that accepts a raw pointer and delegates to `register()`, serving as the C-ABI entry point for dynamic loading
  - Updated doc comments to distinguish between the Rust API (`register`) and FFI entry point (`cljrs_init`)

- **`crates/cljrs-blake3/Cargo.toml`**
  - Added `[lib]` section declaring `crate-type = ["cdylib", "rlib"]` to support both dynamic loading (`.so`/`.dylib`/`.dll`) and use as a workspace dependency

- **`crates/cljrs-blake3/README.md`**
  - Updated API documentation to reflect the `register()` / `cljrs_init()` split
  - Added note explaining the dual `crate-type` configuration and its purpose
  - Updated integration examples to call `register()` instead of `cljrs_init()`

- **`crates/cljrs-blake3/tests/clojure_tests.rs`**
  - Updated test to call `register()` instead of `cljrs_init()`

## Implementation Details

The `cargo_target_dir()` function uses a targeted JSON field extraction rather than a full JSON parser to avoid adding dependencies. It handles the common escape sequences (`\\`, `\"`, `/`, `\n`, `\t`, `\r`) that may appear in file paths. The function gracefully degrades: any failure in the metadata lookup (missing cargo, malformed manifest, etc.) returns `None`, allowing the caller to fall back to the standard `<crate_dir>/target/` location for standalone crates.

https://claude.ai/code/session_01SuveyWGtvLFruxpRkXnJvH