### PR TITLE
gc: gate system-memory on non-wasm32, fixed 64 MB heap for wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,22 @@ jobs:
         env:
           CLJRS_GC_STATS: "-"
         run: cargo run -p cljrs compile -o graph-sample samples/graph.cljrs && ./graph-sample
+
+  wasm:
+    name: WASM build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build cljrs-wasm
+        run: wasm-pack build crates/cljrs-wasm --target web --no-typescript --release

--- a/crates/cljrs-gc/Cargo.toml
+++ b/crates/cljrs-gc/Cargo.toml
@@ -16,4 +16,8 @@ bigdecimal   = { workspace = true }
 num-rational = { workspace = true }
 regex        = { workspace = true }
 cljrs-logging = { workspace = true }
+
+# Not available on wasm32-unknown-unknown (pulls in errno).  The wasm build
+# uses a fixed 64 MB heap limit instead.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 system-memory = "0.1.7"

--- a/crates/cljrs-gc/README.md
+++ b/crates/cljrs-gc/README.md
@@ -3,6 +3,10 @@
 Non-moving, stop-the-world mark-and-sweep garbage collector for clojurust;
 or, with the `no-gc` Cargo feature, a region-based allocator with no GC pauses.
 
+On `wasm32` targets the `system-memory` crate is excluded (it brings in `errno`,
+which does not build for `wasm32-unknown-unknown`).  The GC heap defaults to a
+fixed **64 MB** soft limit instead of consulting total system RAM.
+
 **Phase:** 8.1 (GcVisitor + Trace infrastructure) + 8.2 (GcBox/GcHeap
 raw-pointer implementation) — implemented.  `no-gc` mode (Phases 1–8 of
 `docs/no-gc-plan.md`) — implemented.

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -456,9 +456,14 @@ mod gc_full {
         }
 
         pub fn set_config_from_env(&self) {
+            #[cfg(not(target_arch = "wasm32"))]
+            let default_soft_limit: usize = (system_memory::total() / 3) as usize;
+            #[cfg(target_arch = "wasm32")]
+            let default_soft_limit: usize = 64 * 1024 * 1024;
+
             let soft_limit_mb: usize = match std::env::var("CLJRS_GC_SOFT_LIMIT_MB").ok() {
                 Some(s) => s.parse::<usize>().unwrap() * (1024 * 1024),
-                None => (system_memory::total() / 3) as usize,
+                None => default_soft_limit,
             };
             let hard_limit_mb: usize = match std::env::var("CLJRS_GC_HARD_LIMIT_MB").ok() {
                 Some(s) => s.parse::<usize>().unwrap() * (1024 * 1024),


### PR DESCRIPTION
system-memory pulls in errno, which does not build for
wasm32-unknown-unknown.  Move it to a target-conditional dependency so
it is excluded when compiling the cljrs-wasm crate.

set_config_from_env() now uses a fixed 64 MB soft limit on wasm32
instead of calling system_memory::total(); the env-var overrides
(CLJRS_GC_SOFT_LIMIT_MB / CLJRS_GC_HARD_LIMIT_MB) still work where
the platform supports std::env::var.

https://claude.ai/code/session_01Jf7kP5EAwxSz4uNZt4ugJU