### PR TITLE
Fix WASM "failed" label caused by spawn_local outside LocalSet

### DIFF
--- a/crates/cljrs-async/src/runtime.rs
+++ b/crates/cljrs-async/src/runtime.rs
@@ -64,11 +64,17 @@ fn downcast_channel(val: &Value) -> EvalResult<&CljChannel> {
 ///
 /// Must be called from within a Tokio `LocalSet` context (e.g., from `init`).
 pub(crate) fn spawn_gc_service() {
-    // `spawn_local` panics when called outside a `LocalSet` context (e.g., in
-    // unit tests that call `init()` before entering `block_on_local`).  In that
-    // case the GC service simply won't run, which is fine: the service is a
-    // best-effort background collector; the safepoints inside `await_value`
-    // still fire whenever the code is actually running inside a LocalSet.
+    // On native targets, `spawn_local` panics when called outside a `LocalSet`
+    // context (e.g., in unit tests that call `init()` before `block_on_local`).
+    // `catch_unwind` silences that panic so the rest of init() still runs; the
+    // GC service simply won't run, which is acceptable — safepoints inside
+    // `await_value` still fire whenever code runs inside a LocalSet.
+    //
+    // On wasm32 with wasm-bindgen, panics become JS exceptions that
+    // `catch_unwind` *cannot* catch.  The WASM REPL therefore must only call
+    // `spawn_gc_service` (transitively via `init`) from inside a LocalSet
+    // context — the `Repl` constructor does this via its persistent pump.
+    #[cfg(not(target_arch = "wasm32"))]
     let _ = std::panic::catch_unwind(|| {
         tokio::task::spawn_local(async {
             loop {
@@ -76,5 +82,12 @@ pub(crate) fn spawn_gc_service() {
                 cljrs_env::gc_roots::async_gc_collect();
             }
         });
+    });
+    #[cfg(target_arch = "wasm32")]
+    tokio::task::spawn_local(async {
+        loop {
+            tokio::task::yield_now().await;
+            cljrs_env::gc_roots::async_gc_collect();
+        }
     });
 }

--- a/crates/cljrs-wasm/src/lib.rs
+++ b/crates/cljrs-wasm/src/lib.rs
@@ -66,25 +66,21 @@ impl Repl {
         let globals = cljrs_interp::standard_env_minimal(None, None, None);
         cljrs_stdlib::register(&globals);
 
-        // init outside a LocalSet context: namespace and runtime hook are
-        // registered; spawn_gc_service silently no-ops (catch_unwind inside).
-        // The GC service is instead spawned on the first eval via the LocalSet.
-        cljrs_async::init(&globals);
-
         let local = Rc::new(LocalSet::new());
 
-        // Pump the LocalSet indefinitely from the browser's microtask queue so
-        // that goroutines and channel tasks make progress even between evals.
-        // The init call inside also fires spawn_gc_service in the correct
-        // LocalSet context.
+        // Schedule a persistent LocalSet pump on the browser's microtask queue.
+        // All of cljrs_async::init() — including spawn_gc_service() which calls
+        // tokio::task::spawn_local — runs from *inside* the LocalSet context here.
+        // We must NOT call init() before this block: on WASM, panics are JS
+        // exceptions that std::panic::catch_unwind cannot catch, so calling
+        // spawn_local outside a LocalSet would propagate an exception to the JS
+        // caller and show "failed" in the UI.
         {
             let local2 = local.clone();
             let globals2 = globals.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 local2
                     .run_until(async move {
-                        // Re-run init from within the LocalSet so spawn_gc_service
-                        // actually succeeds (idempotent for namespace loading).
                         cljrs_async::init(&globals2);
                         std::future::pending::<()>().await
                     })


### PR DESCRIPTION
Root cause: Repl::new() called cljrs_async::init() before the LocalSet pump was started. init() calls spawn_gc_service() which calls tokio::task::spawn_local() — that panics when no LocalSet is active. On native the catch_unwind wrapper silences it harmlessly, but on wasm32 with wasm-bindgen panics are JS exceptions that catch_unwind cannot intercept. The exception propagated to new mod.Repl() in loadWasm, which hit the .catch() handler and showed "✕ failed".

Fix: remove the early init() call from Repl::new(). The persistent LocalSet pump (spawned via wasm_bindgen_futures::spawn_local) already calls init() from inside the LocalSet context where spawn_local is safe. The pump fires as a browser microtask before any user-triggered eval, so the namespace and runtime are always ready in time.

Also add explicit #[cfg(not/target_arch = "wasm32")] guards to spawn_gc_service() documenting why catch_unwind is native-only, and providing a direct spawn_local call for the WASM path (which is always reached from inside a LocalSet).

https://claude.ai/code/session_01LkNcDhAJEXNu9u78uDMQpo