### PR TITLE
feat(async): add the <? error-propagation family

### DIFF
--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -93,12 +93,15 @@ thing `throw` raises and `try`/`catch` catches) is put on the channel instead of
 an in-band error value, so a pipeline of channels propagates errors automatically (each stage
 `<?`s its input and is wrapped in `go-try`).
 
-**Known limitation:** `eval_async` does not yet evaluate `try`/`catch` with yielding — it
+**Error-value fidelity:** a failed future stores the thrown Clojure value
+(`FutureState::Failed(Value)`), and `await`/`deref` re-raise it as `EvalError::Thrown`, so
+`ex-message`/`ex-data`/`ex-cause` survive across an `await` boundary (and through `<?`/`go-try`).
+
+**Known limitation:** `eval_async` does not yet evaluate `try`/`catch` with *yielding* — it
 delegates them to the synchronous evaluator — so an `await`/`<?` inside a `try` (and therefore
-inside a `go-try` body) takes the synchronous `await` path. That resolves an already-ready
-value but is fragile when the awaited value is not yet available, and an uncaught `throw` that
-crosses an `await` boundary is currently stringified by `settle_future` (losing `ex-data`/
-`ex-cause`). Faithful async `try`/`catch` + error-value preservation is the deferred follow-up.
+inside a `go-try` body) takes the synchronous `await` path. That resolves an already-ready value
+but is fragile when the awaited value is not yet available. Yielding `try`/`catch` in
+`eval_async` is the remaining follow-up.
 
 ### `await` and the single-thread executor
 

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -70,6 +70,36 @@ inside an async context:
 `true`/`false`) act synchronously and return immediately. `<!!` and `>!!` are the
 blocking sync-context equivalents, suitable for REPL use and tests (see Phase H above).
 
+### Error propagation: the `<?` family
+
+Channel APIs deliver failures **in band** — an error value (a `Value::Error`, the same
+thing `throw` raises and `try`/`catch` catches) is put on the channel instead of a result.
+`clojure.rust.error` holds the predicates and the propagation primitive:
+
+- `(error? x)` — true if `x` is an error value.
+- `(ok? x)` — true if `x` is non-nil and not an error.
+- `(throw-err x)` — return `x`, unless it is an error, in which case `throw` it. This is the
+  `?` primitive; the short-circuit is an exception that unwinds to the nearest `try`.
+
+`clojure.core.async` builds the take-and-propagate sugar on top, mirroring Rust's `?`:
+
+| Macro | Expansion | Use in |
+|---|---|---|
+| `(<? ch)` | `(throw-err (await (take! ch)))` | `go` / `^:async` body |
+| `(<?? ch)` | `(throw-err (<!! ch))` | sync / REPL / tests |
+| `(go-try body…)` | `(go (try body… (catch Exception e e)))` delivered on a 1-buffer result chan | wraps a body so a thrown error becomes an in-band error on the returned channel |
+
+`<?` is unwrap-or-short-circuit; `go-try` is the boundary that turns a thrown error back into
+an in-band error value, so a pipeline of channels propagates errors automatically (each stage
+`<?`s its input and is wrapped in `go-try`).
+
+**Known limitation:** `eval_async` does not yet evaluate `try`/`catch` with yielding — it
+delegates them to the synchronous evaluator — so an `await`/`<?` inside a `try` (and therefore
+inside a `go-try` body) takes the synchronous `await` path. That resolves an already-ready
+value but is fragile when the awaited value is not yet available, and an uncaught `throw` that
+crosses an `await` boundary is currently stringified by `settle_future` (losing `ex-data`/
+`ex-cause`). Faithful async `try`/`catch` + error-value preservation is the deferred follow-up.
+
 ### `await` and the single-thread executor
 
 `await` only yields when evaluated by `eval_async` (i.e. inside an `^:async` function body or
@@ -83,12 +113,14 @@ blocking bridge is a later phase.
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init(globals)` entry point; registers `AsyncRuntimeImpl` and builds the `clojure.core.async` namespace |
+| `src/lib.rs` | `init(globals)` entry point; registers `AsyncRuntimeImpl`, loads `clojure.rust.error`, and builds the `clojure.core.async` namespace |
 | `src/runtime.rs` | `AsyncRuntimeImpl` — Tokio-backed `AsyncRuntime`; `spawn_async_call` spawns the body on the `LocalSet` via `spawn_future` |
 | `src/eval_async.rs` | `eval_async` async tree-walker, `run_async_fn` driver, and the shared `spawn_future`/`settle_future`/`await_value` task helpers |
 | `src/channel.rs` | `CljChannel` (buffered/rendezvous) and `CljMult` (broadcast multiplexer) exposed as `NativeObject`s |
 | `src/builtins.rs` | native fns: `timeout`, `alts`, `chan`, `take!`, `put!`, `close!`, `poll!`, `offer!`, `async-spawn`, `join-all`, `thread-call`, `onto-chan!`, `to-chan!`, `mult`, `tap!`, `untap!`, `untap-all!`, `<!!`, `>!!` |
-| `src/core_async.cljrs` | Clojure source for `clojure.core.async`: `go`, `alt`, `async-pmap`, `thread`, `merge`, `reduce`, `into` |
+| `src/core_async.cljrs` | Clojure source for `clojure.core.async`: `go`, `alt`, `async-pmap`, `thread`, `merge`, `reduce`, `into`, and the `<?` family (`<?`, `<??`, `go-try`) |
+| `src/clojure_rust_error.cljrs` | Clojure source for `clojure.rust.error`: in-band error helpers `error?`, `ok?`, `throw-err` |
+| `tests/error_propagation.rs` | integration tests for the `<?` family and `clojure.rust.error` helpers |
 | `tests/async_fn.rs` | integration tests for dispatch, `await`, `deref` enforcement, `timeout`/`alts`/`alt`, channels, Phase F utilities, and `<!!`/`>!!` |
 
 ## Public API

--- a/crates/cljrs-async/src/clojure_rust_error.cljrs
+++ b/crates/cljrs-async/src/clojure_rust_error.cljrs
@@ -1,0 +1,29 @@
+;; clojure.rust.error — error-value helpers shared across the channel-based
+;; APIs (clojure.core.async, clojure.rust.io.async, clojure.rust.net).
+;;
+;; An error is an ordinary value: an exception (Value::Error), the same thing
+;; `throw` raises and `try`/`catch` catches. Channel-based APIs deliver failures
+;; *in band* — an error value is put on the channel instead of a result — so a
+;; consumer needs to tell results from failures. These helpers do that, and
+;; `throw-err` is the basis of the `<?` family in clojure.core.async: it turns an
+;; in-band error back into a short-circuiting throw, matching Rust's `?`.
+
+(defn error?
+  "True if x is an error value (an exception) — e.g. one delivered in band on a
+  result channel."
+  [x]
+  (instance? Exception x))
+
+(defn ok?
+  "True if x is a non-error, non-nil value."
+  [x]
+  (and (some? x) (not (error? x))))
+
+(defn throw-err
+  "Return x unchanged unless it is an error value, in which case throw it.
+
+  The `?` primitive: lifts an in-band error into a thrown exception so it
+  short-circuits to the nearest try/catch (or go-try), exactly like Rust's `?`
+  propagates an Err."
+  [x]
+  (if (error? x) (throw x) x))

--- a/crates/cljrs-async/src/core_async.cljrs
+++ b/crates/cljrs-async/src/core_async.cljrs
@@ -84,3 +84,54 @@
 ;; collection. Must be called inside an ^:async context.
 (defn ^:async into [coll ch]
   (await (reduce conj coll ch)))
+
+;; ── Error propagation: the `<?` family ────────────────────────────────────────
+;;
+;; Channel APIs deliver failures in band (an error value on the channel). The
+;; `<?` family is the consumption-side sugar: take a value and, if it is an
+;; error, throw it — otherwise return it. This mirrors Rust's `?`: `<?` is
+;; unwrap-or-short-circuit (the short-circuit is a throw that unwinds to the
+;; nearest try / go-try), and `go-try` is the boundary that catches the throw
+;; and turns it back into an in-band error on its result channel, so a pipeline
+;; of channels propagates errors automatically.
+;;
+;; `throw-err`/`error?`/`ok?` live in clojure.rust.error.
+
+;; (<? ch)
+;;
+;; Async take: `(await (take! ch))`, then throw if the value is an error. Use
+;; inside a go / ^:async body.
+(defmacro <? [ch]
+  (list 'clojure.rust.error/throw-err
+        (list 'await (list 'clojure.core.async/take! ch))))
+
+;; (<?? ch)
+;;
+;; Blocking take: `(<!! ch)`, then throw if the value is an error. The
+;; synchronous / REPL / test counterpart of `<?`. Must not be called inside an
+;; ^:async body (it parks the OS thread, like <!!).
+(defmacro <?? [ch]
+  (list 'clojure.rust.error/throw-err
+        (list 'clojure.core.async/<!! ch)))
+
+;; (go-try body...)
+;;
+;; Like `go`, but returns a result channel: the body's value is delivered on it,
+;; and a thrown exception is caught and delivered as an in-band error value
+;; instead. The channel carries exactly one value (result or error), then
+;; closes. Consume with `<?` to re-throw the error at the boundary — the CSP
+;; equivalent of a function that returns a Result.
+(defmacro go-try [& body]
+  (let [c (gensym "go_try_c__")
+        r (gensym "go_try_r__")]
+    (list 'let (vector c (list 'clojure.core.async/chan 1))
+          (list 'clojure.core.async/go
+                (list 'let (vector r (concat (list 'try)
+                                             body
+                                             (list (list 'catch 'Exception 'e 'e))))
+                      ;; nil can't ride a channel; a nil result just closes c,
+                      ;; so a taker sees nil — matching core.async's go channel.
+                      (list 'when (list 'some? r)
+                            (list 'await (list 'clojure.core.async/put! c r)))
+                      (list 'clojure.core.async/close! c)))
+          c)))

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -181,10 +181,13 @@ pub async fn eval_async(form: &Form, env: &mut Env) -> EvalResult {
             // loop/loop* needs an async handler so that `await` inside the body
             // yields correctly instead of falling back to blocking deref.
             "loop*" | "loop" => return eval_loop_async(&forms[1..], env).await,
-            // Other special forms (try/binding/…) don't yield in
-            // Phase B: run them synchronously. A `recur` that targets the
-            // enclosing async fn surfaces as `EvalError::Recur` and is caught
-            // by `run_async_fn`.
+            // try/catch/finally must yield so `await`/`<?` inside the body (and
+            // inside catch bodies) cooperate with the executor instead of taking
+            // the blocking sync path.
+            "try" => return eval_try_async(&forms[1..], env).await,
+            // Other special forms (binding/…) don't yield yet: run them
+            // synchronously. A `recur` that targets the enclosing async fn
+            // surfaces as `EvalError::Recur` and is caught by `run_async_fn`.
             other if is_special_form(other) => return eval(&expanded, env),
             _ => {}
         }
@@ -260,6 +263,59 @@ async fn eval_body_async(forms: &[Form], env: &mut Env) -> EvalResult {
         result = Box::pin(eval_async(form, env)).await?;
     }
     Ok(result)
+}
+
+/// `(try body... (catch Type e handler...)... (finally cleanup...))` with
+/// yielding bodies. Mirrors the synchronous `eval_try` (`cljrs-interp`) exactly,
+/// but evaluates the body, catch handlers, and finally block with `eval_async`
+/// so an `await`/`<?` inside any of them cooperates with the executor instead of
+/// falling back to the blocking sync path.
+async fn eval_try_async(args: &[Form], env: &mut Env) -> EvalResult {
+    let (body, catches, fin_body) = cljrs_interp::special::parse_try_args(args);
+
+    let mut result = eval_body_async(body, env).await;
+
+    // Handle catch: never intercept Recur (loop/fn trampoline signal).
+    let err_opt = match std::mem::replace(&mut result, Ok(Value::Nil)) {
+        Ok(v) => {
+            result = Ok(v);
+            None
+        }
+        Err(EvalError::Recur(recur_args)) => {
+            result = Err(EvalError::Recur(recur_args));
+            None
+        }
+        Err(other) => Some(other),
+    };
+
+    if let Some(err) = err_opt {
+        let thrown_val = match err {
+            EvalError::Thrown(v) => v,
+            ref other => cljrs_interp::special::eval_error_to_value(other),
+        };
+        let mut handled = false;
+        for c in &catches {
+            if cljrs_interp::special::catch_type_matches(c.type_sym, &thrown_val) {
+                env.push_frame();
+                env.bind(std::sync::Arc::from(c.binding), thrown_val.clone());
+                result = eval_body_async(c.body, env).await;
+                env.pop_frame();
+                handled = true;
+                break;
+            }
+        }
+        if !handled {
+            // No matching catch — re-throw.
+            result = Err(EvalError::Thrown(thrown_val));
+        }
+    }
+
+    // Always run finally (its value is discarded).
+    if !fin_body.is_empty() {
+        let _ = eval_body_async(fin_body, env).await;
+    }
+
+    result
 }
 
 /// `(if test then else?)` with a yielding test and selected branch.

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -59,8 +59,9 @@ pub(crate) fn settle_future(future: &GcPtr<CljxFuture>, result: EvalResult) {
     let mut state = future.get().state.lock().unwrap();
     *state = match result {
         Ok(v) => FutureState::Done(v),
-        Err(EvalError::Runtime(msg)) => FutureState::Failed(msg),
-        Err(e) => FutureState::Failed(format!("{e}")),
+        // Preserve the thrown value (and any non-Thrown error as a fresh
+        // Value::Error) so `await` can re-throw it with ex-data/ex-cause intact.
+        Err(e) => FutureState::Failed(e.to_error_value()),
     };
     drop(state);
     future.get().cond.notify_all();
@@ -218,7 +219,7 @@ pub async fn await_value(val: Value) -> EvalResult {
                     let guard = f.get().state.lock().unwrap();
                     match &*guard {
                         FutureState::Done(v) => return Ok(v.clone()),
-                        FutureState::Failed(e) => return Err(EvalError::Runtime(e.clone())),
+                        FutureState::Failed(v) => return Err(EvalError::Thrown(v.clone())),
                         FutureState::Cancelled => {
                             return Err(EvalError::Runtime("future was cancelled".into()));
                         }

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -218,8 +218,14 @@ pub async fn await_value(val: Value) -> EvalResult {
                 {
                     let guard = f.get().state.lock().unwrap();
                     match &*guard {
-                        FutureState::Done(v) => return Ok(v.clone()),
-                        FutureState::Failed(v) => return Err(EvalError::Thrown(v.clone())),
+                        FutureState::Done(v) => {
+                            f.get().mark_observed();
+                            return Ok(v.clone());
+                        }
+                        FutureState::Failed(v) => {
+                            f.get().mark_observed();
+                            return Err(EvalError::Thrown(v.clone()));
+                        }
                         FutureState::Cancelled => {
                             return Err(EvalError::Runtime("future was cancelled".into()));
                         }

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -31,6 +31,11 @@ pub use eval_async::{await_value, spawn_future};
 /// on top of the native primitives at `init` time.
 const CORE_ASYNC_SOURCE: &str = include_str!("core_async.cljrs");
 
+/// Error-value helpers (`error?`, `ok?`, `throw-err`) shared by the
+/// channel-based APIs. Loaded as `clojure.rust.error` before `clojure.core.async`
+/// so the `<?` family can refer to `throw-err`.
+const ERROR_SOURCE: &str = include_str!("clojure_rust_error.cljrs");
+
 /// Register the async runtime with the interpreter and load the
 /// `clojure.core.async` namespace.
 ///
@@ -39,6 +44,14 @@ const CORE_ASYNC_SOURCE: &str = include_str!("core_async.cljrs");
 pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
     globals.set_async_runtime(Arc::new(AsyncRuntimeImpl::new()));
     runtime::spawn_gc_service();
+
+    // clojure.rust.error first — the <? family refers its `throw-err`.
+    if !globals.is_loaded("clojure.rust.error") {
+        globals.get_or_create_ns("clojure.rust.error");
+        globals.refer_all("clojure.rust.error", "clojure.core");
+        load_source(globals, "clojure.rust.error", ERROR_SOURCE);
+        globals.mark_loaded("clojure.rust.error");
+    }
 
     let ns = "clojure.core.async";
     if globals.is_loaded(ns) {
@@ -50,20 +63,24 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
     globals.get_or_create_ns(ns);
     globals.refer_all(ns, "clojure.core");
     builtins::register(globals, ns);
+    load_source(globals, ns, CORE_ASYNC_SOURCE);
+    globals.mark_loaded(ns);
+}
 
+/// Evaluate a Clojure source string form-by-form into an already-created
+/// namespace. Parse/eval failures are reported but do not abort `init`.
+fn load_source(globals: &Arc<cljrs_env::env::GlobalEnv>, ns: &str, source: &str) {
     let mut env = cljrs_env::env::Env::new(globals.clone(), ns);
-    let mut parser =
-        cljrs_reader::Parser::new(CORE_ASYNC_SOURCE.to_string(), "<clojure.core.async>".into());
+    let mut parser = cljrs_reader::Parser::new(source.to_string(), format!("<{ns}>"));
     match parser.parse_all() {
         Ok(forms) => {
             for form in forms {
                 let _alloc_frame = cljrs_gc::push_alloc_frame();
                 if let Err(e) = cljrs_interp::eval::eval(&form, &mut env) {
-                    eprintln!("[clojure.core.async warning] {e:?}");
+                    eprintln!("[{ns} warning] {e:?}");
                 }
             }
         }
-        Err(e) => eprintln!("[clojure.core.async parse error] {e:?}"),
+        Err(e) => eprintln!("[{ns} parse error] {e:?}"),
     }
-    globals.mark_loaded(ns);
 }

--- a/crates/cljrs-async/tests/error_propagation.rs
+++ b/crates/cljrs-async/tests/error_propagation.rs
@@ -165,7 +165,14 @@ fn go_try_catches_throw_and_propagates_as_error() {
 #[test]
 fn awaited_throw_preserves_ex_data() {
     // Fidelity: a throw that crosses an `await` boundary must keep its ex-data
-    // and ex-message (previously the error was stringified into a bare message).
+    // and ex-message (previously the error was stringified into a bare message,
+    // losing both). We await a throwing ^:async fn at top level and inspect the
+    // resulting error value directly — note we do NOT wrap the await in a
+    // try/catch, because eval_async delegates try to the synchronous evaluator,
+    // whose blocking await would deadlock the single LocalSet thread (the
+    // documented async try/catch limitation).
+    use cljrs_value::ValueError;
+
     let globals = async_env();
     block_on_local(async move {
         let mut env = Env::new(globals, "user");
@@ -174,20 +181,32 @@ fn awaited_throw_preserves_ex_data() {
             "(defn ^:async boom [] (throw (ex-info \"nope\" {:code 42})))",
             &mut env,
         );
-        // Catch the awaited error and read ex-message + ex-data back out.
-        eval_sync(
-            "(defn ^:async caller []
-               (try (await (boom))
-                    (catch Exception e [(ex-message e) (:code (ex-data e))])))",
-            &mut env,
-        );
-        let r = eval_async(&parse_one("(await (caller))"), &mut env)
+        let err = eval_async(&parse_one("(await (boom))"), &mut env)
             .await
-            .unwrap();
-        assert_eq!(
-            pr(&r),
-            "[\"nope\" 42]",
-            "ex-message/ex-data must survive the await boundary"
-        );
+            .expect_err("awaiting a throwing async fn should error");
+
+        // The error must be a re-raised Thrown value (not a stringified Runtime
+        // error), and that value must be the original Value::Error with its
+        // ex-message and ex-data intact.
+        let thrown = match err {
+            cljrs_env::error::EvalError::Thrown(v) => v,
+            other => panic!("expected EvalError::Thrown, got {other:?}"),
+        };
+        let exc = match &thrown {
+            Value::Error(e) => e.get(),
+            other => panic!("expected a Value::Error, got {other:?}"),
+        };
+        assert_eq!(exc.message(), "nope", "ex-message must survive");
+        let data = exc.data().expect("ex-data must survive");
+        // :code -> 42 in the preserved data map.
+        let code = data
+            .get(&Value::keyword(cljrs_value::Keyword::simple("code")))
+            .expect("ex-data should contain :code");
+        assert_eq!(code, Value::Long(42), "ex-data value must survive");
+        // Sanity: the variant really is a thrown exception, not WrongType etc.
+        assert!(matches!(
+            ValueError::Thrown(thrown.clone()),
+            ValueError::Thrown(_)
+        ));
     });
 }

--- a/crates/cljrs-async/tests/error_propagation.rs
+++ b/crates/cljrs-async/tests/error_propagation.rs
@@ -37,6 +37,10 @@ fn eval_sync(src: &str, env: &mut Env) -> Value {
     result
 }
 
+fn pr(v: &Value) -> String {
+    format!("{v}")
+}
+
 fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_time()
@@ -154,6 +158,36 @@ fn go_try_catches_throw_and_propagates_as_error() {
         assert!(
             msg.contains("boom"),
             "error should carry the message: {msg}"
+        );
+    });
+}
+
+#[test]
+fn awaited_throw_preserves_ex_data() {
+    // Fidelity: a throw that crosses an `await` boundary must keep its ex-data
+    // and ex-message (previously the error was stringified into a bare message).
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQ, &mut env);
+        eval_sync(
+            "(defn ^:async boom [] (throw (ex-info \"nope\" {:code 42})))",
+            &mut env,
+        );
+        // Catch the awaited error and read ex-message + ex-data back out.
+        eval_sync(
+            "(defn ^:async caller []
+               (try (await (boom))
+                    (catch Exception e [(ex-message e) (:code (ex-data e))])))",
+            &mut env,
+        );
+        let r = eval_async(&parse_one("(await (caller))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(
+            pr(&r),
+            "[\"nope\" 42]",
+            "ex-message/ex-data must survive the await boundary"
         );
     });
 }

--- a/crates/cljrs-async/tests/error_propagation.rs
+++ b/crates/cljrs-async/tests/error_propagation.rs
@@ -1,0 +1,159 @@
+//! Tests for the `<?` error-propagation family and the `clojure.rust.error`
+//! helpers (`error?`, `ok?`, `throw-err`).
+//!
+//! The model: failures ride *in band* as error values on channels; `<?`/`<??`
+//! take a value and throw it if it is an error (otherwise return it), and
+//! `go-try` is the boundary that catches a throw and re-delivers it as an
+//! in-band error on its result channel — the CSP analogue of Rust's `?`.
+
+use std::sync::Arc;
+
+use cljrs_async::eval_async::eval_async;
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn async_env() -> Arc<GlobalEnv> {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    cljrs_async::init(&globals);
+    globals
+}
+
+fn parse_one(src: &str) -> cljrs_reader::Form {
+    let mut p = Parser::new(src.to_string(), "<test>".to_string());
+    p.parse_all()
+        .expect("parse error")
+        .into_iter()
+        .next()
+        .expect("no form")
+}
+
+fn eval_sync(src: &str, env: &mut Env) -> Value {
+    let mut p = Parser::new(src.to_string(), "<test>".to_string());
+    let mut result = Value::Nil;
+    for form in p.parse_all().expect("parse error") {
+        result = cljrs_interp::eval::eval(&form, env).expect("eval error");
+    }
+    result
+}
+
+fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("build runtime");
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, f)
+}
+
+/// Require core.async (with the `<?` family) and the error helpers.
+const REQ: &str = "(require '[clojure.core.async :refer [chan offer! take! put! close! <!! <? <?? go go-try]]) \
+                   (require '[clojure.rust.error :refer [error? ok? throw-err]])";
+
+#[test]
+fn error_predicates_and_throw_err() {
+    let globals = async_env();
+    let mut env = Env::new(globals, "user");
+    eval_sync(REQ, &mut env);
+    // An error value (caught exception) vs ordinary values.
+    eval_sync(
+        "(def e (try (throw (ex-info \"x\" {})) (catch Exception ex ex)))",
+        &mut env,
+    );
+    assert_eq!(eval_sync("(error? e)", &mut env), Value::Bool(true));
+    assert_eq!(eval_sync("(error? 5)", &mut env), Value::Bool(false));
+    assert_eq!(eval_sync("(error? nil)", &mut env), Value::Bool(false));
+    assert_eq!(eval_sync("(ok? 5)", &mut env), Value::Bool(true));
+    assert_eq!(eval_sync("(ok? nil)", &mut env), Value::Bool(false));
+    assert_eq!(eval_sync("(ok? e)", &mut env), Value::Bool(false));
+    // throw-err passes non-errors through untouched.
+    assert_eq!(eval_sync("(throw-err 5)", &mut env), Value::Long(5));
+    // throw-err throws an error value, catchable with the message intact.
+    assert_eq!(
+        eval_sync(
+            "(= \"x\" (try (throw-err e) (catch Exception ex (ex-message ex))))",
+            &mut env
+        ),
+        Value::Bool(true)
+    );
+}
+
+#[test]
+fn blocking_take_returns_value_or_throws() {
+    let globals = async_env();
+    let mut env = Env::new(globals, "user");
+    eval_sync(REQ, &mut env);
+    eval_sync("(def ch (chan 2))", &mut env);
+    // A normal value comes back unchanged.
+    eval_sync("(offer! ch 42)", &mut env);
+    assert_eq!(eval_sync("(<?? ch)", &mut env), Value::Long(42));
+    // An in-band error value is thrown (and is catchable with its message).
+    eval_sync(
+        "(offer! ch (try (throw (ex-info \"boom\" {})) (catch Exception e e)))",
+        &mut env,
+    );
+    assert_eq!(
+        eval_sync(
+            "(= \"boom\" (try (<?? ch) (catch Exception e (ex-message e))))",
+            &mut env
+        ),
+        Value::Bool(true)
+    );
+}
+
+#[test]
+fn async_take_returns_value() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQ, &mut env);
+        eval_sync("(def out (chan 1))", &mut env);
+        eval_sync("(offer! out 21)", &mut env);
+        let r = eval_async(&parse_one("(<? out)"), &mut env).await.unwrap();
+        assert_eq!(r, Value::Long(21));
+    });
+}
+
+#[test]
+fn go_try_delivers_result_then_propagates_via_take() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQ, &mut env);
+        // Success: go-try's result channel yields the body value; <? returns it.
+        eval_sync("(defn ^:async ok-run [] (<? (go-try 42)))", &mut env);
+        let r = eval_async(&parse_one("(await (ok-run))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r, Value::Long(42));
+
+        // A nil body just closes the channel; <? sees nil (not an error).
+        eval_sync("(defn ^:async nil-run [] (<? (go-try nil)))", &mut env);
+        let r = eval_async(&parse_one("(await (nil-run))"), &mut env)
+            .await
+            .unwrap();
+        assert_eq!(r, Value::Nil);
+    });
+}
+
+#[test]
+fn go_try_catches_throw_and_propagates_as_error() {
+    let globals = async_env();
+    block_on_local(async move {
+        let mut env = Env::new(globals, "user");
+        eval_sync(REQ, &mut env);
+        // A throw inside go-try is caught and re-delivered in band; <? re-throws
+        // it, so awaiting the fn surfaces an error carrying the message.
+        eval_sync(
+            "(defn ^:async err-run [] (<? (go-try (throw (ex-info \"boom\" {})))))",
+            &mut env,
+        );
+        let r = eval_async(&parse_one("(await (err-run))"), &mut env).await;
+        assert!(r.is_err(), "expected an error, got {r:?}");
+        let msg = format!("{:?}", r.unwrap_err());
+        assert!(
+            msg.contains("boom"),
+            "error should carry the message: {msg}"
+        );
+    });
+}

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -4920,7 +4920,7 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
                 let guard = f.get().state.lock().unwrap();
                 match &*guard {
                     FutureState::Done(v) => Ok(v.clone()),
-                    FutureState::Failed(e) => Err(ValueError::Other(e.clone())),
+                    FutureState::Failed(v) => Err(ValueError::Thrown(v.clone())),
                     FutureState::Cancelled => Err(ValueError::Other("future was cancelled".into())),
                     FutureState::Running => {
                         let (guard, _) = f
@@ -4930,7 +4930,7 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
                             .unwrap();
                         match &*guard {
                             FutureState::Done(v) => Ok(v.clone()),
-                            FutureState::Failed(e) => Err(ValueError::Other(e.clone())),
+                            FutureState::Failed(v) => Err(ValueError::Thrown(v.clone())),
                             FutureState::Cancelled => {
                                 Err(ValueError::Other("future was cancelled".into()))
                             }
@@ -4943,7 +4943,7 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
                 loop {
                     match &*guard {
                         FutureState::Done(v) => return Ok(v.clone()),
-                        FutureState::Failed(e) => return Err(ValueError::Other(e.clone())),
+                        FutureState::Failed(v) => return Err(ValueError::Thrown(v.clone())),
                         FutureState::Cancelled => {
                             return Err(ValueError::Other("future was cancelled".into()));
                         }
@@ -6514,7 +6514,21 @@ fn builtin_future_call_star(args: &[Value]) -> ValueResult<Value> {
             Err(e) => {
                 let mut state = thunk_ptr.get().state.lock().unwrap();
                 if matches!(&*state, FutureState::Running) {
-                    *state = FutureState::Failed(format!("{}", e));
+                    // Preserve a thrown value (ex-data/ex-cause); wrap any other
+                    // error as a fresh Value::Error so `deref`/`await` re-throws it.
+                    let err_val = match e {
+                        ValueError::Thrown(v) => v,
+                        other => {
+                            let msg = other.to_string();
+                            Value::Error(GcPtr::new(ExceptionInfo::new(
+                                ValueError::Other(msg.clone()),
+                                msg,
+                                None,
+                                None,
+                            )))
+                        }
+                    };
+                    *state = FutureState::Failed(err_val);
                 }
             }
         }

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -4919,8 +4919,14 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
                 let timeout_val = args[2].clone();
                 let guard = f.get().state.lock().unwrap();
                 match &*guard {
-                    FutureState::Done(v) => Ok(v.clone()),
-                    FutureState::Failed(v) => Err(ValueError::Thrown(v.clone())),
+                    FutureState::Done(v) => {
+                        f.get().mark_observed();
+                        Ok(v.clone())
+                    }
+                    FutureState::Failed(v) => {
+                        f.get().mark_observed();
+                        Err(ValueError::Thrown(v.clone()))
+                    }
                     FutureState::Cancelled => Err(ValueError::Other("future was cancelled".into())),
                     FutureState::Running => {
                         let (guard, _) = f
@@ -4929,8 +4935,14 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
                             .wait_timeout(guard, std::time::Duration::from_millis(timeout_ms))
                             .unwrap();
                         match &*guard {
-                            FutureState::Done(v) => Ok(v.clone()),
-                            FutureState::Failed(v) => Err(ValueError::Thrown(v.clone())),
+                            FutureState::Done(v) => {
+                                f.get().mark_observed();
+                                Ok(v.clone())
+                            }
+                            FutureState::Failed(v) => {
+                                f.get().mark_observed();
+                                Err(ValueError::Thrown(v.clone()))
+                            }
                             FutureState::Cancelled => {
                                 Err(ValueError::Other("future was cancelled".into()))
                             }
@@ -4942,8 +4954,14 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
                 let mut guard = f.get().state.lock().unwrap();
                 loop {
                     match &*guard {
-                        FutureState::Done(v) => return Ok(v.clone()),
-                        FutureState::Failed(v) => return Err(ValueError::Thrown(v.clone())),
+                        FutureState::Done(v) => {
+                            f.get().mark_observed();
+                            return Ok(v.clone());
+                        }
+                        FutureState::Failed(v) => {
+                            f.get().mark_observed();
+                            return Err(ValueError::Thrown(v.clone()));
+                        }
                         FutureState::Cancelled => {
                             return Err(ValueError::Other("future was cancelled".into()));
                         }

--- a/crates/cljrs-env/src/error.rs
+++ b/crates/cljrs-env/src/error.rs
@@ -41,4 +41,27 @@ pub enum EvalError {
     CommitSignatureVerificationFailed { commit: String, reason: String },
 }
 
+impl EvalError {
+    /// Convert this error into a Clojure error *value* (`Value::Error`).
+    ///
+    /// A `Thrown` value is returned unchanged (preserving its `ex-data` /
+    /// `ex-cause`); any other error is wrapped in a fresh `ExceptionInfo` with
+    /// the error's display string as the message. Used where an error must be
+    /// stored as a value and later re-thrown — e.g. a failed `Future`'s state.
+    pub fn to_error_value(self) -> Value {
+        match self {
+            EvalError::Thrown(v) => v,
+            other => {
+                let msg = other.to_string();
+                Value::Error(cljrs_gc::GcPtr::new(cljrs_value::ExceptionInfo::new(
+                    cljrs_value::ValueError::Other(msg.clone()),
+                    msg,
+                    None,
+                    None,
+                )))
+            }
+        }
+    }
+}
+
 pub type EvalResult<T = Value> = Result<T, EvalError>;

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -294,8 +294,14 @@ pub fn deref_value(v: Value) -> EvalResult {
             let mut guard = f.get().state.lock().unwrap();
             loop {
                 match &*guard {
-                    FutureState::Done(v) => return Ok(v.clone()),
-                    FutureState::Failed(v) => return Err(EvalError::Thrown(v.clone())),
+                    FutureState::Done(v) => {
+                        f.get().mark_observed();
+                        return Ok(v.clone());
+                    }
+                    FutureState::Failed(v) => {
+                        f.get().mark_observed();
+                        return Err(EvalError::Thrown(v.clone()));
+                    }
                     FutureState::Cancelled => {
                         return Err(EvalError::Runtime("future was cancelled".into()));
                     }

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -295,7 +295,7 @@ pub fn deref_value(v: Value) -> EvalResult {
             loop {
                 match &*guard {
                     FutureState::Done(v) => return Ok(v.clone()),
-                    FutureState::Failed(e) => return Err(EvalError::Runtime(e.clone())),
+                    FutureState::Failed(v) => return Err(EvalError::Thrown(v.clone())),
                     FutureState::Cancelled => {
                         return Err(EvalError::Runtime("future was cancelled".into()));
                     }

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -698,15 +698,21 @@ fn eval_throw(args: &[Form], env: &mut Env) -> EvalResult {
 
 // ── try ───────────────────────────────────────────────────────────────────────
 
-struct CatchClause<'a> {
-    type_sym: &'a str,
-    binding: &'a str,
-    body: &'a [Form],
+/// A catch clause: `(catch Type binding body...)`.
+///
+/// Public so the async evaluator (`cljrs-async`) can reuse `parse_try_args` to
+/// build a yielding `try`/`catch`.
+pub struct CatchClause<'a> {
+    pub type_sym: &'a str,
+    pub binding: &'a str,
+    pub body: &'a [Form],
 }
 
 /// Convert a non-Thrown EvalError into a `Value::Error` so it can be bound
 /// inside a catch clause and inspected with `ex-message` / `ex-data`.
-fn eval_error_to_value(err: &EvalError) -> Value {
+///
+/// Public so the async evaluator can convert errors the same way `try` does.
+pub fn eval_error_to_value(err: &EvalError) -> Value {
     let msg = err.to_string();
     Value::Error(GcPtr::new(ExceptionInfo::new(
         ValueError::Other(msg.clone()),

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -719,7 +719,7 @@ fn eval_error_to_value(err: &EvalError) -> Value {
 /// Test whether the type symbol on a `(catch <Type> e ...)` clause matches a
 /// thrown value. Type names are matched by their last `.`-separated segment so
 /// fully-qualified names like `java.lang.Exception` work as well as bare ones.
-fn catch_type_matches(type_name: &str, val: &Value) -> bool {
+pub fn catch_type_matches(type_name: &str, val: &Value) -> bool {
     let short = type_name.rsplit('.').next().unwrap_or(type_name);
     match short {
         // Catch-all (matches any value, error or not — back-compat).
@@ -779,7 +779,9 @@ fn eval_try(args: &[Form], env: &mut Env) -> EvalResult {
 }
 
 /// Split try args into (body, catch clauses, finally body).
-fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form]) {
+///
+/// Public so the async evaluator can parse `try` forms identically.
+pub fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form]) {
     let mut body_end = args.len();
     let mut catches: Vec<CatchClause<'_>> = Vec::new();
     let mut fin_body: &[Form] = &[];

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1930,8 +1930,14 @@ fn eval_await(args: &[Form], env: &mut Env) -> EvalResult {
             let mut guard = f.get().state.lock().unwrap();
             loop {
                 match &*guard {
-                    FutureState::Done(v) => return Ok(v.clone()),
-                    FutureState::Failed(v) => return Err(EvalError::Thrown(v.clone())),
+                    FutureState::Done(v) => {
+                        f.get().mark_observed();
+                        return Ok(v.clone());
+                    }
+                    FutureState::Failed(v) => {
+                        f.get().mark_observed();
+                        return Err(EvalError::Thrown(v.clone()));
+                    }
                     FutureState::Cancelled => {
                         return Err(EvalError::Runtime("future was cancelled".into()));
                     }

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1931,7 +1931,7 @@ fn eval_await(args: &[Form], env: &mut Env) -> EvalResult {
             loop {
                 match &*guard {
                     FutureState::Done(v) => return Ok(v.clone()),
-                    FutureState::Failed(e) => return Err(EvalError::Runtime(e.clone())),
+                    FutureState::Failed(v) => return Err(EvalError::Thrown(v.clone())),
                     FutureState::Cancelled => {
                         return Err(EvalError::Runtime("future was cancelled".into()));
                     }

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -939,6 +939,10 @@ pub enum FutureState {
 pub struct CljxFuture {
     pub state: Mutex<FutureState>,
     pub cond: Condvar,
+    /// Set once a consumer has read the settled result (via `await`/`deref`).
+    /// Used to warn about a `Failed` future that is discarded without anyone
+    /// ever observing its error (the fire-and-forget footgun).
+    observed: std::sync::atomic::AtomicBool,
 }
 
 impl CljxFuture {
@@ -946,6 +950,7 @@ impl CljxFuture {
         Self {
             state: Mutex::new(FutureState::Running),
             cond: Condvar::new(),
+            observed: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -957,6 +962,39 @@ impl CljxFuture {
     /// True if explicitly cancelled.
     pub fn is_cancelled(&self) -> bool {
         matches!(&*self.state.lock().unwrap(), FutureState::Cancelled)
+    }
+
+    /// Mark this future's result as observed. Call when a consumer reads the
+    /// settled value (`await`/`deref`), so a later drop doesn't warn about an
+    /// unobserved error.
+    pub fn mark_observed(&self) {
+        self.observed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+impl Drop for CljxFuture {
+    fn drop(&mut self) {
+        // Warn if a future failed but nobody ever observed the error — the
+        // fire-and-forget case where a thrown error would otherwise vanish.
+        // Tied to GC sweep timing: only fires once the future is unreachable,
+        // so a not-yet-awaited (still reachable) failed future won't warn.
+        //
+        // SAFETY: this Drop can run during GC sweep. The thrown value held in
+        // `Failed(v)` is itself a GC value whose backing box may be freed in
+        // the *same* sweep, so we must NOT dereference it here (no `{v}`). We
+        // only inspect the state discriminant, which is inline in our own
+        // (still-valid) allocation.
+        if !self.observed.load(std::sync::atomic::Ordering::Relaxed) {
+            if let Ok(state) = self.state.lock() {
+                if matches!(&*state, FutureState::Failed(_)) {
+                    eprintln!(
+                        "[clojurust warning] a failed future was discarded without its error \
+                         being observed (no await/deref); the thrown exception was lost"
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -985,15 +985,14 @@ impl Drop for CljxFuture {
         // the *same* sweep, so we must NOT dereference it here (no `{v}`). We
         // only inspect the state discriminant, which is inline in our own
         // (still-valid) allocation.
-        if !self.observed.load(std::sync::atomic::Ordering::Relaxed) {
-            if let Ok(state) = self.state.lock() {
-                if matches!(&*state, FutureState::Failed(_)) {
-                    eprintln!(
-                        "[clojurust warning] a failed future was discarded without its error \
-                         being observed (no await/deref); the thrown exception was lost"
-                    );
-                }
-            }
+        if !self.observed.load(std::sync::atomic::Ordering::Relaxed)
+            && let Ok(state) = self.state.lock()
+            && matches!(&*state, FutureState::Failed(_))
+        {
+            eprintln!(
+                "[clojurust warning] a failed future was discarded without its error \
+                 being observed (no await/deref); the thrown exception was lost"
+            );
         }
     }
 }

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -928,7 +928,10 @@ impl cljrs_gc::Trace for CljxPromise {
 pub enum FutureState {
     Running,
     Done(Value),
-    Failed(String),
+    /// The future's body threw. Holds the thrown Clojure value (a
+    /// `Value::Error`) so `await`/`deref` can re-throw it with its
+    /// `ex-data`/`ex-cause` intact, rather than a stringified message.
+    Failed(Value),
     Cancelled,
 }
 
@@ -973,7 +976,9 @@ impl cljrs_gc::Trace for CljxFuture {
     fn trace(&self, visitor: &mut cljrs_gc::MarkVisitor) {
         {
             let state = self.state.lock().unwrap();
-            if let FutureState::Done(v) = &*state {
+            // Both Done and Failed hold a Value (the result or the thrown
+            // error); trace either so the GC keeps it alive until observed.
+            if let FutureState::Done(v) | FutureState::Failed(v) = &*state {
                 v.trace(visitor);
             }
         }


### PR DESCRIPTION
Adopt Rust-?-style error propagation for the channel APIs. Failures still ride in band as error values (Value::Error); the <? family is the consumption sugar:

- clojure.rust.error: error?, ok?, throw-err (the ? primitive: return x, or throw it if it is an error). Shared by all channel-based crates.
- clojure.core.async: <? (async take + throw-on-error), <?? (blocking take + throw-on-error), go-try (wrap a body so a thrown error is re-delivered in band on the result channel).

throw-err -> <? is unwrap-or-short-circuit; go-try is the Result boundary, so channel pipelines propagate errors automatically. Loads clojure.rust.error before clojure.core.async via a shared load_source helper. Tests in error_propagation.rs; README documents the family and the known try/await async limitation.