### PR TITLE
Phase E: channel primitives (chan, take!, put!, close!, go)

### DIFF
--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -10,10 +10,10 @@ executor. All Clojure values remain on a single thread, keeping GC pointers (`!S
 
 ## Status
 
-**Phase B (async functions)** — `^:async` function dispatch is implemented. Calling a
-function marked `^:async` (when the runtime is registered) spawns its body as a `LocalSet`
-task and returns a `Value::Future` immediately; `eval_async` drives the body and yields the
-executor at every `await`.
+**Phase E (channels)** — CSP channels are implemented. `(chan)` returns a `CljChannel`
+wrapped as a `Value::NativeObject`; `take!`/`put!` return a `Value::Future` that parks
+(yields) until the operation completes, and `close!`/`poll!`/`offer!` act synchronously. The
+`go` macro spawns its body as an async task via the native `async-spawn`.
 
 Done:
 
@@ -26,10 +26,38 @@ Done:
 - Phase D: `timeout`, `alts`, and the `alt` macro, in a `clojure.core.async` namespace built
   at `init` time. `timeout` and `alts` are native fns that return a `Value::Future`; `alt` is
   a Clojure macro that `await`s `alts` and dispatches to the matching handler.
+- Phase E: `chan`, `take!`, `put!`, `close!`, `poll!`, `offer!`, `async-spawn`, and the `go`
+  macro. Channels are `CljChannel` `NativeObject`s (buffered or unbuffered/rendezvous).
+
+### Channel model
+
+`(chan)` (or `(chan 0)`) is an unbuffered **rendezvous** channel: a `put!` resolves `true`
+only once a `take!` consumes its value. `(chan n)` is **buffered**: `put!` succeeds while the
+buffer has room, `take!` while it is non-empty. A closed channel drains any buffered values,
+then `take!` yields `nil` and `put!` resolves `false`.
+
+Channel operations that can block return a `Value::Future`, so they are used with `await`
+inside an async context:
+
+```clojure
+(require '[clojure.core.async :refer [chan take! put! close! go]])
+
+(def in  (chan 1))
+(def out (chan 1))
+(go (let [v (await (take! in))]
+      (await (put! out (* v 2)))))   ; go spawns the body as an async task
+(await (put! in 21))
+(await (take! out))                  ; => 42
+```
+
+`poll!` (non-blocking take → value or `nil`) and `offer!` (non-blocking buffered put →
+`true`/`false`) act synchronously and return immediately. Blocking sync-context variants
+(`take!!`/`put!!`) are deferred along with the top-level blocking bridge (see below).
 
 Not yet implemented (later phases):
 
-- Phase E: `chan`, `put!`, `take!`, `close!`, `go`.
+- Phase F+: `take!!`/`put!!` (blocking sync ops), `async-pmap`, `join-all`, GC safepoints,
+  IR support, and the wider `clojure.core.async` surface (`thread`, `pipeline`, `mult`, …).
 
 ### `await` and the single-thread executor
 
@@ -47,9 +75,10 @@ blocking bridge is a later phase.
 | `src/lib.rs` | `init(globals)` entry point; registers `AsyncRuntimeImpl` and builds the `clojure.core.async` namespace |
 | `src/runtime.rs` | `AsyncRuntimeImpl` — Tokio-backed `AsyncRuntime`; `spawn_async_call` spawns the body on the `LocalSet` via `spawn_future` |
 | `src/eval_async.rs` | `eval_async` async tree-walker, `run_async_fn` driver, and the shared `spawn_future`/`settle_future`/`await_value` task helpers |
-| `src/builtins.rs` | native `timeout` and `alts` functions |
-| `src/core_async.cljrs` | Clojure source for the `clojure.core.async` namespace (the `alt` macro) |
-| `tests/async_fn.rs` | integration tests for dispatch, `await`, `deref` enforcement, `timeout`/`alts`/`alt` |
+| `src/channel.rs` | `CljChannel` — a buffered/rendezvous CSP channel exposed as a `NativeObject` |
+| `src/builtins.rs` | native fns: `timeout`, `alts`, `chan`, `take!`, `put!`, `close!`, `poll!`, `offer!`, `async-spawn` |
+| `src/core_async.cljrs` | Clojure source for the `clojure.core.async` namespace (the `alt` and `go` macros) |
+| `tests/async_fn.rs` | integration tests for dispatch, `await`, `deref` enforcement, `timeout`/`alts`/`alt`, and channels |
 
 ## Public API
 
@@ -67,6 +96,16 @@ pub mod eval_async {
     /// function-call arguments with yielding; delegates other forms to the
     /// synchronous evaluator.
     pub async fn eval_async(form: &Form, env: &mut Env) -> Result<Value, EvalError>;
+}
+
+pub mod channel {
+    /// A CSP channel (buffered or rendezvous) exposed as a `Value::NativeObject`.
+    /// `(chan)` constructs one; the channel builtins downcast to it.
+    pub struct CljChannel { /* ... */ }
+    impl CljChannel {
+        /// Create a channel. `capacity == 0` is an unbuffered rendezvous channel.
+        pub fn new(capacity: usize) -> Self;
+    }
 }
 ```
 

--- a/crates/cljrs-async/src/builtins.rs
+++ b/crates/cljrs-async/src/builtins.rs
@@ -1,19 +1,27 @@
-//! Native `clojure.core.async` builtins: `timeout` and `alts`.
+//! Native `clojure.core.async` builtins.
 //!
-//! Both return a `Value::Future` immediately and resolve on the `LocalSet`
-//! executor, so they compose with `await` exactly like an `^:async` call.
+//! The futures-returning primitives (`timeout`, `alts`, `take!`, `put!`) return
+//! a `Value::Future` immediately and resolve on the `LocalSet` executor, so they
+//! compose with `await` exactly like an `^:async` call. `close!`, `poll!`, and
+//! `offer!` act on a channel synchronously and return their result directly.
+//! `async-spawn` runs a thunk on the `LocalSet` as an async task (the runtime
+//! backing the `go` macro).
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use cljrs_env::env::GlobalEnv;
+use cljrs_env::env::{Env, GlobalEnv};
 use cljrs_env::error::EvalResult;
 use cljrs_gc::GcPtr;
 use cljrs_interp::destructure::value_to_seq_vec;
-use cljrs_value::{Arity, NativeFn, PersistentVector, Value, ValueError, ValueResult};
+use cljrs_value::{
+    Arity, NativeFn, NativeObjectBox, PersistentVector, Value, ValueError, ValueResult,
+    gc_native_object,
+};
 
+use crate::channel::{CHANNEL_TAG, CljChannel, RvOffer, RvStatus};
 use crate::eval_async::{await_value, spawn_future};
 
 /// One branch of an `alts` race: awaits a future and tags it with its index.
@@ -24,6 +32,13 @@ pub(crate) fn register(globals: &Arc<GlobalEnv>, ns: &str) {
     let fns: Vec<(&str, Arity, fn(&[Value]) -> ValueResult<Value>)> = vec![
         ("timeout", Arity::Fixed(1), builtin_timeout),
         ("alts", Arity::Fixed(1), builtin_alts),
+        ("chan", Arity::Variadic { min: 0 }, builtin_chan),
+        ("take!", Arity::Fixed(1), builtin_take),
+        ("put!", Arity::Fixed(2), builtin_put),
+        ("close!", Arity::Fixed(1), builtin_close),
+        ("poll!", Arity::Fixed(1), builtin_poll),
+        ("offer!", Arity::Fixed(2), builtin_offer),
+        ("async-spawn", Arity::Fixed(1), builtin_async_spawn),
     ];
     for (name, arity, func) in fns {
         let nf = NativeFn::new(name, arity, func);
@@ -81,4 +96,144 @@ async fn alts_select(futures: Vec<Value>) -> Value {
         value,
         Value::Long(idx as i64),
     ])))
+}
+
+// ── Channels ────────────────────────────────────────────────────────────────
+
+/// Extract the channel `GcPtr` from the first argument, erroring if it is not a
+/// channel. The returned pointer is cloned so it can be moved into a spawned
+/// task.
+fn channel_arg(args: &[Value]) -> ValueResult<GcPtr<NativeObjectBox>> {
+    match args.first() {
+        Some(Value::NativeObject(obj)) if obj.get().type_tag() == CHANNEL_TAG => Ok(obj.clone()),
+        other => Err(ValueError::WrongType {
+            expected: "channel",
+            got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+        }),
+    }
+}
+
+/// Borrow the `CljChannel` out of a verified channel native object.
+fn chan_ref(obj: &NativeObjectBox) -> &CljChannel {
+    obj.downcast_ref::<CljChannel>()
+        .expect("channel native object holds a CljChannel")
+}
+
+/// `(chan)` / `(chan n)` — create a channel. No argument (or `0`) yields an
+/// unbuffered rendezvous channel; a positive `n` yields a buffered channel.
+fn builtin_chan(args: &[Value]) -> ValueResult<Value> {
+    let capacity = match args.first() {
+        None | Some(Value::Nil) => 0,
+        Some(Value::Long(n)) if *n >= 0 => *n as usize,
+        Some(other) => {
+            return Err(ValueError::WrongType {
+                expected: "non-negative long (chan capacity)",
+                got: other.type_name().to_string(),
+            });
+        }
+    };
+    if args.len() > 1 {
+        return Err(ValueError::Other(
+            "(chan n xf) transducer channels are not yet supported".into(),
+        ));
+    }
+    Ok(Value::NativeObject(gc_native_object(CljChannel::new(
+        capacity,
+    ))))
+}
+
+/// `(take! ch)` — a Future that resolves to the next value on `ch`, or `nil`
+/// once `ch` is closed and drained. Parks (yields) until a value is available.
+fn builtin_take(args: &[Value]) -> ValueResult<Value> {
+    let ch = channel_arg(args)?;
+    Ok(spawn_future(async move {
+        loop {
+            if let Some(v) = chan_ref(ch.get()).try_take() {
+                return Ok(v);
+            }
+            tokio::task::yield_now().await;
+        }
+    }))
+}
+
+/// `(put! ch val)` — a Future that resolves `true` once `val` is delivered (for
+/// a rendezvous channel) or buffered, or `false` if `ch` is closed. Parks
+/// (yields) while a buffered channel is full or a rendezvous awaits a taker.
+fn builtin_put(args: &[Value]) -> ValueResult<Value> {
+    let ch = channel_arg(args)?;
+    let val = args.get(1).cloned().unwrap_or(Value::Nil);
+    let rendezvous = chan_ref(ch.get()).is_rendezvous();
+    Ok(spawn_future(async move {
+        if rendezvous {
+            // Phase 1: place the value into the channel's single slot.
+            let token = loop {
+                match chan_ref(ch.get()).rv_offer(&val) {
+                    RvOffer::Offered(t) => break t,
+                    RvOffer::Closed => return Ok(Value::Bool(false)),
+                    RvOffer::Full => {}
+                }
+                tokio::task::yield_now().await;
+            };
+            // Phase 2: wait for a taker to consume it (the handoff).
+            loop {
+                match chan_ref(ch.get()).rv_status(token) {
+                    RvStatus::Taken => return Ok(Value::Bool(true)),
+                    RvStatus::ClosedUntaken => return Ok(Value::Bool(false)),
+                    RvStatus::Waiting => {}
+                }
+                tokio::task::yield_now().await;
+            }
+        } else {
+            loop {
+                if let Some(accepted) = chan_ref(ch.get()).try_put_buffered(&val) {
+                    return Ok(Value::Bool(accepted));
+                }
+                tokio::task::yield_now().await;
+            }
+        }
+    }))
+}
+
+/// `(close! ch)` — close the channel. Returns `nil`.
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let ch = channel_arg(args)?;
+    chan_ref(ch.get()).close();
+    Ok(Value::Nil)
+}
+
+/// `(poll! ch)` — non-blocking take. Returns a buffered value, or `nil` if the
+/// channel is empty or closed. Never parks.
+fn builtin_poll(args: &[Value]) -> ValueResult<Value> {
+    let ch = channel_arg(args)?;
+    Ok(chan_ref(ch.get()).try_take().unwrap_or(Value::Nil))
+}
+
+/// `(offer! ch val)` — non-blocking put. Returns `true` if `val` was buffered
+/// immediately, `false` otherwise (full, closed, or a rendezvous channel that
+/// cannot guarantee an immediate taker). Never parks.
+fn builtin_offer(args: &[Value]) -> ValueResult<Value> {
+    let ch = channel_arg(args)?;
+    let val = args.get(1).cloned().unwrap_or(Value::Nil);
+    let obj = ch.get();
+    let chan = chan_ref(obj);
+    if chan.is_rendezvous() {
+        return Ok(Value::Bool(false));
+    }
+    Ok(Value::Bool(chan.try_put_buffered(&val).unwrap_or(false)))
+}
+
+/// `(async-spawn thunk)` — run a zero-arg function as an async task on the
+/// `LocalSet`, returning a `Value::Future`. The thunk body runs in an async
+/// context, so `await` inside it yields. This is the runtime behind `go`.
+fn builtin_async_spawn(args: &[Value]) -> ValueResult<Value> {
+    let thunk = args.first().cloned().unwrap_or(Value::Nil);
+    let (globals, ns) = cljrs_env::callback::capture_eval_context()
+        .ok_or_else(|| ValueError::Other("async-spawn called outside an eval context".into()))?;
+    let rt = globals.async_runtime().ok_or_else(|| {
+        ValueError::Other(
+            "async-spawn requires an async runtime (call cljrs_async::init first)".into(),
+        )
+    })?;
+    let call_env = Env::new(globals, &ns);
+    Ok(rt.spawn_async_call(thunk, Vec::new(), call_env))
 }

--- a/crates/cljrs-async/src/channel.rs
+++ b/crates/cljrs-async/src/channel.rs
@@ -1,0 +1,174 @@
+//! `CljChannel` — a CSP channel exposed to Clojure as a `Value::NativeObject`.
+//!
+//! Channels keep the core `Value` enum free of async concerns: `(chan)` returns
+//! a `Value::NativeObject` wrapping a `CljChannel`, and the channel builtins in
+//! [`crate::builtins`] downcast through [`NativeObjectBox::downcast_ref`].
+//!
+//! A channel is a bounded FIFO queue guarded by a `Mutex`. Two capacity modes:
+//!
+//! - **Buffered** (`capacity >= 1`) — `put!` succeeds while the queue has room,
+//!   `take!` succeeds while it is non-empty.
+//! - **Rendezvous** (`capacity == 0`, the default `(chan)`) — a `put!` parks
+//!   until a `take!` consumes its value, so producer and consumer hand off
+//!   directly. Only one value is in flight at a time.
+//!
+//! The async builtins drive these via short, lock-scoped "try" steps and yield
+//! the `LocalSet` executor between attempts, matching the cooperative polling
+//! model used by [`crate::eval_async::await_value`].
+
+use std::any::Any;
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use cljrs_gc::{MarkVisitor, Trace};
+use cljrs_value::{NativeObject, Value};
+
+/// The native type tag reported by [`NativeObject::type_tag`] for channels.
+pub(crate) const CHANNEL_TAG: &str = "Channel";
+
+/// Outcome of a non-blocking rendezvous offer (capacity-0 `put!`).
+pub(crate) enum RvOffer {
+    /// Value placed into the empty slot; the carried token snapshots the
+    /// take-count so the putter can detect when its value is consumed.
+    Offered(u64),
+    /// A value is already pending; the caller should yield and retry.
+    Full,
+    /// The channel is closed; the `put!` fails.
+    Closed,
+}
+
+/// Status of a rendezvous offer that is waiting to be taken.
+pub(crate) enum RvStatus {
+    /// A taker consumed our value — `put!` resolves `true`.
+    Taken,
+    /// The channel closed before any taker arrived — `put!` resolves `false`.
+    ClosedUntaken,
+    /// Still waiting; the caller should yield and retry.
+    Waiting,
+}
+
+#[derive(Debug)]
+struct ChannelState {
+    queue: VecDeque<Value>,
+    /// Buffered capacity; `0` means unbuffered (rendezvous).
+    capacity: usize,
+    closed: bool,
+    /// Monotonic count of successful takes, used to detect rendezvous handoff.
+    taken: u64,
+}
+
+/// A CSP channel. See the module docs for the buffering model.
+#[derive(Debug)]
+pub struct CljChannel {
+    state: Mutex<ChannelState>,
+}
+
+impl CljChannel {
+    /// Create a channel. `capacity == 0` is a rendezvous (unbuffered) channel.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            state: Mutex::new(ChannelState {
+                queue: VecDeque::new(),
+                capacity,
+                closed: false,
+                taken: 0,
+            }),
+        }
+    }
+
+    /// True for an unbuffered (rendezvous) channel.
+    pub(crate) fn is_rendezvous(&self) -> bool {
+        self.state.lock().unwrap().capacity == 0
+    }
+
+    /// Mark the channel closed. Idempotent. Pending and future takes drain any
+    /// buffered values and then observe `nil`.
+    pub(crate) fn close(&self) {
+        self.state.lock().unwrap().closed = true;
+    }
+
+    /// Non-blocking take.
+    ///
+    /// - `Some(v)` — a buffered or rendezvous-offered value was removed.
+    /// - `Some(Value::Nil)` — the channel is closed and drained.
+    /// - `None` — the channel is open and empty (would block).
+    pub(crate) fn try_take(&self) -> Option<Value> {
+        let mut st = self.state.lock().unwrap();
+        if let Some(v) = st.queue.pop_front() {
+            st.taken = st.taken.wrapping_add(1);
+            return Some(v);
+        }
+        if st.closed {
+            return Some(Value::Nil);
+        }
+        None
+    }
+
+    /// Non-blocking buffered put (capacity >= 1).
+    ///
+    /// - `Some(true)` — accepted into the buffer.
+    /// - `Some(false)` — the channel is closed.
+    /// - `None` — the buffer is full (would block).
+    pub(crate) fn try_put_buffered(&self, v: &Value) -> Option<bool> {
+        let mut st = self.state.lock().unwrap();
+        if st.closed {
+            return Some(false);
+        }
+        if st.queue.len() < st.capacity {
+            st.queue.push_back(v.clone());
+            return Some(true);
+        }
+        None
+    }
+
+    /// Offer a value into a rendezvous channel's single slot.
+    pub(crate) fn rv_offer(&self, v: &Value) -> RvOffer {
+        let mut st = self.state.lock().unwrap();
+        if st.closed {
+            return RvOffer::Closed;
+        }
+        if st.queue.is_empty() {
+            let token = st.taken;
+            st.queue.push_back(v.clone());
+            RvOffer::Offered(token)
+        } else {
+            RvOffer::Full
+        }
+    }
+
+    /// Check whether a rendezvous offer (made at `token`) has been taken.
+    ///
+    /// Because the slot stays full until our value is consumed, no other putter
+    /// can offer in the meantime, so any increment of the take-count past
+    /// `token` is our handoff.
+    pub(crate) fn rv_status(&self, token: u64) -> RvStatus {
+        let mut st = self.state.lock().unwrap();
+        if st.taken != token {
+            return RvStatus::Taken;
+        }
+        if st.closed {
+            st.queue.pop_front(); // cancel our still-pending offer
+            return RvStatus::ClosedUntaken;
+        }
+        RvStatus::Waiting
+    }
+}
+
+impl Trace for CljChannel {
+    fn trace(&self, visitor: &mut MarkVisitor) {
+        let st = self.state.lock().unwrap();
+        for v in st.queue.iter() {
+            v.trace(visitor);
+        }
+    }
+}
+
+impl NativeObject for CljChannel {
+    fn type_tag(&self) -> &str {
+        CHANNEL_TAG
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/cljrs-async/src/core_async.cljrs
+++ b/crates/cljrs-async/src/core_async.cljrs
@@ -1,7 +1,17 @@
 ;; clojure.core.async — Clojure-level definitions.
 ;;
-;; Native primitives (timeout, alts) are registered from Rust before this file
-;; is evaluated. This file adds the macros built on top of them.
+;; Native primitives (timeout, alts, chan, take!, put!, close!, poll!, offer!,
+;; async-spawn) are registered from Rust before this file is evaluated. This
+;; file adds the macros built on top of them.
+
+;; (go body...)
+;;
+;; Spawn `body` as an asynchronous task on the LocalSet executor and return a
+;; Future that delivers the body's value. The body runs in an async context, so
+;; channel operations are used as `(await (take! ch))` / `(await (put! ch v))`.
+(defmacro go [& body]
+  (list 'clojure.core.async/async-spawn
+        (cons 'fn (cons [] body))))
 
 ;; (alt future-expr handler-fn  future-expr handler-fn  ...)
 ;;

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 mod builtins;
+pub mod channel;
 pub mod eval_async;
 mod runtime;
 use runtime::AsyncRuntimeImpl;

--- a/crates/cljrs-async/tests/async_fn.rs
+++ b/crates/cljrs-async/tests/async_fn.rs
@@ -288,3 +288,135 @@ fn alt_dispatches_to_matching_handler() {
         assert_eq!(pr(&r), "[:value :got]");
     });
 }
+
+// ── Phase E: channels (chan, take!, put!, close!, poll!, offer!, go) ─────────
+
+const REQUIRE_CHAN: &str =
+    "(require '[clojure.core.async :refer [chan take! put! close! poll! offer! go]])";
+
+#[test]
+fn buffered_chan_put_then_take() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_CHAN, &mut env);
+        eval_sync("(def ch (chan 4))", &mut env);
+        let put = eval_async(&parse_one("(await (put! ch 42))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(put, Value::Bool(true));
+        let got = eval_async(&parse_one("(await (take! ch))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(got, Value::Long(42));
+    });
+}
+
+#[test]
+fn take_on_closed_channel_yields_nil() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_CHAN, &mut env);
+        eval_sync("(def ch (chan 1))", &mut env);
+        // A buffered value remains takeable after close, then nil.
+        eval_async(&parse_one("(await (put! ch :only))"), &mut env)
+            .await
+            .unwrap();
+        eval_sync("(close! ch)", &mut env);
+        let first = eval_async(&parse_one("(await (take! ch))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(pr(&first), ":only");
+        let second = eval_async(&parse_one("(await (take! ch))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(second, Value::Nil);
+    });
+}
+
+#[test]
+fn put_on_closed_channel_is_false() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_CHAN, &mut env);
+        eval_sync("(def ch (chan 1))", &mut env);
+        eval_sync("(close! ch)", &mut env);
+        let put = eval_async(&parse_one("(await (put! ch 1))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(put, Value::Bool(false));
+    });
+}
+
+#[test]
+fn poll_and_offer_are_nonblocking() {
+    let globals = async_env();
+    let mut env = Env::new(globals, "user");
+    eval_sync(REQUIRE_CHAN, &mut env);
+    eval_sync("(def ch (chan 1))", &mut env);
+    // Buffer has room: offer succeeds; then it is full.
+    assert_eq!(eval_sync("(offer! ch 1)", &mut env), Value::Bool(true));
+    assert_eq!(eval_sync("(offer! ch 2)", &mut env), Value::Bool(false));
+    // poll drains the one value, then returns nil on empty.
+    assert_eq!(eval_sync("(poll! ch)", &mut env), Value::Long(1));
+    assert_eq!(eval_sync("(poll! ch)", &mut env), Value::Nil);
+}
+
+#[test]
+fn go_block_passes_value_through_channels() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_CHAN, &mut env);
+        eval_sync("(def in (chan 1))", &mut env);
+        eval_sync("(def out (chan 1))", &mut env);
+        // A go block takes from `in`, doubles it, and puts it on `out`.
+        eval_sync(
+            "(go (let [v (await (take! in))] (await (put! out (* v 2)))))",
+            &mut env,
+        );
+        eval_async(&parse_one("(await (put! in 21))"), &mut env)
+            .await
+            .unwrap();
+        let r = eval_async(&parse_one("(await (take! out))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r, Value::Long(42));
+    });
+}
+
+#[test]
+fn rendezvous_chan_hands_off_to_taker() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQUIRE_CHAN, &mut env);
+        eval_sync("(def ch (chan))", &mut env); // unbuffered (rendezvous)
+        eval_sync("(def out (chan 1))", &mut env);
+        // A consumer go block relays the rendezvous value to `out`.
+        eval_sync("(go (await (put! out (await (take! ch)))))", &mut env);
+        // The put resolves true only once the consumer has taken the value.
+        let put = eval_async(&parse_one("(await (put! ch :hello))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(put, Value::Bool(true));
+        let r = eval_async(&parse_one("(await (take! out))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(pr(&r), ":hello");
+    });
+}
+
+#[test]
+fn chan_is_a_channel_native_object() {
+    let globals = async_env();
+    let mut env = Env::new(globals, "user");
+    eval_sync(REQUIRE_CHAN, &mut env);
+    let ch = eval_sync("(chan)", &mut env);
+    assert!(
+        matches!(ch, Value::NativeObject(ref o) if o.get().type_tag() == "Channel"),
+        "expected a Channel native object, got {ch:?}"
+    );
+}


### PR DESCRIPTION
Add CSP channels to cljrs-async as a CljChannel NativeObject, keeping the
core Value enum free of async concerns. Channels are buffered or unbuffered
(rendezvous); take!/put! return a Value::Future that parks via the LocalSet
until the operation completes, while close!/poll!/offer! act synchronously.
The go macro spawns its body as an async task via the native async-spawn.

https://claude.ai/code/session_0167Q636VuidMv9qiPsdByRa