### PR TITLE
Fix REPL bar background in light mode

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -254,7 +254,7 @@
       left: 0;
       right: 0;
       z-index: 100;
-      background: var(--bg0-h);
+      background: var(--surface1);
       border-top: 1px solid var(--rule);
     }
 


### PR DESCRIPTION
--bg0-h was never overridden in the light-mode media query, leaving the
REPL bar with a near-black background while the input text was already
styled for light mode. Switch to var(--surface1) which correctly adapts
to both color schemes.

https://claude.ai/code/session_01QGW2FwUzKrQRrkBfghC8XR