### PR TITLE
Add GitHub Actions workflow to deploy www/ via SFTP on push to main

### DIFF
--- a/.github/workflows/www-deploy.yml
+++ b/.github/workflows/www-deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy www
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'www/**'
+
+jobs:
+  deploy:
+    name: Upload www via SFTP
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy via SFTP
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.4
+        with:
+          server: ${{ secrets.SFTP_HOST }}
+          port: ${{ secrets.SFTP_PORT || 22 }}
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          local_path: ./www/*
+          remote_path: ${{ secrets.SFTP_REMOTE_PATH }}
+          sftp_only: true
+          delete_remote_files: false

--- a/.github/workflows/www-deploy.yml
+++ b/.github/workflows/www-deploy.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'www/**'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Upload www via SFTP

--- a/.github/workflows/www-deploy.yml
+++ b/.github/workflows/www-deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'www/**'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Triggers only when files under www/ change. Requires four repository
secrets: SFTP_HOST, SFTP_USERNAME, SFTP_PASSWORD, and SFTP_REMOTE_PATH.
SFTP_PORT is optional and defaults to 22.