### PR TITLE
fix: use themed --rule variable for eval button border and hover in light mode

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -318,7 +318,7 @@
       padding: 2px 10px;
       background: var(--surface2);
       color: var(--accent2);
-      border: 1px solid var(--bg2);
+      border: 1px solid var(--rule);
       border-radius: 3px;
       font-family: inherit;
       font-size: 0.8rem;
@@ -329,7 +329,7 @@
     }
 
     #repl-eval:hover:not(:disabled) {
-      background: var(--bg2);
+      background: var(--rule);
       color: var(--text);
     }
 


### PR DESCRIPTION
--bg2 is only defined for dark mode, causing the eval button border and
hover background to render with a dark gruvbox color in light mode.
Replace with --rule which maps to --bg2 in dark mode and the correct
light surface color in light mode.

https://claude.ai/code/session_01M7uR1LBxnN8zxCXoLpGL9S