### PR TITLE
Fix scroll behavior to prevent entries hidden behind fixed REPL bar

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -503,7 +503,22 @@
       }
 
       out.appendChild(entry);
-      entry.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      scrollToBottom();
+    }
+
+    // ── Scroll the page to the very bottom ────────────────────
+    // The page (not a container) scrolls, and #repl-bar is fixed over
+    // the bottom of the viewport. scrollIntoView would tuck the newest
+    // entry behind the bar, so scroll to the full document height — the
+    // body's bottom padding leaves room for the entry to clear the bar.
+    // rAF lets resize() finalize that padding before we read scrollHeight.
+    function scrollToBottom() {
+      requestAnimationFrame(function () {
+        window.scrollTo({
+          top: document.documentElement.scrollHeight,
+          behavior: 'smooth'
+        });
+      });
     }
 
     // ── Evaluate current input ────────────────────────────────


### PR DESCRIPTION
## Summary

Replace `scrollIntoView()` with a custom `scrollToBottom()` function that scrolls the entire page to its full document height, ensuring new REPL entries are not tucked behind the fixed `#repl-bar` element.

## Changes

- **Replaced `entry.scrollIntoView()`** with a call to new `scrollToBottom()` function that uses `window.scrollTo()` instead
- **Added `scrollToBottom()` helper function** that:
  - Uses `requestAnimationFrame()` to allow the DOM to finalize padding before reading scroll height
  - Scrolls to `document.documentElement.scrollHeight` to reach the absolute bottom of the page
  - Maintains smooth scroll behavior for consistency with the previous implementation
  - Includes detailed comments explaining why this approach is necessary (the fixed positioning of `#repl-bar` would otherwise obscure new entries)

## Implementation Details

The previous `scrollIntoView({ behavior: 'smooth', block: 'end' })` approach would position the entry at the viewport's bottom edge, placing it behind the fixed REPL bar. The new implementation scrolls the entire page to its full height, relying on the body's bottom padding to create clearance for entries to appear above the fixed bar.

The `requestAnimationFrame` wrapper ensures the browser has completed layout calculations before we read `scrollHeight`, preventing potential race conditions.

https://claude.ai/code/session_015SJK1siie6cao7HZuQ2Nua