### PR TITLE
fix: eliminate dev-dep cycles that cause cargo publish deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,6 @@ dependencies = [
  "cljrs-ir",
  "cljrs-logging",
  "cljrs-reader",
- "cljrs-stdlib",
  "cljrs-types",
  "cljrs-value",
 ]
@@ -478,13 +477,8 @@ dependencies = [
 name = "cljrs-ir"
 version = "0.1.0"
 dependencies = [
- "cljrs-env",
- "cljrs-eval",
- "cljrs-gc",
  "cljrs-reader",
- "cljrs-stdlib",
  "cljrs-types",
- "cljrs-value",
  "postcard",
  "serde",
 ]

--- a/crates/cljrs-eval/Cargo.toml
+++ b/crates/cljrs-eval/Cargo.toml
@@ -20,5 +20,3 @@ cljrs-env      = { workspace = true }
 cljrs-builtins = { workspace = true }
 cljrs-interp   = { workspace = true }
 
-[dev-dependencies]
-cljrs-stdlib   = { path = "../cljrs-stdlib" }

--- a/crates/cljrs-eval/tests/region_phi_uaf.rs
+++ b/crates/cljrs-eval/tests/region_phi_uaf.rs
@@ -60,8 +60,8 @@
 use std::sync::Arc;
 
 use cljrs_eval::{Env, ir_interp::interpret_ir};
-use cljrs_ir::{BlockId, Const, Inst, IrFunction, KnownFn, RegionAllocKind, Terminator, VarId};
 use cljrs_interp::standard_env_minimal;
+use cljrs_ir::{BlockId, Const, Inst, IrFunction, KnownFn, RegionAllocKind, Terminator, VarId};
 use cljrs_value::Value;
 
 /// Build the IR sketched in the module docs.

--- a/crates/cljrs-eval/tests/region_phi_uaf.rs
+++ b/crates/cljrs-eval/tests/region_phi_uaf.rs
@@ -61,6 +61,7 @@ use std::sync::Arc;
 
 use cljrs_eval::{Env, ir_interp::interpret_ir};
 use cljrs_ir::{BlockId, Const, Inst, IrFunction, KnownFn, RegionAllocKind, Terminator, VarId};
+use cljrs_interp::standard_env_minimal;
 use cljrs_value::Value;
 
 /// Build the IR sketched in the module docs.
@@ -160,7 +161,7 @@ fn build_phi_over_regions_ir() -> IrFunction {
 fn region_phi_uaf_reproduces_under_interpreter() {
     let _mutator = cljrs_gc::register_mutator();
 
-    let globals = cljrs_stdlib::standard_env();
+    let globals = standard_env_minimal(None, None, None);
     let mut env = Env::new(globals.clone(), "user");
 
     let ir = build_phi_over_regions_ir();

--- a/crates/cljrs-ir/Cargo.toml
+++ b/crates/cljrs-ir/Cargo.toml
@@ -12,9 +12,3 @@ cljrs-reader = { workspace = true }
 serde        = { workspace = true, features = ["rc"] }
 postcard     = { workspace = true, features = ["alloc"] }
 
-[dev-dependencies]
-cljrs-eval   = { path = "../cljrs-eval" }
-cljrs-stdlib = { path = "../cljrs-stdlib" }
-cljrs-value    = { path = "../cljrs-value" }
-cljrs-gc       = { path = "../cljrs-gc" }
-cljrs-env      = { path = "../cljrs-env" }

--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -33,6 +33,9 @@ lazy_static = "1.5.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt", "sync", "rt-multi-thread"] }
 
+[dev-dependencies]
+cljrs-env = { workspace = true }
+
 [build-dependencies]
 cljrs-ir     = { path = "../cljrs-ir",     version = "0.1.0", optional = true }
 cljrs-eval   = { path = "../cljrs-eval",   version = "0.1.0", optional = true }

--- a/crates/cljrs-stdlib/tests/compiler_clojure_tests.rs
+++ b/crates/cljrs-stdlib/tests/compiler_clojure_tests.rs
@@ -1,10 +1,15 @@
 //! Runs the Clojure-side `clojure.test` suites for the namespaces in
 //! `cljrs.compiler.*` against the embedded compiler sources.
 //!
-//! Each test file at `test/cljrs/compiler/<name>_test.cljrs` is required
+//! Each test file at `cljrs-ir/test/cljrs/compiler/<name>_test.cljrs` is required
 //! through the cljrs evaluator, then `(clojure.test/run-tests …)` is invoked
 //! and its `:fail` / `:error` counters are checked.  A non-zero count fails
 //! the Rust test.
+//!
+//! These tests live in `cljrs-stdlib` rather than `cljrs-ir` because they
+//! need the full eval stack (`cljrs-eval`, `cljrs-stdlib`), and putting them
+//! in `cljrs-ir` would create a dev-dependency cycle:
+//!   cljrs-ir --(dev)--> cljrs-eval --(dep)--> cljrs-ir
 
 use std::path::PathBuf;
 
@@ -49,7 +54,8 @@ fn extract_counter(map: &Value, key: &str) -> i64 {
 #[test]
 fn run_clojure_compiler_tests() {
     // Source path so `(require 'cljrs.compiler.ir-test)` finds the test files.
-    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test");
+    // The Clojure test sources live in the cljrs-ir crate tree.
+    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../cljrs-ir/test");
     assert!(
         test_dir.is_dir(),
         "test dir not found: {}",


### PR DESCRIPTION
Two circular dev-dependency structures were triggering the "no packages
ready to publish" error (rust-lang/cargo#17028) during workspace publish:

1. cljrs-eval -(dev)→ cljrs-stdlib -(dep)→ cljrs-eval
2. cljrs-ir   -(dev)→ cljrs-eval   -(dep)→ cljrs-ir

Fix (1): replace cljrs_stdlib::standard_env() in region_phi_uaf.rs with
cljrs_interp::standard_env_minimal(None, None, None). cljrs-interp is
already a regular dep of cljrs-eval, so no new dependency is needed.

Fix (2): move clojure_tests.rs from cljrs-ir/tests/ to
cljrs-stdlib/tests/compiler_clojure_tests.rs, which already depends on
both cljrs-eval and cljrs-ir. The path to the Clojure test sources is
adjusted to point at cljrs-ir/test/ relative to the new manifest dir.
cljrs-env is added as a dev-dep of cljrs-stdlib (no cycle: cljrs-env
does not depend on cljrs-stdlib).

https://claude.ai/code/session_01Segg9ZackfiKLqoJqfHjwb