### PR TITLE
docs(book): add Async & I/O sections (core.async, async I/O)

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -22,6 +22,12 @@
 - [Differences from Clojure](language/differences.md)
 - [New built-in functions](language/builtins.md)
 
+# Async & I/O
+
+- [Overview](async-io/index.md)
+- [core.async](async-io/async.md)
+- [Asynchronous I/O](async-io/io.md)
+
 # Rust Interop
 
 - [Overview](rust-interop/index.md)

--- a/docs/book/src/async-io/async.md
+++ b/docs/book/src/async-io/async.md
@@ -1,0 +1,202 @@
+# core.async
+
+The `clojure.core.async` namespace provides CSP-style concurrency — channels,
+`go` blocks, and the `^:async`/`await` function model — implemented on a Tokio
+`current_thread` runtime and `LocalSet`. It is provided by the `cljrs-async`
+crate and loaded automatically by the `cljrs` CLI.
+
+```clojure
+(require '[clojure.core.async :refer [chan go take! put! close! timeout alts]])
+```
+
+## The execution model
+
+All async tasks cooperate on a **single executor thread**. This is a deliberate
+choice: Clojure values are managed by a tracing GC whose pointers are `!Send`,
+so they cannot be moved between threads. Running every async task on one thread
+via `LocalSet` keeps those pointers sound and keeps garbage collection simple —
+"stop the world" just means "finish the current poll, collect, resume."
+
+Two tiers coexist:
+
+| Tier | Runs on | Used by |
+|---|---|---|
+| Async (single thread) | Tokio `LocalSet` | `^:async` fns, `go`, channels, `timeout`, `alts` |
+| Parallel (thread pool) | OS threads | `future`, `pmap`, `agent` (unchanged core primitives) |
+
+Both tiers produce `Value::Future`, so a caller can `await` or `deref` either.
+
+## `^:async` functions and `await`
+
+A function tagged `^:async` runs its body as an async task. Calling it returns
+a `Future` *immediately*; the body runs cooperatively, yielding the executor at
+every `await`.
+
+```clojure
+(defn ^:async fetch [url]
+  (let [resp (await (http-get url))]   ; yields until the request resolves
+    (:body resp)))
+
+(fetch "https://example.com")          ; returns a Future right away
+(await (fetch "https://example.com"))  ; yields until the body is ready
+```
+
+`await` is a **special form**, not a function — it is syntactically detectable
+so the compiler can recognise yield points. Its behaviour depends on context:
+
+- Inside an `^:async` body (driven by the async evaluator), `(await x)` yields
+  the executor thread until `x` — a `Future`, a `promise`, or a channel op —
+  resolves, then returns the resolved value.
+- Outside any async context, `(await x)` falls back to a **blocking** deref of
+  the value, so the form still works in synchronous code.
+
+`^:async` is *viral*: a function that uses `await` should itself be `^:async`.
+
+### `await` vs. `deref`
+
+`deref` / `@` always blocks the calling OS thread. Calling `deref` on a future
+**inside** an `^:async` body is a runtime error:
+
+```clojure
+(defn ^:async bad [f]
+  @f)            ; error: use (await ...) instead of deref inside an ^:async function
+```
+
+This enforcement (via the interpreter's async-context flag) prevents the
+classic deadlock where a task blocks the only executor thread waiting on a
+future that can only be resolved by that same thread.
+
+## Channels
+
+Channels are CSP conduits between tasks. They are implemented as `NativeObject`s
+(`CljChannel`) rather than a dedicated `Value` variant, keeping the core value
+model free of async concerns.
+
+```clojure
+(chan)      ; unbuffered — a rendezvous channel
+(chan 0)    ; same as (chan)
+(chan 10)   ; buffered, capacity 10
+```
+
+- An **unbuffered** (rendezvous) channel hands a value directly from a `put!` to
+  a `take!`: the `put!` resolves `true` only once a taker consumes the value.
+- A **buffered** channel accepts `put!`s while it has room and serves `take!`s
+  while it is non-empty.
+- A **closed** channel drains any buffered values, then `take!` yields `nil` and
+  `put!` resolves `false`.
+
+### Channel operations
+
+Operations that can block return a `Value::Future`, so they are used with
+`await` inside an async context:
+
+| Operation | Meaning |
+|---|---|
+| `(take! ch)` | await the next value (or `nil` once closed and drained) |
+| `(put! ch v)` | await acceptance of `v`; resolves `true`, or `false` if closed |
+| `(close! ch)` | close the channel (idempotent) |
+
+Non-blocking variants act synchronously and return immediately:
+
+| Operation | Meaning |
+|---|---|
+| `(poll! ch)` | take a buffered value now, or `nil` if none is ready |
+| `(offer! ch v)` | put `v` now if there is buffer room → `true`/`false` |
+
+Blocking variants park the OS thread and are meant for the REPL, tests, and
+other synchronous contexts — **not** for use inside an `^:async` body or from
+the single-threaded executor thread (they deadlock there):
+
+| Operation | Meaning |
+|---|---|
+| `(<!! ch)` | blocking take |
+| `(>!! ch v)` | blocking put |
+
+### `go` blocks
+
+`go` spawns its body as an anonymous async task and returns a `Future`:
+
+```clojure
+(def in  (chan 1))
+(def out (chan 1))
+
+(go (let [v (await (take! in))]
+      (await (put! out (* v 2)))))
+
+(await (put! in 21))
+(await (take! out))    ; => 42
+```
+
+## Selection: `timeout`, `alts`, `alt`
+
+`timeout` returns a future that delivers `nil` after a delay:
+
+```clojure
+(timeout 5000)   ; => Future resolving to nil after 5 s
+```
+
+`alts` waits on a vector of futures (or channel ops) and returns
+`[value index]` for whichever resolves first:
+
+```clojure
+(let [[v i] (await (alts [(take! ch) (timeout 1000)]))]
+  (if (= i 1) (println "timed out") (println "got" v)))
+```
+
+`alt` is a macro that pairs each future with a handler, awaits `alts`, and
+dispatches to the matching handler:
+
+```clojure
+(alt
+  (take! ch1)   (fn [v] (println "ch1:" v))
+  (take! ch2)   (fn [v] (println "ch2:" v))
+  (timeout 500) (fn [_] (println "timed out")))
+```
+
+## Higher-level utilities
+
+| Function | Description |
+|---|---|
+| `(join-all futs)` | await a seq of futures, returning a vector of results (like `Promise.all`) |
+| `(async-pmap f coll)` | spawn `f` over `coll` concurrently and await all results |
+| `(thread f)` / `(thread-call f)` | run `f` on a real OS thread (`spawn_blocking`); deliver its result over a channel |
+| `(onto-chan! ch coll)` | put every element of `coll` onto `ch`, then close it |
+| `(to-chan! coll)` | return a channel and seed it from `coll` in the background |
+| `(merge chs)` | fan several channels into one |
+| `(mult ch)` + `(tap! m ch)` / `(untap! m ch)` / `(untap-all! m)` | broadcast one source channel to many taps |
+| `(reduce f init ch)` | fold over a channel until it closes |
+| `(into coll ch)` | drain a channel into a collection |
+
+## Garbage collection
+
+Because the async tier is single-threaded, GC safepoints are cooperative: the
+runtime collects between poll cycles, and `await` invokes a safepoint before
+each yield. A background GC-service task (spawned by the crate's `init`)
+services collection requests, and explicit root guards keep spawned task
+futures and their captured environments reachable while they are in flight.
+
+## Embedding from Rust
+
+`cljrs-async` is a standalone crate. Call `init` from inside a `LocalSet`
+context, then evaluate code as usual:
+
+```rust
+let rt = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap();
+let local = tokio::task::LocalSet::new();
+rt.block_on(local.run_until(async {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_async::init(&globals);
+    // ... evaluate code ...
+}));
+```
+
+The CLI links this crate when built with its default `async` feature; a minimal
+binary can be produced with `cargo build -p cljrs --no-default-features`.
+
+> **WASM note.** In the browser REPL, `init` may run before a `LocalSet` exists;
+> the GC-service spawn no-ops in that case and should be re-invoked from inside a
+> `LocalSet::run_until` block. `timeout` uses the browser's `setTimeout`
+> (via `gloo-timers`) on `wasm32` instead of `tokio::time::sleep`.

--- a/docs/book/src/async-io/index.md
+++ b/docs/book/src/async-io/index.md
@@ -1,0 +1,44 @@
+# Async & I/O
+
+clojurust ships asynchronous concurrency and non-blocking file I/O as two
+optional crates that layer on top of the interpreter:
+
+| Crate | Namespace | Provides |
+|---|---|---|
+| [`cljrs-async`](async.md) | `clojure.core.async` | CSP channels, `go` blocks, `^:async`/`await`, `timeout`, `alts`/`alt`, pipelines |
+| [`cljrs-io`](io.md) | `clojure.rust.io.async` | non-blocking file reads and writes delivered over core.async channels |
+
+Both are wired into the `cljrs` CLI by default (via its `async` feature) and
+can be embedded by Rust programs that link the crates directly.
+
+## Design at a glance
+
+Async support is delivered as a **separate library**, mirroring how
+`clojure.core.async` ships as its own JAR on the JVM. The core interpreter
+crates contain no Tokio dependency and no `#[cfg(feature = "async")]` guards;
+they expose a single hook trait (`AsyncRuntime`) that `cljrs-async` registers
+into the environment at startup. The only conditional compilation lives in the
+CLI binary.
+
+The whole async tier runs on a Tokio **`current_thread` runtime driving a
+`LocalSet`**. Every Clojure value stays on one thread, which keeps the
+garbage collector's `!Send` pointers (`GcPtr<T>`) sound — no value ever crosses
+a thread boundary inside async code. CPU-bound parallelism continues to use the
+existing thread-based `future`, `pmap`, and `agent` primitives, which are
+unchanged.
+
+## Two ways to wait
+
+clojurust distinguishes async waiting from blocking waiting:
+
+- **`await`** is a special form. Inside an `^:async` function (or a `go`
+  block), it *yields* the single executor thread to other tasks until the value
+  it is given — a `Future`, a `promise`, or a channel operation — resolves.
+- **`deref` / `@`** *blocks* the calling OS thread. Using `deref` on a future
+  from within an `^:async` body is a runtime error that steers you to `await`.
+
+Without `cljrs-async` loaded, `(await x)` falls back to a blocking deref, so the
+form is still meaningful in purely synchronous code.
+
+See the [core.async](async.md) chapter for the concurrency model and the
+[Asynchronous I/O](io.md) chapter for the channel-oriented filesystem API.

--- a/docs/book/src/async-io/io.md
+++ b/docs/book/src/async-io/io.md
@@ -1,0 +1,125 @@
+# Asynchronous I/O
+
+The `clojure.rust.io.async` namespace exposes the host filesystem to Clojure as
+a **non-blocking, channel-oriented** API. Every operation runs on the same Tokio
+`LocalSet` executor that drives [core.async](async.md) and returns a
+`clojure.core.async` channel, so file I/O composes with `go`, `take!`, `alts`,
+and the rest of the async toolkit instead of blocking the interpreter thread.
+
+It is provided by the `cljrs-io` crate and loaded automatically by the `cljrs`
+CLI (with its default-on `async` feature).
+
+```clojure
+(require '[clojure.rust.io.async :as aio]
+         '[clojure.core.async :refer [take!]])
+```
+
+The channels it returns are ordinary core.async channels — `cljrs-io` reuses
+`cljrs-async`'s `CljChannel` rather than defining its own type.
+
+## Two channel shapes
+
+The API deliberately uses two channel shapes, chosen per operation:
+
+- **Streaming reads return a raw channel.** The call returns *immediately* and a
+  background producer task reads the file and puts a sequence of values onto the
+  channel, closing it at EOF. A small buffer (`cap`, default 8) bounds how far
+  the producer reads ahead of the consumer, so even a multi-gigabyte file is
+  streamed with backpressure rather than slurped into memory.
+
+- **Discrete request/response ops return a promise channel.** The call returns a
+  capacity-1 channel onto which the producer delivers exactly one result before
+  closing it. A single `take!` yields the value; a second yields `nil`. This
+  signals "resolves exactly once" while staying uniformly takeable alongside
+  everything else.
+
+## Streaming reads
+
+Each returns a channel immediately and closes it at EOF:
+
+| Function | Yields |
+|---|---|
+| `(chunk-chan path [buf-size [cap]])` | `byte-array` chunks of up to `buf-size` bytes (default 8192) |
+| `(byte-chan path [cap])` | individual bytes as signed `long`s (-128..127) |
+| `(char-chan path [charset [cap]])` | characters decoded with `charset` (default `:utf-8`) |
+| `(line-chan path [charset [cap]])` | lines, without the trailing `\n` / `\r\n` |
+
+```clojure
+(go (loop []
+      (when-let [line (await (take! (line-chan "big.log")))]
+        (println line)
+        (recur))))
+```
+
+## Discrete operations
+
+Each returns a one-shot promise channel carrying a single result:
+
+| Function | Delivers |
+|---|---|
+| `(slurp path [charset])` | the whole file as a decoded string |
+| `(slurp-bytes path)` | the whole file as a `byte-array` |
+| `(read-bytes path n)` | a `byte-array` of up to the first `n` bytes |
+| `(spit path data [charset])` | the number of bytes written (`data` is a string or `byte-array`) |
+
+```clojure
+(go (let [text (await (take! (slurp "config.edn")))]
+      (println text)))
+```
+
+## Error handling
+
+Failures are delivered **in band**: the producer puts an error value (an
+exception) onto the channel and then closes it. Consumers distinguish results
+from failures with the `error?` / `ok?` helpers:
+
+```clojure
+(require '[clojure.core.async :refer [<!!]]
+         '[clojure.rust.io.async :as aio])
+
+(let [result (<!! (aio/slurp "config.edn"))]
+  (if (aio/error? result)
+    (println "read failed:" (ex-message result))
+    (println result)))
+```
+
+> **Top-level consumption.** From `cljrs repl`, `cljrs run`, or `cljrs eval`,
+> consume results with `(await (take! ...))`. The blocking `<!!` / `>!!` ops
+> deadlock the single-threaded executor at the top level — they are for use off
+> the executor thread (separate test threads, embedders), not for top-level CLI
+> forms.
+
+## Charsets
+
+The `charset` argument is a keyword or string label resolved by `encoding_rs`,
+defaulting to UTF-8:
+
+```clojure
+(aio/slurp "data.txt" :utf-8)
+(aio/char-chan "legacy.txt" :windows-1252)
+(aio/line-chan "jp.txt" :shift_jis)
+```
+
+Supported labels include `:utf-8`, `:utf-16le`, `:iso-8859-1`, `:windows-1252`,
+`:shift_jis`, and the rest of the `encoding_rs` set.
+
+## Status and scope
+
+The eight builtins above plus the `error?` / `ok?` helpers are implemented.
+Candidate follow-ups not yet covered: a stateful `AsyncReader` handle with a
+cursor (`open` / `read-chunk!` / `seek`), append/options maps for `spit`,
+directory streaming, and transducer-equipped channels.
+
+## Embedding from Rust
+
+`cljrs-io::init` registers the namespace; it is idempotent and requires
+`cljrs_async::init` and a running `LocalSet`:
+
+```rust
+rt.block_on(local.run_until(async {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_async::init(&globals);   // required first
+    cljrs_io::init(&globals);
+    // ... evaluate code ...
+}));
+```

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -11,6 +11,7 @@ can AOT-compile programs to standalone native binaries.
 - **Rust interop** — Clojure code can call Rust functions through a defined set of conventions and type-marshalling primitives.
 - **Garbage collector** — a tracing GC manages all Clojure values; an optional region-based allocator is available for allocation-heavy code paths.
 - **AOT compilation** — `cljrs compile` produces a standalone native binary via Cranelift.
+- **Async & I/O** — `clojure.core.async` channels and non-blocking file I/O ship as optional crates layered over the interpreter. See the [Async & I/O](async-io/index.md) chapter.
 
 ## Source file extensions
 


### PR DESCRIPTION
Document the cljrs-async (clojure.core.async) and cljrs-io
(clojure.rust.io.async) functionality in the mdbook:

- New 'Async & I/O' section in SUMMARY.md with an overview plus
  dedicated core.async and asynchronous I/O chapters
- Cover the single-threaded LocalSet execution model, ^:async/await,
  channels, go/timeout/alts/alt, and higher-level utilities
- Cover the streaming vs. promise channel I/O API, in-band error
  handling, charsets, and embedding
- Link the new chapter from the introduction