### PR TITLE
fix(publish): remove duplicate dev-deps in blake3; make release tag i…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,9 +65,15 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add -A
-          git commit -m "chore: release $VERSION"
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          # Skip commit+tag+push if the tag already exists on the remote,
+          # making this step idempotent so re-runs of the same workflow job succeed.
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists on remote — skipping release commit"
+          else
+            git commit -m "chore: release $VERSION"
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
+          fi
 
       - name: Publish crates
         env:

--- a/crates/cljrs-blake3/Cargo.toml
+++ b/crates/cljrs-blake3/Cargo.toml
@@ -23,6 +23,4 @@ blake3        = "1"
 cljrs-eval    = { workspace = true }
 cljrs-stdlib  = { workspace = true }
 cljrs-env     = { workspace = true }
-cljrs-gc      = { workspace = true }
-cljrs-interop = { workspace = true }
 cljrs-reader  = { workspace = true }


### PR DESCRIPTION
…dempotent

cljrs-gc and cljrs-interop appeared in both [dependencies] and [dev-dependencies] of cljrs-blake3, causing cargo's in-degree counter to double-count those packages and deadlock the publish ordering for blake3 and its dependents (compiler, ir-viz, wasm, cljrs).

Also make the "Set crate versions" workflow step idempotent: check whether the release tag already exists on the remote before committing and pushing it, so that re-running the same workflow job after a partial publish failure no longer errors out on a duplicate tag.

https://claude.ai/code/session_01Segg9ZackfiKLqoJqfHjwb