### PR TITLE
docs: add networking architecture plan (cljrs-net)

### DIFF
--- a/async-worker-pool-plan.md
+++ b/async-worker-pool-plan.md
@@ -1,0 +1,234 @@
+# Async Worker Pool Plan for clojurust
+
+## Why this document exists
+
+`cljrs-async` today drives all async work on a **single** Tokio `current_thread` + `LocalSet`
+executor. One interpreter thread cannot use more than one core, so any "server" built on it is a
+demo: throughput is capped at one core no matter how many connections or `go` blocks are in flight.
+
+This plan turns that single executor into a **worker pool** so async work — networking
+(`cljrs-net`), file I/O (`cljrs-io`), and ordinary `go`/`^:async` code — can use every core.
+
+It is split out of `networking-plan.md` deliberately: this is a `cljrs-async` (and, at its limits,
+`cljrs-gc`) change that affects *everything* async, not just sockets. `networking-plan.md` Phase H
+references this document; the networking phases are written against a per-worker `LocalSet` so they
+are unaffected by when this lands.
+
+Read `async-plan.md` first — every mechanism here (the `LocalSet` executor, `spawn_future`,
+`await_value`, the GC-service task, safepoints) comes from it.
+
+---
+
+## The crucial precondition: the GC already allows this
+
+The single-thread executor is an **async-runtime choice, not a GC limitation.** `current_thread` +
+`LocalSet` was chosen so eval futures can hold `GcPtr`s across `await` without being `Send` — a
+multi-thread Tokio runtime requires `Send` futures. But the garbage collector underneath is already
+a **shared-heap, multi-mutator, stop-the-world** design:
+
+| Capability | Evidence |
+|---|---|
+| One global, `Mutex`-guarded heap shared by all threads | `static HEAP: GcHeap` (`cljrs-gc/src/lib.rs`); `GcHeapInner` behind a `Mutex`; `unsafe impl Sync for GcHeap` |
+| Thread registration for collection | `cljrs_gc::register_mutator()`, already called at `crates/cljrs/src/main.rs:291` and in test harnesses that `thread::spawn` |
+| STW that parks **all** mutators and traces **each** thread's roots | `begin_stw()` (`cljrs-env/src/gc_roots.rs`); `GC_CANCELLATION` tracks `registered_threads`/`parked_threads` |
+| Per-thread root stacks (no cross-thread root sharing needed) | `ENV_ROOTS` (`cljrs-env/src/gc_roots.rs`), `BINDING_STACK` (`cljrs-env/src/dynamics.rs`), `EVAL_CONTEXT` (`cljrs-env/src/callback.rs`), `ALLOC_ROOTS`/`REGION_STACK` (`cljrs-gc`) |
+| Shared, thread-safe global environment | `GlobalEnv` is `Arc`-shared with `RwLock`/`Mutex` namespace tables (`cljrs-env/src/env.rs`) |
+| `GcPtr` declared movable across threads | `unsafe impl<T: Trace> Send/Sync for GcPtr<T>` (`cljrs-gc/src/lib.rs:302–303`) |
+
+So multiple OS threads can already run interpreters against the same heap. **No GC rewrite is
+required to add a worker pool** — only the async executor and per-thread lifecycle change.
+
+### The safety discipline (what makes the `unsafe impl Send` sound)
+
+`GcPtr: Send + Sync` is sound **only** under a discipline the pool must enforce:
+
+1. **Every thread that holds `GcPtr`s is a registered mutator** (`register_mutator()` held for the
+   thread's lifetime) **and reaches safepoints regularly.** STW prevents cross-thread dereference
+   races *because* all mutators are parked during mark/sweep — a thread that holds `GcPtr`s but
+   never registers / never safepoints is the one real hazard: the collector won't wait for it and
+   can free objects under it.
+2. **Every live value is reachable from some traced root** — a thread-local root stack, a global,
+   or a heap object whose `Trace` walks it. A value handed to another thread must be rooted on the
+   receiver (or held in a traced structure, e.g. a channel buffer) before the sender drops it.
+3. **No `&mut` aliasing of a `Value` across threads.** Values are immutable after allocation;
+   shared mutation goes through `atom`/`ref`/`agent`, which are already synchronized.
+
+This document's design satisfies all three by construction (pinned work + channel handoff with
+traced buffers). The discipline is stated here so it is enforced as an invariant, not rediscovered.
+
+---
+
+## The model: shared-heap, pinned workers
+
+`W` worker OS threads (default ≈ `std::thread::available_parallelism()`, configurable), each:
+
+- running **its own** `current_thread` Tokio runtime + `LocalSet` (so per-worker futures stay
+  `!Send`/local — no change to `spawn_future`/`eval_async`, which keep using `spawn_local`);
+- holding a `register_mutator()` guard for its lifetime;
+- sharing the **one** `GcHeap` and the **one** `Arc<GlobalEnv>` with all other workers.
+
+This is the nginx-workers / BEAM-schedulers shape, but with a **shared heap** rather than one heap
+per worker (the share-nothing variant is the endgame — see Ceilings).
+
+### Work placement
+
+- **A unit of async work is pinned to the worker it starts on.** Its future, the `GcPtr`s it
+  touches, and the byte-arrays it allocates all live on that worker's thread. In steady state **no
+  `GcPtr` crosses threads.**
+- **New work is placed at spawn time.** `async-spawn`/`go`/`^:async` dispatch picks a worker
+  (round-robin or least-loaded) and `spawn_local`s the task onto that worker's `LocalSet` via a
+  per-worker handle. Work started *inside* a task stays on the same worker by default.
+- **External producers hand off `Send` tokens, not `GcPtr`s.** For `cljrs-net`, an accepted socket
+  is handed to a worker as a raw **FD** (an integer — `Send`); the worker builds the
+  `TcpStream`/byte-arrays locally. This is the general pattern: cross-thread boundaries carry `Send`
+  Rust data (`Vec<u8>`, FDs, primitives), and the `!Send` `GcPtr` is constructed on the destination
+  worker.
+
+### Cross-worker communication: channels
+
+When a *value* must move between workers, it goes through a `clojure.core.async` channel. This is
+STW-safe provided:
+
+- **`CljChannel::Trace` walks its buffer** so a value parked in a channel between a `put!` on worker
+  A and a `take!` on worker B stays rooted regardless of which worker collects. **Audit item.**
+- **Cross-runtime wakeups work** — Tokio `Waker`s are `Send`, so a `take!` task parked on worker B
+  is woken when worker A `put!`s. `CljChannel` already uses a `Mutex` + condvar internally, so the
+  cross-thread case is mechanically fine; the work is verifying it under the pool.
+
+---
+
+## Execution / scheduler design
+
+| Concern | Approach |
+|---|---|
+| Per-worker driver | Each worker thread: build `current_thread` runtime, enter a `LocalSet`, `register_mutator()`, run the GC-service task, then `block_on` the `LocalSet` until shutdown. |
+| Spawn routing | A `Pool` holds `W` `LocalSet` spawn handles (`tokio::task::LocalSet::spawn_local` via a per-worker channel of boxed task-builders, since `spawn_local` must run on the owning thread). `spawn_future` gains a "spawn on worker *i*" path; the default picks a worker by a placement policy. |
+| Placement policy | Start with round-robin for top-level spawns; child tasks inherit their parent's worker. Least-loaded (by in-flight task count) is a later refinement. |
+| Blocking ops (`<!!`/`>!!`) | Already condvar-parked across threads; unchanged, but documented as "safe from any worker / any non-worker thread, never from inside an `^:async` body." |
+| GC-service task | One per worker (each worker services its own safepoint/STW participation), coordinated by the existing global `GC_CANCELLATION`. |
+| Shutdown | Drain/cancel per-worker `LocalSet`s, drop mutator guards, join threads. |
+
+The core insight that keeps this tractable: **`spawn_local` stays `spawn_local`.** We are not making
+futures `Send`; we are running *N independent single-threaded executors* that happen to share a
+heap. Each executor is exactly today's executor.
+
+---
+
+## Phased implementation
+
+### Phase 1 — Pool scaffolding (no behavior change)
+
+- Introduce a `WorkerPool` in `cljrs-async` that can spin up `W` worker threads, each with its own
+  `current_thread` runtime + `LocalSet` + `register_mutator()` + GC-service task.
+- `W = 1` by default initially, so behavior is identical to today; the CLI/embedder gains a knob
+  (`--workers N` / `init_with_workers(n)`).
+- `init()` becomes pool-aware but still routes everything to worker 0.
+
+**Done when:** existing async tests pass unchanged with the pool at `W = 1`, and `W > 1` boots `W`
+idle workers that all register as mutators and participate in STW.
+
+### Phase 2 — Spawn routing across workers
+
+- `spawn_future` / `async-spawn` / `go` / `^:async` dispatch route new top-level tasks to a worker
+  by placement policy (round-robin first); child tasks inherit the parent worker.
+- Verify per-worker locality: a task and everything it allocates stay on one thread.
+
+**Done when:** with `W > 1`, independent `go`/`^:async` workloads measurably spread across cores,
+and a CPU-bound benchmark scales with `W` (up to the allocation-mutex ceiling).
+
+### Phase 3 — Cross-worker correctness audit
+
+- **Audit `CljChannel::Trace`**: confirm buffered values are traced; add a test that `put!`s on one
+  worker, forces STW, then `take!`s on another and checks the value survived.
+- Confirm cross-runtime wakeups for `take!`/`put!`/`alts!` parked on a different worker than the
+  producer.
+- Stress STW under multi-worker load: many workers allocating, one triggering collection, verify
+  all park at safepoints and every worker's roots are traced.
+
+**Done when:** a cross-worker channel ping-pong survives aggressive forced GC with no UAF/leak under
+the GC's debug provenance assertions.
+
+### Phase 4 — Safepoint coverage for long native calls
+
+- Ensure native/FFI calls reachable from async paths poll safepoints (or are wrapped to do so) so a
+  single busy worker cannot stall global STW for the rest.
+- Document the rule for `interop` authors: long-running native fns must yield to safepoints.
+
+**Done when:** a deliberately long native call on one worker does not deadlock GC for others
+(bounded pause), with a regression test.
+
+### Phase 5 — External `Send` handoff API (enables `cljrs-net`)
+
+- Public API for "build this on worker *i* from `Send` inputs": e.g. `spawn_on(worker, FnOnce ->
+  Future)` and an FD/`Vec<u8>` handoff helper.
+- This is what `cljrs-net`'s accept path calls to pin a connection to a worker.
+
+**Done when:** `cljrs-net` (or a stand-in test) can accept on one thread and run a pinned
+connection's reader/writer on a chosen worker, with byte-arrays built on that worker.
+
+---
+
+## The two ceilings (and the endgame)
+
+The shared-heap pool scales to a point and then hits two walls. Naming them up front so they are
+chosen, not stumbled into:
+
+1. **Global STW.** Every worker must reach a safepoint before *any* collection runs (Phase 4
+   mitigates the stall risk but not the fundamental coordination). I/O `await` points are
+   safepoints, so I/O-bound serving is fine; allocation-heavy CPU-bound work pays coordination cost.
+2. **The single global heap `Mutex` is the allocation bottleneck.** Every `GcPtr::new` locks the one
+   heap; at high allocation rates across many cores this serializes and becomes the scaling wall.
+
+### Endgame (deferred — `cljrs-gc` changes, separate plan when pursued)
+
+- **TLABs (thread-local allocation buffers).** Each worker gets a private bump region and only takes
+  the global lock to refill it. Relieves ceiling #2 with no change to the shared-heap / global-STW
+  model. The natural *first* `cljrs-gc` follow-up once Phase 2 shows allocation contention.
+- **Share-nothing per-worker heaps** (the BEAM/Ractor model). De-globalize `static HEAP` into a
+  per-worker heap: no shared alloc lock (ceiling #2 gone), no global STW (ceiling #1 gone — each
+  worker collects independently), cross-worker messages **copied/serialized** rather than shared.
+  This is the real linear-scaling design and a substantial `cljrs-gc` refactor. The pinned-work +
+  `Send`-handoff + channel design in this plan is already the share-nothing message-passing shape,
+  so application code and `cljrs-net` port to it unchanged — only the channel handoff switches from
+  "share a `GcPtr`" to "copy across heaps."
+
+---
+
+## Risks & open questions
+
+- **Placement policy.** Round-robin ignores task cost; least-loaded needs cheap load metrics. Start
+  simple, measure, refine. Bad placement hurts throughput but not correctness.
+- **Work stealing.** Not in scope — pinned tasks can't be stolen (they hold `!Send` `GcPtr`s).
+  Imbalance is handled by placement, not migration. Revisit only with share-nothing heaps.
+- **`thread_local!` correctness.** `EVAL_CONTEXT`, `BINDING_STACK`, `ALLOC_ROOTS`, `REGION_STACK`
+  are per-thread, which is *correct* for per-worker pinning, but anything that implicitly assumed a
+  single global thread-local must be audited (dynamic `binding` does not cross workers — by design,
+  matching Clojure's thread-local `binding` semantics).
+- **Determinism of tests.** Multi-worker scheduling is nondeterministic; keep `W = 1` as the default
+  for deterministic test runs and gate multi-worker tests explicitly.
+- **Embedder impact.** Embedders calling `cljrs_async::init` get `W = 1` (today's behavior); opting
+  into a pool is explicit.
+
+---
+
+## Relationship to other crates
+
+- **`cljrs-async`** — owns the pool (this plan).
+- **`cljrs-gc`** — unchanged for Phases 1–5; owns the deferred TLAB / share-nothing endgame.
+- **`cljrs-net`** — consumes the Phase 5 `Send`-handoff API to pin connections (see
+  `networking-plan.md` Phase H, which points here).
+- **`cljrs-io`** — file I/O tasks become poolable for free once spawn routing (Phase 2) lands; no
+  `cljrs-io` change required.
+
+---
+
+## Phase summary
+
+| Phase | Deliverable | Crate |
+|---|---|---|
+| 1 | `WorkerPool` scaffolding; `W=1` default; per-worker runtime + mutator + GC-service | `cljrs-async` |
+| 2 | Spawn routing across workers; parent-inherits-worker; per-worker locality | `cljrs-async` |
+| 3 | Cross-worker channel audit (`CljChannel::Trace`, wakeups, STW stress) | `cljrs-async` (+ `cljrs-gc` tests) |
+| 4 | Safepoint coverage for long native calls | `cljrs-async`, `cljrs-interop` |
+| 5 | `Send`-handoff / `spawn_on(worker, …)` API for external producers | `cljrs-async` |
+| — | **Deferred:** TLABs, then share-nothing per-worker heaps | `cljrs-gc` (separate plan) |

--- a/async-worker-pool-plan.md
+++ b/async-worker-pool-plan.md
@@ -1,234 +1,232 @@
-# Async Worker Pool Plan for clojurust
+# Async Concurrency Plan for clojurust — Isolates (A→B)
 
 ## Why this document exists
 
 `cljrs-async` today drives all async work on a **single** Tokio `current_thread` + `LocalSet`
 executor. One interpreter thread cannot use more than one core, so any "server" built on it is a
-demo: throughput is capped at one core no matter how many connections or `go` blocks are in flight.
+demo. This plan makes async work scale across cores **without** an unsafe shared-heap discipline,
+by moving to an **isolate** model:
 
-This plan turns that single executor into a **worker pool** so async work — networking
-(`cljrs-net`), file I/O (`cljrs-io`), and ordinary `go`/`^:async` code — can use every core.
+- **Model A (first step):** a single interpreter/heap thread, plus a Rust worker pool that does only
+  `Send` work on non-GC data (socket I/O, TLS crypto, compression, hashing) and hands `Send` results
+  back. `GcPtr` becomes **honestly `!Send`** — the `unsafe impl Send/Sync` is deleted. Scales
+  I/O-bound serving; Clojure logic stays on one core.
+- **Model B (target):** independent per-worker **isolates**, each with its own heap, runtime,
+  `LocalSet`, and collector, **collected in parallel**. Crossing an isolate boundary is a **copy**,
+  not a shared pointer — enforced by `!Send`. A **shared static arena** holds immortal, immutable
+  data (code, interned keywords/symbols, large blobs) so isolates don't copy the world.
 
-It is split out of `networking-plan.md` deliberately: this is a `cljrs-async` (and, at its limits,
-`cljrs-gc`) change that affects *everything* async, not just sockets. `networking-plan.md` Phase H
-references this document; the networking phases are written against a per-worker `LocalSet` so they
-are unaffected by when this lands.
+This supersedes the earlier shared-heap, multi-mutator design. That design was the only option that
+(a) kept the `unsafe` `Send` impl, (b) gave *serialized* global STW instead of parallel collection,
+and (c) had a single-heap allocation-mutex ceiling. Isolates remove all three.
 
-Read `async-plan.md` first — every mechanism here (the `LocalSet` executor, `spawn_future`,
-`await_value`, the GC-service task, safepoints) comes from it.
-
----
-
-## The crucial precondition: the GC already allows this
-
-The single-thread executor is an **async-runtime choice, not a GC limitation.** `current_thread` +
-`LocalSet` was chosen so eval futures can hold `GcPtr`s across `await` without being `Send` — a
-multi-thread Tokio runtime requires `Send` futures. But the garbage collector underneath is already
-a **shared-heap, multi-mutator, stop-the-world** design:
-
-| Capability | Evidence |
-|---|---|
-| One global, `Mutex`-guarded heap shared by all threads | `static HEAP: GcHeap` (`cljrs-gc/src/lib.rs`); `GcHeapInner` behind a `Mutex`; `unsafe impl Sync for GcHeap` |
-| Thread registration for collection | `cljrs_gc::register_mutator()`, already called at `crates/cljrs/src/main.rs:291` and in test harnesses that `thread::spawn` |
-| STW that parks **all** mutators and traces **each** thread's roots | `begin_stw()` (`cljrs-env/src/gc_roots.rs`); `GC_CANCELLATION` tracks `registered_threads`/`parked_threads` |
-| Per-thread root stacks (no cross-thread root sharing needed) | `ENV_ROOTS` (`cljrs-env/src/gc_roots.rs`), `BINDING_STACK` (`cljrs-env/src/dynamics.rs`), `EVAL_CONTEXT` (`cljrs-env/src/callback.rs`), `ALLOC_ROOTS`/`REGION_STACK` (`cljrs-gc`) |
-| Shared, thread-safe global environment | `GlobalEnv` is `Arc`-shared with `RwLock`/`Mutex` namespace tables (`cljrs-env/src/env.rs`) |
-| `GcPtr` declared movable across threads | `unsafe impl<T: Trace> Send/Sync for GcPtr<T>` (`cljrs-gc/src/lib.rs:302–303`) |
-
-So multiple OS threads can already run interpreters against the same heap. **No GC rewrite is
-required to add a worker pool** — only the async executor and per-thread lifecycle change.
-
-### The safety discipline (what makes the `unsafe impl Send` sound)
-
-`GcPtr: Send + Sync` is sound **only** under a discipline the pool must enforce:
-
-1. **Every thread that holds `GcPtr`s is a registered mutator** (`register_mutator()` held for the
-   thread's lifetime) **and reaches safepoints regularly.** STW prevents cross-thread dereference
-   races *because* all mutators are parked during mark/sweep — a thread that holds `GcPtr`s but
-   never registers / never safepoints is the one real hazard: the collector won't wait for it and
-   can free objects under it.
-2. **Every live value is reachable from some traced root** — a thread-local root stack, a global,
-   or a heap object whose `Trace` walks it. A value handed to another thread must be rooted on the
-   receiver (or held in a traced structure, e.g. a channel buffer) before the sender drops it.
-3. **No `&mut` aliasing of a `Value` across threads.** Values are immutable after allocation;
-   shared mutation goes through `atom`/`ref`/`agent`, which are already synchronized.
-
-This document's design satisfies all three by construction (pinned work + channel handoff with
-traced buffers). The discipline is stated here so it is enforced as an invariant, not rediscovered.
+Read `async-plan.md` first for the existing executor (`spawn_future`, `await_value`, the
+GC-service task, safepoints). `networking-plan.md` Phase H references this document.
 
 ---
 
-## The model: shared-heap, pinned workers
+## The shape of the decision
 
-`W` worker OS threads (default ≈ `std::thread::available_parallelism()`, configurable), each:
+These three facts are one decision, not three:
 
-- running **its own** `current_thread` Tokio runtime + `LocalSet` (so per-worker futures stay
-  `!Send`/local — no change to `spawn_future`/`eval_async`, which keep using `spawn_local`);
-- holding a `register_mutator()` guard for its lifetime;
-- sharing the **one** `GcHeap` and the **one** `Arc<GlobalEnv>` with all other workers.
+1. **Parallel collection requires independent heaps.** A single shared heap can only be collected
+   stop-the-world (park every mutator, one collector). "Collected in parallel" ⇒ per-isolate heaps.
+2. **Independent heaps make `Send`/`Sync` honest.** If a `GcPtr` never crosses a thread, it is
+   genuinely `!Send` — no `unsafe impl`, and transients (deliberately thread-confined, unsynchronized)
+   stop being a soundness hole. Cross-isolate transfer is a copy.
+3. **Cross-thread memory pressure becomes observable and actionable per-isolate** instead of a
+   single global cliff (see "Memory pressure").
 
-This is the nginx-workers / BEAM-schedulers shape, but with a **shared heap** rather than one heap
-per worker (the share-nothing variant is the endgame — see Ceilings).
-
-### Work placement
-
-- **A unit of async work is pinned to the worker it starts on.** Its future, the `GcPtr`s it
-  touches, and the byte-arrays it allocates all live on that worker's thread. In steady state **no
-  `GcPtr` crosses threads.**
-- **New work is placed at spawn time.** `async-spawn`/`go`/`^:async` dispatch picks a worker
-  (round-robin or least-loaded) and `spawn_local`s the task onto that worker's `LocalSet` via a
-  per-worker handle. Work started *inside* a task stays on the same worker by default.
-- **External producers hand off `Send` tokens, not `GcPtr`s.** For `cljrs-net`, an accepted socket
-  is handed to a worker as a raw **FD** (an integer — `Send`); the worker builds the
-  `TcpStream`/byte-arrays locally. This is the general pattern: cross-thread boundaries carry `Send`
-  Rust data (`Vec<u8>`, FDs, primitives), and the `!Send` `GcPtr` is constructed on the destination
-  worker.
-
-### Cross-worker communication: channels
-
-When a *value* must move between workers, it goes through a `clojure.core.async` channel. This is
-STW-safe provided:
-
-- **`CljChannel::Trace` walks its buffer** so a value parked in a channel between a `put!` on worker
-  A and a `take!` on worker B stays rooted regardless of which worker collects. **Audit item.**
-- **Cross-runtime wakeups work** — Tokio `Waker`s are `Send`, so a `take!` task parked on worker B
-  is woken when worker A `put!`s. `CljChannel` already uses a `Mutex` + condvar internally, so the
-  cross-thread case is mechanically fine; the work is verifying it under the pool.
+So the model is: **run today's single-threaded executor, N times, with a copy boundary between
+instances and a shared immortal arena underneath.**
 
 ---
 
-## Execution / scheduler design
+## What in the code makes this feasible (and what fights it)
 
-| Concern | Approach |
-|---|---|
-| Per-worker driver | Each worker thread: build `current_thread` runtime, enter a `LocalSet`, `register_mutator()`, run the GC-service task, then `block_on` the `LocalSet` until shutdown. |
-| Spawn routing | A `Pool` holds `W` `LocalSet` spawn handles (`tokio::task::LocalSet::spawn_local` via a per-worker channel of boxed task-builders, since `spawn_local` must run on the owning thread). `spawn_future` gains a "spawn on worker *i*" path; the default picks a worker by a placement policy. |
-| Placement policy | Start with round-robin for top-level spawns; child tasks inherit their parent's worker. Least-loaded (by in-flight task count) is a later refinement. |
-| Blocking ops (`<!!`/`>!!`) | Already condvar-parked across threads; unchanged, but documented as "safe from any worker / any non-worker thread, never from inside an `^:async` body." |
-| GC-service task | One per worker (each worker services its own safepoint/STW participation), coordinated by the existing global `GC_CANCELLATION`. |
-| Shutdown | Drain/cancel per-worker `LocalSet`s, drop mutator guards, join threads. |
+**Feasible:**
 
-The core insight that keeps this tractable: **`spawn_local` stays `spawn_local`.** We are not making
-futures `Send`; we are running *N independent single-threaded executors* that happen to share a
-heap. Each executor is exactly today's executor.
+- **`static_arena.rs` already exists**, is `Send + Sync`, and is program-lifetime / never swept —
+  this is the shared immortal arena (Model B) ready-made. `is_static_addr(addr)` already lets a
+  collector recognize a pointer into it and **stop tracing** there, so a per-isolate collector can
+  safely ignore shared-arena references.
+- **Interior mutability is already synchronized** — `LazySeq.state`, `Atom`, `Var`, `Multimethod`,
+  `Namespace` are all `Mutex`-guarded. So shareable immutable values placed in the static arena are
+  safe to read from any isolate.
+- **The executor is already single-threaded per instance** (`spawn_local`, `current_thread`). An
+  isolate *is* today's executor; we instantiate it N times instead of changing its internals.
 
----
+**Fights it (must be migrated):**
 
-## Phased implementation
-
-### Phase 1 — Pool scaffolding (no behavior change)
-
-- Introduce a `WorkerPool` in `cljrs-async` that can spin up `W` worker threads, each with its own
-  `current_thread` runtime + `LocalSet` + `register_mutator()` + GC-service task.
-- `W = 1` by default initially, so behavior is identical to today; the CLI/embedder gains a knob
-  (`--workers N` / `init_with_workers(n)`).
-- `init()` becomes pool-aware but still routes everything to worker 0.
-
-**Done when:** existing async tests pass unchanged with the pool at `W = 1`, and `W > 1` boots `W`
-idle workers that all register as mutators and participate in STW.
-
-### Phase 2 — Spawn routing across workers
-
-- `spawn_future` / `async-spawn` / `go` / `^:async` dispatch route new top-level tasks to a worker
-  by placement policy (round-robin first); child tasks inherit the parent worker.
-- Verify per-worker locality: a task and everything it allocates stay on one thread.
-
-**Done when:** with `W > 1`, independent `go`/`^:async` workloads measurably spread across cores,
-and a CPU-bound benchmark scales with `W` (up to the allocation-mutex ceiling).
-
-### Phase 3 — Cross-worker correctness audit
-
-- **Audit `CljChannel::Trace`**: confirm buffered values are traced; add a test that `put!`s on one
-  worker, forces STW, then `take!`s on another and checks the value survived.
-- Confirm cross-runtime wakeups for `take!`/`put!`/`alts!` parked on a different worker than the
-  producer.
-- Stress STW under multi-worker load: many workers allocating, one triggering collection, verify
-  all park at safepoints and every worker's roots are traced.
-
-**Done when:** a cross-worker channel ping-pong survives aggressive forced GC with no UAF/leak under
-the GC's debug provenance assertions.
-
-### Phase 4 — Safepoint coverage for long native calls
-
-- Ensure native/FFI calls reachable from async paths poll safepoints (or are wrapped to do so) so a
-  single busy worker cannot stall global STW for the rest.
-- Document the rule for `interop` authors: long-running native fns must yield to safepoints.
-
-**Done when:** a deliberately long native call on one worker does not deadlock GC for others
-(bounded pause), with a regression test.
-
-### Phase 5 — External `Send` handoff API (enables `cljrs-net`)
-
-- Public API for "build this on worker *i* from `Send` inputs": e.g. `spawn_on(worker, FnOnce ->
-  Future)` and an FD/`Vec<u8>` handoff helper.
-- This is what `cljrs-net`'s accept path calls to pin a connection to a worker.
-
-**Done when:** `cljrs-net` (or a stand-in test) can accept on one thread and run a pinned
-connection's reader/writer on a chosen worker, with byte-arrays built on that worker.
+- **`GcPtr: Send + Sync` is currently `unsafe impl`'d** (`cljrs-gc/src/lib.rs:302–303`) and several
+  paths rely on it: the `future`/`agent` builtins `thread::spawn` + `register_mutator()` and allocate
+  off the main thread; `register_mutator` is called at `crates/cljrs/src/main.rs:291`. Deleting the
+  impl is a **forcing function** — flip it and the compiler enumerates every cross-thread `GcPtr`
+  move to migrate.
+- **`future`/`agent` semantics.** In Model A a `future` body running Clojure code cannot run on
+  another thread (no off-thread `GcPtr`). Like JS, `future` becomes loop-async; *parallel* execution
+  needs an isolate (Model B). This is a behavior change to document.
 
 ---
 
-## The two ceilings (and the endgame)
+## The hard part, stated honestly: shared vars/atoms vs share-nothing
 
-The shared-heap pool scales to a point and then hits two walls. Naming them up front so they are
-chosen, not stumbled into:
+Clojure's **vars and atoms are globally shared mutable references**; the isolate model is
+share-nothing. This is the central tension and it determines whether the result "feels like Clojure."
+Three options, to be decided before Model B is built:
 
-1. **Global STW.** Every worker must reach a safepoint before *any* collection runs (Phase 4
-   mitigates the stall risk but not the fundamental coordination). I/O `await` points are
-   safepoints, so I/O-bound serving is fine; allocation-heavy CPU-bound work pays coordination cost.
-2. **The single global heap `Mutex` is the allocation bottleneck.** Every `GcPtr::new` locks the one
-   heap; at high allocation rates across many cores this serializes and becomes the scaling wall.
+1. **Arena-promote on publish.** Var root values and atom contents must be *shareable* — deeply
+   immutable with no isolate-local pointers — and are copied into the shared static arena on
+   `def`/`reset!`. Reads from any isolate are then safe. Cost: every published value is copied once
+   into the arena; non-shareable values (e.g. one holding a native resource) can't be published.
+2. **Confine + message-pass.** Atoms/refs are owned by an isolate; cross-isolate access goes through
+   messages (un-Clojure-like, but pure share-nothing — the BEAM/ETS model).
+3. **Hybrid (recommended starting point).** *Immortal* shared state — code (compiled fns,
+   namespaces), interned keywords/symbols, and large `byte-array` blobs — lives in the static arena
+   and is referenced everywhere with no copy. *User-level mutable* state (atoms) starts
+   **isolate-confined**, with an explicit `shared-atom` (arena-promoted, copy-on-publish) for the
+   cases that genuinely need cross-isolate sharing. Vars: root bindings are arena-promoted (option 1)
+   since `def` is comparatively rare and global by nature; dynamic `binding` is already thread-local
+   and maps cleanly to per-isolate.
 
-### Endgame (deferred — `cljrs-gc` changes, separate plan when pursued)
-
-- **TLABs (thread-local allocation buffers).** Each worker gets a private bump region and only takes
-  the global lock to refill it. Relieves ceiling #2 with no change to the shared-heap / global-STW
-  model. The natural *first* `cljrs-gc` follow-up once Phase 2 shows allocation contention.
-- **Share-nothing per-worker heaps** (the BEAM/Ractor model). De-globalize `static HEAP` into a
-  per-worker heap: no shared alloc lock (ceiling #2 gone), no global STW (ceiling #1 gone — each
-  worker collects independently), cross-worker messages **copied/serialized** rather than shared.
-  This is the real linear-scaling design and a substantial `cljrs-gc` refactor. The pinned-work +
-  `Send`-handoff + channel design in this plan is already the share-nothing message-passing shape,
-  so application code and `cljrs-net` port to it unchanged — only the channel handoff switches from
-  "share a `GcPtr`" to "copy across heaps."
-
----
-
-## Risks & open questions
-
-- **Placement policy.** Round-robin ignores task cost; least-loaded needs cheap load metrics. Start
-  simple, measure, refine. Bad placement hurts throughput but not correctness.
-- **Work stealing.** Not in scope — pinned tasks can't be stolen (they hold `!Send` `GcPtr`s).
-  Imbalance is handled by placement, not migration. Revisit only with share-nothing heaps.
-- **`thread_local!` correctness.** `EVAL_CONTEXT`, `BINDING_STACK`, `ALLOC_ROOTS`, `REGION_STACK`
-  are per-thread, which is *correct* for per-worker pinning, but anything that implicitly assumed a
-  single global thread-local must be audited (dynamic `binding` does not cross workers — by design,
-  matching Clojure's thread-local `binding` semantics).
-- **Determinism of tests.** Multi-worker scheduling is nondeterministic; keep `W = 1` as the default
-  for deterministic test runs and gate multi-worker tests explicitly.
-- **Embedder impact.** Embedders calling `cljrs_async::init` get `W = 1` (today's behavior); opting
-  into a pool is explicit.
+This is the one place the model can go wrong in a way that's expensive to undo, so it gets resolved
+explicitly (an ADR) before Phase B2.
 
 ---
 
-## Relationship to other crates
+## Model A — single heap + `Send` worker pool
 
-- **`cljrs-async`** — owns the pool (this plan).
-- **`cljrs-gc`** — unchanged for Phases 1–5; owns the deferred TLAB / share-nothing endgame.
-- **`cljrs-net`** — consumes the Phase 5 `Send`-handoff API to pin connections (see
-  `networking-plan.md` Phase H, which points here).
-- **`cljrs-io`** — file I/O tasks become poolable for free once spawn routing (Phase 2) lands; no
-  `cljrs-io` change required.
+The safe, small first step. Delete the unsafe impl; parallelize only `Send` work.
+
+### A1 — Make `GcPtr` honestly `!Send`
+
+- Remove `unsafe impl Send/Sync for GcPtr` (and the supporting `GcBoxHeader` impls where they exist
+  only to enable cross-thread `GcPtr`). Let the compiler list every violation.
+- Migrate `future`/`agent` off `thread::spawn`+`register_mutator`: `future` bodies run as loop-async
+  tasks on the heap thread; CPU-parallel work is redirected to the Send pool (A2) or deferred to
+  isolates (Model B).
+- Keep exactly one `register_mutator()` (the heap thread). STW becomes a single-thread cooperative
+  pause again — simpler than today.
+
+**Done when:** the tree builds with `GcPtr: !Send`, all async tests pass, and no code moves a
+`GcPtr` across a thread.
+
+### A2 — `Send` worker pool for non-GC work
+
+- A `tokio` multi-thread runtime (or `rayon`) used **only** for `Send` work: socket read/write into
+  `Vec<u8>`, TLS handshake/encrypt/decrypt (rustls operates on byte buffers — `Send`), compression,
+  hashing, byte-level regex.
+- Results return as `Send` data over a oneshot/mpsc to the heap thread, which builds the `GcPtr`
+  (`byte-array`, etc.). This is the seam `cljrs-net` uses: the socket lives in the pool as `Vec<u8>`
+  traffic; the heap thread only ever sees byte-arrays it constructed.
+
+**Done when:** TLS bulk transfer and compression run on pool threads while the heap thread stays
+responsive; an I/O-bound benchmark scales with pool size though Clojure logic stays single-core.
+
+---
+
+## Model B — independent isolates (parallel collection)
+
+An isolate = today's single-threaded executor + its own heap + its own collector. Run N of them.
+
+### B1 — De-globalize the heap into per-isolate heaps
+
+- Replace the `static HEAP: GcHeap` singleton with a **per-isolate** heap (thread-local or
+  instance-handle threaded through the allocator). The static arena stays global and shared.
+- Each isolate: own `current_thread` runtime + `LocalSet`, own heap, own collector, own root stacks
+  (the root stacks are *already* thread-local — `ENV_ROOTS`, `BINDING_STACK`, `ALLOC_ROOTS`,
+  `REGION_STACK` — so this part is nearly free).
+- Collection is now **fully parallel and independent**: an isolate collects its own heap with no
+  global STW and no cross-isolate coordination. A collector that encounters a static-arena pointer
+  (`is_static_addr`) stops there; it can never see another isolate's heap because nothing is shared.
+
+**Done when:** two isolates run concurrent allocation-heavy workloads and each GCs independently;
+total throughput scales ~linearly with isolate count (no shared alloc lock, no global pause).
+
+### B2 — The copy boundary
+
+- A **structured-clone / serialize step** for moving a value between isolates: deep-copy a shareable
+  value from isolate A's heap to isolate B's heap (or to the shared arena). This is the only way a
+  value crosses; `!Send` makes "accidentally sharing a pointer" a compile error.
+- Reuse / share machinery with a future nippy-like persistent serializer — clojurust wants this
+  format anyway for IPC and on-disk values.
+- Non-shareable values (holding a native `Resource`/FD) cannot cross; the FD-handoff pattern moves
+  the `Send` token instead and rebuilds on the destination isolate (this is exactly the `cljrs-net`
+  pinned-connection seam).
+
+**Done when:** a value sent over a cross-isolate channel arrives as an independent copy in the
+receiver's heap, verified independently collectable on both sides.
+
+### B3 — Shared immortal arena for code, keywords, blobs
+
+- Interned **keywords/symbols** live in the static arena behind a global `Mutex` intern table, so
+  keyword *identity* is consistent across isolates (critical for map lookups). Loaded
+  **namespaces/compiled fns** live there too — all isolates run the same code with zero copy.
+- Large **`byte-array` blobs** can be arena-allocated and refcounted (the BEAM off-heap-binary
+  trick) so big payloads are shared, not copied, across the boundary.
+- Resolve vars/atoms per the "hard part" ADR (start: hybrid — immortal shared code/keywords,
+  isolate-confined atoms + explicit `shared-atom`).
+
+**Done when:** isolates share code and keyword identity through the arena and only per-request
+mutable state is copied at the boundary.
+
+---
+
+## Memory pressure signaling
+
+- **Per-isolate accounting** plus a global `AtomicUsize` of total live bytes (each isolate adjusts on
+  collect). A coordinator watches per-isolate `GcStats` (live set, alloc rate).
+- The coordinator drives a `tokio::sync::watch<PressureLevel>` (Green/Yellow/Red) that every isolate
+  reads at safepoints. Responses are **local and graduated**: Yellow → collect more eagerly / lower
+  the young-gen threshold; Red → **stop taking from `:conns`** (the accept backpressure already in
+  `networking-plan.md`) and shed load. Memory pressure reuses the same channel-backpressure
+  mechanism as the rest of the system.
+- Optional real signals into the coordinator on Linux: cgroup v2 **PSI** memory pressure, RSS
+  watermarks.
+
+This is strictly better than the shared-heap cliff: pressure is per-isolate observable and per-isolate
+actionable.
 
 ---
 
 ## Phase summary
 
-| Phase | Deliverable | Crate |
+| Phase | Deliverable | Crate(s) |
 |---|---|---|
-| 1 | `WorkerPool` scaffolding; `W=1` default; per-worker runtime + mutator + GC-service | `cljrs-async` |
-| 2 | Spawn routing across workers; parent-inherits-worker; per-worker locality | `cljrs-async` |
-| 3 | Cross-worker channel audit (`CljChannel::Trace`, wakeups, STW stress) | `cljrs-async` (+ `cljrs-gc` tests) |
-| 4 | Safepoint coverage for long native calls | `cljrs-async`, `cljrs-interop` |
-| 5 | `Send`-handoff / `spawn_on(worker, …)` API for external producers | `cljrs-async` |
-| — | **Deferred:** TLABs, then share-nothing per-worker heaps | `cljrs-gc` (separate plan) |
+| A1 | Delete `unsafe impl Send/Sync for GcPtr`; migrate `future`/`agent`; single registered mutator | `cljrs-gc`, `cljrs-builtins`, `cljrs-async` |
+| A2 | `Send`-only worker pool (I/O, TLS crypto, compression, hashing) with `Send`-result handoff | `cljrs-async` |
+| B1 | Per-isolate heaps; independent parallel collection; arena pointers skipped via `is_static_addr` | `cljrs-gc`, `cljrs-async` |
+| B2 | Copy/structured-clone boundary; `Send`-token handoff for resources (the `cljrs-net` seam) | `cljrs-async`, `cljrs-value` |
+| B3 | Shared static arena for code, interned keywords/symbols, refcounted blobs | `cljrs-gc`, `cljrs-value`, `cljrs-env` |
+| — | **ADR (before B2):** vars/atoms reconciliation (hybrid: immortal-shared + isolate-confined + `shared-atom`) | design |
+
+A1+A2 (Model A) ship a safe, faster, `unsafe`-free runtime on their own. B1–B3 (Model B) add
+parallel collection and multicore Clojure execution.
+
+---
+
+## Risks & open questions
+
+- **Vars/atoms vs share-nothing** — the central one (above); resolved by ADR before B2.
+- **`future`/`agent` behavior change** — parallel→loop-async in Model A; re-parallelized via isolates
+  in Model B. Document clearly; it diverges from JVM Clojure's thread-per-future.
+- **De-globalizing `HEAP`** — touches every allocation site; the thread-local root stacks already
+  being per-thread limits the blast radius, but the allocator entry points (`GcPtr::new`,
+  `alloc_ctx`, regions) must learn "which isolate's heap."
+- **Copy cost at the boundary** — mitigated by the shared arena (code/keywords/blobs never copy) and
+  by pinning work so most values never cross. Measure; promote hot shared data to the arena.
+- **Determinism in tests** — default to one isolate for deterministic runs; gate multi-isolate tests.
+- **Keyword interning contention** — the global intern table is a shared lock; keywords are created
+  often. May need a sharded or lock-free intern table.
+
+---
+
+## Relationship to other crates
+
+- **`cljrs-gc`** — owns `!Send` `GcPtr` (A1), per-isolate heaps + the shared arena (B1/B3).
+- **`cljrs-async`** — owns the `Send` worker pool (A2) and isolate runtimes (B1) and the copy
+  boundary (B2).
+- **`cljrs-value`/`cljrs-env`** — structured-clone (B2), arena-resident keywords/code/vars (B3).
+- **`cljrs-net`** — consumes the `Send`-token (FD) handoff to pin a connection to an isolate; see
+  `networking-plan.md` Phase H.
+- **`cljrs-io`** — file I/O becomes pool/isolate-friendly for free; no change required.

--- a/async-worker-pool-plan.md
+++ b/async-worker-pool-plan.md
@@ -69,28 +69,81 @@ instances and a shared immortal arena underneath.**
 
 ---
 
-## The hard part, stated honestly: shared vars/atoms vs share-nothing
+## Guiding principle: pure-Clojure compatibility is not a constraint
 
-Clojure's **vars and atoms are globally shared mutable references**; the isolate model is
-share-nothing. This is the central tension and it determines whether the result "feels like Clojure."
-Three options, to be decided before Model B is built:
+clojurust does **not** aim to reproduce JVM-Clojure's concurrency semantics bit-for-bit. Where an
+honest separation of concerns conflicts with Clojure compatibility, separation wins, and we add
+new primitives on top where they make sense. The two-tier atom below is the first concrete
+application of this: rather than force one `atom` to satisfy both fast local use *and* cross-isolate
+sharing, we keep `atom` local-and-fast and add `shared-atom` as an explicit, separate tool.
 
-1. **Arena-promote on publish.** Var root values and atom contents must be *shareable* — deeply
-   immutable with no isolate-local pointers — and are copied into the shared static arena on
-   `def`/`reset!`. Reads from any isolate are then safe. Cost: every published value is copied once
-   into the arena; non-shareable values (e.g. one holding a native resource) can't be published.
-2. **Confine + message-pass.** Atoms/refs are owned by an isolate; cross-isolate access goes through
-   messages (un-Clojure-like, but pure share-nothing — the BEAM/ETS model).
-3. **Hybrid (recommended starting point).** *Immortal* shared state — code (compiled fns,
-   namespaces), interned keywords/symbols, and large `byte-array` blobs — lives in the static arena
-   and is referenced everywhere with no copy. *User-level mutable* state (atoms) starts
-   **isolate-confined**, with an explicit `shared-atom` (arena-promoted, copy-on-publish) for the
-   cases that genuinely need cross-isolate sharing. Vars: root bindings are arena-promoted (option 1)
-   since `def` is comparatively rare and global by nature; dynamic `binding` is already thread-local
-   and maps cleanly to per-isolate.
+---
 
-This is the one place the model can go wrong in a way that's expensive to undo, so it gets resolved
-explicitly (an ADR) before Phase B2.
+## ADR: vars/atoms across isolates — two-tier, decided
+
+Clojure's vars and atoms are globally-shared mutable references; the isolate model is share-nothing.
+**Resolved (this is no longer open):** a **two-tier** design, with `Arc` providing the shared cell
+and a `Send + Sync` value representation providing the shared contents.
+
+### Tier 1 — `atom` (isolate-local, the fast common case)
+
+Unchanged from today: a GC-heap-backed `Mutex<Value>` confined to one isolate. Bump-allocated,
+no refcount churn, `!Send` like everything else in an isolate. This is what `(atom …)` returns.
+
+### Tier 2 — `shared-atom` (explicit, cross-isolate)
+
+A new primitive for genuinely shared mutable state:
+
+```
+SharedAtom  = Arc<ArcSwap<SharedValue>>          ; Send + Sync; lock-free cross-isolate CAS
+SharedValue = immediate                           ; long/double/bool/nil/char — no allocation
+            | Arc<…>                               ; refcounted, acyclic, immutable structure
+            | ResourceHandle | static-arena ref    ; existing Send+Sync escape hatches
+```
+
+- **Cell:** `Arc<ArcSwap<…>>` gives identity, lifetime, and **lock-free atomic `swap!`/`reset!`**
+  across isolates — exactly an atom's CAS-retry semantics, off the shelf.
+- **Contents:** must be `Send + Sync`. Immutable persistent collections are **acyclic DAGs**, so
+  plain `Arc` refcounting is sufficient and leak-free — no tracing GC needed for shared values. This
+  reuses the pattern already in the tree: `ResourceHandle` is `Arc<dyn Resource>` and `static_arena`
+  is program-lifetime `Send + Sync`; `SharedValue` is the third instance of "an Arc/arena thing
+  beside the GC, not inside it."
+- **`Value` gains a shared variant** that points at a `SharedValue` (the same way `Value::Resource`
+  wraps an `Arc`), so both isolates' interpreters read it directly — no copy on read; `deref` is an
+  atomic refcount bump.
+- **Promote-on-publish:** `swap!`/`reset!` deep-copy any isolate-local parts of the new value into
+  `SharedValue` form before the atomic store (zero-copy if already shared). Reads are cheap.
+
+### Constraints (all the same "plain data only" rule)
+
+1. **Transitive shareability.** Everything reachable from a `shared-atom` must be shareable:
+   immediates + Arc/arena data. Values holding a **closure that captured isolate-local state** or a
+   **native resource bound to one isolate** cannot be published — same rule as message-copying.
+2. **Cycles leak.** Pure `Arc` refcounting leaks cycles, and a `shared-atom` holding another mutable
+   ref could build one. **Start by restricting `shared-atom` to hold immutable acyclic data only**
+   (no embedded refs/closures); revisit with a small dedicated collector for the shared tier only if
+   ref-holding-ref is ever needed.
+3. **Promotion cost** is paid once on publish; reads are cheap. Local `atom` avoids all of it.
+
+### Vars
+
+A var's root binding is the same shape as a shared mutable cell, so it uses the **same mechanism**:
+`Arc<ArcSwap<SharedValue>>`, promote-on-`def`. `def` is comparatively rare and global by nature, so
+the promotion cost is acceptable. Dynamic `binding` is already thread-local and maps directly to
+per-isolate — no change.
+
+### Immortal shared state (orthogonal, also decided)
+
+Code (compiled fns, namespaces), interned keywords/symbols, and large `byte-array` blobs live in the
+shared **static arena** and are referenced from every isolate with **no copy** (see B3). This is
+separate from the atom tiers and not in tension with anything.
+
+### Rejected alternative
+
+**Uniform Arc-backed atoms** (one tier, all atoms cross-isolate-capable). Rejected: every atom would
+pay refcounting + promotion and lose GC bump-allocation speed, and the cyclic-leak problem would
+become universal rather than confined to an opt-in primitive. The two-tier split keeps the common
+case fast and makes sharing an explicit, honest choice.
 
 ---
 
@@ -164,8 +217,8 @@ receiver's heap, verified independently collectable on both sides.
   **namespaces/compiled fns** live there too — all isolates run the same code with zero copy.
 - Large **`byte-array` blobs** can be arena-allocated and refcounted (the BEAM off-heap-binary
   trick) so big payloads are shared, not copied, across the boundary.
-- Resolve vars/atoms per the "hard part" ADR (start: hybrid — immortal shared code/keywords,
-  isolate-confined atoms + explicit `shared-atom`).
+- Implement the two-tier atoms / `shared-atom` / var-root mechanism per the ADR above
+  (`Arc<ArcSwap<SharedValue>>`, promote-on-publish; local `atom` stays GC-backed).
 
 **Done when:** isolates share code and keyword identity through the arena and only per-request
 mutable state is copied at the boundary.
@@ -198,7 +251,7 @@ actionable.
 | B1 | Per-isolate heaps; independent parallel collection; arena pointers skipped via `is_static_addr` | `cljrs-gc`, `cljrs-async` |
 | B2 | Copy/structured-clone boundary; `Send`-token handoff for resources (the `cljrs-net` seam) | `cljrs-async`, `cljrs-value` |
 | B3 | Shared static arena for code, interned keywords/symbols, refcounted blobs | `cljrs-gc`, `cljrs-value`, `cljrs-env` |
-| — | **ADR (before B2):** vars/atoms reconciliation (hybrid: immortal-shared + isolate-confined + `shared-atom`) | design |
+| — | **ADR (decided):** two-tier atoms — local `atom` (GC-backed) + `shared-atom`/var-root (`Arc<ArcSwap<SharedValue>>`, promote-on-publish) | design |
 
 A1+A2 (Model A) ship a safe, faster, `unsafe`-free runtime on their own. B1–B3 (Model B) add
 parallel collection and multicore Clojure execution.
@@ -207,7 +260,9 @@ parallel collection and multicore Clojure execution.
 
 ## Risks & open questions
 
-- **Vars/atoms vs share-nothing** — the central one (above); resolved by ADR before B2.
+- **Vars/atoms vs share-nothing** — *decided* (two-tier ADR above). Residual risks are narrow:
+  cycle leaks in the shared tier (mitigated by restricting `shared-atom` to acyclic immutable data)
+  and promotion cost on publish (mitigated by the shared static arena + work pinning).
 - **`future`/`agent` behavior change** — parallel→loop-async in Model A; re-parallelized via isolates
   in Model B. Document clearly; it diverges from JVM Clojure's thread-per-future.
 - **De-globalizing `HEAP`** — touches every allocation site; the thread-local root stacks already

--- a/networking-plan.md
+++ b/networking-plan.md
@@ -101,71 +101,44 @@ inherits from choosing core.async over a Manifold-style stream.
 
 ---
 
-## Execution Model — a worker pool, not a single thread
+## Execution Model — isolates, not one thread
 
-A single `LocalSet` thread is a demo, not a server: one interpreter thread cannot use more than
-one core, so meaningful concurrent serving needs real worker threads. The good news is that the
-GC already supports this — see Phase H below. The networking layer is designed against a
-**worker pool** from the start.
+A single `LocalSet` thread is a demo, not a server: one interpreter thread cannot use more than one
+core. The networking layer is designed against the **isolate** model defined in
+`async-worker-pool-plan.md` (A→B): a single heap thread plus a `Send`-only Rust worker pool first
+(Model A), then independent per-isolate heaps collected in parallel (Model B). The key property
+`cljrs-net` relies on is that **`GcPtr` is `!Send`** — connections are pinned to one isolate and
+nothing shares a `GcPtr` across threads.
 
-### What the GC already allows
+### What `cljrs-net` needs from the runtime
 
-The single-thread `LocalSet` in today's `cljrs-async` is an *async-runtime* choice
-(`current_thread` + `LocalSet` lets eval futures hold `GcPtr`s across `await` without being
-`Send`), **not** a GC limitation. The collector is already a *shared-heap, multi-mutator,
-stop-the-world* design:
+- **`GcPtr: !Send`.** A connection's `:in`/`:out` channels, its byte-arrays, and its handler all live
+  on **one** isolate. Bytes are constructed on that isolate's thread from `Send` `Vec<u8>` buffers.
+- **`Send`-token (FD) handoff.** A raw socket FD is an integer — it *is* `Send`. The accept path
+  hands the FD to an isolate (Model A: the single heap thread; Model B: a chosen worker isolate),
+  which builds the `TcpStream` + channels **locally**. Distribution is a dedicated accept task
+  routing FDs, or `SO_REUSEPORT` with one listener per isolate (kernel load-balances).
+- **`Send` worker pool** (Model A2) for the bytes-in-flight that don't need the heap: socket
+  read/write into `Vec<u8>`, and especially **TLS crypto** (rustls operates on byte buffers —
+  `Send`), so handshakes/bulk encryption don't compete with eval. Results return as `Send` data; the
+  isolate builds the `byte-array`.
 
-- one global `Mutex`-guarded `GcHeap` static (`cljrs-gc/src/lib.rs`); allocation across threads is
-  already serialized and sound;
-- `cljrs_gc::register_mutator()` exists and is already called per thread
-  (`crates/cljrs/src/main.rs:291`, plus test harnesses that `thread::spawn`);
-- `begin_stw()` (`cljrs-env/src/gc_roots.rs`) parks **all** registered mutators at safepoints and
-  traces **each** thread's thread-local root stack;
-- `GlobalEnv` is `Arc`-shared with `RwLock`/`Mutex`-guarded namespace tables, so all threads see
-  the same defs.
+### Per connection
 
-So multiple OS threads can each run an interpreter against the same heap today. `GcPtr`'s
-`unsafe impl Send + Sync` is sound **under one discipline**: every thread that holds `GcPtr`s is a
-registered mutator that reaches safepoints, and every live value stays reachable from some traced
-root. Cross-thread dereference races are prevented *by* STW — during mark/sweep every mutator is
-parked. The only real hazard is a thread holding `GcPtr`s that never registers / never safepoints.
+On the owning isolate, two tasks (via `spawn_future`):
 
-### The model: shared-heap, pinned-connection workers
+1. a **reader task** — read into `Vec<u8>` (`Send`, optionally via the Model A2 pool), convert to a
+   `byte-array` **on the isolate thread**, `put!` to `:in`, until EOF/error;
+2. a **writer task** — `<!` from `:out`, write to the socket, until `:out` closes, then shut down the
+   write half.
 
-`cljrs-async` grows a **worker pool** (Phase H): `W` worker OS threads (default ≈ core count),
-each running its own `current_thread` runtime + `LocalSet`, each a registered mutator, all sharing
-the one heap and one `Arc<GlobalEnv>`. This is the nginx-workers / BEAM-schedulers shape, but with
-a shared heap.
+### Cross-isolate handoff
 
-- **Connections are pinned to a worker.** A raw socket FD is an integer — it *is* `Send`. An
-  accept path (a dedicated accept task, or `SO_REUSEPORT` with one listener per worker) hands the
-  FD to a worker, which builds the `TcpStream` + `:in`/`:out` channels **in its own `LocalSet`**.
-  Thereafter that connection's bytes, framing, and handler all run on that worker — so in steady
-  state **no `GcPtr` crosses threads** and per-worker futures stay `!Send`/local.
-- **Per connection**, the owning worker spawns two tasks (via `spawn_future`):
-  1. a **reader task** — `socket.read()` into a plain `Vec<u8>` (`Send`), convert to a `byte-array`
-     `Value` **on that worker thread** (byte-arrays are `!Send` GC values, built on the heap by a
-     registered mutator), `put!` to `:in`, until EOF/error;
-  2. a **writer task** — `<!` from `:out`, write to the socket, until `:out` closes, then shut down
-     the write half.
-- **Cross-worker handoff** (when a value must move between workers) goes through a channel. A
-  `GcPtr` value put by worker A and taken by worker B is safe because collection is STW (both are
-  parked during mark/sweep) **provided `CljChannel`'s `Trace` walks its buffer** so buffered values
-  stay rooted — verify this as part of Phase H. Tokio wakers are `Send`, so waking a parked
-  take/put task on another worker's runtime works.
-
-### The two ceilings (named honestly)
-
-1. **Global STW.** Every worker must reach a safepoint before any collection runs. I/O `await`
-   points are safepoints, so I/O-bound serving is fine, but a long CPU-bound native/FFI call with
-   no safepoint polling stalls GC for *all* workers. Long native calls must poll safepoints.
-2. **The single global heap mutex is the allocation bottleneck.** Every `GcPtr::new` locks the one
-   heap; at high allocation rates across many cores this serializes. The first scaling lever is
-   **thread-local allocation buffers (TLABs)**: a per-worker bump region that hits the global lock
-   only to refill. The endgame for linear scaling is **share-nothing workers** (per-worker heap,
-   no shared alloc lock, no global STW, cross-worker messages copied) — a `cljrs-gc` refactor
-   deferred to Future Work. The pinned-connection + channel-handoff design here is already the
-   share-nothing message-passing shape, so it ports forward unchanged.
+A connection never needs to move between isolates in steady state (it's pinned). When a *value* must
+cross isolates (Model B), it is **copied** at the boundary (structured-clone) — `!Send` makes
+accidental pointer-sharing a compile error. Large `byte-array` payloads can be shared via the static
+arena rather than copied (see `async-worker-pool-plan.md` B3). This is the share-nothing
+message-passing shape, so the networking design is forward-compatible with Model B unchanged.
 
 ---
 
@@ -321,29 +294,29 @@ same channel-of-connections server as TCP — only the address is a filesystem p
 
 ---
 
-## Phase H — Worker pool (the part that makes it not a toy)
+## Phase H — Isolate runtime (the part that makes it not a toy)
 
 The multicore executor that lets every preceding phase use more than one core lives in
 **`cljrs-async`**, not `cljrs-net`, because it affects all async work (file I/O, `go`, `^:async`),
-not just sockets. It has its own design doc: **`async-worker-pool-plan.md`**.
+not just sockets. It has its own design doc: **`async-worker-pool-plan.md`** (the isolate A→B model).
 
 What `cljrs-net` needs from it (the seam between the two plans):
 
-- A **`Send`-handoff / `spawn_on(worker, …)` API** (worker-pool plan Phase 5) so the accept path
-  can hand an accepted socket **FD** (an integer — `Send`) to a chosen worker, which builds the
-  `TcpStream` + `:in`/`:out` channels in *its own* `LocalSet`. From then on the connection is
-  **pinned** to that worker — bytes, framing, and handler all run there, so no `GcPtr` crosses
-  threads in steady state.
-- Accept distribution is either a dedicated accept task routing FDs, or `SO_REUSEPORT` with one
-  listener per worker (kernel load-balances).
-- Cross-worker value handoff (when used) goes through channels and is STW-safe once the worker-pool
-  plan's `CljChannel::Trace` audit lands.
+- **`GcPtr: !Send`** (worker-pool plan A1) so a connection is safely pinned to one isolate with no
+  cross-thread pointer sharing.
+- A **`Send`-token (FD) handoff API** (worker-pool plan A2/B2) so the accept path can hand an accepted
+  socket **FD** to a chosen isolate, which builds the `TcpStream` + `:in`/`:out` channels locally.
+  Distribution: a dedicated accept task routing FDs, or `SO_REUSEPORT` per isolate.
+- A **`Send` worker pool** (worker-pool plan A2) for TLS crypto and raw socket byte movement, so
+  encryption/handshakes run off the isolate thread; results return as `Send` data the isolate turns
+  into byte-arrays.
 
-A–G are written against a per-worker `LocalSet`, so they are unaffected by *when* the pool arrives.
+A–G are written against a single-threaded isolate executor, so they are unaffected by *when* Model B
+(multiple isolates) arrives — Model A already runs them safely on one heap thread + the Send pool.
 
-**Done when:** an echo/line server saturates multiple cores under concurrent clients (load spread
-across workers), with GC STW pauses correctly parking and tracing every worker. (Tracked in
-`async-worker-pool-plan.md`.)
+**Done when (Model A):** TLS + socket byte movement run on the pool while the heap thread stays
+responsive. **Done when (Model B):** an echo/line server saturates multiple cores under concurrent
+clients, isolates collecting in parallel. (Both tracked in `async-worker-pool-plan.md`.)
 
 ---
 
@@ -365,10 +338,10 @@ across workers), with GC STW pauses correctly parking and tracing every worker. 
 
 ## Key Design Constraints
 
-- **Socket I/O runs on a pool of per-worker `LocalSet`s, not one thread** (Phase H). Each
-  connection is pinned to a worker; byte-arrays (`!Send` GC values) are built on that worker from
-  `Send` `Vec<u8>` buffers. The single-thread executor is an async-runtime default, not a GC limit —
-  the GC is already a shared-heap, multi-mutator, STW collector (`register_mutator`/`begin_stw`).
+- **Connections are pinned to one isolate; `GcPtr` is `!Send`** (Phase H / `async-worker-pool-plan.md`).
+  Byte-arrays are built on the owning isolate from `Send` `Vec<u8>` buffers; TLS crypto and raw byte
+  movement run on a `Send` worker pool. Cross-isolate value transfer is a copy, never a shared
+  pointer.
 - **Sockets are `Resource` (Arc), never `GcPtr`.** Deterministic close; no FD leaks. The GC has no
   finalizers. `resource.rs` already anticipates this.
 - **Backpressure is channel-native.** Bounded `:in`/`:out`/`:conns` buffers translate directly to
@@ -397,19 +370,19 @@ across workers), with GC STW pauses correctly parking and tracing every worker. 
 | E | TLS client + server via `rustls`/`tokio-rustls` (same `{:in :out}` shape) | A, B |
 | F | Unix-domain stream sockets (`#[cfg(unix)]`) | A, B |
 | G | Lifecycle: `with-open`, timeouts, half-close, error/EOF split helper | A–F |
-| H | Worker pool — see **`async-worker-pool-plan.md`**; `cljrs-net` consumes its Phase 5 `Send`-handoff API to pin connections | `cljrs-async`; parallel with A–G |
+| H | Isolate runtime — see **`async-worker-pool-plan.md`**; `cljrs-net` consumes `GcPtr: !Send`, the FD-handoff, and the `Send` crypto pool | `cljrs-async`, `cljrs-gc`; parallel with A–G |
 
-Phase H is the multicore enabler and the one cross-crate change — it lives in `cljrs-async` and has
-its own plan (`async-worker-pool-plan.md`). A–G are written against a per-worker `LocalSet` so they
-are unaffected by when it lands.
+Phase H is the multicore enabler and the one cross-crate change — it lives in `cljrs-async`/`cljrs-gc`
+and has its own plan (`async-worker-pool-plan.md`, the isolate A→B model). A–G are written against a
+single-threaded isolate executor so they are unaffected by when Model B lands.
 
 ---
 
 ## Future Work (not in scope now)
 
-- The executor scaling work (TLABs, then share-nothing per-worker heaps) is owned by
-  `async-worker-pool-plan.md`, not this plan — the networking design ports to share-nothing
-  unchanged (pinned connections + channel handoff is already the message-passing shape).
+- The executor/heap concurrency work (isolates, parallel collection, the copy boundary, shared
+  static arena) is owned by `async-worker-pool-plan.md`, not this plan — the networking design ports
+  to isolates unchanged (pinned connections + FD handoff is already the share-nothing shape).
 - Higher-level protocol crates built on `cljrs-net`: HTTP/1.1, WebSocket, HTTP/2 (the aleph stack),
   each as a separate crate consuming the `{:in :out}` connection + framing layer.
 - Connection pooling and a client-side reconnect/backoff helper.

--- a/networking-plan.md
+++ b/networking-plan.md
@@ -323,31 +323,27 @@ same channel-of-connections server as TCP — only the address is a filesystem p
 
 ## Phase H — Worker pool (the part that makes it not a toy)
 
-This phase lives in **`cljrs-async`**, not `cljrs-net` — it is the executor change that lets every
-preceding phase use more than one core. It can land before or in parallel with A–G; A–G are written
-to a per-worker `LocalSet` so they don't change when the pool arrives.
+The multicore executor that lets every preceding phase use more than one core lives in
+**`cljrs-async`**, not `cljrs-net`, because it affects all async work (file I/O, `go`, `^:async`),
+not just sockets. It has its own design doc: **`async-worker-pool-plan.md`**.
 
-- **Pool runtime.** Replace the single `current_thread` + `LocalSet` driver with `W` worker OS
-  threads (default ≈ available parallelism, configurable), each its own `current_thread` runtime +
-  `LocalSet`. Each worker calls `cljrs_gc::register_mutator()` on startup and runs to shutdown.
-- **Work distribution for sockets.** Either a dedicated accept task that round-robins / least-loaded
-  hands accepted **FDs** (which are `Send`) to workers over an mpsc, or `SO_REUSEPORT` with one
-  listener bound per worker so the kernel load-balances. The accepting code builds the
-  `TcpStream`/channels *on the destination worker's* `LocalSet`.
-- **Pinning.** Each connection's reader/writer/handler tasks stay on the worker that owns it; the
-  `{:in :out}` channels and all its byte-arrays are allocated and consumed on that one thread.
-- **Cross-worker channels.** Sending a value between workers is allowed and STW-safe; the work item
-  is to **audit `CljChannel::Trace`** so a value sitting in a channel buffer is traced (kept alive)
-  regardless of which worker collects, and to confirm cross-runtime wakeups behave (they do —
-  wakers are `Send`).
-- **Safepoint coverage.** Ensure long native calls reachable from the network path poll safepoints
-  so one busy worker can't stall global STW (ties into the existing `cljrs-async` GC-service task).
+What `cljrs-net` needs from it (the seam between the two plans):
 
-**Explicitly deferred (Future Work):** TLABs to relieve the global heap mutex, and share-nothing
-per-worker heaps for linear scaling. Both are `cljrs-gc` changes, not networking ones.
+- A **`Send`-handoff / `spawn_on(worker, …)` API** (worker-pool plan Phase 5) so the accept path
+  can hand an accepted socket **FD** (an integer — `Send`) to a chosen worker, which builds the
+  `TcpStream` + `:in`/`:out` channels in *its own* `LocalSet`. From then on the connection is
+  **pinned** to that worker — bytes, framing, and handler all run there, so no `GcPtr` crosses
+  threads in steady state.
+- Accept distribution is either a dedicated accept task routing FDs, or `SO_REUSEPORT` with one
+  listener per worker (kernel load-balances).
+- Cross-worker value handoff (when used) goes through channels and is STW-safe once the worker-pool
+  plan's `CljChannel::Trace` audit lands.
+
+A–G are written against a per-worker `LocalSet`, so they are unaffected by *when* the pool arrives.
 
 **Done when:** an echo/line server saturates multiple cores under concurrent clients (load spread
-across workers), with GC STW pauses correctly parking and tracing every worker.
+across workers), with GC STW pauses correctly parking and tracing every worker. (Tracked in
+`async-worker-pool-plan.md`.)
 
 ---
 
@@ -401,20 +397,19 @@ across workers), with GC STW pauses correctly parking and tracing every worker.
 | E | TLS client + server via `rustls`/`tokio-rustls` (same `{:in :out}` shape) | A, B |
 | F | Unix-domain stream sockets (`#[cfg(unix)]`) | A, B |
 | G | Lifecycle: `with-open`, timeouts, half-close, error/EOF split helper | A–F |
-| H | **Worker pool** in `cljrs-async`: `W` per-worker `LocalSet`s, FD handoff, pinned connections, `CljChannel::Trace` audit | `cljrs-gc` STW (exists); parallel with A–G |
+| H | Worker pool — see **`async-worker-pool-plan.md`**; `cljrs-net` consumes its Phase 5 `Send`-handoff API to pin connections | `cljrs-async`; parallel with A–G |
 
-Phase H is the multicore enabler and the one cross-crate change (it lives in `cljrs-async`). A–G
-are written against a per-worker `LocalSet` so they are unaffected by when H lands.
+Phase H is the multicore enabler and the one cross-crate change — it lives in `cljrs-async` and has
+its own plan (`async-worker-pool-plan.md`). A–G are written against a per-worker `LocalSet` so they
+are unaffected by when it lands.
 
 ---
 
 ## Future Work (not in scope now)
 
-- **TLABs** (thread-local allocation buffers) to relieve the single global heap mutex once the
-  worker pool is allocation-bound; a `cljrs-gc` change.
-- **Share-nothing per-worker heaps** (the BEAM/Ractor endgame) for linear scaling — de-globalize
-  the `static HEAP`, drop the shared alloc lock and global STW, copy cross-worker messages. Larger
-  `cljrs-gc` refactor; the pinned-connection + channel-handoff design ports to it unchanged.
+- The executor scaling work (TLABs, then share-nothing per-worker heaps) is owned by
+  `async-worker-pool-plan.md`, not this plan — the networking design ports to share-nothing
+  unchanged (pinned connections + channel handoff is already the message-passing shape).
 - Higher-level protocol crates built on `cljrs-net`: HTTP/1.1, WebSocket, HTTP/2 (the aleph stack),
   each as a separate crate consuming the `{:in :out}` connection + framing layer.
 - Connection pooling and a client-side reconnect/backoff helper.

--- a/networking-plan.md
+++ b/networking-plan.md
@@ -1,0 +1,333 @@
+# Networking Plan for clojurust
+
+## Design Philosophy
+
+Networking is delivered as **`cljrs-net`**, a separate Rust crate that sits *on top of*
+`cljrs-async` (channels, the Tokio `LocalSet` executor, `spawn_future`) and mirrors the
+conventions established by `cljrs-io`. The model is **aleph/netty, expressed in core.async**:
+
+- The **bottom layer is byte-stream oriented**. A connection is a duplex pair of
+  `clojure.core.async` channels — `:in` carries `byte-array` chunks read off the socket,
+  `:out` accepts `byte-array`/string values to write. This is the same shape as
+  `cljrs-io`'s `chunk-chan`, so network bytes compose with `go`, `<!`, `alts!`, transducers,
+  and the rest of the async toolkit.
+- **Higher-level protocols are higher-order functions over those channels** — stateful
+  transducers for pure byte→message reframing, and `(fn [in] -> out)` pipe functions for
+  anything that needs async. Framing a TCP byte stream into application messages is the same
+  operation whether the bytes came from a file or a socket.
+- **Transports are interchangeable** behind that channel shape: Unix sockets, TCP, and TLS
+  (via `rustls`/`tokio-rustls`) all yield the identical duplex `{:in :out}` connection. UDP
+  is the deliberate exception (datagrams, not a stream — see Phase D).
+
+Like `cljrs-async` and `cljrs-io`, the core crates know nothing about sockets. The CLI binary
+links `cljrs-net` by default (same as `cljrs-io`); embedders opt in via `Cargo.toml`.
+
+This document mirrors `async-plan.md`. Read that first — every mechanism here (the single-thread
+`!Send` executor, `spawn_future`, the in-band `Value::Error` convention, channel backpressure)
+is inherited from it.
+
+---
+
+## Crate Layout
+
+```
+cljrs-async        ← channels (CljChannel), LocalSet executor, spawn_future, await_value
+cljrs-io           ← channel-oriented async file I/O (the pattern cljrs-net follows)
+cljrs-net          ← NEW: TCP / Unix / TLS / UDP transports + framing, over core.async channels
+cljrs (CLI)        ← feature "net" (default = on, like "async") links cljrs-net and calls init()
+```
+
+`cljrs-net` depends on: `cljrs-async` (channels + `spawn_future`), the value/env/interp core
+crates (as `cljrs-io` does), `tokio` (`net`, `io-util`, `rt`), `tokio-rustls` + `rustls` +
+`rustls-pemfile` + `webpki-roots` (TLS), and `tokio` Unix support behind `#[cfg(unix)]`.
+
+### Why a separate crate
+
+Identical reasoning to `async-plan.md`: no `#[cfg(feature)]` guards or `tokio`/`rustls`
+dependencies leak into the core. `clojure.core.async` ships as a separate JAR; aleph ships
+separately from Clojure. `cljrs-net` is the same — the runtime gains sockets only when the
+crate is linked and `cljrs_net::init` is called.
+
+---
+
+## Namespaces
+
+| Namespace | Contents |
+|---|---|
+| `clojure.rust.net` | umbrella: `connect`, `listen`, `start-server`, `close`, `with-open`-style helper |
+| `clojure.rust.net.tcp` | TCP client/server (also the default transport of the umbrella fns) |
+| `clojure.rust.net.unix` | Unix-domain stream sockets (`#[cfg(unix)]`) |
+| `clojure.rust.net.tls` | TLS over TCP via `rustls`; client config (SNI, roots) and server config (cert/key) |
+| `clojure.rust.net.udp` | UDP datagram sockets (datagram channel shape, not a byte stream) |
+| `clojure.rust.net.frame` | framing transducers + pipe-fns: `lines`, `length-prefixed`, `by-delimiter` |
+
+The umbrella `connect`/`listen` take a `:transport` key (`:tcp` default, `:unix`, `:tls`) so
+callers can stay transport-agnostic; the per-transport namespaces are the explicit forms.
+
+---
+
+## The Connection Model
+
+A connection is a **plain map of two simplex channels** (core.async has no duplex channel
+primitive, so a pair is the idiomatic representation):
+
+```clojure
+{:in          <chan>        ; byte-array chunks read from the peer; closed at EOF/peer-close
+ :out         <chan>        ; put byte-arrays/strings here to send; close to half-close write
+ :remote-addr "1.2.3.4:443"
+ :local-addr  "0.0.0.0:54321"
+ :resource    <handle>}     ; the underlying socket Resource (Arc-backed, deterministic close)
+```
+
+- **`:in`** is a *raw* streaming channel (exactly `cljrs-io`'s `chunk-chan` contract): a producer
+  task reads the socket and `put!`s `byte-array` chunks; the channel's bounded buffer (`:in-buf`,
+  default 8) bounds read-ahead, so a slow consumer applies TCP-window backpressure to the peer.
+  The channel **closes at EOF / peer half-close**.
+- **`:out`** is a channel the user `put!`s onto; a writer task drains it to the socket. **Closing
+  `:out` triggers a write-half shutdown** (TCP FIN) after the buffer drains. Its bounded buffer
+  (`:out-buf`) means `put!` parks when the socket can't keep up — backpressure in the send
+  direction.
+- **`:resource`** holds the socket as an `Arc<dyn Resource>` (see `cljrs-value/src/resource.rs` —
+  its doc comment already names sockets and uses `"TcpStream"` as the example `type_tag`).
+  `(close conn)` closes both channels and the FD **deterministically**. GC never finalizes the
+  socket; this is the whole reason sockets are `Resource` (Arc) and not `NativeObject` (GcPtr).
+
+### Errors, in band
+
+Following the `cljrs-io` convention exactly: a read/write failure is delivered as a
+`Value::Error` `put!` onto `:in` (then the channel closes). Consumers use the existing
+`error?`/`ok?` helpers. See "Key Design Constraints" for the error-propagation caveat this
+inherits from choosing core.async over a Manifold-style stream.
+
+---
+
+## Execution Model
+
+Identical to `cljrs-async`/`cljrs-io`: everything runs on the single-thread Tokio `current_thread`
++ `LocalSet` executor. Per connection, `cljrs-net` spawns (via `spawn_future`) two tasks:
+
+1. a **reader task** — `socket.read()` into a plain `Vec<u8>` (which is `Send`), convert to a
+   `byte-array` `Value` **on the executor thread**, `put!` to `:in`, repeat until EOF/error.
+2. a **writer task** — `<!` from `:out`, write the bytes to the socket, repeat until `:out`
+   closes, then shut down the write half.
+
+The `Vec<u8> → byte-array` conversion happens on the GC thread because byte-arrays are `!Send`
+GC values and cannot be constructed off-thread. Keeping socket I/O on the LocalSet is the
+simplest correct design and matches `cljrs-io`. The fallback if TLS crypto throughput on the
+interp thread ever bites (read on a worker pool, ship `Vec<u8>` across, build the byte-array on
+the GC thread) is recorded under "Future Work" — not built now.
+
+---
+
+## Phase A — Crate Foundation & TCP Client
+
+`cljrs-net` crate, `init(globals)` entry point (idempotent, requires `cljrs_async::init` and a
+running `LocalSet`), CLI wiring under a default-on `net` feature.
+
+- `TcpStreamResource` implementing `Resource` (close = shutdown + drop the socket halves).
+- `connect` / `clojure.rust.net.tcp/connect`:
+  ```clojure
+  (connect {:host "example.com" :port 80})        ; => promise chan yielding a connection map
+  ```
+  Returns a **capacity-1 promise channel** (the `cljrs-io` discrete-op shape) that yields the
+  connection map once connected, or a `Value::Error` on failure. The connection map's `:in`/`:out`
+  are live streaming channels.
+- Reader + writer tasks per the Execution Model.
+- `close` closes `:out`, drains, shuts the socket, closes `:in`.
+
+**Done when:** a client can connect, `(>! out req-bytes)`, `(close! out)`, and drain `:in` to EOF.
+
+---
+
+## Phase B — TCP Server (channel of connections)
+
+The server primitive is a **channel of connections** (most core.async-native; the callback form
+is sugar on top):
+
+```clojure
+(listen {:port 8080})            ; => {:conns <chan> :resource <listener-handle>}
+;; (<! conns) yields a connection map per accepted socket; closes when the listener closes.
+
+(start-server (fn [conn] ...) {:port 8080})   ; sugar: go-loop taking from :conns, calls handler
+```
+
+- `TcpListenerResource` (`Resource`); an accept-loop task `put!`s connection maps onto `:conns`.
+- Bounded `:conns` buffer ⇒ accept backpressure (stop accepting when the app is behind).
+- `(close server)` stops accepting and closes the listener FD; in-flight connections are
+  independent and outlive it unless separately closed.
+
+**Done when:** an echo server built from `listen` + `go` round-trips bytes from a `connect` client.
+
+---
+
+## Phase C — Framing: protocols as higher-order fns
+
+This is the "higher level protocols using higher order functions to transform byte streams" layer
+— `clojure.rust.net.frame`. Two composable idioms:
+
+### Stateful transducers (pure byte → message)
+
+core.async `(chan buf xform)` accepts a transducer. A framing transducer buffers partial bytes
+across chunk boundaries (the `partition-by` pattern — leftover state in the reducing fn) and emits
+complete frames:
+
+```clojure
+(lines)                         ; byte-array chunks -> strings (split on \n, decode utf-8)
+(by-delimiter (byte 0))         ; chunks -> byte-array frames split on a delimiter byte
+(length-prefixed {:bytes 4 :endian :big})  ; chunks -> length-delimited byte-array frames
+```
+
+Apply by attaching to a derived channel, or via a `frame` helper that pipes `:in` through the
+xform into a new channel:
+
+```clojure
+(let [msgs (frame (:in conn) (length-prefixed {:bytes 4}))]
+  (go-loop [] (when-let [m (<! msgs)] (handle m) (recur))))
+```
+
+The encode direction is an ordinary `map` xform on the write side (frame → length-prefixed
+byte-array), attached to a channel that pipes into `:out`.
+
+### Pipe-fns (async transforms)
+
+For protocols needing async (request/response correlation, lookups, coupled backpressure):
+`(fn [in-chan] -> out-chan)` that spawns a `go-loop`. More general than transducers, less
+composable — used when a pure transducer can't express the transform.
+
+**Done when:** a line-protocol and a length-prefixed-frame protocol both work end-to-end over a
+TCP connection, built purely from `frame` + transducers.
+
+---
+
+## Phase D — UDP (datagrams)
+
+UDP does **not** fit the byte-stream duplex; it is message-oriented, so it gets its own shape:
+
+```clojure
+(udp/socket {:port 9000})       ; => {:in <chan> :out <chan> :resource h}
+;; :in  yields  {:data <byte-array> :addr "ip:port"}
+;; :out accepts {:data <byte-array> :addr "ip:port"}
+```
+
+- `UdpSocketResource` (`Resource`); reader task `recv_from` → `{:data :addr}` maps; writer task
+  `send_to` per outgoing map.
+- No connection/accept concept; one socket multiplexes peers by address.
+
+**Done when:** a UDP echo responder round-trips datagrams with correct `:addr`.
+
+---
+
+## Phase E — TLS (rustls)
+
+TLS wraps a TCP stream and produces the **identical** `{:in :out}` connection shape, so all of
+Phases A–C compose over it unchanged. Built on `tokio-rustls`.
+
+### Client
+
+```clojure
+(tls/connect {:host "example.com" :port 443})   ; SNI = :host; roots from webpki-roots by default
+(tls/connect {:host ... :port ...
+              :roots :system|:webpki|<pem-path>  ; trust anchors
+              :alpn ["h2" "http/1.1"]
+              :insecure-skip-verify false})      ; explicit opt-out, off by default
+```
+
+- SNI derived from `:host`; a custom `ServerName` allowed via `:sni`.
+- `rustls::ClientConfig` built once and cached; per-connection `TlsConnector`.
+
+### Server
+
+```clojure
+(tls/listen {:port 8443 :cert "server.pem" :key "server-key.pem" :alpn [...]})
+```
+
+- `rustls::ServerConfig` from a cert chain + private key (`rustls-pemfile`), optional client-auth.
+- Yields the same `{:conns <chan> ...}` shape as the plaintext server; each accepted connection is
+  TLS-wrapped before its map is put on `:conns`.
+
+`TlsStreamResource` wraps `tokio_rustls::{client,server}::TlsStream<TcpStream>`. The handshake runs
+on the LocalSet as part of the connect/accept task; failures surface as a `Value::Error` on the
+promise/conns channel.
+
+**Done when:** a `tls/connect` to a public HTTPS host completes a handshake and exchanges bytes,
+and a local `tls/listen` server round-trips with a `tls/connect` client using a test cert.
+
+---
+
+## Phase F — Unix-domain sockets
+
+`#[cfg(unix)]`. `tokio::net::{UnixStream, UnixListener}`. Same duplex `{:in :out}` connection and
+same channel-of-connections server as TCP — only the address is a filesystem path:
+
+```clojure
+(unix/connect {:path "/tmp/app.sock"})
+(unix/listen  {:path "/tmp/app.sock"})
+```
+
+`UnixListenerResource::close` unlinks the socket path. On non-unix targets the namespace is absent
+(or its fns throw a clear "unsupported on this platform" error).
+
+**Done when:** a Unix-socket echo server round-trips with a Unix-socket client.
+
+---
+
+## Phase G — Lifecycle, timeouts, ergonomics
+
+- **Deterministic teardown.** A `with-open`-style binding macro (or reuse an existing one) so a
+  dropped connection map cannot leak an FD — GC will not finalize the `Resource`. Document that
+  connections must be `close`d.
+- **Connect / read / write timeouts** via the existing `clojure.core.async/timeout` + `alts!`
+  (`connect` already returns a channel — race it against `timeout`). Provide `:connect-timeout-ms`
+  sugar.
+- **Half-close** semantics documented: closing `:out` sends FIN but `:in` keeps draining until the
+  peer closes; full `close` tears down both.
+- **Error/EOF helper.** Because we chose core.async + in-band `Value::Error` (not a Manifold-style
+  stream), add `(drain-to in)` / a split helper that separates the value stream from a single
+  terminal error/EOF promise, so consumers don't have to `error?`-check every take.
+
+---
+
+## Key Design Constraints
+
+- **All socket I/O on the single-thread `!Send` LocalSet.** Byte-arrays are `!Send` GC values;
+  they are constructed on the executor thread from `Send` `Vec<u8>` buffers. Inherited from
+  `cljrs-async`/`cljrs-io`.
+- **Sockets are `Resource` (Arc), never `GcPtr`.** Deterministic close; no FD leaks. The GC has no
+  finalizers. `resource.rs` already anticipates this.
+- **Backpressure is channel-native.** Bounded `:in`/`:out`/`:conns` buffers translate directly to
+  TCP window / accept backpressure. No separate flow-control mechanism.
+- **Errors are in band** (`Value::Error` + close), matching `cljrs-io`. **Caveat — the aleph
+  lesson:** aleph deliberately built Manifold instead of using core.async because core.async
+  channels don't propagate errors and have no "closed-because-of-exception" state, and
+  `mult`/`pipeline` are awkward across a network backpressure boundary. clojurust takes the
+  opposite bet for consistency with `cljrs-io`; the cost is that "drained OK" vs "drained due to
+  error" is only visible by inspecting the last value, which Phase G's split helper mitigates.
+- **UDP is not a byte stream.** It keeps a distinct `{:data :addr}` datagram shape rather than
+  being forced into the duplex byte-stream abstraction.
+- **Transports share one connection shape.** TCP, Unix, and TLS all yield `{:in :out …}`, so
+  framing (Phase C) and any protocol built on it work over every transport unchanged.
+
+---
+
+## Implementation Phases Summary
+
+| Phase | Deliverable | Depends on |
+|---|---|---|
+| A | `cljrs-net` crate, `TcpStreamResource`, `connect`, reader/writer tasks, CLI wiring | `cljrs-async`, `cljrs-io` patterns |
+| B | TCP server: `listen` (channel of conns) + `start-server` sugar | A |
+| C | Framing: `clojure.rust.net.frame` transducers (`lines`, `length-prefixed`, `by-delimiter`) + pipe-fns | A, B |
+| D | UDP datagram sockets (`{:data :addr}` shape) | A |
+| E | TLS client + server via `rustls`/`tokio-rustls` (same `{:in :out}` shape) | A, B |
+| F | Unix-domain stream sockets (`#[cfg(unix)]`) | A, B |
+| G | Lifecycle: `with-open`, timeouts, half-close, error/EOF split helper | A–F |
+
+---
+
+## Future Work (not in scope now)
+
+- Off-thread socket I/O with a worker pool feeding `Vec<u8>` to the GC thread, if TLS crypto
+  throughput on the interp thread becomes a bottleneck.
+- Higher-level protocol crates built on `cljrs-net`: HTTP/1.1, WebSocket, HTTP/2 (the aleph stack),
+  each as a separate crate consuming the `{:in :out}` connection + framing layer.
+- Connection pooling and a client-side reconnect/backoff helper.
+- `SO_*` socket options (keepalive, nodelay, reuseaddr) on the `connect`/`listen` opts maps.

--- a/networking-plan.md
+++ b/networking-plan.md
@@ -101,21 +101,71 @@ inherits from choosing core.async over a Manifold-style stream.
 
 ---
 
-## Execution Model
+## Execution Model — a worker pool, not a single thread
 
-Identical to `cljrs-async`/`cljrs-io`: everything runs on the single-thread Tokio `current_thread`
-+ `LocalSet` executor. Per connection, `cljrs-net` spawns (via `spawn_future`) two tasks:
+A single `LocalSet` thread is a demo, not a server: one interpreter thread cannot use more than
+one core, so meaningful concurrent serving needs real worker threads. The good news is that the
+GC already supports this — see Phase H below. The networking layer is designed against a
+**worker pool** from the start.
 
-1. a **reader task** — `socket.read()` into a plain `Vec<u8>` (which is `Send`), convert to a
-   `byte-array` `Value` **on the executor thread**, `put!` to `:in`, repeat until EOF/error.
-2. a **writer task** — `<!` from `:out`, write the bytes to the socket, repeat until `:out`
-   closes, then shut down the write half.
+### What the GC already allows
 
-The `Vec<u8> → byte-array` conversion happens on the GC thread because byte-arrays are `!Send`
-GC values and cannot be constructed off-thread. Keeping socket I/O on the LocalSet is the
-simplest correct design and matches `cljrs-io`. The fallback if TLS crypto throughput on the
-interp thread ever bites (read on a worker pool, ship `Vec<u8>` across, build the byte-array on
-the GC thread) is recorded under "Future Work" — not built now.
+The single-thread `LocalSet` in today's `cljrs-async` is an *async-runtime* choice
+(`current_thread` + `LocalSet` lets eval futures hold `GcPtr`s across `await` without being
+`Send`), **not** a GC limitation. The collector is already a *shared-heap, multi-mutator,
+stop-the-world* design:
+
+- one global `Mutex`-guarded `GcHeap` static (`cljrs-gc/src/lib.rs`); allocation across threads is
+  already serialized and sound;
+- `cljrs_gc::register_mutator()` exists and is already called per thread
+  (`crates/cljrs/src/main.rs:291`, plus test harnesses that `thread::spawn`);
+- `begin_stw()` (`cljrs-env/src/gc_roots.rs`) parks **all** registered mutators at safepoints and
+  traces **each** thread's thread-local root stack;
+- `GlobalEnv` is `Arc`-shared with `RwLock`/`Mutex`-guarded namespace tables, so all threads see
+  the same defs.
+
+So multiple OS threads can each run an interpreter against the same heap today. `GcPtr`'s
+`unsafe impl Send + Sync` is sound **under one discipline**: every thread that holds `GcPtr`s is a
+registered mutator that reaches safepoints, and every live value stays reachable from some traced
+root. Cross-thread dereference races are prevented *by* STW — during mark/sweep every mutator is
+parked. The only real hazard is a thread holding `GcPtr`s that never registers / never safepoints.
+
+### The model: shared-heap, pinned-connection workers
+
+`cljrs-async` grows a **worker pool** (Phase H): `W` worker OS threads (default ≈ core count),
+each running its own `current_thread` runtime + `LocalSet`, each a registered mutator, all sharing
+the one heap and one `Arc<GlobalEnv>`. This is the nginx-workers / BEAM-schedulers shape, but with
+a shared heap.
+
+- **Connections are pinned to a worker.** A raw socket FD is an integer — it *is* `Send`. An
+  accept path (a dedicated accept task, or `SO_REUSEPORT` with one listener per worker) hands the
+  FD to a worker, which builds the `TcpStream` + `:in`/`:out` channels **in its own `LocalSet`**.
+  Thereafter that connection's bytes, framing, and handler all run on that worker — so in steady
+  state **no `GcPtr` crosses threads** and per-worker futures stay `!Send`/local.
+- **Per connection**, the owning worker spawns two tasks (via `spawn_future`):
+  1. a **reader task** — `socket.read()` into a plain `Vec<u8>` (`Send`), convert to a `byte-array`
+     `Value` **on that worker thread** (byte-arrays are `!Send` GC values, built on the heap by a
+     registered mutator), `put!` to `:in`, until EOF/error;
+  2. a **writer task** — `<!` from `:out`, write to the socket, until `:out` closes, then shut down
+     the write half.
+- **Cross-worker handoff** (when a value must move between workers) goes through a channel. A
+  `GcPtr` value put by worker A and taken by worker B is safe because collection is STW (both are
+  parked during mark/sweep) **provided `CljChannel`'s `Trace` walks its buffer** so buffered values
+  stay rooted — verify this as part of Phase H. Tokio wakers are `Send`, so waking a parked
+  take/put task on another worker's runtime works.
+
+### The two ceilings (named honestly)
+
+1. **Global STW.** Every worker must reach a safepoint before any collection runs. I/O `await`
+   points are safepoints, so I/O-bound serving is fine, but a long CPU-bound native/FFI call with
+   no safepoint polling stalls GC for *all* workers. Long native calls must poll safepoints.
+2. **The single global heap mutex is the allocation bottleneck.** Every `GcPtr::new` locks the one
+   heap; at high allocation rates across many cores this serializes. The first scaling lever is
+   **thread-local allocation buffers (TLABs)**: a per-worker bump region that hits the global lock
+   only to refill. The endgame for linear scaling is **share-nothing workers** (per-worker heap,
+   no shared alloc lock, no global STW, cross-worker messages copied) — a `cljrs-gc` refactor
+   deferred to Future Work. The pinned-connection + channel-handoff design here is already the
+   share-nothing message-passing shape, so it ports forward unchanged.
 
 ---
 
@@ -271,6 +321,36 @@ same channel-of-connections server as TCP — only the address is a filesystem p
 
 ---
 
+## Phase H — Worker pool (the part that makes it not a toy)
+
+This phase lives in **`cljrs-async`**, not `cljrs-net` — it is the executor change that lets every
+preceding phase use more than one core. It can land before or in parallel with A–G; A–G are written
+to a per-worker `LocalSet` so they don't change when the pool arrives.
+
+- **Pool runtime.** Replace the single `current_thread` + `LocalSet` driver with `W` worker OS
+  threads (default ≈ available parallelism, configurable), each its own `current_thread` runtime +
+  `LocalSet`. Each worker calls `cljrs_gc::register_mutator()` on startup and runs to shutdown.
+- **Work distribution for sockets.** Either a dedicated accept task that round-robins / least-loaded
+  hands accepted **FDs** (which are `Send`) to workers over an mpsc, or `SO_REUSEPORT` with one
+  listener bound per worker so the kernel load-balances. The accepting code builds the
+  `TcpStream`/channels *on the destination worker's* `LocalSet`.
+- **Pinning.** Each connection's reader/writer/handler tasks stay on the worker that owns it; the
+  `{:in :out}` channels and all its byte-arrays are allocated and consumed on that one thread.
+- **Cross-worker channels.** Sending a value between workers is allowed and STW-safe; the work item
+  is to **audit `CljChannel::Trace`** so a value sitting in a channel buffer is traced (kept alive)
+  regardless of which worker collects, and to confirm cross-runtime wakeups behave (they do —
+  wakers are `Send`).
+- **Safepoint coverage.** Ensure long native calls reachable from the network path poll safepoints
+  so one busy worker can't stall global STW (ties into the existing `cljrs-async` GC-service task).
+
+**Explicitly deferred (Future Work):** TLABs to relieve the global heap mutex, and share-nothing
+per-worker heaps for linear scaling. Both are `cljrs-gc` changes, not networking ones.
+
+**Done when:** an echo/line server saturates multiple cores under concurrent clients (load spread
+across workers), with GC STW pauses correctly parking and tracing every worker.
+
+---
+
 ## Phase G — Lifecycle, timeouts, ergonomics
 
 - **Deterministic teardown.** A `with-open`-style binding macro (or reuse an existing one) so a
@@ -289,9 +369,10 @@ same channel-of-connections server as TCP — only the address is a filesystem p
 
 ## Key Design Constraints
 
-- **All socket I/O on the single-thread `!Send` LocalSet.** Byte-arrays are `!Send` GC values;
-  they are constructed on the executor thread from `Send` `Vec<u8>` buffers. Inherited from
-  `cljrs-async`/`cljrs-io`.
+- **Socket I/O runs on a pool of per-worker `LocalSet`s, not one thread** (Phase H). Each
+  connection is pinned to a worker; byte-arrays (`!Send` GC values) are built on that worker from
+  `Send` `Vec<u8>` buffers. The single-thread executor is an async-runtime default, not a GC limit —
+  the GC is already a shared-heap, multi-mutator, STW collector (`register_mutator`/`begin_stw`).
 - **Sockets are `Resource` (Arc), never `GcPtr`.** Deterministic close; no FD leaks. The GC has no
   finalizers. `resource.rs` already anticipates this.
 - **Backpressure is channel-native.** Bounded `:in`/`:out`/`:conns` buffers translate directly to
@@ -320,14 +401,21 @@ same channel-of-connections server as TCP — only the address is a filesystem p
 | E | TLS client + server via `rustls`/`tokio-rustls` (same `{:in :out}` shape) | A, B |
 | F | Unix-domain stream sockets (`#[cfg(unix)]`) | A, B |
 | G | Lifecycle: `with-open`, timeouts, half-close, error/EOF split helper | A–F |
+| H | **Worker pool** in `cljrs-async`: `W` per-worker `LocalSet`s, FD handoff, pinned connections, `CljChannel::Trace` audit | `cljrs-gc` STW (exists); parallel with A–G |
+
+Phase H is the multicore enabler and the one cross-crate change (it lives in `cljrs-async`). A–G
+are written against a per-worker `LocalSet` so they are unaffected by when H lands.
 
 ---
 
 ## Future Work (not in scope now)
 
-- Off-thread socket I/O with a worker pool feeding `Vec<u8>` to the GC thread, if TLS crypto
-  throughput on the interp thread becomes a bottleneck.
+- **TLABs** (thread-local allocation buffers) to relieve the single global heap mutex once the
+  worker pool is allocation-bound; a `cljrs-gc` change.
+- **Share-nothing per-worker heaps** (the BEAM/Ractor endgame) for linear scaling — de-globalize
+  the `static HEAP`, drop the shared alloc lock and global STW, copy cross-worker messages. Larger
+  `cljrs-gc` refactor; the pinned-connection + channel-handoff design ports to it unchanged.
 - Higher-level protocol crates built on `cljrs-net`: HTTP/1.1, WebSocket, HTTP/2 (the aleph stack),
   each as a separate crate consuming the `{:in :out}` connection + framing layer.
 - Connection pooling and a client-side reconnect/backoff helper.
-- `SO_*` socket options (keepalive, nodelay, reuseaddr) on the `connect`/`listen` opts maps.
+- `SO_*` socket options (keepalive, nodelay, reuseaddr, reuseport) on the `connect`/`listen` opts.


### PR DESCRIPTION
Channel-oriented networking modeled on aleph/netty, built on cljrs-async
channels and the cljrs-io I/O patterns. Connections are a duplex pair of
core.async channels ({:in :out}); servers expose a channel of connections.
Covers TCP, Unix, TLS (rustls), and UDP transports plus a framing layer of
higher-order byte-stream transforms, phased A-G.