### PR TITLE
Increase GC_INITIAL_LIVES from 2 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: cargo test --workspace
 
       - name: Clojure Tests
-        run: cargo run -p cljrs compile -o test-suite --test ./clojure-test-suite/test && CLJRS_GC_STATS=- ./test-suite
+        run: cargo run -p cljrs compile -o test-suite --test ./clojure-test-suite/test && CLJRS_GC_STATS=- CLJRS_X_FLAG=debug:gc ./test-suite
 
       - name: Graph sample (region-alloc smoke test)
         env:

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -145,7 +145,8 @@ mod gc_header {
     // next GC safepoint (where VALUE_ROOTS or a new alloc frame re-roots it).
     // 10 was chosen conservatively but keeps 9× more garbage in RAM than
     // necessary, worsening OOM pressure under test suites with many forms.
-    pub(crate) const GC_INITIAL_LIVES: u8 = 2;
+    // bump back to 4, 2 may be too small
+    pub(crate) const GC_INITIAL_LIVES: u8 = 4;
 
     #[cfg(debug_assertions)]
     pub(crate) const GC_MAGIC_ALIVE: u64 = 0xCAFE_BABE_DEAD_BEEF;


### PR DESCRIPTION
We seem to get random crashes with this set to 2. Try using 4.