### PR TITLE
Bring cljrs-async into the WASM REPL with a fully async eval context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "cljrs-types",
  "cljrs-value",
  "futures-util",
+ "gloo-timers",
  "tokio",
 ]
 
@@ -587,6 +588,7 @@ dependencies = [
 name = "cljrs-wasm"
 version = "0.1.0"
 dependencies = [
+ "cljrs-async",
  "cljrs-builtins",
  "cljrs-env",
  "cljrs-gc",
@@ -597,8 +599,10 @@ dependencies = [
  "cljrs-value",
  "console_error_panic_hook",
  "getrandom",
+ "tokio",
  "uuid",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -882,6 +886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +962,18 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1863,6 +1888,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +1974,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a4a3f055a804a2f3d86e816a9df78a8fa57762212a8506164959224a40cd48"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ bigdecimal   = "0.4"
 rand         = "0.10.1"
 rpds         = "1"
 uuid         = "1.22.0"
-tokio        = { version = "1.50.0", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+tokio        = { version = "1.50.0", features = ["rt", "sync", "time", "macros"] }
 futures-util = "0.3"
 regex        = "1.12.3"
 serde        = "1.0.228"

--- a/crates/cljrs-async/Cargo.toml
+++ b/crates/cljrs-async/Cargo.toml
@@ -16,3 +16,6 @@ cljrs-builtins = { workspace = true }
 cljrs-interp   = { workspace = true }
 tokio          = { workspace = true, features = ["rt", "sync", "time", "macros"] }
 futures-util   = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { version = "0.3", features = ["futures"] }

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -107,6 +107,11 @@ pub mod eval_async {
     /// function-call arguments with yielding; delegates other forms to the
     /// synchronous evaluator.
     pub async fn eval_async(form: &Form, env: &mut Env) -> Result<Value, EvalError>;
+
+    /// Cooperatively await a Clojure value inside a LocalSet context.
+    /// Futures and promises yield until resolved; any other value is returned as-is.
+    /// Used by the WASM REPL for implicit top-level await.
+    pub async fn await_value(val: Value) -> Result<Value, EvalError>;
 }
 
 pub mod channel {
@@ -135,8 +140,8 @@ pub mod channel {
 
 ## Integration
 
-The `cljrs` CLI links this crate when built with the `async` feature (on by default).
-Rust embedders add `cljrs-async` to their `Cargo.toml` and call `init` manually:
+**Native (CLI):** The `cljrs` CLI links this crate when built with the `async` feature (on by default).
+Rust embedders call `init` from within a Tokio `LocalSet` context:
 
 ```rust
 let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
@@ -147,3 +152,12 @@ rt.block_on(local.run_until(async {
     // ... eval code ...
 }));
 ```
+
+**WASM (browser REPL):** `init` may be called before a `LocalSet` context exists
+(e.g. in `Repl::new()`); `spawn_gc_service` silently no-ops via `catch_unwind` in that
+case. Re-call `init` from inside a `LocalSet::run_until` block to start the GC service.
+`timeout` uses `gloo_timers::future::sleep` on `wasm32` instead of `tokio::time::sleep`.
+
+**Timer portability:** On `wasm32` the `time` feature of tokio is present but
+`platform_sleep` (used internally by `timeout`) delegates to `gloo-timers` so that
+the browser's `setTimeout` is used instead of a non-functional OS-level clock.

--- a/crates/cljrs-async/src/builtins.rs
+++ b/crates/cljrs-async/src/builtins.rs
@@ -72,9 +72,21 @@ fn builtin_timeout(args: &[Value]) -> ValueResult<Value> {
         }
     };
     Ok(spawn_future(async move {
-        tokio::time::sleep(Duration::from_millis(ms)).await;
+        platform_sleep(ms).await;
         Ok(Value::Nil)
     }))
+}
+
+/// Sleep for `ms` milliseconds using the best available platform timer.
+#[cfg(not(target_arch = "wasm32"))]
+async fn platform_sleep(ms: u64) {
+    tokio::time::sleep(Duration::from_millis(ms)).await;
+}
+
+/// On WASM use the browser's timer instead of tokio's OS-level clock.
+#[cfg(target_arch = "wasm32")]
+async fn platform_sleep(ms: u64) {
+    gloo_timers::future::sleep(Duration::from_millis(ms)).await;
 }
 
 /// `(alts coll)` — a Future delivering `[value index]` for whichever future in

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -161,7 +161,7 @@ async fn eval_await_async(args: &[Form], env: &mut Env) -> EvalResult {
 
 /// Cooperatively await a Clojure value. Futures and promises yield to the
 /// executor until resolved; any other value is returned as-is.
-pub(crate) async fn await_value(val: Value) -> EvalResult {
+pub async fn await_value(val: Value) -> EvalResult {
     match val {
         Value::Future(f) => {
             // Root the future across GC cycles: the alloc frame of the scope that

--- a/crates/cljrs-wasm/Cargo.toml
+++ b/crates/cljrs-wasm/Cargo.toml
@@ -18,8 +18,11 @@ cljrs-reader   = { workspace = true }
 cljrs-builtins = { workspace = true }
 cljrs-gc       = { workspace = true }
 cljrs-types    = { workspace = true }
-wasm-bindgen = "0.2"
+cljrs-async    = { workspace = true }
+wasm-bindgen          = "0.2"
+wasm-bindgen-futures  = "0.4"
 console_error_panic_hook = "0.1"
+tokio = { workspace = true, features = ["rt", "sync", "macros"] }
 
 # Activate getrandom's JS/browser entropy source for rand on wasm32.
 # rand uses getrandom 0.4; declaring it here with wasm_js unifies the feature

--- a/crates/cljrs-wasm/README.md
+++ b/crates/cljrs-wasm/README.md
@@ -6,13 +6,13 @@ WebAssembly browser REPL for clojurust.  Compiles the tree-walking interpreter t
 
 ## Status
 
-Phase 12-ext — browser REPL.  Targets `wasm32-unknown-unknown`; no AOT/IR compilation, no interop, no threading, no filesystem I/O.
+Phase 12-ext — async browser REPL.  Targets `wasm32-unknown-unknown`; no AOT/IR compilation, no interop, no filesystem I/O.  Full `clojure.core.async` support via a Tokio `LocalSet` driven by `wasm-bindgen-futures`.
 
 ## File layout
 
 | File | Description |
 |------|-------------|
-| `src/lib.rs` | `Repl` and `EvalResult` wasm-bindgen exports; bootstraps `standard_env_minimal` |
+| `src/lib.rs` | `Repl` and `EvalResult` wasm-bindgen exports; bootstraps `standard_env_minimal`, initialises `cljrs-async`, drives a persistent `LocalSet` pump |
 | `www/index.html` | Self-contained browser REPL UI (pure JS, no bundler required once wasm-pack output is present) |
 
 ## Public API
@@ -22,8 +22,15 @@ Phase 12-ext — browser REPL.  Targets `wasm32-unknown-unknown`; no AOT/IR comp
 pub struct Repl;
 
 impl Repl {
+    /// Create a new REPL session. Initialises clojure.core.async and
+    /// starts a persistent LocalSet pump so goroutines and channel tasks
+    /// make progress between eval calls.
     pub fn new() -> Repl;
-    pub fn eval(&self, input: &str) -> EvalResult;
+
+    /// Evaluate one or more Clojure forms asynchronously.
+    /// Returns a JS Promise that resolves to an EvalResult.
+    /// Top-level Future/Promise results are implicitly awaited.
+    pub async fn eval(&self, input: String) -> EvalResult;
 }
 
 #[wasm_bindgen]
@@ -34,6 +41,19 @@ impl EvalResult {
     pub fn result(&self) -> String;   // pr-str of last value, or error message
     pub fn is_error(&self) -> bool;
 }
+```
+
+From JavaScript, `eval` is an `async` method that returns a `Promise`:
+
+```js
+const repl = new Repl();
+const r = await repl.eval("(require '[clojure.core.async :refer [chan go put! take!]])");
+const r2 = await repl.eval(`
+  (def c (chan 1))
+  (go (put! c (* 6 7)))
+  (await (take! c))
+`);
+console.log(r2.result); // "42"
 ```
 
 ## Building
@@ -57,11 +77,17 @@ cd crates/cljrs-wasm/www && python3 -m http.server 8080
 - Persistent collections: list, vector, map, set
 - `print` / `println` / `prn` — output captured per eval call and returned in `EvalResult.output`
 - `require` for built-in namespaces (`clojure.string`, `clojure.set`, etc.) loaded lazily on first use
+- **Full `clojure.core.async`**: `^:async` functions, `await`, `chan`, `go`, `put!`, `take!`,
+  `timeout`, `alts`, `alt`, `mult`/`tap!`, `join-all`, `async-pmap`, `thread`, etc.
+- Top-level `await` is implicit: evaluating `(timeout 500)` at the REPL waits 500 ms and
+  returns `nil` rather than an opaque future wrapper.
+- Background goroutines and channel tasks persist across eval calls (driven by a long-lived
+  `LocalSet` pump).
 
 ## What is intentionally excluded
 
 - Versioned symbols (`name@commit`) — no git available in the browser
-- `agent`, `future`, `promise` — no threads in `wasm32-unknown-unknown`
+- `<!!` / `>!!` blocking ops — no OS threads in `wasm32-unknown-unknown`
 - Filesystem I/O (`slurp`, `spit`, `load-file`)
 - Rust interop (`cljrs-interop`, `#[export]`)
 - AOT/IR compilation (`cljrs-compiler`, `cljrs-ir`)

--- a/crates/cljrs-wasm/src/lib.rs
+++ b/crates/cljrs-wasm/src/lib.rs
@@ -106,17 +106,16 @@ impl Repl {
 
         local
             .run_until(async move {
-                let forms =
-                    match Parser::new(input, "<repl>".to_string()).parse_all() {
-                        Ok(f) => f,
-                        Err(e) => {
-                            return EvalResult {
-                                output: String::new(),
-                                result: format!("Read error: {e}"),
-                                is_error: true,
-                            };
-                        }
-                    };
+                let forms = match Parser::new(input, "<repl>".to_string()).parse_all() {
+                    Ok(f) => f,
+                    Err(e) => {
+                        return EvalResult {
+                            output: String::new(),
+                            result: format!("Read error: {e}"),
+                            is_error: true,
+                        };
+                    }
+                };
 
                 if forms.is_empty() {
                     return EvalResult {

--- a/crates/cljrs-wasm/src/lib.rs
+++ b/crates/cljrs-wasm/src/lib.rs
@@ -1,18 +1,26 @@
+use std::rc::Rc;
 use std::sync::Arc;
+
+use tokio::task::LocalSet;
 use wasm_bindgen::prelude::*;
 
+use cljrs_async::eval_async::{await_value, eval_async as eval_form_async};
 use cljrs_builtins::builtins::{pop_output_capture, push_output_capture};
 use cljrs_env::env::{Env, GlobalEnv};
-use cljrs_env::error::EvalError;
-use cljrs_interp::eval::eval;
 use cljrs_reader::Parser;
 use cljrs_value::Value;
 
-/// A stateful Clojure REPL.  The `GlobalEnv` holds all defined vars across
-/// calls; a fresh `Env` (local frame stack) is created per `eval` call.
+/// A stateful Clojure REPL running entirely in an async context.
+///
+/// Backed by a Tokio `LocalSet` driven from the browser's Promise scheduler via
+/// `wasm-bindgen-futures`.  Each `eval` call drives the LocalSet for the
+/// duration of the evaluation, giving background tasks (goroutines, channel
+/// operations) a chance to make progress.  Top-level `Value::Future` results
+/// are implicitly awaited before the result is returned.
 #[wasm_bindgen]
 pub struct Repl {
     globals: Arc<GlobalEnv>,
+    local: Rc<LocalSet>,
 }
 
 /// The result of a single `Repl::eval` call.
@@ -57,68 +65,117 @@ impl Repl {
         console_error_panic_hook::set_once();
         let globals = cljrs_interp::standard_env_minimal(None, None, None);
         cljrs_stdlib::register(&globals);
-        Repl { globals }
-    }
 
-    /// Evaluate one or more Clojure forms.  Returns captured print output and
-    /// the `pr-str` of the last form's value (or an error message).
-    pub fn eval(&self, input: &str) -> EvalResult {
-        let mut env = Env::new(self.globals.clone(), "user");
+        // init outside a LocalSet context: namespace and runtime hook are
+        // registered; spawn_gc_service silently no-ops (catch_unwind inside).
+        // The GC service is instead spawned on the first eval via the LocalSet.
+        cljrs_async::init(&globals);
 
-        let forms = match Parser::new(input.to_string(), "<repl>".to_string()).parse_all() {
-            Ok(f) => f,
-            Err(e) => {
-                return EvalResult {
-                    output: String::new(),
-                    result: format!("Read error: {e}"),
-                    is_error: true,
-                };
-            }
-        };
+        let local = Rc::new(LocalSet::new());
 
-        if forms.is_empty() {
-            return EvalResult {
-                output: String::new(),
-                result: String::new(),
-                is_error: false,
-            };
+        // Pump the LocalSet indefinitely from the browser's microtask queue so
+        // that goroutines and channel tasks make progress even between evals.
+        // The init call inside also fires spawn_gc_service in the correct
+        // LocalSet context.
+        {
+            let local2 = local.clone();
+            let globals2 = globals.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                local2
+                    .run_until(async move {
+                        // Re-run init from within the LocalSet so spawn_gc_service
+                        // actually succeeds (idempotent for namespace loading).
+                        cljrs_async::init(&globals2);
+                        std::future::pending::<()>().await
+                    })
+                    .await;
+            });
         }
 
-        push_output_capture();
+        Repl { globals, local }
+    }
 
-        let mut last_val = Value::Nil;
-        let mut error: Option<String> = None;
+    /// Evaluate one or more Clojure forms.
+    ///
+    /// Runs inside the session's `LocalSet`, so `^:async` functions, `await`,
+    /// channels, and `go` all work.  A top-level `Value::Future` result is
+    /// implicitly awaited before the readable representation is returned.
+    pub async fn eval(&self, input: String) -> EvalResult {
+        let local = self.local.clone();
+        let globals = self.globals.clone();
 
-        for form in &forms {
-            let _frame = cljrs_gc::push_alloc_frame();
-            match eval(form, &mut env) {
-                Ok(val) => last_val = val,
-                Err(e) => {
-                    error = Some(format_error(e));
-                    break;
+        local
+            .run_until(async move {
+                let forms =
+                    match Parser::new(input, "<repl>".to_string()).parse_all() {
+                        Ok(f) => f,
+                        Err(e) => {
+                            return EvalResult {
+                                output: String::new(),
+                                result: format!("Read error: {e}"),
+                                is_error: true,
+                            };
+                        }
+                    };
+
+                if forms.is_empty() {
+                    return EvalResult {
+                        output: String::new(),
+                        result: String::new(),
+                        is_error: false,
+                    };
                 }
-            }
-        }
 
-        let output = pop_output_capture().unwrap_or_default();
+                push_output_capture();
 
-        match error {
-            Some(msg) => EvalResult {
-                output,
-                result: msg,
-                is_error: true,
-            },
-            None => EvalResult {
-                output,
-                result: pr_str(&self.globals, last_val),
-                is_error: false,
-            },
-        }
+                let mut env = Env::new(globals.clone(), "user");
+                env.is_async = true;
+
+                let mut last_val = Value::Nil;
+                let mut error: Option<String> = None;
+
+                for form in &forms {
+                    let _frame = cljrs_gc::push_alloc_frame();
+                    match eval_form_async(form, &mut env).await {
+                        Ok(val) => last_val = val,
+                        Err(e) => {
+                            error = Some(e.to_string());
+                            break;
+                        }
+                    }
+                }
+
+                // Implicitly await a top-level Future/Promise so the user sees
+                // the resolved value rather than an opaque future wrapper.
+                let final_val = if error.is_none() {
+                    match await_value(last_val).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error = Some(e.to_string());
+                            Value::Nil
+                        }
+                    }
+                } else {
+                    last_val
+                };
+
+                let output = pop_output_capture().unwrap_or_default();
+
+                match error {
+                    Some(msg) => EvalResult {
+                        output,
+                        result: msg,
+                        is_error: true,
+                    },
+                    None => EvalResult {
+                        output,
+                        result: pr_str(&globals, final_val),
+                        is_error: false,
+                    },
+                }
+            })
+            .await
     }
-}
-
-fn format_error(e: EvalError) -> String {
-    e.to_string()
 }
 
 fn pr_str(globals: &Arc<GlobalEnv>, val: Value) -> String {

--- a/crates/cljrs-wasm/www/index.html
+++ b/crates/cljrs-wasm/www/index.html
@@ -141,8 +141,9 @@
 </header>
 
 <div id="output">
-  <div class="welcome">; clojurust browser REPL — pure Clojure, tree-walking interpreter</div>
+  <div class="welcome">; clojurust browser REPL — Clojure + clojure.core.async</div>
   <div class="welcome">; Enter expressions and press Enter (Shift+Enter for newline)</div>
+  <div class="welcome">; Async ops work natively: (await (timeout 1000)), (go ...), (chan), etc.</div>
   <div class="welcome">; Use ↑ / ↓ to navigate history</div>
 </div>
 
@@ -222,7 +223,9 @@
   }
 
   // ── Evaluation ─────────────────────────────────────────────────────────────
-  function evalInput(text) {
+  // repl.eval() is async (returns a Promise); disable input while in-flight so
+  // concurrent submissions don't race on the shared LocalSet.
+  async function evalInput(text) {
     const trimmed = text.trim();
     if (!trimmed) return;
 
@@ -233,8 +236,21 @@
     historyIdx = -1;
     liveInput = '';
 
-    const out = repl.eval(trimmed);
-    appendEntry(trimmed, out.output, out.result, out.is_error);
+    inputEl.disabled = true;
+    statusEl.textContent = 'Evaluating…';
+    statusEl.className = 'status loading';
+
+    try {
+      const out = await repl.eval(trimmed);
+      appendEntry(trimmed, out.output, out.result, out.is_error);
+    } catch (err) {
+      appendEntry(trimmed, '', String(err), true);
+    } finally {
+      inputEl.disabled = false;
+      statusEl.textContent = 'Ready';
+      statusEl.className = 'status';
+      inputEl.focus();
+    }
   }
 
   // ── Auto-resize textarea ───────────────────────────────────────────────────
@@ -261,15 +277,17 @@
   }
 
   // ── Key handling ──────────────────────────────────────────────────────────
-  inputEl.addEventListener('keydown', (e) => {
+  inputEl.addEventListener('keydown', async (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       const text = inputEl.value;
       // Submit if balanced or empty (so the user can submit intentionally).
       if (!text.trim() || isBalanced(text)) {
-        evalInput(text);
+        // Clear immediately so the user sees the form was accepted; evalInput
+        // then disables the textarea for the duration of the async eval.
         inputEl.value = '';
         resize();
+        await evalInput(text);
       } else {
         // Unbalanced — insert a newline so the user can keep typing.
         const pos = inputEl.selectionStart;


### PR DESCRIPTION
- cljrs-wasm: add cljrs-async, wasm-bindgen-futures, and tokio deps
- Repl::new() calls cljrs_async::init() and spins up a persistent Tokio
  LocalSet pump via wasm_bindgen_futures::spawn_local so goroutines and
  channel tasks make progress between eval calls
- Repl::eval() is now async (returns a JS Promise); evaluation runs inside
  local.run_until() so tokio::task::spawn_local works correctly
- Top-level Value::Future/Promise results are implicitly awaited before
  returning, giving the REPL a fully async top-level context
- env.is_async = true set for each eval so explicit (await ...) forms
  yield correctly at the top level
- cljrs-async: make await_value pub so cljrs-wasm can call it directly
- cljrs-async: replace tokio::time::sleep with platform_sleep helper;
  on wasm32 delegates to gloo_timers::future::sleep (browser setTimeout),
  on native keeps tokio::time::sleep — Option A timer strategy
- Update cljrs-async and cljrs-wasm READMEs

https://claude.ai/code/session_01LkNcDhAJEXNu9u78uDMQpo