### PR TITLE
Add -main entry point for cljrs run and AOT binaries

### DIFF
--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -103,6 +103,11 @@ pub enum AotError { Io, Parse, Codegen, Eval, Link, NoGcBlacklist(Vec<BlacklistV
 
 Pipeline: read source → parse → evaluate preamble → macro-expand → discover required namespaces → ANF lower (Clojure) → optimize (escape analysis + region alloc) → IR convert → **[no-gc] blacklist check** → Cranelift codegen → generate Cargo harness → `cargo build --release` → copy binary.
 
+The generated harness `main()` calls `-main` (via `resolve`) after
+`__cljrs_main` returns, forwarding all command-line arguments (skipping the
+program name) as individual strings.  If `-main` is not defined the binary
+exits normally; if `-main` throws, the binary prints the error and exits 1.
+
 The generated harness `main()` (and the `compile_test_harness` test runner)
 calls `cljrs_gc::dump_stats_from_env()` once at exit, so AOT binaries honor
 the `CLJRS_GC_STATS` env var (empty/`"-"` → stdout, otherwise a file path).

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -778,6 +778,53 @@ cljrs-compiler = {{ path = "{ws}/crates/cljrs-compiler" }}
     }
 
     // Write main.rs — calls into the compiled __cljrs_main.
+
+    // Generated Rust block that calls -main after the compiled body runs.
+    // Uses resolve to check existence, then builds and evals the call expression.
+    let main_call_code = r#"
+    // Call -main if defined, forwarding command-line arguments (skip program name).
+    {
+        let __argv: Vec<String> = std::env::args().skip(1).collect();
+        let __check = cljrs_reader::Parser::new(
+            "(resolve '-main)".to_string(),
+            "<main-check>".to_string(),
+        )
+        .parse_all()
+        .ok()
+        .and_then(|fs| cljrs_eval::eval(&fs[0], &mut env).ok());
+        if let Some(r) = __check {
+            if r != cljrs_value::Value::Nil {
+                let escaped: Vec<String> = __argv
+                    .iter()
+                    .map(|a| {
+                        let mut s = String::with_capacity(a.len() + 2);
+                        s.push('"');
+                        for ch in a.chars() {
+                            match ch {
+                                '"' => s.push_str("\\\""),
+                                '\\' => s.push_str("\\\\"),
+                                '\n' => s.push_str("\\n"),
+                                '\r' => s.push_str("\\r"),
+                                '\t' => s.push_str("\\t"),
+                                c => s.push(c),
+                            }
+                        }
+                        s.push('"');
+                        s
+                    })
+                    .collect();
+                let call = format!("(-main {})", escaped.join(" "));
+                if let Ok(fs) = cljrs_reader::Parser::new(call, "<main>".to_string()).parse_all() {
+                    if let Err(e) = cljrs_eval::eval(&fs[0], &mut env) {
+                        eprintln!("cljrs: error in -main: {e:?}");
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+    }
+"#;
+
     let preamble_code = if has_preamble {
         r#"
     // Evaluate interpreted preamble (ns, require, defn, defmacro, etc.).
@@ -839,7 +886,7 @@ fn main() {{
 {preamble}
     // Call the compiled code.
     let _result = unsafe {{ __cljrs_main() }};
-
+{main_call}
     // Pop the eval context.
     cljrs_env::callback::pop_eval_context();
 
@@ -850,6 +897,7 @@ fn main() {{
         preamble = preamble_code,
         bundled = bundled_registration,
         native_init = native_init_code,
+        main_call = main_call_code,
     );
     std::fs::write(harness_dir.join("src/main.rs"), main_rs)?;
 

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -30,12 +30,32 @@ src/
 | `deps fetch`  | Clone / update git dependencies declared in `cljrs.edn`                |
 | `deps status` | Show which dependencies are cached and which are missing               |
 
+### -main entry point
+
+After all top-level forms in the source file are evaluated, `cljrs run` looks
+up `-main` in the current namespace.  If the var exists it is called with the
+arguments that follow `--` on the command line, each as an individual string:
+
+```bash
+cljrs run app.cljrs -- hello world   # calls (-main "hello" "world")
+cljrs run app.cljrs                  # calls (-main) if -main is defined
+```
+
+The same convention applies to AOT binaries produced by `cljrs compile`: the
+compiled binary calls `-main` after `__cljrs_main` finishes, passing all
+`argv` entries (skipping the program name) as individual string arguments.
+
+If `-main` is not defined the program exits normally without error.
+
 ### Per-subcommand flags
 
 `run`, `repl`, `compile`, `test` accept:
 - `--src-path <DIR>` — repeatable; directories searched by `require`
 - `--gc-soft-limit-mb <MB>` — soft GC threshold
 - `--gc-hard-limit-mb <MB>` — hard GC threshold
+
+`run` additionally accepts:
+- `[-- ARGS…]` — positional arguments forwarded verbatim to `-main`
 
 `compile` additionally accepts:
 - `-o, --out <PATH>` — output binary path (required)
@@ -82,6 +102,7 @@ These appear before the subcommand and apply to every command:
 # Interpret a file
 cljrs run hello.cljrs
 cljrs run main.cljrs --src-path src --src-path lib
+cljrs run app.cljrs -- arg1 arg2    # args forwarded to -main
 
 # REPL
 cljrs repl --src-path src

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -491,7 +491,12 @@ fn eval_source(src: &str, filename: &str, globals: Arc<GlobalEnv>) -> miette::Re
 }
 
 /// Run a source file: evaluate all top-level forms, then call `-main` if defined.
-fn run_source(src: &str, filename: &str, globals: Arc<GlobalEnv>, args: &[String]) -> miette::Result<()> {
+fn run_source(
+    src: &str,
+    filename: &str,
+    globals: Arc<GlobalEnv>,
+    args: &[String],
+) -> miette::Result<()> {
     let mut env = Env::new(globals, "user");
     eval_in(&mut env, src, filename)?;
     call_main_if_defined(&mut env, args)?;
@@ -502,8 +507,7 @@ fn run_source(src: &str, filename: &str, globals: Arc<GlobalEnv>, args: &[String
 /// individual string arguments. Silently skips if `-main` is not defined.
 fn call_main_if_defined(env: &mut Env, args: &[String]) -> miette::Result<()> {
     // resolve returns nil for undefined symbols; swallow lookup errors defensively.
-    let resolved = eval_in(env, "(resolve '-main)", "<main-check>")
-        .unwrap_or(Value::Nil);
+    let resolved = eval_in(env, "(resolve '-main)", "<main-check>").unwrap_or(Value::Nil);
     if resolved == Value::Nil {
         return Ok(());
     }

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -78,6 +78,9 @@ enum Commands {
         /// GC hard memory limit in MB (forces collection when exceeded).
         #[arg(long)]
         gc_hard_limit_mb: Option<usize>,
+        /// Arguments forwarded to -main (everything after `--`).
+        #[arg(last = true, value_name = "ARGS")]
+        args: Vec<String>,
     },
     /// Start an interactive REPL.
     Repl {
@@ -288,13 +291,14 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
             src_paths,
             gc_soft_limit_mb,
             gc_hard_limit_mb,
+            args,
         } => {
             let src = std::fs::read_to_string(&file)
                 .map_err(|e| miette::miette!("{}: {}", file.display(), e))?;
             let filename = file.display().to_string();
             let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
             let globals = setup_globals(src_paths, gc_config, verify_commit_signatures);
-            run_source(&src, &filename, globals)?;
+            run_source(&src, &filename, globals, &args)?;
             Ok(0)
         }
         Commands::Repl {
@@ -486,11 +490,45 @@ fn eval_source(src: &str, filename: &str, globals: Arc<GlobalEnv>) -> miette::Re
     eval_in(&mut env, src, filename)
 }
 
-/// Run a source file: evaluate all top-level forms, print nothing on success.
-fn run_source(src: &str, filename: &str, globals: Arc<GlobalEnv>) -> miette::Result<()> {
+/// Run a source file: evaluate all top-level forms, then call `-main` if defined.
+fn run_source(src: &str, filename: &str, globals: Arc<GlobalEnv>, args: &[String]) -> miette::Result<()> {
     let mut env = Env::new(globals, "user");
     eval_in(&mut env, src, filename)?;
+    call_main_if_defined(&mut env, args)?;
     Ok(())
+}
+
+/// Call `-main` in the current namespace if it is defined, passing `args` as
+/// individual string arguments. Silently skips if `-main` is not defined.
+fn call_main_if_defined(env: &mut Env, args: &[String]) -> miette::Result<()> {
+    // resolve returns nil for undefined symbols; swallow lookup errors defensively.
+    let resolved = eval_in(env, "(resolve '-main)", "<main-check>")
+        .unwrap_or(Value::Nil);
+    if resolved == Value::Nil {
+        return Ok(());
+    }
+    let escaped: Vec<String> = args.iter().map(|s| escape_clojure_string(s)).collect();
+    let call = format!("(-main {})", escaped.join(" "));
+    eval_in(env, &call, "<main>")?;
+    Ok(())
+}
+
+/// Produce a Clojure string literal (double-quoted, with escapes) for `s`.
+fn escape_clojure_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Evaluate `src` in an existing `Env`. Returns the last value.


### PR DESCRIPTION
After all top-level forms are evaluated, both the interpreter (cljrs run)
and AOT-compiled binaries now automatically call -main in the current
namespace if it is defined, forwarding command-line arguments as individual
strings. cljrs run accepts program args after `--`; AOT binaries receive
all argv entries after the program name.

Resolves the workaround in samples/graph.cljrs where -main had to be
called explicitly because the runtime did not invoke it automatically.