### PR TITLE
Phase B: Implement ^:async function dispatch and eval_async

### DIFF
--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -23,10 +23,12 @@ Done:
 - Phase C: `deref`/`@` of a future inside an `^:async` body is a runtime error that steers
   callers to `await` (enforced in `cljrs-builtins` and `cljrs-interp` via the
   `cljrs_env::callback::current_is_async` context flag).
+- Phase D: `timeout`, `alts`, and the `alt` macro, in a `clojure.core.async` namespace built
+  at `init` time. `timeout` and `alts` are native fns that return a `Value::Future`; `alt` is
+  a Clojure macro that `await`s `alts` and dispatches to the matching handler.
 
 Not yet implemented (later phases):
 
-- Phase D: `timeout`, `alts`, `alt`.
 - Phase E: `chan`, `put!`, `take!`, `close!`, `go`.
 
 ### `await` and the single-thread executor
@@ -42,10 +44,12 @@ blocking bridge is a later phase.
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init(globals)` entry point; registers `AsyncRuntimeImpl` |
-| `src/runtime.rs` | `AsyncRuntimeImpl` — Tokio-backed `AsyncRuntime`; `spawn_async_call` spawns the body on the `LocalSet` and delivers the result into a `CljxFuture` |
-| `src/eval_async.rs` | `eval_async` async tree-walker and `run_async_fn` driver for `^:async` bodies |
-| `tests/async_fn.rs` | Phase B integration tests for dispatch, `await`, `let`/`if`, and error propagation |
+| `src/lib.rs` | `init(globals)` entry point; registers `AsyncRuntimeImpl` and builds the `clojure.core.async` namespace |
+| `src/runtime.rs` | `AsyncRuntimeImpl` — Tokio-backed `AsyncRuntime`; `spawn_async_call` spawns the body on the `LocalSet` via `spawn_future` |
+| `src/eval_async.rs` | `eval_async` async tree-walker, `run_async_fn` driver, and the shared `spawn_future`/`settle_future`/`await_value` task helpers |
+| `src/builtins.rs` | native `timeout` and `alts` functions |
+| `src/core_async.cljrs` | Clojure source for the `clojure.core.async` namespace (the `alt` macro) |
+| `tests/async_fn.rs` | integration tests for dispatch, `await`, `deref` enforcement, `timeout`/`alts`/`alt` |
 
 ## Public API
 

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -10,27 +10,58 @@ executor. All Clojure values remain on a single thread, keeping GC pointers (`!S
 
 ## Status
 
-**Phase A (foundation)** — skeleton crate. `init()` registers the async runtime hook with the
-interpreter. No actual async operations work yet; those are implemented in later phases:
+**Phase B (async functions)** — `^:async` function dispatch is implemented. Calling a
+function marked `^:async` (when the runtime is registered) spawns its body as a `LocalSet`
+task and returns a `Value::Future` immediately; `eval_async` drives the body and yields the
+executor at every `await`.
 
-- Phase B: `^:async` fn dispatch, `eval_async`, `await` yielding
-- Phase C: `deref` enforcement in async context
-- Phase D: `timeout`, `alts`, `alt`
-- Phase E: `chan`, `put!`, `take!`, `close!`, `go`
+Done:
+
+- Phase A: `init()` registers the async runtime hook with the interpreter.
+- Phase B: `^:async` fn dispatch via the `AsyncRuntime` hook; `eval_async` tree-walker;
+  cooperative `await` of futures/promises.
+
+Not yet implemented (later phases):
+
+- Phase C: `deref` blocking enforcement in async context.
+- Phase D: `timeout`, `alts`, `alt`.
+- Phase E: `chan`, `put!`, `take!`, `close!`, `go`.
+
+### `await` and the single-thread executor
+
+`await` only yields when evaluated by `eval_async` (i.e. inside an `^:async` function body or
+another async driver). The synchronous `await`/`deref` fallback in `cljrs-interp` blocks the OS
+thread on a condvar; doing that to an *async-spawned* future from the `LocalSet` driver thread
+deadlocks, because the task that would resolve the future cannot run while the only executor
+thread is parked. In Phase B, await async results from within async context. A top-level
+blocking bridge is a later phase.
 
 ## File layout
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init(globals)` entry point |
-| `src/runtime.rs` | `AsyncRuntimeImpl` — Tokio-backed `AsyncRuntime` impl |
+| `src/lib.rs` | `init(globals)` entry point; registers `AsyncRuntimeImpl` |
+| `src/runtime.rs` | `AsyncRuntimeImpl` — Tokio-backed `AsyncRuntime`; `spawn_async_call` spawns the body on the `LocalSet` and delivers the result into a `CljxFuture` |
+| `src/eval_async.rs` | `eval_async` async tree-walker and `run_async_fn` driver for `^:async` bodies |
+| `tests/async_fn.rs` | Phase B integration tests for dispatch, `await`, `let`/`if`, and error propagation |
 
 ## Public API
 
 ```rust
 /// Register the async runtime and load clojure.core.async.
-/// Must be called inside a Tokio LocalSet context.
+/// Must be called inside a Tokio LocalSet context for spawned tasks to run.
 pub fn init(globals: &Arc<GlobalEnv>);
+
+pub mod eval_async {
+    /// Drive an ^:async fn body to completion, yielding at every await.
+    pub async fn run_async_fn(callee: Value, args: Vec<Value>, base: &Env)
+        -> Result<Value, EvalError>;
+
+    /// Asynchronously evaluate a single form. Handles await/do/if/let and
+    /// function-call arguments with yielding; delegates other forms to the
+    /// synchronous evaluator.
+    pub async fn eval_async(form: &Form, env: &mut Env) -> Result<Value, EvalError>;
+}
 ```
 
 ## Integration

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -20,10 +20,12 @@ Done:
 - Phase A: `init()` registers the async runtime hook with the interpreter.
 - Phase B: `^:async` fn dispatch via the `AsyncRuntime` hook; `eval_async` tree-walker;
   cooperative `await` of futures/promises.
+- Phase C: `deref`/`@` of a future inside an `^:async` body is a runtime error that steers
+  callers to `await` (enforced in `cljrs-builtins` and `cljrs-interp` via the
+  `cljrs_env::callback::current_is_async` context flag).
 
 Not yet implemented (later phases):
 
-- Phase C: `deref` blocking enforcement in async context.
 - Phase D: `timeout`, `alts`, `alt`.
 - Phase E: `chan`, `put!`, `take!`, `close!`, `go`.
 

--- a/crates/cljrs-async/src/builtins.rs
+++ b/crates/cljrs-async/src/builtins.rs
@@ -1,0 +1,84 @@
+//! Native `clojure.core.async` builtins: `timeout` and `alts`.
+//!
+//! Both return a `Value::Future` immediately and resolve on the `LocalSet`
+//! executor, so they compose with `await` exactly like an `^:async` call.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cljrs_env::env::GlobalEnv;
+use cljrs_env::error::EvalResult;
+use cljrs_gc::GcPtr;
+use cljrs_interp::destructure::value_to_seq_vec;
+use cljrs_value::{Arity, NativeFn, PersistentVector, Value, ValueError, ValueResult};
+
+use crate::eval_async::{await_value, spawn_future};
+
+/// One branch of an `alts` race: awaits a future and tags it with its index.
+type AltBranch = Pin<Box<dyn Future<Output = (EvalResult, usize)>>>;
+
+/// Register the async native functions into the given namespace.
+pub(crate) fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, fn(&[Value]) -> ValueResult<Value>)> = vec![
+        ("timeout", Arity::Fixed(1), builtin_timeout),
+        ("alts", Arity::Fixed(1), builtin_alts),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+/// `(timeout ms)` — a Future that delivers `nil` after `ms` milliseconds.
+fn builtin_timeout(args: &[Value]) -> ValueResult<Value> {
+    let ms = match args.first() {
+        Some(Value::Long(n)) => (*n).max(0) as u64,
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "long (timeout ms)",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    Ok(spawn_future(async move {
+        tokio::time::sleep(Duration::from_millis(ms)).await;
+        Ok(Value::Nil)
+    }))
+}
+
+/// `(alts coll)` — a Future delivering `[value index]` for whichever future in
+/// `coll` resolves first.
+fn builtin_alts(args: &[Value]) -> ValueResult<Value> {
+    let futures = match args.first() {
+        Some(v) => value_to_seq_vec(v),
+        None => Vec::new(),
+    };
+    Ok(spawn_future(async move { Ok(alts_select(futures).await) }))
+}
+
+/// Await all `futures` concurrently; return `[value index]` of the first to
+/// complete. An empty input resolves to `nil`. A future that completes with an
+/// error contributes `nil` as its value.
+async fn alts_select(futures: Vec<Value>) -> Value {
+    if futures.is_empty() {
+        return Value::Nil;
+    }
+    let branches: Vec<AltBranch> = futures
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| {
+            Box::pin(async move {
+                let result = await_value(v).await;
+                (result, i)
+            }) as AltBranch
+        })
+        .collect();
+    let ((result, idx), _, _) = futures_util::future::select_all(branches).await;
+    let value = result.unwrap_or(Value::Nil);
+    Value::Vector(GcPtr::new(PersistentVector::from_iter([
+        value,
+        Value::Long(idx as i64),
+    ])))
+}

--- a/crates/cljrs-async/src/core_async.cljrs
+++ b/crates/cljrs-async/src/core_async.cljrs
@@ -1,0 +1,18 @@
+;; clojure.core.async — Clojure-level definitions.
+;;
+;; Native primitives (timeout, alts) are registered from Rust before this file
+;; is evaluated. This file adds the macros built on top of them.
+
+;; (alt future-expr handler-fn  future-expr handler-fn  ...)
+;;
+;; Evaluates every future expression, awaits whichever completes first via
+;; `alts`, and invokes the matching handler with the produced value. Must be
+;; used inside an ^:async function body (it awaits).
+(defmacro alt [& clauses]
+  (let [pairs    (partition 2 clauses)
+        futs     (vec (map first pairs))
+        handlers (vec (map second pairs))
+        r        (gensym "alt_r__")]
+    (list 'let (vector r (list 'await (list 'alts futs)))
+          (list (list 'nth handlers (list 'second r))
+                (list 'first r)))))

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -12,15 +12,48 @@
 //! expanded here first via [`cljrs_interp::macros::macroexpand`] so their
 //! desugared `if`/`do`/`let` shapes are handled with proper yielding.
 
+use std::future::Future;
+
 use cljrs_env::env::Env;
 use cljrs_env::error::{EvalError, EvalResult};
+use cljrs_gc::GcPtr;
 use cljrs_interp::apply::{bind_fn_params, select_arity};
 use cljrs_interp::destructure::{bind_pattern, value_to_seq_vec};
 use cljrs_interp::eval::{eval, is_special_form};
 use cljrs_interp::macros::macroexpand;
 use cljrs_reader::Form;
 use cljrs_reader::form::FormKind;
-use cljrs_value::{CljxFnArity, FutureState, Value};
+use cljrs_value::{CljxFnArity, CljxFuture, FutureState, Value};
+
+/// Spawn `task` on the current `LocalSet` and return a `Value::Future` that the
+/// task settles on completion. The single delivery point for every async
+/// primitive (`^:async` calls, `timeout`, `alts`).
+///
+/// Must be called from within a Tokio `LocalSet` context.
+pub(crate) fn spawn_future<F>(task: F) -> Value
+where
+    F: Future<Output = EvalResult> + 'static,
+{
+    let future = GcPtr::new(CljxFuture::new());
+    let task_future = future.clone();
+    tokio::task::spawn_local(async move {
+        let result = task.await;
+        settle_future(&task_future, result);
+    });
+    Value::Future(future)
+}
+
+/// Write a completed result into a future and wake blocking `deref` waiters.
+pub(crate) fn settle_future(future: &GcPtr<CljxFuture>, result: EvalResult) {
+    let mut state = future.get().state.lock().unwrap();
+    *state = match result {
+        Ok(v) => FutureState::Done(v),
+        Err(EvalError::Runtime(msg)) => FutureState::Failed(msg),
+        Err(e) => FutureState::Failed(format!("{e}")),
+    };
+    drop(state);
+    future.get().cond.notify_all();
+}
 
 /// Run the body of an `^:async` function to completion, yielding at every
 /// `await`. Returns the value of the last body form.
@@ -117,7 +150,7 @@ async fn eval_await_async(args: &[Form], env: &mut Env) -> EvalResult {
 
 /// Cooperatively await a Clojure value. Futures and promises yield to the
 /// executor until resolved; any other value is returned as-is.
-async fn await_value(val: Value) -> EvalResult {
+pub(crate) async fn await_value(val: Value) -> EvalResult {
     match val {
         Value::Future(f) => loop {
             {

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -1,0 +1,286 @@
+//! Asynchronous tree-walking evaluation for `^:async` function bodies.
+//!
+//! [`eval_async`] mirrors the synchronous [`cljrs_interp::eval::eval`] for the
+//! handful of forms where an `await` can legitimately appear — `await` itself,
+//! `do`, `if`, `let`/`let*`, and function-call arguments — and delegates every
+//! other form to the synchronous evaluator. When it reaches an `(await x)` it
+//! cooperatively yields to the Tokio `LocalSet` executor until the awaited
+//! `Future`/`Promise` resolves, instead of blocking the OS thread the way the
+//! sync `await` fallback does.
+//!
+//! Forms that the sync evaluator macro-expands (`when`, `cond`, `->`, …) are
+//! expanded here first via [`cljrs_interp::macros::macroexpand`] so their
+//! desugared `if`/`do`/`let` shapes are handled with proper yielding.
+
+use cljrs_env::env::Env;
+use cljrs_env::error::{EvalError, EvalResult};
+use cljrs_interp::apply::{bind_fn_params, select_arity};
+use cljrs_interp::destructure::{bind_pattern, value_to_seq_vec};
+use cljrs_interp::eval::{eval, is_special_form};
+use cljrs_interp::macros::macroexpand;
+use cljrs_reader::Form;
+use cljrs_reader::form::FormKind;
+use cljrs_value::{CljxFnArity, FutureState, Value};
+
+/// Run the body of an `^:async` function to completion, yielding at every
+/// `await`. Returns the value of the last body form.
+///
+/// `callee` must be a `Value::Fn`; `args` are the already-evaluated call
+/// arguments. A fresh environment is built from the function's closure with
+/// `is_async = true` so nested `await`s take the yielding path.
+pub async fn run_async_fn(callee: Value, args: Vec<Value>, base: &Env) -> EvalResult {
+    let f = match &callee {
+        Value::Fn(f) => f.get().clone(),
+        other => {
+            return Err(EvalError::Runtime(format!(
+                "async dispatch expected a fn, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let arity = select_arity(&f, args.len())?.clone();
+    let mut env = Env::with_closure(base.globals.clone(), &f.defining_ns, &f);
+    env.is_async = true;
+
+    let mut current_args = args;
+    loop {
+        env.push_frame();
+        bind_fn_params(&arity, &current_args, &mut env)?;
+        if let Some(name) = &f.name {
+            env.bind(name.clone(), callee.clone());
+        }
+
+        let mut result = Ok(Value::Nil);
+        for form in &arity.body {
+            result = Box::pin(eval_async(form, &mut env)).await;
+            if result.is_err() {
+                break;
+            }
+        }
+        env.pop_frame();
+
+        match result {
+            Ok(v) => return Ok(v),
+            Err(EvalError::Recur(new_args)) => {
+                current_args = flatten_recur_args(&arity, new_args);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Asynchronously evaluate a single form.
+pub async fn eval_async(form: &Form, env: &mut Env) -> EvalResult {
+    // Only list forms can contain control flow or an `await`; everything else
+    // is a leaf the sync evaluator handles directly.
+    if !matches!(form.kind, FormKind::List(_)) {
+        return eval(form, env);
+    }
+
+    // Reduce control-flow macros (when, cond, ->, …) to their special-form core
+    // so awaits nested inside them take the yielding path.
+    let expanded = macroexpand(form, env)?;
+    let forms = match &expanded.kind {
+        FormKind::List(forms) if !forms.is_empty() => forms,
+        _ => return eval(&expanded, env),
+    };
+
+    if let FormKind::Symbol(s) = &forms[0].kind {
+        match s.as_str() {
+            "await" => return eval_await_async(&forms[1..], env).await,
+            "do" => return eval_body_async(&forms[1..], env).await,
+            "if" => return eval_if_async(&forms[1..], env).await,
+            "let*" | "let" => return eval_let_async(&forms[1..], env).await,
+            // Other special forms (loop/recur/try/binding/…) don't yield in
+            // Phase B: run them synchronously. A `recur` that targets the
+            // enclosing async fn surfaces as `EvalError::Recur` and is caught
+            // by `run_async_fn`.
+            other if is_special_form(other) => return eval(&expanded, env),
+            _ => {}
+        }
+        return eval_call_async(&forms[0], &forms[1..], &expanded, env).await;
+    }
+
+    // Non-symbol head (e.g. `((f) args)`): no yielding in Phase B.
+    eval(&expanded, env)
+}
+
+/// `(await x)` — evaluate `x`, then yield until the resulting future/promise
+/// resolves.
+async fn eval_await_async(args: &[Form], env: &mut Env) -> EvalResult {
+    let Some(arg) = args.first() else {
+        return Err(EvalError::Runtime("await requires one argument".into()));
+    };
+    let val = Box::pin(eval_async(arg, env)).await?;
+    await_value(val).await
+}
+
+/// Cooperatively await a Clojure value. Futures and promises yield to the
+/// executor until resolved; any other value is returned as-is.
+async fn await_value(val: Value) -> EvalResult {
+    match val {
+        Value::Future(f) => loop {
+            {
+                let guard = f.get().state.lock().unwrap();
+                match &*guard {
+                    FutureState::Done(v) => return Ok(v.clone()),
+                    FutureState::Failed(e) => return Err(EvalError::Runtime(e.clone())),
+                    FutureState::Cancelled => {
+                        return Err(EvalError::Runtime("future was cancelled".into()));
+                    }
+                    FutureState::Running => {}
+                }
+            }
+            tokio::task::yield_now().await;
+        },
+        Value::Promise(p) => loop {
+            {
+                if let Some(v) = p.get().value.lock().unwrap().as_ref() {
+                    return Ok(v.clone());
+                }
+            }
+            tokio::task::yield_now().await;
+        },
+        other => Ok(other),
+    }
+}
+
+/// Evaluate a sequence of body forms, returning the value of the last.
+async fn eval_body_async(forms: &[Form], env: &mut Env) -> EvalResult {
+    let mut result = Value::Nil;
+    for form in forms {
+        result = Box::pin(eval_async(form, env)).await?;
+    }
+    Ok(result)
+}
+
+/// `(if test then else?)` with a yielding test and selected branch.
+async fn eval_if_async(args: &[Form], env: &mut Env) -> EvalResult {
+    let Some(test_form) = args.first() else {
+        return Err(EvalError::Runtime("if requires a test".into()));
+    };
+    let test = Box::pin(eval_async(test_form, env)).await?;
+    let truthy = !matches!(test, Value::Nil | Value::Bool(false));
+    if truthy {
+        match args.get(1) {
+            Some(then) => Box::pin(eval_async(then, env)).await,
+            None => Ok(Value::Nil),
+        }
+    } else {
+        match args.get(2) {
+            Some(els) => Box::pin(eval_async(els, env)).await,
+            None => Ok(Value::Nil),
+        }
+    }
+}
+
+/// `(let* [bindings] body…)` with yielding binding inits and body. Destructuring
+/// patterns are bound via the shared [`bind_pattern`] helper.
+async fn eval_let_async(args: &[Form], env: &mut Env) -> EvalResult {
+    let bindings = match args.first().map(|f| &f.kind) {
+        Some(FormKind::Vector(v)) => v.clone(),
+        _ => return Err(EvalError::Runtime("let* requires a binding vector".into())),
+    };
+    if bindings.len() % 2 != 0 {
+        return Err(EvalError::Runtime(
+            "let* binding vector must have even length".into(),
+        ));
+    }
+
+    env.push_frame();
+    for pair in bindings.chunks(2) {
+        let val = match Box::pin(eval_async(&pair[1], env)).await {
+            Ok(v) => v,
+            Err(e) => {
+                env.pop_frame();
+                return Err(e);
+            }
+        };
+        if let Err(e) = bind_pattern(&pair[0], val, env) {
+            env.pop_frame();
+            return Err(e);
+        }
+    }
+    let result = eval_body_async(&args[1..], env).await;
+    env.pop_frame();
+    result
+}
+
+/// A function call whose arguments may contain `await`s. Arguments are
+/// evaluated with [`eval_async`] (so awaits yield), then the callee is applied.
+///
+/// Calls whose head resolves to a form-intercepted native fn (`apply`, `swap!`,
+/// …) are delegated wholesale to the synchronous evaluator, which performs the
+/// special spreading/atom handling those builtins require. Such calls do not
+/// yield on awaits inside their arguments in Phase B.
+async fn eval_call_async(head: &Form, args: &[Form], whole: &Form, env: &mut Env) -> EvalResult {
+    let callee = eval(head, env)?;
+    match &callee {
+        Value::NativeFunction(nf) if is_form_intercepted(&nf.get().name) => {
+            return eval(whole, env);
+        }
+        // A macro head should have been expanded already, but guard regardless.
+        Value::Macro(_) => return eval(whole, env),
+        _ => {}
+    }
+
+    let _callee_root = cljrs_env::gc_roots::root_value(&callee);
+    let mut argv: Vec<Value> = Vec::with_capacity(args.len());
+    for a in args {
+        let _args_root = cljrs_env::gc_roots::root_values(&argv);
+        argv.push(Box::pin(eval_async(a, env)).await?);
+    }
+    cljrs_env::apply::apply_value(&callee, argv, env)
+}
+
+/// Native functions that `cljrs_interp::eval_call` intercepts at the form level
+/// (they require unevaluated forms or env access) and that therefore cannot be
+/// driven through `apply_value` with pre-evaluated arguments.
+fn is_form_intercepted(name: &str) -> bool {
+    matches!(
+        name,
+        "apply"
+            | "atom"
+            | "reset!"
+            | "swap!"
+            | "volatile!"
+            | "vreset!"
+            | "agent"
+            | "make-lazy-seq"
+            | "make-delay"
+            | "vswap!"
+            | "send"
+            | "send-off"
+            | "with-bindings*"
+            | "alter-var-root"
+            | "vary-meta"
+            | "find-ns"
+            | "the-ns"
+            | "all-ns"
+            | "create-ns"
+            | "ns-aliases"
+            | "remove-ns"
+            | "alter-meta!"
+            | "ns-resolve"
+            | "resolve"
+            | "intern"
+            | "bound-fn*"
+    )
+}
+
+/// Flatten `recur` arguments for a variadic arity so the rest collection is
+/// spread back into individual positional arguments (mirrors `call_cljrs_fn`).
+fn flatten_recur_args(arity: &CljxFnArity, new_args: Vec<Value>) -> Vec<Value> {
+    if arity.rest_param.is_some() {
+        let n = arity.params.len();
+        if new_args.len() == n + 1 {
+            let mut flat = new_args[..n].to_vec();
+            match &new_args[n] {
+                Value::Nil => {}
+                rest_val => flat.extend(value_to_seq_vec(rest_val)),
+            }
+            return flat;
+        }
+    }
+    new_args
+}

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -15,6 +15,7 @@
 
 use std::sync::Arc;
 
+pub mod eval_async;
 mod runtime;
 use runtime::AsyncRuntimeImpl;
 

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 //! Async runtime for clojurust — `clojure.core.async` via Tokio.
 //!
 //! # Usage
@@ -7,24 +8,55 @@
 //! cljrs_async::init(&globals);
 //! ```
 //!
-//! After `init`, `^:async` functions and all `clojure.core.async` primitives
-//! (`go`, `chan`, `put!`, `take!`, `timeout`, `alts`, `alt`) are available.
+//! After `init`, `^:async` functions, `await`, and the `clojure.core.async`
+//! primitives implemented so far (`timeout`, `alts`, `alt`) are available.
 //! The Tokio `current_thread` + `LocalSet` executor must be running on the
 //! calling thread (the CLI sets this up automatically when built with the
 //! `async` feature).
 
 use std::sync::Arc;
 
+mod builtins;
 pub mod eval_async;
 mod runtime;
 use runtime::AsyncRuntimeImpl;
 
+/// Clojure-level `clojure.core.async` definitions (the `alt` macro), evaluated
+/// on top of the native primitives at `init` time.
+const CORE_ASYNC_SOURCE: &str = include_str!("core_async.cljrs");
+
 /// Register the async runtime with the interpreter and load the
 /// `clojure.core.async` namespace.
 ///
-/// Must be called from within a Tokio `LocalSet` context. Calling more than
-/// once is a no-op (the second registration is silently ignored).
+/// Must be called from within a Tokio `LocalSet` context for spawned tasks to
+/// run. Idempotent: the namespace is built only once.
 pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
     globals.set_async_runtime(Arc::new(AsyncRuntimeImpl::new()));
-    // Phase D-E: register clojure.core.async builtins and namespace here.
+
+    let ns = "clojure.core.async";
+    if globals.is_loaded(ns) {
+        return;
+    }
+
+    // Build the namespace: refer clojure.core so the macro source can use core
+    // fns/macros, register the native primitives, then evaluate the source.
+    globals.get_or_create_ns(ns);
+    globals.refer_all(ns, "clojure.core");
+    builtins::register(globals, ns);
+
+    let mut env = cljrs_env::env::Env::new(globals.clone(), ns);
+    let mut parser =
+        cljrs_reader::Parser::new(CORE_ASYNC_SOURCE.to_string(), "<clojure.core.async>".into());
+    match parser.parse_all() {
+        Ok(forms) => {
+            for form in forms {
+                let _alloc_frame = cljrs_gc::push_alloc_frame();
+                if let Err(e) = cljrs_interp::eval::eval(&form, &mut env) {
+                    eprintln!("[clojure.core.async warning] {e:?}");
+                }
+            }
+        }
+        Err(e) => eprintln!("[clojure.core.async parse error] {e:?}"),
+    }
+    globals.mark_loaded(ns);
 }

--- a/crates/cljrs-async/src/runtime.rs
+++ b/crates/cljrs-async/src/runtime.rs
@@ -2,11 +2,9 @@
 
 use cljrs_env::async_hook::AsyncRuntime;
 use cljrs_env::env::Env;
-use cljrs_env::error::EvalError;
-use cljrs_gc::GcPtr;
-use cljrs_value::{CljxFuture, FutureState, Value};
+use cljrs_value::Value;
 
-use crate::eval_async::run_async_fn;
+use crate::eval_async::{run_async_fn, spawn_future};
 
 pub(crate) struct AsyncRuntimeImpl;
 
@@ -18,31 +16,9 @@ impl AsyncRuntimeImpl {
 
 impl AsyncRuntime for AsyncRuntimeImpl {
     fn spawn_async_call(&self, callee: Value, args: Vec<Value>, env: Env) -> Value {
-        // The result is delivered into a fresh condvar-backed `CljxFuture`,
-        // shared between this handle and the spawned task.
-        let future = GcPtr::new(CljxFuture::new());
-        let task_future = future.clone();
-
-        // `spawn_local` keeps the task on the current LocalSet thread, so the
-        // `!Send` Clojure values (env, args, GcPtrs) never cross threads.
-        tokio::task::spawn_local(async move {
-            let result = run_async_fn(callee, args, &env).await;
-            deliver(&task_future, result);
-        });
-
-        Value::Future(future)
+        // `spawn_future` keeps the task on the current LocalSet thread, so the
+        // `!Send` Clojure values (env, args, GcPtrs) never cross threads, and
+        // delivers the body's result into the returned Future.
+        spawn_future(async move { run_async_fn(callee, args, &env).await })
     }
-}
-
-/// Write a completed `^:async` call's result into its future and wake any
-/// blocking `deref`/`await` waiters.
-fn deliver(future: &GcPtr<CljxFuture>, result: Result<Value, EvalError>) {
-    let mut state = future.get().state.lock().unwrap();
-    *state = match result {
-        Ok(v) => FutureState::Done(v),
-        Err(EvalError::Runtime(msg)) => FutureState::Failed(msg),
-        Err(e) => FutureState::Failed(format!("{e}")),
-    };
-    drop(state);
-    future.get().cond.notify_all();
 }

--- a/crates/cljrs-async/src/runtime.rs
+++ b/crates/cljrs-async/src/runtime.rs
@@ -2,7 +2,11 @@
 
 use cljrs_env::async_hook::AsyncRuntime;
 use cljrs_env::env::Env;
-use cljrs_value::Value;
+use cljrs_env::error::EvalError;
+use cljrs_gc::GcPtr;
+use cljrs_value::{CljxFuture, FutureState, Value};
+
+use crate::eval_async::run_async_fn;
 
 pub(crate) struct AsyncRuntimeImpl;
 
@@ -13,8 +17,32 @@ impl AsyncRuntimeImpl {
 }
 
 impl AsyncRuntime for AsyncRuntimeImpl {
-    fn spawn_async_call(&self, _callee: Value, _args: Vec<Value>, _env: Env) -> Value {
-        // Phase B: spawn the ^:async fn body as a spawn_local task, return Value::Future.
-        todo!("cljrs-async: ^:async dispatch not yet implemented (Phase B)")
+    fn spawn_async_call(&self, callee: Value, args: Vec<Value>, env: Env) -> Value {
+        // The result is delivered into a fresh condvar-backed `CljxFuture`,
+        // shared between this handle and the spawned task.
+        let future = GcPtr::new(CljxFuture::new());
+        let task_future = future.clone();
+
+        // `spawn_local` keeps the task on the current LocalSet thread, so the
+        // `!Send` Clojure values (env, args, GcPtrs) never cross threads.
+        tokio::task::spawn_local(async move {
+            let result = run_async_fn(callee, args, &env).await;
+            deliver(&task_future, result);
+        });
+
+        Value::Future(future)
     }
+}
+
+/// Write a completed `^:async` call's result into its future and wake any
+/// blocking `deref`/`await` waiters.
+fn deliver(future: &GcPtr<CljxFuture>, result: Result<Value, EvalError>) {
+    let mut state = future.get().state.lock().unwrap();
+    *state = match result {
+        Ok(v) => FutureState::Done(v),
+        Err(EvalError::Runtime(msg)) => FutureState::Failed(msg),
+        Err(e) => FutureState::Failed(format!("{e}")),
+    };
+    drop(state);
+    future.get().cond.notify_all();
 }

--- a/crates/cljrs-async/tests/async_fn.rs
+++ b/crates/cljrs-async/tests/async_fn.rs
@@ -1,0 +1,166 @@
+//! Phase B integration tests: `^:async` dispatch, `eval_async`, and `await`.
+
+use std::sync::Arc;
+
+use cljrs_async::eval_async::eval_async;
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+/// Build a standard environment with the async runtime registered.
+fn async_env() -> Arc<GlobalEnv> {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    cljrs_async::init(&globals);
+    globals
+}
+
+/// Build a standard environment *without* an async runtime.
+fn sync_env() -> Arc<GlobalEnv> {
+    cljrs_interp::standard_env(None, None, None)
+}
+
+fn parse_one(src: &str) -> cljrs_reader::Form {
+    let mut p = Parser::new(src.to_string(), "<test>".to_string());
+    p.parse_all()
+        .expect("parse error")
+        .into_iter()
+        .next()
+        .expect("no form")
+}
+
+/// Synchronously evaluate every form in `src`, returning the last value.
+fn eval_sync(src: &str, env: &mut Env) -> Value {
+    let mut p = Parser::new(src.to_string(), "<test>".to_string());
+    let mut result = Value::Nil;
+    for form in p.parse_all().expect("parse error") {
+        result = cljrs_interp::eval::eval(&form, env).expect("eval error");
+    }
+    result
+}
+
+/// Run a `!Send` future to completion on a current-thread Tokio LocalSet.
+fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("build runtime");
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, f)
+}
+
+#[test]
+fn async_fn_call_returns_future_immediately() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync("(defn ^:async dbl [x] (* x 2))", &mut env);
+        // The call returns a Future, not the computed Long, even though the
+        // body produces a Long synchronously.
+        let v = cljrs_interp::eval::eval(&parse_one("(dbl 21)"), &mut env).unwrap();
+        assert!(matches!(v, Value::Future(_)), "expected Future, got {v:?}");
+    });
+}
+
+#[test]
+fn await_resolves_async_fn_result() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync("(defn ^:async dbl [x] (* x 2))", &mut env);
+        let r = eval_async(&parse_one("(await (dbl 21))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r, Value::Long(42));
+    });
+}
+
+#[test]
+fn await_inside_let_and_nested_async_calls() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync("(defn ^:async inc-async [x] (+ x 1))", &mut env);
+        eval_sync(
+            "(defn ^:async add-both [a b]
+               (let [x (await (inc-async a))
+                     y (await (inc-async b))]
+                 (+ x y)))",
+            &mut env,
+        );
+        let r = eval_async(&parse_one("(await (add-both 10 20))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r, Value::Long(32));
+    });
+}
+
+#[test]
+fn anonymous_fn_async_metadata_is_detected() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        let r = eval_async(
+            &parse_one("(let [f (fn ^:async [x] (* x 2))] (await (f 5)))"),
+            &mut env,
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, Value::Long(10));
+    });
+}
+
+#[test]
+fn await_in_if_branch_yields() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(
+            "(defn ^:async pick [x] (if (pos? x) (await (id-async x)) 0))",
+            &mut env,
+        );
+        eval_sync("(defn ^:async id-async [x] x)", &mut env);
+        let r = eval_async(&parse_one("(await (pick 7))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r, Value::Long(7));
+        let r0 = eval_async(&parse_one("(await (pick -1))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r0, Value::Long(0));
+    });
+}
+
+#[test]
+fn awaiting_failed_async_fn_propagates_error() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(
+            "(defn ^:async boom [] (throw (ex-info \"nope\" {})))",
+            &mut env,
+        );
+        let r = eval_async(&parse_one("(await (boom))"), &mut env).await;
+        assert!(r.is_err(), "expected error, got {r:?}");
+    });
+}
+
+#[test]
+fn without_runtime_async_fn_runs_synchronously() {
+    // No async runtime registered: `^:async` is inert and the call runs inline,
+    // returning the computed value rather than a Future.
+    let globals = sync_env();
+    let mut env = Env::new(globals, "user");
+    eval_sync("(defn ^:async dbl [x] (* x 2))", &mut env);
+    let v = eval_sync("(dbl 21)", &mut env);
+    assert_eq!(v, Value::Long(42));
+}
+
+#[test]
+fn defn_attr_map_marks_async() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync("(defn dbl {:async true} [x] (* x 2))", &mut env);
+        let v = cljrs_interp::eval::eval(&parse_one("(dbl 21)"), &mut env).unwrap();
+        assert!(matches!(v, Value::Future(_)), "expected Future, got {v:?}");
+    });
+}

--- a/crates/cljrs-async/tests/async_fn.rs
+++ b/crates/cljrs-async/tests/async_fn.rs
@@ -164,3 +164,44 @@ fn defn_attr_map_marks_async() {
         assert!(matches!(v, Value::Future(_)), "expected Future, got {v:?}");
     });
 }
+
+// ── Phase C: deref enforcement in async context ────────────────────────────
+
+#[test]
+fn deref_of_future_in_async_fn_errors() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync("(defn ^:async producer [] 42)", &mut env);
+        eval_sync("(defn ^:async bad [] (deref (producer)))", &mut env);
+        let r = eval_async(&parse_one("(await (bad))"), &mut env).await;
+        let err = format!("{:?}", r.unwrap_err());
+        assert!(err.contains("await"), "error should steer to await: {err}");
+    });
+}
+
+#[test]
+fn at_deref_of_future_in_async_fn_errors() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync("(defn ^:async producer [] 42)", &mut env);
+        eval_sync("(defn ^:async bad [] @(producer))", &mut env);
+        let r = eval_async(&parse_one("(await (bad))"), &mut env).await;
+        let err = format!("{:?}", r.unwrap_err());
+        assert!(err.contains("await"), "error should steer to await: {err}");
+    });
+}
+
+#[test]
+fn deref_of_future_in_sync_context_still_works() {
+    // With the async runtime registered, a *sync* (non-^:async) deref of a
+    // thread-based future must still block-and-return, not error.
+    let globals = async_env();
+    let mut env = Env::new(globals, "user");
+    assert_eq!(
+        eval_sync("(deref (future (+ 1 2)))", &mut env),
+        Value::Long(3)
+    );
+    assert_eq!(eval_sync("@(future (* 6 7))", &mut env), Value::Long(42));
+}

--- a/crates/cljrs-async/tests/async_fn.rs
+++ b/crates/cljrs-async/tests/async_fn.rs
@@ -39,12 +39,19 @@ fn eval_sync(src: &str, env: &mut Env) -> Value {
 }
 
 /// Run a `!Send` future to completion on a current-thread Tokio LocalSet.
+/// Timers are enabled so `timeout` works.
 fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
     let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
         .build()
         .expect("build runtime");
     let local = tokio::task::LocalSet::new();
     local.block_on(&rt, f)
+}
+
+/// Print a value the way Clojure would (for asserting on collection results).
+fn pr(v: &Value) -> String {
+    format!("{v}")
 }
 
 #[test]
@@ -204,4 +211,80 @@ fn deref_of_future_in_sync_context_still_works() {
         Value::Long(3)
     );
     assert_eq!(eval_sync("@(future (* 6 7))", &mut env), Value::Long(42));
+}
+
+// ── Phase D: timeout, alts, alt ────────────────────────────────────────────
+
+const REQUIRE_ASYNC: &str = "(require '[clojure.core.async :refer [timeout alts alt]])";
+
+#[test]
+fn timeout_resolves_to_nil() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_ASYNC, &mut env);
+        let r = eval_async(&parse_one("(await (timeout 5))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r, Value::Nil);
+    });
+}
+
+#[test]
+fn alts_picks_first_ready_value_and_index() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_ASYNC, &mut env);
+        eval_sync("(defn ^:async producer [] 42)", &mut env);
+        // The immediate producer resolves before the 1s timeout: index 0.
+        let val = eval_async(
+            &parse_one("(first (await (alts [(producer) (timeout 1000)])))"),
+            &mut env,
+        )
+        .await
+        .unwrap();
+        assert_eq!(val, Value::Long(42));
+        let idx = eval_async(
+            &parse_one("(second (await (alts [(producer) (timeout 1000)])))"),
+            &mut env,
+        )
+        .await
+        .unwrap();
+        assert_eq!(idx, Value::Long(0));
+    });
+}
+
+#[test]
+fn alts_selects_timeout_when_it_wins() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_ASYNC, &mut env);
+        // Only a timeout in the set: it must win at index 0 with value nil.
+        let r = eval_async(&parse_one("(await (alts [(timeout 5)]))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(pr(&r), "[nil 0]");
+    });
+}
+
+#[test]
+fn alt_dispatches_to_matching_handler() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_ASYNC, &mut env);
+        eval_sync("(defn ^:async producer [] :got)", &mut env);
+        eval_sync(
+            "(defn ^:async runner []
+               (alt (producer)     (fn [v] [:value v])
+                    (timeout 1000)  (fn [_] [:timed-out])))",
+            &mut env,
+        );
+        let r = eval_async(&parse_one("(await (runner))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(pr(&r), "[:value :got]");
+    });
 }

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -4899,6 +4899,13 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
             }
         }
         Value::Future(f) => {
+            // `deref` blocks the OS thread; inside an `^:async` function that
+            // would park the single LocalSet executor. Steer callers to `await`.
+            if cljrs_env::callback::current_is_async() {
+                return Err(ValueError::Other(
+                    "deref on a future is not allowed inside an ^:async function; use (await ...) instead".into(),
+                ));
+            }
             if with_timeout {
                 let timeout_ms = match &args[1] {
                     Value::Long(n) => *n as u64,

--- a/crates/cljrs-env/src/apply.rs
+++ b/crates/cljrs-env/src/apply.rs
@@ -55,6 +55,23 @@ pub fn type_tag_of(val: &Value) -> Arc<str> {
     }
 }
 
+/// If `callee` is an `^:async` Clojure function and an async runtime is
+/// registered, spawn its body as a task and return a `Value::Future`.
+///
+/// Returns `None` when there is no async runtime or the callee is not an async
+/// function, in which case the caller proceeds with the normal synchronous
+/// call path. This is the single dispatch point shared by `apply_value` here
+/// and `eval_call` in `cljrs-interp`.
+pub fn dispatch_if_async(callee: &Value, args: &[Value], env: &Env) -> Option<Value> {
+    let Value::Fn(f) = callee else { return None };
+    if !f.get().is_async {
+        return None;
+    }
+    let rt = env.globals.async_runtime()?;
+    let call_env = Env::new(env.globals.clone(), &env.current_ns);
+    Some(rt.spawn_async_call(callee.clone(), args.to_vec(), call_env))
+}
+
 /// Apply `callee` to the already-evaluated `args`.
 pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResult {
     // Root the callee and args so they survive any GC triggered at the safepoint.
@@ -78,7 +95,12 @@ pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResul
             crate::callback::pop_eval_context();
             result
         }
-        Value::Fn(f) => env.call_cljrs_fn(f.get(), &args),
+        Value::Fn(f) => {
+            if let Some(fut) = dispatch_if_async(callee, &args, env) {
+                return Ok(fut);
+            }
+            env.call_cljrs_fn(f.get(), &args)
+        }
         Value::BoundFn(bf) => {
             let bf_ref = bf.get();
             // Push captured bindings as a frame on top of the current stack.

--- a/crates/cljrs-env/src/callback.rs
+++ b/crates/cljrs-env/src/callback.rs
@@ -17,6 +17,9 @@ use crate::env::{Env, GlobalEnv};
 struct EvalContext {
     globals: Arc<GlobalEnv>,
     current_ns: Arc<str>,
+    /// True when the active call originates from inside an `^:async` function
+    /// body. Lets blocking builtins (`deref`) reject use that should be `await`.
+    is_async: bool,
 }
 
 thread_local! {
@@ -29,8 +32,15 @@ pub fn push_eval_context(env: &Env) {
         stack.borrow_mut().push(EvalContext {
             globals: env.globals.clone(),
             current_ns: env.current_ns.clone(),
+            is_async: env.is_async,
         });
     });
+}
+
+/// True when the innermost active eval context is inside an `^:async` function
+/// body. Returns `false` when there is no active context.
+pub fn current_is_async() -> bool {
+    EVAL_CONTEXT.with(|stack| stack.borrow().last().is_some_and(|ec| ec.is_async))
 }
 
 /// Pop the eval context after a native function returns.
@@ -59,6 +69,9 @@ pub fn install_eval_context(globals: Arc<GlobalEnv>, ns: Arc<str>) {
         stack.borrow_mut().push(EvalContext {
             globals,
             current_ns: ns,
+            // Cross-thread installs (agent/future worker threads) run blocking,
+            // synchronous work — never an async-yielding context.
+            is_async: false,
         });
     });
 }

--- a/crates/cljrs-interp/README.md
+++ b/crates/cljrs-interp/README.md
@@ -70,8 +70,17 @@ so intermediate allocations are freed per iteration.
 
 ### `eval_defn(args, env) -> EvalResult`
 
-Evaluate a `defn` form.  Under `no-gc`, wraps fn creation in `StaticCtxGuard`
-so the `CljxFn` object lands in the `StaticArena`.
+Evaluate a `defn` form.  Accepts metadata on the name (`(defn ^:async f …)`) and
+an attr-map (`(defn f {:async true} …)`); `^:async` marks the resulting `CljxFn`
+as async.  Under `no-gc`, wraps fn creation in `StaticCtxGuard` so the `CljxFn`
+object lands in the `StaticArena`.
+
+### `meta_form_is_async(meta: &Form) -> bool`
+
+Returns true when a `^meta` form (or attr-map literal) requests `:async` — either
+the keyword shorthand `^:async` or an explicit `{:async true}` map.  `fn`/`defn`
+use it to set `CljxFn::is_async`, which `cljrs-env::apply::dispatch_if_async`
+checks at call time to route through the async runtime.
 
 ### Special handlers in `apply.rs`
 

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -250,6 +250,11 @@ pub fn eval_call(func_form: &Form, arg_forms: &[Form], env: &mut Env) -> EvalRes
     // Extract the function pointer before the call so the borrow checker sees
     // only one mutable borrow of `env` at the call site.
     if let Value::Fn(f) = &callee {
+        // `^:async` functions dispatch through the async runtime (when one is
+        // registered), spawning the body and returning a Future immediately.
+        if let Some(fut) = cljrs_env::apply::dispatch_if_async(&callee, &args, env) {
+            return Ok(fut);
+        }
         let _args_root = cljrs_env::gc_roots::root_values(&args);
         cljrs_env::gc_roots::gc_safepoint(env);
         let call_fn = env.globals.call_cljrs_fn;

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -96,6 +96,11 @@ pub fn eval(form: &Form, env: &mut Env) -> EvalResult {
         )),
         FormKind::Deref(inner) => {
             let v = eval(inner, env)?;
+            if env.is_async && matches!(v, Value::Future(_)) {
+                return Err(EvalError::Runtime(
+                    "deref (@) on a future is not allowed inside an ^:async function; use (await ...) instead".into(),
+                ));
+            }
             deref_value(v)
         }
         FormKind::Var(inner) => {

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -127,7 +127,43 @@ fn compile_meta_form(meta: &Form, env: &mut Env) -> EvalResult<Value> {
 
 // ── fn* ───────────────────────────────────────────────────────────────────────
 
+/// Does a `^meta` form (or metadata map literal) request `:async`?
+///
+/// Handles the keyword shorthand `^:async` (a bare `:async` keyword form) and
+/// an explicit map such as `^{:async true}` or a `defn` attr-map `{:async true}`.
+pub fn meta_form_is_async(meta: &Form) -> bool {
+    match &meta.kind {
+        FormKind::Keyword(k) => k == "async",
+        FormKind::Map(entries) => entries.chunks(2).any(|kv| {
+            matches!(&kv[0].kind, FormKind::Keyword(k) if k == "async")
+                && !matches!(
+                    kv.get(1).map(|f| &f.kind),
+                    None | Some(FormKind::Bool(false)) | Some(FormKind::Nil)
+                )
+        }),
+        _ => false,
+    }
+}
+
 fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
+    // Peel any leading `^meta` wrappers, e.g. `(fn ^:async [..] ..)` or
+    // `(fn ^:async name [..] ..)`, recording whether `:async` was requested.
+    let mut is_async = false;
+    let peeled: Vec<Form>;
+    let args: &[Form] = if matches!(args.first().map(|f| &f.kind), Some(FormKind::Meta(..))) {
+        let mut head = args[0].clone();
+        while let FormKind::Meta(meta, inner) = head.kind {
+            is_async |= meta_form_is_async(&meta);
+            head = *inner;
+        }
+        peeled = std::iter::once(head)
+            .chain(args[1..].iter().cloned())
+            .collect();
+        &peeled
+    } else {
+        args
+    };
+
     let mut idx = 0;
     let mut name: Option<Arc<str>> = None;
 
@@ -174,7 +210,7 @@ fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
     // Capture closed-over locals.
     let (closed_over_names, closed_over_vals) = env.all_local_bindings();
 
-    let cljrs_fn = CljxFn::new(
+    let mut cljrs_fn = CljxFn::new(
         name.clone(),
         arities,
         closed_over_names,
@@ -182,6 +218,7 @@ fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
         false,
         Arc::clone(&env.current_ns),
     );
+    cljrs_fn.is_async = is_async;
 
     env.on_fn_defined(&cljrs_fn);
 
@@ -786,7 +823,15 @@ fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form]) {
 // ── defn ──────────────────────────────────────────────────────────────────────
 
 pub fn eval_defn(args: &[Form], env: &mut Env) -> EvalResult {
-    let name = require_sym(args, 0, "defn")?;
+    // The name may carry reader metadata, e.g. `(defn ^:async fetch ...)`.
+    let (name, mut is_async) = match args.first().map(|f| &f.kind) {
+        Some(FormKind::Symbol(s)) => (s.clone(), false),
+        Some(FormKind::Meta(meta, inner)) => match &inner.kind {
+            FormKind::Symbol(s) => (s.clone(), meta_form_is_async(meta)),
+            _ => return Err(EvalError::Runtime("defn name must be a symbol".into())),
+        },
+        _ => return Err(EvalError::Runtime("defn requires a symbol name".into())),
+    };
     // Skip optional docstring and/or metadata map after the name.
     // Valid orderings: (defn name body...), (defn name "doc" body...),
     // (defn name {:meta ...} body...), (defn name "doc" {:meta ...} body...).
@@ -795,6 +840,8 @@ pub fn eval_defn(args: &[Form], env: &mut Env) -> EvalResult {
         rest_start += 1;
     }
     if rest_start < args.len() && matches!(args[rest_start].kind, FormKind::Map(_)) {
+        // An attr-map such as `{:async true}` can also request async dispatch.
+        is_async |= meta_form_is_async(&args[rest_start]);
         rest_start += 1;
     }
     // Build (fn* name ...)
@@ -807,10 +854,13 @@ pub fn eval_defn(args: &[Form], env: &mut Env) -> EvalResult {
     // intern outlives all scratch regions.
     #[cfg(feature = "no-gc")]
     let _static_ctx = cljrs_gc::alloc_ctx::StaticCtxGuard::new();
-    let fn_val = eval_fn(&fn_args, env)?;
+    let mut fn_val = eval_fn(&fn_args, env)?;
+    if is_async && let Value::Fn(ref mut f) = fn_val {
+        f.get_mut().is_async = true;
+    }
     let var = env
         .globals
-        .intern(&env.current_ns, Arc::from(name), fn_val.clone());
+        .intern(&env.current_ns, Arc::from(name.as_str()), fn_val.clone());
     Ok(Value::Var(var))
 }
 

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -157,8 +157,14 @@ pub struct CljxFn {
     pub closed_over_names: Vec<Arc<str>>,
     pub closed_over_vals: Vec<Value>,
     pub is_macro: bool,
+    pub is_async: bool, // ^:async — dispatched via the async runtime when one is registered
+    pub defining_ns: Arc<str>,
 }
 ```
+
+`is_async` is set by the interpreter when a `fn`/`defn` carries `^:async` (or an
+`{:async true}` attr-map). `CljxFn::new` defaults it to `false`; `cljrs-env`'s
+`dispatch_if_async` checks it at call time.
 
 ### `Namespace` (Phase 4)
 

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -540,6 +540,11 @@ pub struct CljxFn {
     pub closed_over_vals: Vec<Value>,
     /// True if this function was defined with `defmacro`.
     pub is_macro: bool,
+    /// True if this function carries `^:async` metadata. When an async runtime
+    /// (`cljrs-async`) is registered, calling such a function spawns its body as
+    /// a task and returns a `Value::Future` immediately instead of running it
+    /// synchronously. Without a runtime it runs synchronously like any other fn.
+    pub is_async: bool,
     /// Namespace in which this function was defined (for macro hygiene).
     pub defining_ns: Arc<str>,
 }
@@ -559,6 +564,7 @@ impl CljxFn {
             closed_over_names,
             closed_over_vals,
             is_macro,
+            is_async: false,
             defining_ns,
         }
     }


### PR DESCRIPTION
## Summary

Implements Phase B of the async runtime: `^:async` function dispatch, the `eval_async` tree-walker, and cooperative `await` yielding. Calling a function marked `^:async` (when the async runtime is registered) now spawns its body as a `LocalSet` task and returns a `Value::Future` immediately; `eval_async` drives the body and yields the executor at every `await`.

## Key Changes

**Core async evaluation** (`cljrs-async/src/eval_async.rs` — new):
- `run_async_fn`: Drives an `^:async` function body to completion, handling `recur` and yielding at every `await`
- `eval_async`: Async tree-walker that handles `await`, `do`, `if`, `let`/`let*`, and function calls with yielding; delegates other forms to the synchronous evaluator
- `await_value`: Cooperatively yields to the Tokio executor until a `Future` or `Promise` resolves, instead of blocking the OS thread
- Macro expansion (`when`, `cond`, `->`, etc.) is performed upfront so desugared forms take the yielding path

**Async dispatch** (`cljrs-env/src/apply.rs`):
- `dispatch_if_async`: New dispatch point that checks if a callee is an `^:async` function with a registered runtime; spawns the body as a task and returns a `Value::Future`
- Integrated into `apply_value` so both direct calls and `apply` dispatch through async when appropriate

**Metadata parsing** (`cljrs-interp/src/special.rs`):
- `meta_form_is_async`: Detects `:async` in both shorthand (`^:async`) and explicit map (`^{:async true}`) forms
- `eval_fn`: Peels leading `^meta` wrappers and sets `CljxFn::is_async` accordingly
- `eval_defn`: Accepts metadata on the name and attr-maps; propagates `:async` to the resulting function

**Runtime integration** (`cljrs-async/src/runtime.rs`):
- `AsyncRuntimeImpl::spawn_async_call`: Spawns the body on the current `LocalSet` thread via `spawn_local`, delivers the result into a `CljxFuture`, and returns it immediately
- Uses a condvar-backed future so blocking `deref`/`await` can wake when the task completes

**Type updates** (`cljrs-value/src/types.rs`):
- `CljxFn::is_async`: New boolean flag set by the interpreter when `^:async` is present
- `CljxFn::defining_ns`: Captured namespace for proper closure construction in async contexts

**Tests** (`cljrs-async/tests/async_fn.rs` — new):
- Comprehensive Phase B integration tests: dispatch, `await` resolution, nested async calls, `let`/`if` with awaits, error propagation, and behavior without a registered runtime

## Notable Implementation Details

- **Single-thread executor**: `await` only yields when evaluated by `eval_async` (inside an `^:async` function or another async driver). The synchronous fallback blocks the OS thread; doing that from the `LocalSet` driver thread would deadlock.
- **Form interception**: Calls to form-intercepted natives (`apply`, `swap!`, etc.) are delegated wholesale to the synchronous evaluator, so awaits in their arguments do not yield in Phase B.
- **Variadic recur**: `flatten_recur_args` spreads the rest collection back into positional arguments for variadic arities, mirroring the synchronous `call_cljrs_fn`.
- **GC safety**: Callee and arguments are rooted during async evaluation to survive any GC safepoints.

## Documentation

Updated `README.md` files in both `cljrs-async` and `cljrs-interp` to reflect Phase B completion and document the new public API (`eval_async`, `run_async_fn`).

https://claude.ai/code/session_01QRDyiKEi4wHd8ye4ccyyBH