### PR TITLE
Add core.async AOT sample and fix async eval for collection literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
           CLJRS_GC_STATS: "-"
         run: cargo run -p cljrs compile -o life-sample samples/life.cljrs && ./life-sample
 
+      - name: core.async sample (CSP showcase)
+        run: cargo run -p cljrs compile -o async-sample samples/core_async.cljrs && ./async-sample
+
   wasm:
     name: WASM build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .cljrs-aot-test-harness
 /test-suite
 /graph-sample
+/async-sample
 **/.DS_Store
 # AOT test/debug artifacts
 /1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
 name = "cljrs-compiler"
 version = "0.1.0"
 dependencies = [
+ "cljrs-async",
  "cljrs-builtins",
  "cljrs-deps",
  "cljrs-env",

--- a/crates/cljrs-async/src/core_async.cljrs
+++ b/crates/cljrs-async/src/core_async.cljrs
@@ -24,7 +24,7 @@
         futs     (vec (map first pairs))
         handlers (vec (map second pairs))
         r        (gensym "alt_r__")]
-    (list 'let (vector r (list 'await (list 'alts futs)))
+    (list 'let (vector r (list 'await (list 'clojure.core.async/alts futs)))
           (list (list 'nth handlers (list 'second r))
                 (list 'first r)))))
 

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -23,7 +23,10 @@ use cljrs_interp::eval::{eval, is_special_form};
 use cljrs_interp::macros::macroexpand;
 use cljrs_reader::Form;
 use cljrs_reader::form::FormKind;
-use cljrs_value::{CljxFnArity, CljxFuture, FutureState, Value};
+use cljrs_value::value::SetValue;
+use cljrs_value::{
+    CljxFnArity, CljxFuture, FutureState, MapValue, PersistentHashSet, PersistentVector, Value,
+};
 
 /// Spawn `task` on the current `LocalSet` and return a `Value::Future` that the
 /// task settles on completion. The single delivery point for every async
@@ -112,10 +115,48 @@ pub async fn run_async_fn(callee: Value, args: Vec<Value>, base: &Env) -> EvalRe
 
 /// Asynchronously evaluate a single form.
 pub async fn eval_async(form: &Form, env: &mut Env) -> EvalResult {
-    // Only list forms can contain control flow or an `await`; everything else
-    // is a leaf the sync evaluator handles directly.
-    if !matches!(form.kind, FormKind::List(_)) {
-        return eval(form, env);
+    // Collection literals may contain `await` sub-expressions (e.g. the
+    // return value of a ^:async fn is `[(await x) (await y)]`). Evaluate
+    // each element with eval_async so awaits yield cooperatively instead of
+    // blocking the LocalSet thread via the sync condvar path.
+    match &form.kind {
+        FormKind::Vector(elems) => {
+            let elems = elems.clone();
+            let mut vals: Vec<Value> = Vec::with_capacity(elems.len());
+            for f in &elems {
+                vals.push(Box::pin(eval_async(f, env)).await?);
+            }
+            return Ok(Value::Vector(GcPtr::new(PersistentVector::from_iter(vals))));
+        }
+        FormKind::Map(elems) => {
+            if elems.len() % 2 != 0 {
+                return Err(EvalError::Runtime(
+                    "map literal must have an even number of forms".into(),
+                ));
+            }
+            let elems = elems.clone();
+            let mut pairs: Vec<Value> = Vec::with_capacity(elems.len());
+            for f in &elems {
+                pairs.push(Box::pin(eval_async(f, env)).await?);
+            }
+            let kv_pairs: Vec<(Value, Value)> = pairs
+                .chunks(2)
+                .map(|pair| (pair[0].clone(), pair[1].clone()))
+                .collect();
+            return Ok(Value::Map(MapValue::from_pairs(kv_pairs)));
+        }
+        FormKind::Set(elems) => {
+            let elems = elems.clone();
+            let mut vals: Vec<Value> = Vec::with_capacity(elems.len());
+            for f in &elems {
+                vals.push(Box::pin(eval_async(f, env)).await?);
+            }
+            return Ok(Value::Set(SetValue::Hash(GcPtr::new(
+                PersistentHashSet::from_iter(vals),
+            ))));
+        }
+        FormKind::List(_) => {} // fall through to list handling below
+        _ => return eval(form, env),
     }
 
     // Reduce control-flow macros (when, cond, ->, …) to their special-form core

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -11,6 +11,7 @@ aot_full_test = []
 no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc", "cljrs-eval/no-gc", "cljrs-interp/no-gc", "cljrs-stdlib/no-gc"]
 
 [dependencies]
+cljrs-async    = { workspace = true }
 cljrs-builtins = { workspace = true }
 cljrs-deps     = { workspace = true }
 cljrs-types    = { workspace = true }

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -408,6 +408,10 @@ pub fn compile_file(
     } else {
         cljrs_stdlib::standard_env_with_paths(src_dirs.to_vec())
     };
+    // Register clojure.core.async so that (require '[clojure.core.async ...])
+    // and the `go`/`alt` macros resolve during macro-expansion. The GC
+    // service is silently skipped when there is no LocalSet context.
+    cljrs_async::init(&globals);
     let mut env = cljrs_eval::Env::new(globals, "user");
 
     // Snapshot loaded namespaces before expansion so we can detect
@@ -585,17 +589,21 @@ fn is_interpreter_only_sym(s: &str) -> bool {
 }
 
 /// Check the macro-expanded form for constructs that the AOT compiler
-/// cannot handle (e.g. alter-meta!, vary-meta). This recurses
+/// cannot handle (e.g. alter-meta!, vary-meta, await). This recurses
 /// into the form tree so that e.g. `(do (def x ...) (alter-meta! ...))` is caught.
+/// `await` and `async-spawn` are async special forms only the interpreter understands;
+/// any top-level form whose expansion tree contains them must stay interpreted.
 fn expanded_needs_interpreter(form: &cljrs_reader::Form) -> bool {
     use cljrs_reader::form::FormKind;
     match &form.kind {
         FormKind::List(parts) => {
             if let Some(head) = parts.first()
                 && let FormKind::Symbol(s) = &head.kind
-                && is_interpreter_only_sym(s)
             {
-                return true;
+                let base = s.rsplit('/').next().unwrap_or(s.as_str());
+                if is_interpreter_only_sym(s.as_str()) || base == "await" {
+                    return true;
+                }
             }
             parts.iter().any(expanded_needs_interpreter)
         }
@@ -740,6 +748,8 @@ cljrs-env      = {{ path = "{ws}/crates/cljrs-env" }}
 cljrs-eval     = {{ path = "{ws}/crates/cljrs-eval" }}
 cljrs-stdlib   = {{ path = "{ws}/crates/cljrs-stdlib" }}
 cljrs-compiler = {{ path = "{ws}/crates/cljrs-compiler" }}
+cljrs-async    = {{ path = "{ws}/crates/cljrs-async" }}
+tokio          = {{ version = "1", features = ["rt", "time"] }}
 {native_deps}"#,
     );
     std::fs::write(harness_dir.join("Cargo.toml"), cargo_toml)?;
@@ -816,9 +826,19 @@ cljrs-compiler = {{ path = "{ws}/crates/cljrs-compiler" }}
                     .collect();
                 let call = format!("(-main {})", escaped.join(" "));
                 if let Ok(fs) = cljrs_reader::Parser::new(call, "<main>".to_string()).parse_all() {
-                    if let Err(e) = cljrs_eval::eval(&fs[0], &mut env) {
-                        eprintln!("cljrs: error in -main: {e:?}");
-                        std::process::exit(1);
+                    match cljrs_eval::eval(&fs[0], &mut env) {
+                        Ok(main_result) => {
+                            // If -main is ^:async it returns a Future; await it on the
+                            // current LocalSet so all spawned go-blocks drain to completion.
+                            if let Err(e) = cljrs_async::eval_async::await_value(main_result).await {
+                                eprintln!("cljrs: error in -main: {e:?}");
+                                std::process::exit(1);
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("cljrs: error in -main: {e:?}");
+                            std::process::exit(1);
+                        }
                     }
                 }
             }
@@ -869,7 +889,7 @@ unsafe extern "C" {{
     fn __cljrs_main() -> *const Value;
 }}
 
-fn run() {{
+async fn run() {{
     // Parse environment -X flags.
     cljrs_logging::set_feature_levels_from_env().unwrap();
 
@@ -879,6 +899,9 @@ fn run() {{
     // Initialize the standard environment so that rt_call and other
     // runtime bridge functions can look up builtins.
     let globals = cljrs_stdlib::standard_env();
+
+    // Register the async runtime (clojure.core.async, ^:async dispatch, await).
+    cljrs_async::init(&globals);
 
     // Register bundled dependency sources so require can find them
     // without needing source files on disk.
@@ -904,7 +927,17 @@ fn main() {{
     const STACK_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
     let thread = std::thread::Builder::new()
         .stack_size(STACK_SIZE)
-        .spawn(run)
+        .spawn(|| {{
+            // Drive all async tasks (go blocks, ^:async fns, channels) on a
+            // single-threaded Tokio LocalSet so GcPtr<!Send> values stay on
+            // one OS thread throughout execution.
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .expect("failed to build Tokio runtime");
+            let local = tokio::task::LocalSet::new();
+            local.block_on(&rt, run());
+        }})
         .expect("failed to spawn main thread");
     if let Err(e) = thread.join() {{
         std::panic::resume_unwind(e);

--- a/samples/core_async.cljrs
+++ b/samples/core_async.cljrs
@@ -1,0 +1,136 @@
+;; core.async sample — CSP pipeline and concurrency showcase.
+;;
+;; Why this is a good async/channel showcase:
+;;
+;;   The pipeline demo fans work across k workers via a shared buffered
+;;   channel: a producer puts integers onto work-ch, each worker squares
+;;   its input and forwards the result to result-ch, and a supervisor
+;;   closes result-ch once all workers drain. The main goroutine sums the
+;;   results with a tail-recursive drain loop.
+;;
+;;   The broadcast demo wires a mult to two taps: values forwarded by the
+;;   mult background task appear on both taps concurrently.
+;;
+;;   The race demo shows alt/timeout for deadline-aware channel selects.
+;;
+;;   async-pmap demonstrates the high-level parallel-map combinator.
+
+(ns core-async-sample)
+
+(require '[clojure.core.async
+           :refer [chan go take! put! close! timeout alt
+                   join-all async-pmap mult tap!]])
+
+;; ── Pipeline helpers ──────────────────────────────────────────────────────────
+
+(defn ^:async producer
+  "Put integers [0, n) onto work-ch and then close it."
+  [n work-ch]
+  (loop [i 0]
+    (when (< i n)
+      (await (put! work-ch i))
+      (recur (inc i))))
+  (close! work-ch))
+
+(defn ^:async worker
+  "Take values from in-ch, apply f, put results on out-ch until in-ch closes."
+  [f in-ch out-ch]
+  (loop []
+    (let [v (await (take! in-ch))]
+      (when-not (nil? v)
+        (await (put! out-ch (f v)))
+        (recur)))))
+
+(defn ^:async drain-sum
+  "Drain all longs from ch until it closes and return their sum."
+  [ch]
+  (loop [acc 0]
+    (let [v (await (take! ch))]
+      (if (nil? v)
+        acc
+        (recur (+ acc v))))))
+
+(defn ^:async pipeline
+  "Compute sum of (f i) for i in [0, n) using k parallel workers."
+  [n k f]
+  (let [work-ch   (chan k)
+        result-ch (chan k)
+        ;; Calling a ^:async fn spawns it on the LocalSet and returns a Future.
+        workers   (mapv (fn [_] (worker f work-ch result-ch)) (range k))]
+    (go (await (producer n work-ch)))
+    (go (await (join-all workers))
+        (close! result-ch))
+    (await (drain-sum result-ch))))
+
+;; ── Broadcast helpers ─────────────────────────────────────────────────────────
+
+(defn ^:async drain-n
+  "Take exactly n values from ch and return them as a vector."
+  [ch n]
+  (loop [acc [] i 0]
+    (if (= i n)
+      acc
+      ;; Use a let binding so (await ...) is evaluated in the async context
+      ;; before recur — await inside recur args goes through sync eval.
+      (let [v (await (take! ch))]
+        (recur (conj acc v) (inc i))))))
+
+(defn ^:async broadcast-demo
+  "Fan-out values over a mult to two taps; return [tap1-vals tap2-vals]."
+  [values]
+  (let [n    (count values)
+        src  (chan n)
+        m    (mult src)
+        tap1 (chan n)
+        tap2 (chan n)]
+    (tap! m tap1)
+    (tap! m tap2)
+    ;; Fill src using an explicit loop so `await` runs in the async context.
+    ;; (doseq with await inside doesn't work: doseq expands to a callback
+    ;; that the sync evaluator handles, so the await would block.)
+    (loop [vs (seq values)]
+      (when vs
+        (await (put! src (first vs)))
+        (recur (next vs))))
+    (close! src)
+    ;; Drain taps — yields here let the mult task forward the buffered values.
+    [(await (drain-n tap1 n))
+     (await (drain-n tap2 n))]))
+
+;; ── Main ─────────────────────────────────────────────────────────────────────
+
+(defn ^:async -main [& _args]
+  (println "=== core.async sample ===")
+
+  ;; 1. Parallel pipeline: sum of squares 0..99 across 4 workers.
+  (println "\n[pipeline] summing squares of 0..99 with 4 workers")
+  (let [start   (nanotime)
+        result  (await (pipeline 100 4 (fn [x] (* x x))))
+        elapsed (/ (- (nanotime) start) 1e6)
+        expected (reduce + (map (fn [x] (* x x)) (range 100)))]
+    (println "Sum of squares:" result)
+    (println "Expected:      " expected)
+    (println "Match?         " (= result expected))
+    (println "Time (ms):     " elapsed))
+
+  ;; 2. async-pmap: double each element of a small vector concurrently.
+  (println "\n[async-pmap] doubling [1 2 3 4 5] concurrently")
+  (let [doubled (await (async-pmap (fn ^:async [x] (* 2 x)) [1 2 3 4 5]))]
+    (println "Doubled:" doubled))
+
+  ;; 3. Broadcast: one source channel, two taps via mult.
+  (println "\n[broadcast] sending [:a :b :c] to two taps via mult")
+  (let [[t1 t2] (await (broadcast-demo [:a :b :c]))]
+    (println "Tap 1:" t1)
+    (println "Tap 2:" t2)
+    (println "Taps equal?" (= t1 t2)))
+
+  ;; 4. Deadline race: fast channel wins over a 1-second timeout.
+  (println "\n[alt/timeout] racing fast computation vs 1s timeout")
+  (let [fast-ch (chan 1)]
+    (go (await (put! fast-ch :done)))
+    (let [winner (alt (take! fast-ch) (fn [_] :fast-wins)
+                      (timeout 1000)  (fn [_] :timed-out))]
+      (println "Winner:" winner)))
+
+  (println "\n=== done ==="))


### PR DESCRIPTION
Adds `samples/core_async.cljrs` demonstrating CSP patterns: parallel
pipeline (fan-out workers), async-pmap, mult/tap broadcast, and
alt/timeout deadline race. The sample is compiled AOT via `cljrs compile`
and exercised in CI.

Three bugs fixed along the way:

1. `eval_async` only dispatched `FormKind::List` to the yielding path;
   vector, map, and set literals fell through to the sync `eval`, which
   deadlocked when `await` appeared inside them (sync `await` blocks the
   LocalSet thread via a condvar). Now vector/map/set elements are each
   evaluated with `eval_async`.

2. The `alt` macro emitted an unqualified `'alts` symbol, failing when
   the caller did not explicitly `:refer` `alts`. Changed to emit
   `'clojure.core.async/alts` so it resolves regardless of the call site.

3. `cljrs-compiler` now calls `cljrs_async::init()` during macro-expansion
   so `clojure.core.async` symbols resolve at AOT compile time, and the
   generated harness uses a Tokio LocalSet + `async fn run()` so that
   `^:async -main` futures drain to completion.

https://claude.ai/code/session_01AhNtsMcQdXkrHcub7mx3Mf