### PR TITLE
Add cljrs-io crate: async file I/O over core.async channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "cljrs-eval",
  "cljrs-gc",
  "cljrs-interop",
+ "cljrs-io",
  "cljrs-ir-viz",
  "cljrs-logging",
  "cljrs-reader",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +477,21 @@ dependencies = [
  "cljrs-vcs",
  "regex",
  "uuid",
+]
+
+[[package]]
+name = "cljrs-io"
+version = "0.1.0"
+dependencies = [
+ "cljrs-async",
+ "cljrs-env",
+ "cljrs-gc",
+ "cljrs-interp",
+ "cljrs-reader",
+ "cljrs-types",
+ "cljrs-value",
+ "encoding_rs",
+ "tokio",
 ]
 
 [[package]]
@@ -826,6 +847,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endian-type"
@@ -1713,6 +1743,7 @@ version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
+ "bytes",
  "pin-project-lite",
  "tokio-macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ members = [
     "crates/cljrs-vcs",
     "crates/cljrs-blake3",
     "crates/cljrs-wasm",
-    "crates/cljrs-async"]
+    "crates/cljrs-async",
+    "crates/cljrs-io"]
 resolver = "2"
 
 [workspace.package]
@@ -51,6 +52,7 @@ cljrs-ir-viz       = { path = "crates/cljrs-ir-viz",       version = "0.1.0" }
 cljrs-deps         = { path = "crates/cljrs-deps",         version = "0.1.0" }
 cljrs-vcs          = { path = "crates/cljrs-vcs",          version = "0.1.0" }
 cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0" }
+cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"
@@ -65,6 +67,7 @@ rpds         = "1"
 uuid         = "1.22.0"
 tokio        = { version = "1.50.0", features = ["rt", "sync", "time", "macros"] }
 futures-util = "0.3"
+encoding_rs  = "0.8"
 regex        = "1.12.3"
 serde        = "1.0.228"
 postcard     = "1.1.3"

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -98,7 +98,18 @@ blocking bridge is a later phase.
 /// Must be called inside a Tokio LocalSet context for spawned tasks to run.
 pub fn init(globals: &Arc<GlobalEnv>);
 
+/// Re-exports for sibling native crates (e.g. cljrs-io) that drive their own
+/// work onto the shared LocalSet executor.
+pub use eval_async::{await_value, spawn_future};
+
 pub mod eval_async {
+    /// Spawn `task` on the current LocalSet and return a `Value::Future` that
+    /// settles when it completes. The shared delivery point for async primitives;
+    /// public so other native crates can produce results through the same path.
+    pub fn spawn_future<F>(task: F) -> Value
+    where
+        F: Future<Output = Result<Value, EvalError>> + 'static;
+
     /// Drive an ^:async fn body to completion, yielding at every await.
     pub async fn run_async_fn(callee: Value, args: Vec<Value>, base: &Env)
         -> Result<Value, EvalError>;
@@ -121,6 +132,12 @@ pub mod channel {
     impl CljChannel {
         /// Create a channel. `capacity == 0` is an unbuffered rendezvous channel.
         pub fn new(capacity: usize) -> Self;
+        /// Async put: yield to the LocalSet until the value is accepted (buffered
+        /// or handed off). `true` on success, `false` if the channel is closed.
+        /// The building block other crates use to stream produced values.
+        pub async fn put(&self, v: Value) -> bool;
+        /// Close the channel (idempotent). Buffered values still drain to takers.
+        pub fn close(&self);
         /// Block the calling OS thread until a value is available (or channel closes → nil).
         /// Uses Condvar with a 1 ms timeout to avoid deadlock on the LocalSet thread.
         pub fn take_blocking(&self) -> Value;

--- a/crates/cljrs-async/src/builtins.rs
+++ b/crates/cljrs-async/src/builtins.rs
@@ -188,35 +188,8 @@ fn builtin_take(args: &[Value]) -> ValueResult<Value> {
 fn builtin_put(args: &[Value]) -> ValueResult<Value> {
     let ch = channel_arg(args)?;
     let val = args.get(1).cloned().unwrap_or(Value::Nil);
-    let rendezvous = chan_ref(ch.get()).is_rendezvous();
     Ok(spawn_future(async move {
-        if rendezvous {
-            // Phase 1: place the value into the channel's single slot.
-            let token = loop {
-                match chan_ref(ch.get()).rv_offer(&val) {
-                    RvOffer::Offered(t) => break t,
-                    RvOffer::Closed => return Ok(Value::Bool(false)),
-                    RvOffer::Full => {}
-                }
-                tokio::task::yield_now().await;
-            };
-            // Phase 2: wait for a taker to consume it (the handoff).
-            loop {
-                match chan_ref(ch.get()).rv_status(token) {
-                    RvStatus::Taken => return Ok(Value::Bool(true)),
-                    RvStatus::ClosedUntaken => return Ok(Value::Bool(false)),
-                    RvStatus::Waiting => {}
-                }
-                tokio::task::yield_now().await;
-            }
-        } else {
-            loop {
-                if let Some(accepted) = chan_ref(ch.get()).try_put_buffered(&val) {
-                    return Ok(Value::Bool(accepted));
-                }
-                tokio::task::yield_now().await;
-            }
-        }
+        Ok(Value::Bool(chan_ref(ch.get()).put(val).await))
     }))
 }
 

--- a/crates/cljrs-async/src/channel.rs
+++ b/crates/cljrs-async/src/channel.rs
@@ -96,7 +96,7 @@ impl CljChannel {
 
     /// Mark the channel closed. Idempotent. Pending and future takes drain any
     /// buffered values and then observe `nil`.
-    pub(crate) fn close(&self) {
+    pub fn close(&self) {
         self.state.lock().unwrap().closed = true;
         // Wake any threads blocking in take_blocking / put_blocking.
         self.not_empty.notify_all();
@@ -249,6 +249,44 @@ impl CljChannel {
                     .wait_timeout(guard, Duration::from_millis(1))
                     .unwrap();
                 guard = g;
+            }
+        }
+    }
+
+    /// Asynchronously put `v` onto the channel, cooperatively yielding to the
+    /// `LocalSet` executor until the value is accepted — buffered (capacity >= 1)
+    /// or handed off to a taker (rendezvous). Resolves `true` on success, or
+    /// `false` if the channel is (or becomes) closed before the value lands.
+    ///
+    /// This is the async counterpart to [`Self::put_blocking`] and the building
+    /// block other native crates use to stream produced values onto a channel.
+    /// Must run within a Tokio `LocalSet` context.
+    pub async fn put(&self, v: Value) -> bool {
+        if self.is_rendezvous() {
+            // Phase 1: claim the channel's single slot.
+            let token = loop {
+                match self.rv_offer(&v) {
+                    RvOffer::Offered(t) => break t,
+                    RvOffer::Closed => return false,
+                    RvOffer::Full => {}
+                }
+                tokio::task::yield_now().await;
+            };
+            // Phase 2: wait for a taker to consume the offered value.
+            loop {
+                match self.rv_status(token) {
+                    RvStatus::Taken => return true,
+                    RvStatus::ClosedUntaken => return false,
+                    RvStatus::Waiting => {}
+                }
+                tokio::task::yield_now().await;
+            }
+        } else {
+            loop {
+                if let Some(accepted) = self.try_put_buffered(&v) {
+                    return accepted;
+                }
+                tokio::task::yield_now().await;
             }
         }
     }

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -32,8 +32,12 @@ use cljrs_value::{
 /// task settles on completion. The single delivery point for every async
 /// primitive (`^:async` calls, `timeout`, `alts`).
 ///
+/// Public so other native crates (e.g. `cljrs-io`) can drive their own async
+/// work onto the shared executor and deliver results through the same `Future`
+/// machinery.
+///
 /// Must be called from within a Tokio `LocalSet` context.
-pub(crate) fn spawn_future<F>(task: F) -> Value
+pub fn spawn_future<F>(task: F) -> Value
 where
     F: Future<Output = EvalResult> + 'static,
 {

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -22,6 +22,11 @@ pub mod eval_async;
 mod runtime;
 use runtime::AsyncRuntimeImpl;
 
+// Re-exported so sibling native crates (e.g. `cljrs-io`) can spawn work onto the
+// shared `LocalSet` executor and await Clojure futures/promises without reaching
+// into private modules.
+pub use eval_async::{await_value, spawn_future};
+
 /// Clojure-level `clojure.core.async` definitions (the `alt` macro), evaluated
 /// on top of the native primitives at `init` time.
 const CORE_ASYNC_SOURCE: &str = include_str!("core_async.cljrs");

--- a/crates/cljrs-io/Cargo.toml
+++ b/crates/cljrs-io/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cljrs-io"
+version = "0.1.0"
+edition = "2024"
+description = "Asynchronous file I/O for clojurust — tokio-backed reads/writes delivered over core.async channels"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cljrs-types    = { workspace = true }
+cljrs-gc       = { workspace = true }
+cljrs-value    = { workspace = true }
+cljrs-env      = { workspace = true }
+cljrs-reader   = { workspace = true }
+cljrs-interp   = { workspace = true }
+cljrs-async    = { workspace = true }
+tokio          = { workspace = true, features = ["fs", "io-util"] }
+encoding_rs    = { workspace = true }

--- a/crates/cljrs-io/README.md
+++ b/crates/cljrs-io/README.md
@@ -62,6 +62,12 @@ helpers. Not yet covered (candidate follow-ups): a stateful `AsyncReader` handle
 with a cursor (`open` / `read-chunk!` / `seek`), append/options maps for `spit`,
 directory streaming, and transducer-equipped channels.
 
+The `cljrs` CLI wires this in automatically: with its default-on `async`
+feature it calls `cljrs_io::init` at startup and drives each top-level form on
+a shared `LocalSet`, so `clojure.rust.io.async` works from `cljrs repl`,
+`cljrs run`, and `cljrs eval`. Consume results with `(await (take! ...))` — the
+blocking `<!!`/`>!!` ops deadlock the single-threaded executor at the top level.
+
 ## File layout
 
 | File | Description |

--- a/crates/cljrs-io/README.md
+++ b/crates/cljrs-io/README.md
@@ -1,0 +1,115 @@
+# cljrs-io
+
+Asynchronous file I/O for clojurust — tokio-backed reads and writes whose
+results are delivered over `clojure.core.async` channels.
+
+**Phase:** runtime I/O (Phase 7+) — initial implementation.
+
+## Purpose
+
+Expose the host filesystem to Clojure code as a non-blocking, channel-oriented
+API. Every operation runs on the shared Tokio `LocalSet` executor (the same one
+`cljrs-async` drives) and returns a `clojure.core.async` channel, so file I/O
+composes with `go`, `<!`, `alts!`, and the rest of the async toolkit instead of
+blocking the interpreter thread.
+
+The crate reuses `cljrs-async`'s `CljChannel` rather than defining its own
+channel type, so the channels it returns are ordinary core.async channels.
+
+## Channel shape: raw vs. promise
+
+The API deliberately uses **two** channel shapes, chosen per operation — this is
+the recommendation that came out of the design discussion:
+
+- **Streaming reads → a raw channel.** `chunk-chan`, `byte-chan`, `char-chan`,
+  and `line-chan` return a channel *immediately* and spawn a producer task that
+  reads the file and puts a sequence of values onto it, closing it at EOF. The
+  channel's small buffer (`cap`, default 8) bounds how far the producer reads
+  ahead of the consumer, so a multi-gigabyte file is streamed, never slurped.
+  This is where channels earn their keep: a sequence + backpressure.
+
+- **Discrete request/response ops → a promise channel.** `slurp`, `slurp-bytes`,
+  `read-bytes`, and `spit` return a capacity-1 channel onto which the producer
+  delivers exactly one result before closing it. A single `(<! ...)` yields the
+  value; a second take yields `nil`. Returning a one-shot channel (rather than a
+  streaming one) signals "this resolves once" while staying uniformly
+  `<!`-able with everything else.
+
+A pure-`Future`/promise-only API was rejected because it forces re-calling for
+streamed data and provides no backpressure; a raw-channel-only API was rejected
+because it muddies the "resolves exactly once" contract of discrete ops.
+
+### Errors
+
+Failures are delivered **in band**: the producer puts a `Value::Error` (an
+exception value) on the channel and then closes it. Consumers distinguish
+results from failures with the `error?` helper:
+
+```clojure
+(require '[clojure.core.async :refer [<!!]]
+         '[clojure.rust.io.async :as aio])
+
+(let [result (<!! (aio/slurp "config.edn"))]
+  (if (aio/error? result)
+    (println "read failed:" (ex-message result))
+    (println result)))
+```
+
+## Status
+
+Implemented (initial): the eight builtins below plus the `error?`/`ok?` Clojure
+helpers. Not yet covered (candidate follow-ups): a stateful `AsyncReader` handle
+with a cursor (`open` / `read-chunk!` / `seek`), append/options maps for `spit`,
+directory streaming, and transducer-equipped channels.
+
+## File layout
+
+| File | Description |
+|---|---|
+| `src/lib.rs` | `init(globals)` entry point; registers builtins and loads the namespace; re-exports `charset` and `fs` modules. |
+| `src/fs.rs` | The native builtins (streaming + discrete) and their channel/value/argument helpers. |
+| `src/charset.rs` | Charset-label resolution via `encoding_rs` and the incremental `CharDecoder` used by `char-chan`/`line-chan`. |
+| `src/clojure_rust_io_async.cljrs` | Clojure-level helpers (`error?`, `ok?`) loaded at init. |
+
+## Public API (Rust)
+
+- `cljrs_io::init(globals: &Arc<GlobalEnv>)` — register and load the
+  `clojure.rust.io.async` namespace. Idempotent. Requires `cljrs_async::init`
+  and a running `LocalSet`.
+- `cljrs_io::NS: &str` — the namespace name, `"clojure.rust.io.async"`.
+- `fs::register(globals, ns)` — register only the native functions into `ns`.
+- `charset::resolve_charset(arg: Option<&Value>) -> ValueResult<&'static Encoding>`
+  — resolve a keyword/string charset label (default UTF-8).
+- `charset::CharDecoder` — incremental byte→`char` decoder (`new`, `push`,
+  `finish`).
+
+## Public API (Clojure — `clojure.rust.io.async`)
+
+Streaming reads (raw channel, closed at EOF):
+
+| Function | Yields |
+|---|---|
+| `(chunk-chan path [buf-size [cap]])` | `byte-array` chunks of up to `buf-size` bytes (default 8192). |
+| `(byte-chan path [cap])` | individual bytes as signed `long`s (-128..127). |
+| `(char-chan path [charset [cap]])` | characters decoded with `charset` (default `:utf-8`). |
+| `(line-chan path [charset [cap]])` | lines (without trailing `\n`/`\r\n`). |
+
+Discrete ops (promise channel — one value, then closed):
+
+| Function | Delivers |
+|---|---|
+| `(slurp path [charset])` | the whole file as a decoded string. |
+| `(slurp-bytes path)` | the whole file as a `byte-array`. |
+| `(read-bytes path n)` | a `byte-array` of up to the first `n` bytes. |
+| `(spit path data [charset])` | the number of bytes written (`data` is a string or `byte-array`). |
+
+Helpers: `(error? x)`, `(ok? x)`.
+
+`charset` is a keyword or string label resolved by `encoding_rs` (`:utf-8`,
+`:utf-16le`, `:iso-8859-1`, `:windows-1252`, `:shift_jis`, …).
+
+## Dependencies
+
+`cljrs-types`, `cljrs-gc`, `cljrs-value`, `cljrs-env`, `cljrs-reader`,
+`cljrs-interp`, `cljrs-async` (channels + `spawn_future`), `tokio` (with the
+`fs` and `io-util` features), and `encoding_rs`.

--- a/crates/cljrs-io/src/charset.rs
+++ b/crates/cljrs-io/src/charset.rs
@@ -1,0 +1,74 @@
+//! Charset resolution and streaming character decoding.
+//!
+//! The async character reader ([`crate::fs::builtin_char_chan`]) decodes a byte
+//! stream into a sequence of `char`s using a caller-supplied charset. Charset
+//! labels are resolved through [`encoding_rs`] — the WHATWG-standard, pure-Rust
+//! decoder — so any label it recognises (`utf-8`, `utf-16le`, `iso-8859-1`,
+//! `windows-1252`, `shift_jis`, …) is accepted, given as either a Clojure
+//! keyword (`:utf-8`) or string (`"utf-8"`). A missing/`nil` charset is UTF-8.
+
+use encoding_rs::{Decoder, Encoding};
+
+use cljrs_value::{Value, ValueError, ValueResult};
+
+/// Resolve an optional charset argument to an [`Encoding`].
+///
+/// Accepts a keyword or string label; `None`/`nil` defaults to UTF-8. Returns a
+/// `WrongType`/`Other` error for non-label values or labels `encoding_rs` does
+/// not recognise.
+pub fn resolve_charset(arg: Option<&Value>) -> ValueResult<&'static Encoding> {
+    let label = match arg {
+        None | Some(Value::Nil) => return Ok(encoding_rs::UTF_8),
+        Some(Value::Keyword(k)) => k.get().name.as_ref().to_string(),
+        Some(Value::Str(s)) => s.get().clone(),
+        Some(other) => {
+            return Err(ValueError::WrongType {
+                expected: "charset keyword or string",
+                got: other.type_name().to_string(),
+            });
+        }
+    };
+    Encoding::for_label(label.as_bytes())
+        .ok_or_else(|| ValueError::Other(format!("unknown charset: {label}")))
+}
+
+/// An incremental byte-to-`char` decoder wrapping an [`encoding_rs::Decoder`].
+///
+/// Bytes are fed one chunk at a time via [`Self::push`]; the trailing partial
+/// code unit (if any) is buffered inside the decoder and completed by the next
+/// chunk or flushed by [`Self::finish`]. Malformed input is replaced with the
+/// Unicode replacement character (U+FFFD), matching `encoding_rs`'s
+/// non-fatal decode contract.
+pub struct CharDecoder {
+    decoder: Decoder,
+}
+
+impl CharDecoder {
+    pub fn new(encoding: &'static Encoding) -> Self {
+        Self {
+            decoder: encoding.new_decoder(),
+        }
+    }
+
+    /// Decode `src` (a non-final chunk), returning the text produced so far.
+    pub fn push(&mut self, src: &[u8]) -> String {
+        self.decode(src, false)
+    }
+
+    /// Flush any buffered trailing bytes at end-of-stream.
+    pub fn finish(&mut self) -> String {
+        self.decode(&[], true)
+    }
+
+    fn decode(&mut self, src: &[u8], last: bool) -> String {
+        // `max_utf8_buffer_length` sizes `out` so a single `decode_to_string`
+        // call consumes all of `src`, so no re-loop is required.
+        let cap = self
+            .decoder
+            .max_utf8_buffer_length(src.len())
+            .unwrap_or(src.len().saturating_mul(4));
+        let mut out = String::with_capacity(cap);
+        let _ = self.decoder.decode_to_string(src, &mut out, last);
+        out
+    }
+}

--- a/crates/cljrs-io/src/clojure_rust_io_async.cljrs
+++ b/crates/cljrs-io/src/clojure_rust_io_async.cljrs
@@ -1,0 +1,17 @@
+;; clojure.rust.io.async — Clojure-level helpers over the native async I/O
+;; primitives. The reading/writing functions themselves (chunk-chan, byte-chan,
+;; char-chan, line-chan, slurp, slurp-bytes, read-bytes, spit) are registered
+;; natively by cljrs-io; this file adds small conveniences on top.
+
+;; Results are delivered on core.async channels. A failed I/O step delivers an
+;; error value (an exception) on the channel instead of a normal result; use
+;; `error?` to distinguish the two after taking a value.
+(defn error?
+  "True if x is an I/O error value delivered on a result channel."
+  [x]
+  (instance? Exception x))
+
+(defn ok?
+  "True if x is a non-error, non-nil result value."
+  [x]
+  (and (some? x) (not (error? x))))

--- a/crates/cljrs-io/src/fs.rs
+++ b/crates/cljrs-io/src/fs.rs
@@ -1,0 +1,434 @@
+//! Native async file-I/O builtins for `clojure.rust.io.async`.
+//!
+//! Two delivery shapes, picked per operation (see the crate README for the
+//! rationale):
+//!
+//! - **Streaming reads** — `chunk-chan`, `byte-chan`, `char-chan`, `line-chan`
+//!   return a `core.async` channel *immediately* and spawn a producer task that
+//!   reads the file and puts a sequence of values onto the channel, closing it
+//!   at EOF. The channel's small buffer provides backpressure, so the producer
+//!   only reads as far ahead as the consumer takes — large files never need to
+//!   fit in memory.
+//!
+//! - **Discrete ops** — `slurp`, `slurp-bytes`, `read-bytes`, `spit` return a
+//!   *promise channel* (capacity 1): the producer delivers exactly one result
+//!   and closes the channel, so a single `(<! ...)` yields the value.
+//!
+//! Failures are delivered in-band as a `Value::Error` value (constructed by
+//! [`io_error`]) on the same channel, then the channel is closed. Consumers can
+//! test results with the `error?` helper in the namespace's Clojure source.
+//!
+//! All channels are ordinary `cljrs-async` [`CljChannel`]s, so the full
+//! `clojure.core.async` API (`<!`, `<!!`, `alts!`, `go`, …) operates on them.
+
+use std::sync::{Arc, Mutex};
+
+use tokio::io::AsyncReadExt;
+
+use cljrs_async::channel::CljChannel;
+use cljrs_async::spawn_future;
+use cljrs_env::env::GlobalEnv;
+use cljrs_gc::GcPtr;
+use cljrs_value::{
+    Arity, ExceptionInfo, NativeFn, NativeObjectBox, Value, ValueError, ValueResult,
+    gc_native_object,
+};
+
+use crate::charset::{CharDecoder, resolve_charset};
+
+/// Default read buffer for `chunk-chan` / `byte-chan` / decoded streams.
+const DEFAULT_BUF: usize = 8192;
+/// Default backpressure buffer for streaming channels: the producer may read at
+/// most this many values ahead of the consumer.
+const DEFAULT_STREAM_CAP: usize = 8;
+
+/// Signature shared by every native builtin in this crate.
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+/// Register the async I/O native functions into the given namespace.
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        // Streaming reads (raw channels).
+        ("chunk-chan", Arity::Variadic { min: 1 }, builtin_chunk_chan),
+        ("byte-chan", Arity::Variadic { min: 1 }, builtin_byte_chan),
+        ("char-chan", Arity::Variadic { min: 1 }, builtin_char_chan),
+        ("line-chan", Arity::Variadic { min: 1 }, builtin_line_chan),
+        // Discrete ops (promise channels).
+        ("slurp", Arity::Variadic { min: 1 }, builtin_slurp),
+        ("slurp-bytes", Arity::Fixed(1), builtin_slurp_bytes),
+        ("read-bytes", Arity::Fixed(2), builtin_read_bytes),
+        ("spit", Arity::Variadic { min: 2 }, builtin_spit),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── Value/channel helpers ─────────────────────────────────────────────────────
+
+/// Create a fresh `core.async` channel and return its `GcPtr` handle.
+fn make_chan(capacity: usize) -> GcPtr<NativeObjectBox> {
+    gc_native_object(CljChannel::new(capacity))
+}
+
+/// Borrow the `CljChannel` out of a channel native object.
+fn chan_ref(obj: &NativeObjectBox) -> &CljChannel {
+    obj.downcast_ref::<CljChannel>()
+        .expect("io channel native object holds a CljChannel")
+}
+
+/// Wrap raw bytes as a Clojure `byte-array` (`Value::ByteArray`, signed `i8`s).
+fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+/// Build an in-band error value to put on a channel when an I/O step fails.
+fn io_error(msg: impl Into<String>) -> Value {
+    let msg = msg.into();
+    Value::Error(GcPtr::new(ExceptionInfo::new(
+        ValueError::Other(msg.clone()),
+        msg,
+        None,
+        None,
+    )))
+}
+
+/// Put `v` onto `ch`, yielding until accepted (ignoring a closed consumer).
+async fn put(ch: &GcPtr<NativeObjectBox>, v: Value) -> bool {
+    chan_ref(ch.get()).put(v).await
+}
+
+/// Deliver a single result on a promise channel, then close it.
+async fn deliver(ch: &GcPtr<NativeObjectBox>, v: Value) {
+    let _ = chan_ref(ch.get()).put(v).await;
+    chan_ref(ch.get()).close();
+}
+
+// ── Argument parsing ──────────────────────────────────────────────────────────
+
+fn str_arg(args: &[Value], idx: usize, expected: &'static str) -> ValueResult<String> {
+    match args.get(idx) {
+        Some(Value::Str(s)) => Ok(s.get().clone()),
+        other => Err(ValueError::WrongType {
+            expected,
+            got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+        }),
+    }
+}
+
+/// Read an optional positive-`usize` argument (e.g. buffer/capacity), clamping
+/// to at least 1 and falling back to `default` when absent/`nil`.
+fn size_arg_or(args: &[Value], idx: usize, default: usize) -> ValueResult<usize> {
+    match args.get(idx) {
+        None | Some(Value::Nil) => Ok(default),
+        Some(Value::Long(n)) if *n >= 0 => Ok((*n as usize).max(1)),
+        Some(other) => Err(ValueError::WrongType {
+            expected: "non-negative long",
+            got: other.type_name().to_string(),
+        }),
+    }
+}
+
+// ── Streaming reads ───────────────────────────────────────────────────────────
+
+/// `(chunk-chan path)` / `(chunk-chan path buf-size)` /
+/// `(chunk-chan path buf-size cap)` — a channel of `byte-array` chunks of up to
+/// `buf-size` bytes (default 8192), closed at EOF. `cap` sets the channel's
+/// backpressure buffer (default 8).
+fn builtin_chunk_chan(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let buf_size = size_arg_or(args, 1, DEFAULT_BUF)?;
+    let cap = size_arg_or(args, 2, DEFAULT_STREAM_CAP)?;
+    let ch = make_chan(cap);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let mut file = match tokio::fs::File::open(&path).await {
+            Ok(f) => f,
+            Err(e) => {
+                put(&ch, io_error(format!("cannot open {path}: {e}"))).await;
+                chan_ref(ch.get()).close();
+                return Ok(Value::Nil);
+            }
+        };
+        let mut buf = vec![0u8; buf_size];
+        loop {
+            match file.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    if !put(&ch, bytes_value(&buf[..n])).await {
+                        break; // consumer closed the channel
+                    }
+                }
+                Err(e) => {
+                    put(&ch, io_error(format!("read error on {path}: {e}"))).await;
+                    break;
+                }
+            }
+        }
+        chan_ref(ch.get()).close();
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}
+
+/// `(byte-chan path)` / `(byte-chan path cap)` — a channel of individual bytes
+/// as signed `long`s (-128..127, matching `byte-array`/`aget` semantics),
+/// closed at EOF.
+fn builtin_byte_chan(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let cap = size_arg_or(args, 1, DEFAULT_STREAM_CAP)?;
+    let ch = make_chan(cap);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let mut file = match tokio::fs::File::open(&path).await {
+            Ok(f) => f,
+            Err(e) => {
+                put(&ch, io_error(format!("cannot open {path}: {e}"))).await;
+                chan_ref(ch.get()).close();
+                return Ok(Value::Nil);
+            }
+        };
+        let mut buf = vec![0u8; DEFAULT_BUF];
+        'outer: loop {
+            match file.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    for &b in &buf[..n] {
+                        if !put(&ch, Value::Long((b as i8) as i64)).await {
+                            break 'outer;
+                        }
+                    }
+                }
+                Err(e) => {
+                    put(&ch, io_error(format!("read error on {path}: {e}"))).await;
+                    break;
+                }
+            }
+        }
+        chan_ref(ch.get()).close();
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}
+
+/// `(char-chan path)` / `(char-chan path charset)` /
+/// `(char-chan path charset cap)` — a channel of characters decoded from the
+/// file with `charset` (default `:utf-8`), closed at EOF.
+fn builtin_char_chan(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let encoding = resolve_charset(args.get(1))?;
+    let cap = size_arg_or(args, 2, DEFAULT_STREAM_CAP)?;
+    let ch = make_chan(cap);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let mut file = match tokio::fs::File::open(&path).await {
+            Ok(f) => f,
+            Err(e) => {
+                put(&ch, io_error(format!("cannot open {path}: {e}"))).await;
+                chan_ref(ch.get()).close();
+                return Ok(Value::Nil);
+            }
+        };
+        let mut decoder = CharDecoder::new(encoding);
+        let mut buf = vec![0u8; DEFAULT_BUF];
+        'outer: loop {
+            match file.read(&mut buf).await {
+                Ok(0) => {
+                    for c in decoder.finish().chars() {
+                        let _ = put(&ch, Value::Char(c)).await;
+                    }
+                    break;
+                }
+                Ok(n) => {
+                    for c in decoder.push(&buf[..n]).chars() {
+                        if !put(&ch, Value::Char(c)).await {
+                            break 'outer;
+                        }
+                    }
+                }
+                Err(e) => {
+                    put(&ch, io_error(format!("read error on {path}: {e}"))).await;
+                    break;
+                }
+            }
+        }
+        chan_ref(ch.get()).close();
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}
+
+/// `(line-chan path)` / `(line-chan path charset)` /
+/// `(line-chan path charset cap)` — a channel of lines (without their trailing
+/// `\n`/`\r\n`) decoded from the file with `charset` (default `:utf-8`), closed
+/// at EOF.
+fn builtin_line_chan(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let encoding = resolve_charset(args.get(1))?;
+    let cap = size_arg_or(args, 2, DEFAULT_STREAM_CAP)?;
+    let ch = make_chan(cap);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let mut file = match tokio::fs::File::open(&path).await {
+            Ok(f) => f,
+            Err(e) => {
+                put(&ch, io_error(format!("cannot open {path}: {e}"))).await;
+                chan_ref(ch.get()).close();
+                return Ok(Value::Nil);
+            }
+        };
+        let mut decoder = CharDecoder::new(encoding);
+        let mut pending = String::new();
+        let mut buf = vec![0u8; DEFAULT_BUF];
+        'outer: loop {
+            let (text, eof) = match file.read(&mut buf).await {
+                Ok(0) => (decoder.finish(), true),
+                Ok(n) => (decoder.push(&buf[..n]), false),
+                Err(e) => {
+                    put(&ch, io_error(format!("read error on {path}: {e}"))).await;
+                    break;
+                }
+            };
+            pending.push_str(&text);
+            while let Some(idx) = pending.find('\n') {
+                let mut line = pending[..idx].to_string();
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+                pending.replace_range(..=idx, "");
+                if !put(&ch, Value::string(line)).await {
+                    break 'outer;
+                }
+            }
+            if eof {
+                if !pending.is_empty() {
+                    let _ = put(&ch, Value::string(std::mem::take(&mut pending))).await;
+                }
+                break;
+            }
+        }
+        chan_ref(ch.get()).close();
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}
+
+// ── Discrete ops (promise channels) ───────────────────────────────────────────
+
+/// `(slurp path)` / `(slurp path charset)` — a promise channel delivering the
+/// whole file decoded to a string with `charset` (default `:utf-8`).
+fn builtin_slurp(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let encoding = resolve_charset(args.get(1))?;
+    let ch = make_chan(1);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let result = match tokio::fs::read(&path).await {
+            Ok(bytes) => {
+                let (text, _, _) = encoding.decode(&bytes);
+                Value::string(text.into_owned())
+            }
+            Err(e) => io_error(format!("cannot read {path}: {e}")),
+        };
+        deliver(&ch, result).await;
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}
+
+/// `(slurp-bytes path)` — a promise channel delivering the whole file as a
+/// `byte-array`.
+fn builtin_slurp_bytes(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let ch = make_chan(1);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let result = match tokio::fs::read(&path).await {
+            Ok(bytes) => bytes_value(&bytes),
+            Err(e) => io_error(format!("cannot read {path}: {e}")),
+        };
+        deliver(&ch, result).await;
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}
+
+/// `(read-bytes path n)` — a promise channel delivering a `byte-array` of up to
+/// the first `n` bytes of the file (fewer if the file is shorter).
+fn builtin_read_bytes(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let n = match args.get(1) {
+        Some(Value::Long(n)) if *n >= 0 => *n as usize,
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "non-negative long (byte count)",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let ch = make_chan(1);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let result = read_n_bytes(&path, n).await;
+        deliver(&ch, result).await;
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}
+
+/// Read up to `n` bytes from `path`, returning a `byte-array` value or an error
+/// value.
+async fn read_n_bytes(path: &str, n: usize) -> Value {
+    let mut file = match tokio::fs::File::open(path).await {
+        Ok(f) => f,
+        Err(e) => return io_error(format!("cannot open {path}: {e}")),
+    };
+    let mut out: Vec<u8> = Vec::with_capacity(n);
+    let mut buf = vec![0u8; n.clamp(1, DEFAULT_BUF)];
+    while out.len() < n {
+        let want = buf.len().min(n - out.len());
+        match file.read(&mut buf[..want]).await {
+            Ok(0) => break,
+            Ok(m) => out.extend_from_slice(&buf[..m]),
+            Err(e) => return io_error(format!("read error on {path}: {e}")),
+        }
+    }
+    bytes_value(&out)
+}
+
+/// `(spit path data)` / `(spit path data charset)` — write `data` (a string or
+/// `byte-array`) to `path`, truncating any existing contents. Returns a promise
+/// channel delivering the number of bytes written. Strings are encoded with
+/// `charset` (default `:utf-8`).
+fn builtin_spit(args: &[Value]) -> ValueResult<Value> {
+    let path = str_arg(args, 0, "string (path)")?;
+    let encoding = resolve_charset(args.get(2))?;
+    // Materialise the bytes synchronously so no `Value`/`GcPtr` crosses into the
+    // spawned task (the produced `Vec<u8>` is plain data).
+    let bytes: Vec<u8> = match args.get(1) {
+        Some(Value::Str(s)) => {
+            let (encoded, _, _) = encoding.encode(s.get());
+            encoded.into_owned()
+        }
+        Some(Value::ByteArray(a)) => a.get().lock().unwrap().iter().map(|&b| b as u8).collect(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "string or byte-array (data)",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let ch = make_chan(1);
+    let ch_val = Value::NativeObject(ch.clone());
+    spawn_future(async move {
+        let result = match tokio::fs::write(&path, &bytes).await {
+            Ok(()) => Value::Long(bytes.len() as i64),
+            Err(e) => io_error(format!("cannot write {path}: {e}")),
+        };
+        deliver(&ch, result).await;
+        Ok(Value::Nil)
+    });
+    Ok(ch_val)
+}

--- a/crates/cljrs-io/src/lib.rs
+++ b/crates/cljrs-io/src/lib.rs
@@ -1,0 +1,76 @@
+//! Asynchronous file I/O for clojurust — `clojure.rust.io.async`.
+//!
+//! Tokio-backed file reads and writes whose results are delivered over
+//! `clojure.core.async` channels. The crate offers two complementary shapes:
+//!
+//! - **Streaming reads** return a *raw channel* that yields a sequence of values
+//!   and closes at EOF (`chunk-chan`, `byte-chan`, `char-chan`, `line-chan`).
+//!   The channel's buffer bounds read-ahead, giving natural backpressure for
+//!   large files.
+//! - **Discrete ops** return a *promise channel* (capacity 1) that delivers a
+//!   single result and closes (`slurp`, `slurp-bytes`, `read-bytes`, `spit`).
+//!
+//! Both shapes are built on `cljrs-async` [`CljChannel`]s, so the whole
+//! `clojure.core.async` API operates on them uniformly. See the crate README
+//! for the design rationale behind the raw-vs-promise split.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! let globals = cljrs_stdlib::standard_env();
+//! cljrs_async::init(&globals); // channels + executor (required)
+//! cljrs_io::init(&globals);    // async file I/O
+//! ```
+//!
+//! Like `cljrs-async`, the spawned producer tasks require a Tokio
+//! `current_thread` + `LocalSet` executor running on the calling thread.
+//!
+//! [`CljChannel`]: cljrs_async::channel::CljChannel
+
+use std::sync::Arc;
+
+pub mod charset;
+pub mod fs;
+
+use cljrs_env::env::GlobalEnv;
+
+/// Clojure-level helpers (`error?`, `ok?`) loaded on top of the native
+/// primitives at `init` time.
+const IO_ASYNC_SOURCE: &str = include_str!("clojure_rust_io_async.cljrs");
+
+/// The namespace this crate populates.
+pub const NS: &str = "clojure.rust.io.async";
+
+/// Register the async I/O native functions and load the
+/// `clojure.rust.io.async` namespace.
+///
+/// Requires the async runtime (`cljrs_async::init`) for channel consumption and
+/// a running `LocalSet` for the producer tasks. Idempotent: the namespace is
+/// built only once.
+pub fn init(globals: &Arc<GlobalEnv>) {
+    if globals.is_loaded(NS) {
+        return;
+    }
+
+    globals.get_or_create_ns(NS);
+    globals.refer_all(NS, "clojure.core");
+    fs::register(globals, NS);
+
+    let mut env = cljrs_env::env::Env::new(globals.clone(), NS);
+    let mut parser = cljrs_reader::Parser::new(
+        IO_ASYNC_SOURCE.to_string(),
+        "<clojure.rust.io.async>".into(),
+    );
+    match parser.parse_all() {
+        Ok(forms) => {
+            for form in forms {
+                let _alloc_frame = cljrs_gc::push_alloc_frame();
+                if let Err(e) = cljrs_interp::eval::eval(&form, &mut env) {
+                    eprintln!("[clojure.rust.io.async warning] {e:?}");
+                }
+            }
+        }
+        Err(e) => eprintln!("[clojure.rust.io.async parse error] {e:?}"),
+    }
+    globals.mark_loaded(NS);
+}

--- a/crates/cljrs-io/tests/io_async.rs
+++ b/crates/cljrs-io/tests/io_async.rs
@@ -101,15 +101,21 @@ fn char_chan_streams_then_closes() {
             &mut env,
         );
         for expected in ['a', 'b', 'c'] {
-            let c = eval_async(&parse_one("(await (clojure.core.async/take! ch))"), &mut env)
-                .await
-                .unwrap();
+            let c = eval_async(
+                &parse_one("(await (clojure.core.async/take! ch))"),
+                &mut env,
+            )
+            .await
+            .unwrap();
             assert_eq!(c, Value::Char(expected));
         }
         // Channel closes at EOF: the next take yields nil.
-        let end = eval_async(&parse_one("(await (clojure.core.async/take! ch))"), &mut env)
-            .await
-            .unwrap();
+        let end = eval_async(
+            &parse_one("(await (clojure.core.async/take! ch))"),
+            &mut env,
+        )
+        .await
+        .unwrap();
         assert_eq!(end, Value::Nil);
     });
     let _ = std::fs::remove_file(&cleanup);

--- a/crates/cljrs-io/tests/io_async.rs
+++ b/crates/cljrs-io/tests/io_async.rs
@@ -1,0 +1,138 @@
+//! Integration tests for `clojure.rust.io.async`: round-tripping writes/reads
+//! and streaming a file's characters, all driven on a current-thread LocalSet.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use cljrs_async::eval_async::eval_async;
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+/// Standard env with both the async runtime and async I/O registered.
+fn io_env() -> Arc<GlobalEnv> {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    cljrs_async::init(&globals);
+    cljrs_io::init(&globals);
+    globals
+}
+
+fn parse_one(src: &str) -> cljrs_reader::Form {
+    let mut p = Parser::new(src.to_string(), "<test>".to_string());
+    p.parse_all()
+        .expect("parse error")
+        .into_iter()
+        .next()
+        .expect("no form")
+}
+
+fn eval_sync(src: &str, env: &mut Env) -> Value {
+    let mut p = Parser::new(src.to_string(), "<test>".to_string());
+    let mut result = Value::Nil;
+    for form in p.parse_all().expect("parse error") {
+        result = cljrs_interp::eval::eval(&form, env).expect("eval error");
+    }
+    result
+}
+
+fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("build runtime");
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, f)
+}
+
+/// A unique temp path so concurrent test runs don't collide.
+fn temp_path(tag: &str) -> String {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!("cljrs-io-{}-{}-{}.tmp", tag, std::process::id(), n));
+    p.to_string_lossy().into_owned()
+}
+
+#[test]
+fn spit_then_slurp_round_trip() {
+    let globals = io_env();
+    let path = temp_path("roundtrip");
+    let cleanup = path.clone();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+
+        // spit delivers the number of bytes written on its promise channel.
+        let written = eval_async(
+            &parse_one(&format!(
+                "(await (clojure.core.async/take! \
+                   (clojure.rust.io.async/spit \"{path}\" \"hello, world\")))"
+            )),
+            &mut env,
+        )
+        .await
+        .unwrap();
+        assert_eq!(written, Value::Long(12));
+
+        // slurp reads it back as a string on its promise channel.
+        let read = eval_async(
+            &parse_one(&format!(
+                "(await (clojure.core.async/take! \
+                   (clojure.rust.io.async/slurp \"{path}\")))"
+            )),
+            &mut env,
+        )
+        .await
+        .unwrap();
+        assert_eq!(read, Value::string("hello, world"));
+    });
+    let _ = std::fs::remove_file(&cleanup);
+}
+
+#[test]
+fn char_chan_streams_then_closes() {
+    let globals = io_env();
+    let path = temp_path("chars");
+    std::fs::write(&path, "abc").unwrap();
+    let cleanup = path.clone();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(
+            &format!("(def ch (clojure.rust.io.async/char-chan \"{path}\"))"),
+            &mut env,
+        );
+        for expected in ['a', 'b', 'c'] {
+            let c = eval_async(&parse_one("(await (clojure.core.async/take! ch))"), &mut env)
+                .await
+                .unwrap();
+            assert_eq!(c, Value::Char(expected));
+        }
+        // Channel closes at EOF: the next take yields nil.
+        let end = eval_async(&parse_one("(await (clojure.core.async/take! ch))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(end, Value::Nil);
+    });
+    let _ = std::fs::remove_file(&cleanup);
+}
+
+#[test]
+fn read_bytes_returns_prefix_byte_array() {
+    let globals = io_env();
+    let path = temp_path("prefix");
+    std::fs::write(&path, "hello").unwrap();
+    let cleanup = path.clone();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        let len = eval_async(
+            &parse_one(&format!(
+                "(alength (await (clojure.core.async/take! \
+                   (clojure.rust.io.async/read-bytes \"{path}\" 3))))"
+            )),
+            &mut env,
+        )
+        .await
+        .unwrap();
+        assert_eq!(len, Value::Long(3));
+    });
+    let _ = std::fs::remove_file(&cleanup);
+}

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -18,7 +18,7 @@ no-gc = [
     "cljrs-stdlib/no-gc",
 ]
 enable-rustyline = ["rustyline"]
-async = ["dep:cljrs-async", "dep:tokio"]
+async = ["dep:cljrs-async", "dep:cljrs-io", "dep:tokio"]
 
 [[bin]]
 name = "cljrs"
@@ -45,4 +45,5 @@ tracing = "0.1.44"
 rustyline   = { workspace = true, optional = true }
 libloading  = { workspace = true }
 cljrs-async = { workspace = true, optional = true }
+cljrs-io    = { workspace = true, optional = true }
 tokio       = { workspace = true, optional = true }

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -142,6 +142,7 @@ cljrs deps status              # show cached vs missing deps
 
 | Feature             | Effect                                                                        |
 |---------------------|-------------------------------------------------------------------------------|
+| `async` (default **on**) | Pulls in `cljrs-async` and `cljrs-io` and builds the Tokio runtime that drives top-level async evaluation (see implementation notes). Without it, `^:async`/`core.async`/`clojure.rust.io.async` are unavailable and evaluation is purely synchronous. |
 | `no-gc` (default off) | Propagated to `cljrs-gc`/`cljrs-value`/`cljrs-eval`/`cljrs-compiler`/`cljrs-runtime`/`cljrs-stdlib`.  Disables the tracing GC; only region-allocated and stack values are permitted.  Compiles fail (`AotError::NoGcBlacklist`) if the program contains allocations the optimizer can't lift onto regions. |
 | `enable-rustyline`  | Pulls in `rustyline` for a line-editing REPL.  Without it, `cljrs repl` falls back to a plain `BufRead` loop.                                                                                |
 
@@ -155,6 +156,7 @@ Build with e.g. `cargo build --release --features enable-rustyline,no-gc`.
 - The miette error hook is installed at startup so `CljxError` propagated to `main` renders with terminal-linked source snippets.
 - A worker thread is spawned with the configured stack size to run the actual command; the main thread only handles signal/exit setup.
 - The REPL prints results, paginates errors via `miette`, and persists multi-line input across blank prompts.
+- **Top-level async (with the `async` feature).** `main` builds a single-threaded Tokio runtime + `LocalSet` and stashes it in a thread-local `AsyncDriver` rather than wrapping the whole session in one `block_on`. Each top-level form is then evaluated through `cljrs_async::eval_async` via `LocalSet::block_on` in `eval_form`, so spawned tasks (core.async producers, `^:async` calls, `clojure.rust.io.async` readers/writers) make progress and a top-level `await` resolves. Tasks that outlive a form — e.g. a channel `def`d at one REPL prompt and consumed at the next — stay queued on the shared `LocalSet` and continue on the next form's drive. Note: blocking ops (`<!!`/`>!!`) still park the single executor thread and so are not usable at the top level; use `(await (take! ch))` / `go` instead.
 - `ir-viz` runs the AOT pipeline through region optimization (via `cljrs_compiler::aot::lower_file_to_ir`) and hands the resulting `IrFunction` to `cljrs_ir_viz::render_html`.
 
 ---
@@ -173,6 +175,9 @@ Build with e.g. `cargo build --release --features enable-rustyline,no-gc`.
 | `cljrs-compiler` (workspace)| AOT pipeline (`compile_file`, `compile_test_harness`, `lower_file_to_ir`) |
 | `cljrs-ir-viz` (workspace)  | HTML IR visualizer used by `ir-viz`                                |
 | `cljrs-interop` (workspace) | Rust ↔ Clojure FFI                                                |
+| `cljrs-async` (workspace, optional) | `clojure.core.async` runtime + `eval_async`; enabled by `async`  |
+| `cljrs-io` (workspace, optional) | `clojure.rust.io.async` async file I/O; enabled by `async`       |
+| `tokio` (workspace, optional) | Single-threaded runtime + `LocalSet` driving async; enabled by `async` |
 | `cljrs-logging` (workspace) | `--debug` / `--trace` / `-X` flag handling                        |
 | `cljrs-deps` (workspace)    | `cljrs.edn` parser; `DepsConfig` / `Dependency` types             |
 | `cljrs-vcs` (workspace)     | Git subprocess helpers: `fetch_remote`, `cache_path_for_url`      |

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -461,7 +461,10 @@ fn setup_globals(
         apply_deps_config(&globals, &cwd);
     }
     #[cfg(feature = "async")]
-    cljrs_async::init(&globals);
+    {
+        cljrs_async::init(&globals);
+        cljrs_io::init(&globals);
+    }
     globals
 }
 

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -252,12 +252,23 @@ fn main() -> miette::Result<()> {
         .spawn(move || {
             #[cfg(feature = "async")]
             {
+                // Build the single-threaded runtime + LocalSet that every async
+                // task (core.async producers, ^:async calls, cljrs-io readers)
+                // runs on, and stash it so `eval_in` can drive each top-level
+                // form on it. We deliberately do *not* wrap `run` in a single
+                // `block_on`/`run_until`: top-level evaluation is synchronous
+                // (it reads stdin, dispatches commands), and each form is driven
+                // individually via `LocalSet::block_on`, which would panic if
+                // nested inside an outer `block_on`.
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
                     .expect("failed to build Tokio runtime");
                 let local = tokio::task::LocalSet::new();
-                rt.block_on(local.run_until(async move { run(cli) }))
+                ASYNC_DRIVER.with(|d| *d.borrow_mut() = Some(AsyncDriver { rt, local }));
+                let result = run(cli);
+                ASYNC_DRIVER.with(|d| *d.borrow_mut() = None);
+                result
             }
             #[cfg(not(feature = "async"))]
             run(cli)
@@ -460,11 +471,22 @@ fn setup_globals(
     if let Ok(cwd) = std::env::current_dir() {
         apply_deps_config(&globals, &cwd);
     }
+    // Initialise async inside the LocalSet so `cljrs_async::init` can spawn its
+    // background GC-service task (it calls `spawn_local`, which requires a
+    // LocalSet context). The task persists on the LocalSet and is serviced by
+    // each subsequent per-form drive in `eval_form`.
     #[cfg(feature = "async")]
-    {
-        cljrs_async::init(&globals);
-        cljrs_io::init(&globals);
-    }
+    ASYNC_DRIVER.with(|d| {
+        let guard = d.borrow();
+        let init = |g: &Arc<GlobalEnv>| {
+            cljrs_async::init(g);
+            cljrs_io::init(g);
+        };
+        match guard.as_ref() {
+            Some(drv) => drv.local.block_on(&drv.rt, async { init(&globals) }),
+            None => init(&globals),
+        }
+    });
     globals
 }
 
@@ -562,9 +584,54 @@ fn eval_in(env: &mut Env, src: &str, filename: &str) -> miette::Result<Value> {
     let mut result = Value::Nil;
     for form in forms {
         let _alloc_frame = cljrs_gc::push_alloc_frame();
-        result = eval(&form, env).map_err(format_eval_error)?;
+        result = eval_form(&form, env).map_err(format_eval_error)?;
     }
     Ok(result)
+}
+
+/// The Tokio runtime + `LocalSet` that drive async evaluation, set up once in
+/// `main` and reused for the lifetime of the process.
+#[cfg(feature = "async")]
+struct AsyncDriver {
+    rt: tokio::runtime::Runtime,
+    local: tokio::task::LocalSet,
+}
+
+#[cfg(feature = "async")]
+thread_local! {
+    static ASYNC_DRIVER: std::cell::RefCell<Option<AsyncDriver>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Evaluate a single top-level form.
+///
+/// With the `async` feature, the form is driven on the shared `LocalSet` via
+/// [`tokio::task::LocalSet::block_on`], so spawned tasks — core.async channel
+/// producers, `^:async` calls, the `cljrs-io` readers/writers — make progress
+/// and a top-level `await` resolves. Tasks that outlive a form (e.g. a producer
+/// feeding a channel `def`d in one REPL line and consumed in the next) stay
+/// queued on the `LocalSet` and continue on the next form's drive. Without the
+/// feature it is a plain synchronous `eval`.
+#[cfg(feature = "async")]
+#[allow(clippy::result_large_err)]
+fn eval_form(form: &cljrs_reader::Form, env: &mut Env) -> Result<Value, EvalError> {
+    ASYNC_DRIVER.with(|d| {
+        let guard = d.borrow();
+        match guard.as_ref() {
+            Some(drv) => drv
+                .local
+                .block_on(&drv.rt, cljrs_async::eval_async::eval_async(form, env)),
+            // No driver installed (shouldn't happen once `main` runs): fall back
+            // to a synchronous evaluation rather than panicking.
+            None => eval(form, env),
+        }
+    })
+}
+
+#[cfg(not(feature = "async"))]
+#[allow(clippy::result_large_err)]
+fn eval_form(form: &cljrs_reader::Form, env: &mut Env) -> Result<Value, EvalError> {
+    eval(form, env)
 }
 
 fn format_eval_error(e: EvalError) -> miette::Report {


### PR DESCRIPTION
Introduce `cljrs-io`, exposing tokio-backed file I/O to Clojure as a
non-blocking, channel-oriented API in the `clojure.rust.io.async`
namespace. Results are delivered over `clojure.core.async` channels using
two shapes, chosen per operation:

- Streaming reads return a raw channel that yields a sequence and closes at
  EOF, with the channel buffer providing backpressure: `chunk-chan`
  (byte-array chunks of a given buffer size), `byte-chan` (individual
  bytes), `char-chan` (characters decoded with a charset), `line-chan`.
- Discrete ops return a single-value promise channel: `slurp`,
  `slurp-bytes`, `read-bytes`, `spit`.

Charsets are resolved via encoding_rs (UTF-8 default); I/O failures are
delivered in-band as exception values, distinguished with `error?`/`ok?`.

Channels reuse cljrs-async's CljChannel rather than a new type, so the full
core.async API operates on them. To support that, expose a public
`CljChannel::put`/`close` and make `spawn_future` public; `put!` is
refactored to use the shared put helper.

Includes integration tests (spit/slurp round-trip, char streaming, prefix
reads) and a crate README.