### PR TITLE
Fix WASM REPL missing built-in namespaces (clojure.string, .set, .test, etc.)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "cljrs-gc",
  "cljrs-interp",
  "cljrs-reader",
+ "cljrs-stdlib",
  "cljrs-types",
  "cljrs-value",
  "console_error_panic_hook",

--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -28,8 +28,10 @@ cljrs-value    = { workspace = true }
 cljrs-eval     = { workspace = true }
 cljrs-reader   = { workspace = true }
 cljrs-interp   = { workspace = true }
-tokio        = { workspace = true, features = ["rt", "sync", "rt-multi-thread"] }
 lazy_static = "1.5.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt", "sync", "rt-multi-thread"] }
 
 [build-dependencies]
 cljrs-ir     = { path = "../cljrs-ir",     version = "0.1.0", optional = true }

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -13,10 +13,14 @@
 use std::sync::Arc;
 
 use cljrs_eval::GlobalEnv;
+#[cfg(not(target_arch = "wasm32"))]
 use cljrs_gc::GcConfig;
 
 mod core_async;
+// io and edn use std::fs which is not available on wasm32-unknown-unknown
+#[cfg(not(target_arch = "wasm32"))]
 mod edn;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod io;
 mod set;
 mod string;
@@ -26,7 +30,9 @@ const CLOJURE_TEST_SRC: &str = include_str!("clojure/test.cljrs");
 const CLOJURE_STRING_SRC: &str = include_str!("clojure/string.cljrs");
 const CLOJURE_SET_SRC: &str = include_str!("clojure/set.cljrs");
 const CLOJURE_TEMPLATE_SRC: &str = include_str!("clojure/template.cljrs");
+#[cfg(not(target_arch = "wasm32"))]
 const CLOJURE_RUST_IO_SRC: &str = include_str!("clojure/rust/io.cljrs");
+#[cfg(not(target_arch = "wasm32"))]
 const CLOJURE_EDN_SRC: &str = include_str!("clojure/edn.cljrs");
 const CLOJURE_WALK_SRC: &str = include_str!("clojure/walk.cljrs");
 const CLOJURE_DATA_SRC: &str = include_str!("clojure/data.cljrs");
@@ -76,13 +82,15 @@ pub fn register(globals: &Arc<GlobalEnv>) {
     // clojure.test ─ pure Clojure, no native helpers.
     globals.register_builtin_source("clojure.test", CLOJURE_TEST_SRC);
 
-    // clojure.rust.io ─ I/O resources.
-    io::register(globals, "clojure.rust.io");
-    globals.register_builtin_source("clojure.rust.io", CLOJURE_RUST_IO_SRC);
+    // clojure.rust.io and clojure.edn use std::fs, unavailable on wasm32.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        io::register(globals, "clojure.rust.io");
+        globals.register_builtin_source("clojure.rust.io", CLOJURE_RUST_IO_SRC);
 
-    // clojure.edn ─ EDN reader.
-    edn::register(globals, "clojure.edn");
-    globals.register_builtin_source("clojure.edn", CLOJURE_EDN_SRC);
+        edn::register(globals, "clojure.edn");
+        globals.register_builtin_source("clojure.edn", CLOJURE_EDN_SRC);
+    }
 
     // clojure.walk ─ pure Clojure, no native helpers.
     globals.register_builtin_source("clojure.walk", CLOJURE_WALK_SRC);
@@ -139,6 +147,7 @@ fn load_prebuilt_compiler_ir(_globals: &Arc<GlobalEnv>) {}
 /// Prefer this over `cljrs_eval::standard_env()` in the `cljrs` binary so that
 /// stdlib namespaces are loaded lazily (only on first `require`) instead of
 /// eagerly at startup.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn standard_env() -> Arc<GlobalEnv> {
     let globals = cljrs_eval::standard_env_minimal();
     register(&globals);
@@ -202,6 +211,7 @@ pub fn standard_env() -> Arc<GlobalEnv> {
 }
 
 /// Like [`standard_env()`] but also sets user source paths for `require`.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn standard_env_with_paths(source_paths: Vec<std::path::PathBuf>) -> Arc<GlobalEnv> {
     let globals = standard_env();
     globals.set_source_paths(source_paths);
@@ -209,6 +219,7 @@ pub fn standard_env_with_paths(source_paths: Vec<std::path::PathBuf>) -> Arc<Glo
 }
 
 /// Like [`standard_env_with_paths()`] but also sets GC configuration.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn standard_env_with_paths_and_config(
     source_paths: Vec<std::path::PathBuf>,
     gc_config: Arc<GcConfig>,

--- a/crates/cljrs-wasm/Cargo.toml
+++ b/crates/cljrs-wasm/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cljrs-interp   = { workspace = true }
+cljrs-stdlib   = { workspace = true }
 cljrs-env      = { workspace = true }
 cljrs-value    = { workspace = true }
 cljrs-reader   = { workspace = true }

--- a/crates/cljrs-wasm/src/lib.rs
+++ b/crates/cljrs-wasm/src/lib.rs
@@ -56,6 +56,7 @@ impl Repl {
     pub fn new() -> Repl {
         console_error_panic_hook::set_once();
         let globals = cljrs_interp::standard_env_minimal(None, None, None);
+        cljrs_stdlib::register(&globals);
         Repl { globals }
     }
 


### PR DESCRIPTION
The WASM REPL called standard_env_minimal() which only initializes
clojure.core; it never called cljrs_stdlib::register(), so built-in
namespace sources were not registered and (require '[clojure.string ...])
always failed.

- Add cljrs-stdlib dependency to cljrs-wasm/Cargo.toml
- Call cljrs_stdlib::register(&globals) in Repl::new() after env init
- Gate std::fs-dependent modules (io, edn) behind cfg(not(wasm32)) in
  cljrs-stdlib so the crate compiles for wasm32-unknown-unknown
- Move tokio (rt-multi-thread) to a non-wasm target dependency since
  it is not available on wasm32-unknown-unknown
- Gate standard_env/standard_env_with_paths* behind cfg(not(wasm32))
  as they spawn OS threads

clojure.string, clojure.set, clojure.test, clojure.template,
clojure.walk, clojure.data, and clojure.zip are now available in the
WASM REPL via require. clojure.rust.io and clojure.edn are omitted on
WASM because they depend on the filesystem.

https://claude.ai/code/session_01F4PV3bGHBkNg4ANZ9gpmJw