### PR TITLE
async: Phase G — GC safepoints and root safety for LocalSet tasks

### DIFF
--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -10,12 +10,13 @@ executor. All Clojure values remain on a single thread, keeping GC pointers (`!S
 
 ## Status
 
-**Phase F (higher-level async utilities)** — All core `clojure.core.async` primitives are
-implemented. `join-all`, `thread-call`, `onto-chan!`, `to-chan!`, `mult`, `tap!`, `untap!`, and
-`untap-all!` are native Rust builtins; `async-pmap`, `thread`, `merge`, `reduce`, and `into`
-are defined in `core_async.cljrs`. `await` works correctly inside `loop/recur` bodies.
+**Phase G (GC safety for the async runtime)** — complete. GC safepoints are integrated at
+cooperative yield points. `async_gc_collect()` is called before every `yield_now().await` in
+`await_value`, and a background GC-service task (spawned by `init`) services GC requests between
+poll cycles. Explicit GC root guards protect `task_future` in `spawn_future`, callee/env in
+`run_async_fn`, and awaited futures/promises in `await_value`.
 
-Done:
+Done (Phases A–G):
 
 - Phase A: `init()` registers the async runtime hook with the interpreter.
 - Phase B: `^:async` fn dispatch via the `AsyncRuntime` hook; `eval_async` tree-walker;
@@ -34,6 +35,10 @@ Done:
   finishes (background task). `mult` broadcasts a source channel to all registered tap channels
   (`tap!`/`untap!`/`untap-all!`). Clojure-level: `async-pmap`, `thread` macro, `merge`,
   `reduce`, `into`. `eval_loop_async` enables proper `await` yielding inside `loop/recur`.
+- Phase G: GC safepoints at async yield points via `cljrs_env::gc_roots::async_gc_collect()`,
+  called before each `yield_now().await` in `await_value`. Background GC-service task spawned
+  by `init()`. Explicit GC root guards for `task_future` in `spawn_future`, callee/env in
+  `run_async_fn`, and awaited futures/promises in `await_value`.
 
 ### Channel model
 
@@ -62,7 +67,7 @@ inside an async context:
 
 Not yet implemented (later phases):
 
-- Phase G+: `take!!`/`put!!` (blocking sync ops), `pipeline`, GC safepoints, IR support.
+- Phase G+: `take!!`/`put!!` (blocking sync ops), `pipeline`, IR support.
 
 ### `await` and the single-thread executor
 

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -37,6 +37,10 @@ where
     let future = GcPtr::new(CljxFuture::new());
     let task_future = future.clone();
     tokio::task::spawn_local(async move {
+        // Root the result future across GC cycles: the spawning scope's alloc
+        // frame may have dropped before the task gets to run.
+        let anchor = Value::Future(task_future.clone());
+        let _root = cljrs_env::gc_roots::root_value(&anchor);
         let result = task.await;
         settle_future(&task_future, result);
     });
@@ -74,6 +78,10 @@ pub async fn run_async_fn(callee: Value, args: Vec<Value>, base: &Env) -> EvalRe
     let arity = select_arity(&f, args.len())?.clone();
     let mut env = Env::with_closure(base.globals.clone(), &f.defining_ns, &f);
     env.is_async = true;
+
+    // Keep callee and the local env alive across GC cycles at async yield points.
+    let _callee_root = cljrs_env::gc_roots::root_value(&callee);
+    let _env_root = cljrs_env::gc_roots::push_env_root(&env);
 
     let mut current_args = args;
     loop {
@@ -155,28 +163,40 @@ async fn eval_await_async(args: &[Form], env: &mut Env) -> EvalResult {
 /// executor until resolved; any other value is returned as-is.
 pub(crate) async fn await_value(val: Value) -> EvalResult {
     match val {
-        Value::Future(f) => loop {
-            {
-                let guard = f.get().state.lock().unwrap();
-                match &*guard {
-                    FutureState::Done(v) => return Ok(v.clone()),
-                    FutureState::Failed(e) => return Err(EvalError::Runtime(e.clone())),
-                    FutureState::Cancelled => {
-                        return Err(EvalError::Runtime("future was cancelled".into()));
+        Value::Future(f) => {
+            // Root the future across GC cycles: the alloc frame of the scope that
+            // produced it may have dropped before this task reached a yield point.
+            let anchor = Value::Future(f.clone());
+            let _root = cljrs_env::gc_roots::root_value(&anchor);
+            loop {
+                {
+                    let guard = f.get().state.lock().unwrap();
+                    match &*guard {
+                        FutureState::Done(v) => return Ok(v.clone()),
+                        FutureState::Failed(e) => return Err(EvalError::Runtime(e.clone())),
+                        FutureState::Cancelled => {
+                            return Err(EvalError::Runtime("future was cancelled".into()));
+                        }
+                        FutureState::Running => {}
                     }
-                    FutureState::Running => {}
                 }
+                cljrs_env::gc_roots::async_gc_collect();
+                tokio::task::yield_now().await;
             }
-            tokio::task::yield_now().await;
-        },
-        Value::Promise(p) => loop {
-            {
-                if let Some(v) = p.get().value.lock().unwrap().as_ref() {
-                    return Ok(v.clone());
+        }
+        Value::Promise(p) => {
+            let anchor = Value::Promise(p.clone());
+            let _root = cljrs_env::gc_roots::root_value(&anchor);
+            loop {
+                {
+                    if let Some(v) = p.get().value.lock().unwrap().as_ref() {
+                        return Ok(v.clone());
+                    }
                 }
+                cljrs_env::gc_roots::async_gc_collect();
+                tokio::task::yield_now().await;
             }
-            tokio::task::yield_now().await;
-        },
+        }
         other => Ok(other),
     }
 }

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -33,6 +33,7 @@ const CORE_ASYNC_SOURCE: &str = include_str!("core_async.cljrs");
 /// run. Idempotent: the namespace is built only once.
 pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
     globals.set_async_runtime(Arc::new(AsyncRuntimeImpl::new()));
+    runtime::spawn_gc_service();
 
     let ns = "clojure.core.async";
     if globals.is_loaded(ns) {

--- a/crates/cljrs-async/src/runtime.rs
+++ b/crates/cljrs-async/src/runtime.rs
@@ -22,3 +22,27 @@ impl AsyncRuntime for AsyncRuntimeImpl {
         spawn_future(async move { run_async_fn(callee, args, &env).await })
     }
 }
+
+/// Spawn a long-lived background task on the current `LocalSet` that services
+/// GC requests between poll cycles.
+///
+/// At each cooperative yield the task calls [`cljrs_env::gc_roots::async_gc_collect`].
+/// Because `LocalSet` is single-threaded, no other tasks run while that function
+/// executes, making it safe to scan thread-local root stacks for all suspended tasks.
+///
+/// Must be called from within a Tokio `LocalSet` context (e.g., from `init`).
+pub(crate) fn spawn_gc_service() {
+    // `spawn_local` panics when called outside a `LocalSet` context (e.g., in
+    // unit tests that call `init()` before entering `block_on_local`).  In that
+    // case the GC service simply won't run, which is fine: the service is a
+    // best-effort background collector; the safepoints inside `await_value`
+    // still fire whenever the code is actually running inside a LocalSet.
+    let _ = std::panic::catch_unwind(|| {
+        tokio::task::spawn_local(async {
+            loop {
+                tokio::task::yield_now().await;
+                cljrs_env::gc_roots::async_gc_collect();
+            }
+        });
+    });
+}

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -1,3 +1,15 @@
 # cljrs-env
 
 Environments for running programs in.
+
+## gc_roots module
+
+The `gc_roots` module manages GC root registration for the interpreter's Rust call stack. Public API includes:
+
+- `push_env_root(env: &Env) -> EnvRootGuard` — registers an `Env` pointer as a GC root; guard removes on drop
+- `root_value(val: &Value) -> ValueRootGuard` — registers a single `Value` pointer as a GC root
+- `root_values(vals: &[Value]) -> ValueRootGuard` — registers a slice of `Value` pointers as GC roots
+- `root_option_values(vals: &[Option<Value>]) -> OptionValueRootGuard` — registers an `Option<Value>` slice (e.g. IR register file)
+- `gc_safepoint(env: &Env)` — interpreter-level safepoint: parks if collection in progress, or initiates collection on memory pressure
+- `force_collect(env: &Env)` — immediately initiates a GC collection bypassing memory-pressure threshold
+- `async_gc_collect()` — services a pending GC request from a Tokio `LocalSet` task at a cooperative yield point; safe to call when no other tasks are polling, so thread-local root stacks are stable and fully describe all suspended-task `GcPtr`s

--- a/crates/cljrs-env/src/gc_roots.rs
+++ b/crates/cljrs-env/src/gc_roots.rs
@@ -284,3 +284,42 @@ fn trace_globals(globals: &GlobalEnv, visitor: &mut cljrs_gc::MarkVisitor) {
         visitor.visit(ns_ptr);
     }
 }
+
+/// Service a pending GC request from an async (LocalSet) context.
+///
+/// Safe to call from within a Tokio `LocalSet` task at any cooperative yield
+/// point: when this executes, no other tasks are polling, so thread-local root
+/// stacks (ENV_ROOTS, VALUE_ROOTS, ALLOC_ROOTS) fully describe all GcPtrs held
+/// by suspended tasks and can be scanned safely.
+///
+/// Under `no-gc` this is a no-op.
+#[cfg(feature = "no-gc")]
+pub fn async_gc_collect() {}
+
+#[cfg(not(feature = "no-gc"))]
+pub fn async_gc_collect() {
+    if !cljrs_gc::gc_requested() && !cljrs_gc::CONFIG_CANCELLATION.in_progress() {
+        return;
+    }
+    if cljrs_gc::CONFIG_CANCELLATION.in_progress() {
+        cljrs_gc::safepoint();
+        return;
+    }
+    if !cljrs_gc::take_gc_request() {
+        cljrs_gc::safepoint();
+        return;
+    }
+    let Some(_stw_guard) = cljrs_gc::begin_stw() else {
+        cljrs_gc::safepoint();
+        return;
+    };
+    cljrs_gc::HEAP.collect(|visitor| {
+        cljrs_gc::HEAP.trace_registered_roots(visitor);
+        trace_thread_env_roots(visitor);
+        trace_value_roots(visitor);
+        trace_option_value_roots(visitor);
+        dynamics::trace_current(visitor);
+        crate::taps::trace_roots(visitor);
+        cljrs_gc::trace_thread_alloc_roots(visitor);
+    });
+}


### PR DESCRIPTION
- Add `cljrs_env::gc_roots::async_gc_collect()`: services a pending GC
  request from within a Tokio LocalSet task. Safe at any cooperative
  yield point because no other tasks are polling; thread-local root
  stacks (VALUE_ROOTS, ENV_ROOTS, ALLOC_ROOTS, dynamics) fully describe
  all GcPtrs held by suspended tasks.

- `spawn_future`: root `task_future` inside the spawned task via a
  Value anchor + ValueRootGuard. The spawning scope's alloc frame may
  drop before the task runs; the anchor keeps the CljxFuture box alive.

- `run_async_fn`: add `root_value(&callee)` and `push_env_root(&env)`
  guards so the fn object and its local environment are reachable as GC
  roots across all body-evaluation await points.

- `await_value`: root the awaited future/promise via a Value anchor and
  call `async_gc_collect()` before each `yield_now().await`. This
  combines GC root safety with a direct GC service point at every
  future/promise await.

- `runtime::spawn_gc_service()`: background LocalSet task that loops
  `yield_now().await` / `async_gc_collect()`, servicing GC between poll
  cycles. Called from `init()` via `catch_unwind` so it silently
  becomes a no-op when called outside a LocalSet context (e.g., in
  tests that init before entering block_on_local).

https://claude.ai/code/session_01X9J6GWuqLpMHEk9d6LNdEv