### PR TITLE
feat(net): implement networking-plan.md Phase A — cljrs-net crate + TCP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "cljrs-io",
  "cljrs-ir-viz",
  "cljrs-logging",
+ "cljrs-net",
  "cljrs-reader",
  "cljrs-runtime",
  "cljrs-stdlib",
@@ -531,6 +532,21 @@ dependencies = [
 [[package]]
 name = "cljrs-logging"
 version = "0.1.0"
+
+[[package]]
+name = "cljrs-net"
+version = "0.1.0"
+dependencies = [
+ "cljrs-async",
+ "cljrs-env",
+ "cljrs-gc",
+ "cljrs-interp",
+ "cljrs-reader",
+ "cljrs-stdlib",
+ "cljrs-types",
+ "cljrs-value",
+ "tokio",
+]
 
 [[package]]
 name = "cljrs-reader"
@@ -1219,6 +1235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1632,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,8 +1782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1881,6 +1922,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ members = [
     "crates/cljrs-blake3",
     "crates/cljrs-wasm",
     "crates/cljrs-async",
-    "crates/cljrs-io"]
+    "crates/cljrs-io",
+    "crates/cljrs-net"]
 resolver = "2"
 
 [workspace.package]
@@ -53,6 +54,7 @@ cljrs-deps         = { path = "crates/cljrs-deps",         version = "0.1.0" }
 cljrs-vcs          = { path = "crates/cljrs-vcs",          version = "0.1.0" }
 cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0" }
 cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
+cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/crates/cljrs-async/src/channel.rs
+++ b/crates/cljrs-async/src/channel.rs
@@ -253,6 +253,22 @@ impl CljChannel {
         }
     }
 
+    /// Asynchronously take a value from the channel, cooperatively yielding to
+    /// the `LocalSet` executor until a value is available or the channel closes.
+    /// Returns `Value::Nil` when the channel is closed and drained.
+    ///
+    /// This is the async counterpart to [`Self::take_blocking`] and the
+    /// building block other native crates use to consume channel values.
+    /// Must run within a Tokio `LocalSet` context.
+    pub async fn take(&self) -> Value {
+        loop {
+            if let Some(v) = self.try_take() {
+                return v;
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
     /// Asynchronously put `v` onto the channel, cooperatively yielding to the
     /// `LocalSet` executor until the value is accepted — buffered (capacity >= 1)
     /// or handed off to a taker (rendezvous). Resolves `true` on success, or

--- a/crates/cljrs-async/src/channel.rs
+++ b/crates/cljrs-async/src/channel.rs
@@ -22,7 +22,7 @@ use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
 use cljrs_gc::{GcPtr, MarkVisitor, Trace};
-use cljrs_value::{NativeObject, NativeObjectBox, Value};
+use cljrs_value::{NativeObject, NativeObjectBox, Value, gc_native_object};
 
 /// The native type tag reported by [`NativeObject::type_tag`] for channels.
 pub(crate) const CHANNEL_TAG: &str = "Channel";
@@ -387,4 +387,38 @@ impl NativeObject for CljMult {
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+// ── GcPtr<NativeObjectBox> helpers for channel consumers ─────────────────────
+
+/// Create a fresh `CljChannel` wrapped as a `Value::NativeObject`-ready pointer.
+pub fn make_chan(capacity: usize) -> GcPtr<NativeObjectBox> {
+    gc_native_object(CljChannel::new(capacity))
+}
+
+/// Borrow the `CljChannel` out of a `NativeObjectBox`.
+///
+/// Panics if `obj` does not hold a `CljChannel`; that is always the case for
+/// objects created by [`make_chan`] or the `(chan)` builtin.
+pub fn chan_ref(obj: &NativeObjectBox) -> &CljChannel {
+    obj.downcast_ref::<CljChannel>()
+        .expect("NativeObjectBox holds a CljChannel")
+}
+
+/// Asynchronously put `v` onto `ch`, yielding until accepted.
+/// Returns `false` if the channel is closed before the value lands.
+pub async fn chan_put(ch: &GcPtr<NativeObjectBox>, v: Value) -> bool {
+    chan_ref(ch.get()).put(v).await
+}
+
+/// Deliver exactly one value on a promise (capacity-1) channel, then close it.
+pub async fn chan_deliver(ch: &GcPtr<NativeObjectBox>, v: Value) {
+    let _ = chan_ref(ch.get()).put(v).await;
+    chan_ref(ch.get()).close();
+}
+
+/// Asynchronously take a value from `ch`, yielding until one is available.
+/// Returns `Value::Nil` when the channel is closed and drained.
+pub async fn chan_take(ch: &GcPtr<NativeObjectBox>) -> Value {
+    chan_ref(ch.get()).take().await
 }

--- a/crates/cljrs-async/src/channel.rs
+++ b/crates/cljrs-async/src/channel.rs
@@ -12,9 +12,9 @@
 //!   until a `take!` consumes its value, so producer and consumer hand off
 //!   directly. Only one value is in flight at a time.
 //!
-//! The async builtins drive these via short, lock-scoped "try" steps and yield
-//! the `LocalSet` executor between attempts, matching the cooperative polling
-//! model used by [`crate::eval_async::await_value`].
+//! The async `put` and `take` methods use `tokio::sync::Notify` for wakeups:
+//! a waiting task parks until a producer/consumer fires the relevant `Notify`,
+//! so no spinning or busy-polling occurs on the executor.
 
 use std::any::Any;
 use std::collections::VecDeque;
@@ -23,6 +23,7 @@ use std::time::Duration;
 
 use cljrs_gc::{GcPtr, MarkVisitor, Trace};
 use cljrs_value::{NativeObject, NativeObjectBox, Value, gc_native_object};
+use tokio::sync::Notify;
 
 /// The native type tag reported by [`NativeObject::type_tag`] for channels.
 pub(crate) const CHANNEL_TAG: &str = "Channel";
@@ -72,6 +73,10 @@ pub struct CljChannel {
     /// Wakes blocking putters waiting for space, and rendezvous putters waiting
     /// for their offered value to be consumed.
     not_full: Condvar,
+    /// Async wakeup for `take`: fired when an item is enqueued or the channel closes.
+    async_not_empty: Notify,
+    /// Async wakeup for `put`: fired when an item is dequeued or the channel closes.
+    async_not_full: Notify,
 }
 
 impl CljChannel {
@@ -86,6 +91,8 @@ impl CljChannel {
             }),
             not_empty: Condvar::new(),
             not_full: Condvar::new(),
+            async_not_empty: Notify::new(),
+            async_not_full: Notify::new(),
         }
     }
 
@@ -98,9 +105,12 @@ impl CljChannel {
     /// buffered values and then observe `nil`.
     pub fn close(&self) {
         self.state.lock().unwrap().closed = true;
-        // Wake any threads blocking in take_blocking / put_blocking.
+        // Wake blocking (sync) callers.
         self.not_empty.notify_all();
         self.not_full.notify_all();
+        // Wake one async taker/putter; they cascade the notification on exit.
+        self.async_not_empty.notify_one();
+        self.async_not_full.notify_one();
     }
 
     /// Non-blocking take.
@@ -114,6 +124,7 @@ impl CljChannel {
             st.taken = st.taken.wrapping_add(1);
             drop(st);
             self.not_full.notify_all();
+            self.async_not_full.notify_one();
             return Some(v);
         }
         if st.closed {
@@ -136,6 +147,7 @@ impl CljChannel {
             st.queue.push_back(v.clone());
             drop(st);
             self.not_empty.notify_all();
+            self.async_not_empty.notify_one();
             return Some(true);
         }
         None
@@ -152,6 +164,7 @@ impl CljChannel {
             st.queue.push_back(v.clone());
             drop(st);
             self.not_empty.notify_all();
+            self.async_not_empty.notify_one();
             RvOffer::Offered(token)
         } else {
             RvOffer::Full
@@ -263,9 +276,13 @@ impl CljChannel {
     pub async fn take(&self) -> Value {
         loop {
             if let Some(v) = self.try_take() {
+                if matches!(v, Value::Nil) {
+                    // Channel closed: cascade so other parked takers wake too.
+                    self.async_not_empty.notify_one();
+                }
                 return v;
             }
-            tokio::task::yield_now().await;
+            self.async_not_empty.notified().await;
         }
     }
 
@@ -286,7 +303,7 @@ impl CljChannel {
                     RvOffer::Closed => return false,
                     RvOffer::Full => {}
                 }
-                tokio::task::yield_now().await;
+                self.async_not_full.notified().await;
             };
             // Phase 2: wait for a taker to consume the offered value.
             loop {
@@ -295,14 +312,14 @@ impl CljChannel {
                     RvStatus::ClosedUntaken => return false,
                     RvStatus::Waiting => {}
                 }
-                tokio::task::yield_now().await;
+                self.async_not_full.notified().await;
             }
         } else {
             loop {
                 if let Some(accepted) = self.try_put_buffered(&v) {
                     return accepted;
                 }
-                tokio::task::yield_now().await;
+                self.async_not_full.notified().await;
             }
         }
     }

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -69,7 +69,8 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
 
 /// Evaluate a Clojure source string form-by-form into an already-created
 /// namespace. Parse/eval failures are reported but do not abort `init`.
-fn load_source(globals: &Arc<cljrs_env::env::GlobalEnv>, ns: &str, source: &str) {
+/// Exported for use by crates that register their own namespaces.
+pub fn load_source(globals: &Arc<cljrs_env::env::GlobalEnv>, ns: &str, source: &str) {
     let mut env = cljrs_env::env::Env::new(globals.clone(), ns);
     let mut parser = cljrs_reader::Parser::new(source.to_string(), format!("<{ns}>"));
     match parser.parse_all() {

--- a/crates/cljrs-io/src/fs.rs
+++ b/crates/cljrs-io/src/fs.rs
@@ -25,13 +25,12 @@ use std::sync::{Arc, Mutex};
 
 use tokio::io::AsyncReadExt;
 
-use cljrs_async::channel::CljChannel;
+use cljrs_async::channel::{chan_deliver as deliver, chan_put as put, chan_ref, make_chan};
 use cljrs_async::spawn_future;
 use cljrs_env::env::GlobalEnv;
 use cljrs_gc::GcPtr;
 use cljrs_value::{
-    Arity, ExceptionInfo, NativeFn, NativeObjectBox, Value, ValueError, ValueResult,
-    gc_native_object,
+    Arity, ExceptionInfo, NativeFn, Value, ValueError, ValueResult,
 };
 
 use crate::charset::{CharDecoder, resolve_charset};
@@ -65,18 +64,7 @@ pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
     }
 }
 
-// ── Value/channel helpers ─────────────────────────────────────────────────────
-
-/// Create a fresh `core.async` channel and return its `GcPtr` handle.
-fn make_chan(capacity: usize) -> GcPtr<NativeObjectBox> {
-    gc_native_object(CljChannel::new(capacity))
-}
-
-/// Borrow the `CljChannel` out of a channel native object.
-fn chan_ref(obj: &NativeObjectBox) -> &CljChannel {
-    obj.downcast_ref::<CljChannel>()
-        .expect("io channel native object holds a CljChannel")
-}
+// ── Value helpers ─────────────────────────────────────────────────────────────
 
 /// Wrap raw bytes as a Clojure `byte-array` (`Value::ByteArray`, signed `i8`s).
 fn bytes_value(bytes: &[u8]) -> Value {
@@ -93,17 +81,6 @@ fn io_error(msg: impl Into<String>) -> Value {
         None,
         None,
     )))
-}
-
-/// Put `v` onto `ch`, yielding until accepted (ignoring a closed consumer).
-async fn put(ch: &GcPtr<NativeObjectBox>, v: Value) -> bool {
-    chan_ref(ch.get()).put(v).await
-}
-
-/// Deliver a single result on a promise channel, then close it.
-async fn deliver(ch: &GcPtr<NativeObjectBox>, v: Value) {
-    let _ = chan_ref(ch.get()).put(v).await;
-    chan_ref(ch.get()).close();
 }
 
 // ── Argument parsing ──────────────────────────────────────────────────────────

--- a/crates/cljrs-io/src/fs.rs
+++ b/crates/cljrs-io/src/fs.rs
@@ -29,9 +29,7 @@ use cljrs_async::channel::{chan_deliver as deliver, chan_put as put, chan_ref, m
 use cljrs_async::spawn_future;
 use cljrs_env::env::GlobalEnv;
 use cljrs_gc::GcPtr;
-use cljrs_value::{
-    Arity, ExceptionInfo, NativeFn, Value, ValueError, ValueResult,
-};
+use cljrs_value::{Arity, ExceptionInfo, NativeFn, Value, ValueError, ValueResult};
 
 use crate::charset::{CharDecoder, resolve_charset};
 

--- a/crates/cljrs-io/src/lib.rs
+++ b/crates/cljrs-io/src/lib.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 pub mod charset;
 pub mod fs;
 
+use cljrs_async::load_source;
 use cljrs_env::env::GlobalEnv;
 
 /// Clojure-level helpers (`error?`, `ok?`) loaded on top of the native
@@ -55,22 +56,6 @@ pub fn init(globals: &Arc<GlobalEnv>) {
     globals.get_or_create_ns(NS);
     globals.refer_all(NS, "clojure.core");
     fs::register(globals, NS);
-
-    let mut env = cljrs_env::env::Env::new(globals.clone(), NS);
-    let mut parser = cljrs_reader::Parser::new(
-        IO_ASYNC_SOURCE.to_string(),
-        "<clojure.rust.io.async>".into(),
-    );
-    match parser.parse_all() {
-        Ok(forms) => {
-            for form in forms {
-                let _alloc_frame = cljrs_gc::push_alloc_frame();
-                if let Err(e) = cljrs_interp::eval::eval(&form, &mut env) {
-                    eprintln!("[clojure.rust.io.async warning] {e:?}");
-                }
-            }
-        }
-        Err(e) => eprintln!("[clojure.rust.io.async parse error] {e:?}"),
-    }
+    load_source(globals, NS, IO_ASYNC_SOURCE);
     globals.mark_loaded(NS);
 }

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cljrs-net"
+version = "0.1.0"
+edition = "2024"
+description = "TCP/Unix/TLS networking for clojurust — channel-oriented sockets over core.async"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cljrs-types    = { workspace = true }
+cljrs-gc       = { workspace = true }
+cljrs-value    = { workspace = true }
+cljrs-env      = { workspace = true }
+cljrs-reader   = { workspace = true }
+cljrs-interp   = { workspace = true }
+cljrs-async    = { workspace = true }
+tokio          = { workspace = true, features = ["net", "io-util"] }
+
+[dev-dependencies]
+cljrs-stdlib   = { workspace = true }
+tokio          = { workspace = true, features = ["net", "io-util", "sync"] }

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -1,0 +1,79 @@
+# cljrs-net
+
+**Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
+
+**Status**: Phase A implemented (TCP client: `connect`, `close`). Phases B–F (server, framing, UDP, TLS, Unix) are stubs.
+
+**Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. Higher-level protocols are higher-order functions over those channels.
+
+## File Layout
+
+| File | Description |
+|---|---|
+| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp` and `clojure.rust.net` |
+| `src/tcp.rs` | `TcpStreamResource`, `connect`, `close`, reader/writer tasks |
+| `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp` |
+| `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net` |
+
+## Public API
+
+### `clojure.rust.net.tcp`
+
+```clojure
+(connect {:host "example.com" :port 80})
+;; => promise-chan — yields {:in ch :out ch :remote-addr str :local-addr str :resource h}
+;;    or Value::Error on failure
+
+(close conn)  ;; => nil — closes :in/:out channels and aborts tasks
+```
+
+### `clojure.rust.net` (umbrella)
+
+```clojure
+(connect opts)  ;; delegates to tcp/connect; :transport key (default :tcp)
+(close conn)    ;; delegates to tcp/close
+```
+
+### Rust
+
+```rust
+pub fn init(globals: &Arc<GlobalEnv>)
+```
+
+Registers `clojure.rust.net.tcp` and `clojure.rust.net`. Calls `cljrs_async::init` internally. Idempotent.
+
+### `TcpStreamResource`
+
+Implements `cljrs_value::Resource` (Arc-backed, `Send + Sync`). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks, dropping the `OwnedReadHalf`/`OwnedWriteHalf` and releasing the file descriptor.
+
+## Connection Model
+
+`connect` returns a capacity-1 promise channel (the `cljrs-io` discrete-op shape). When connected, it yields:
+
+```clojure
+{:in          <chan>          ; byte-array chunks, closed at EOF/error
+ :out         <chan>          ; put byte-arrays/strings here; close to half-close
+ :remote-addr "ip:port"
+ :local-addr  "ip:port"
+ :resource    <TcpStream>}   ; Arc<TcpStreamResource> — call (close conn) to release
+```
+
+Two tasks are spawned per connection on the `LocalSet`:
+- **reader task** — reads the socket into `byte-array` chunks and puts them on `:in`
+- **writer task** — takes from `:out` and writes to the socket; shuts down the write half when `:out` closes
+
+## Usage Example
+
+```clojure
+(require '[clojure.core.async :refer [<!! >!! close!]])
+(require '[clojure.rust.net.tcp :as tcp])
+
+(let [conn (<!! (tcp/connect {:host "example.com" :port 80}))]
+  (>!! (:out conn) (.getBytes "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"))
+  (close! (:out conn))
+  (loop []
+    (when-let [chunk (<!! (:in conn))]
+      (print (String. (byte-array (map #(bit-and % 0xff) chunk))))
+      (recur)))
+  (tcp/close conn))
+```

--- a/crates/cljrs-net/src/clojure_rust_net.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net.cljrs
@@ -1,0 +1,32 @@
+;; clojure.rust.net — umbrella networking namespace.
+;;
+;; Delegates to the transport-specific namespaces. For Phase A only TCP is
+;; implemented; later phases add :unix and :tls transports behind the same
+;; connect/listen/close API.
+
+(require 'clojure.rust.net.tcp)
+
+(defn connect
+  "Connect to a remote host. Returns a promise channel that yields a connection
+  map {:in ch :out ch :remote-addr str :local-addr str :resource handle} once
+  the handshake completes, or a Value::Error on failure.
+
+  Opts:
+    :host          string (required)
+    :port          integer (required, 1-65535)
+    :transport     :tcp (default) — future: :unix, :tls
+    :in-buf        channel buffer depth for :in (default 8)
+    :out-buf       channel buffer depth for :out (default 8)"
+  [opts]
+  (let [transport (get opts :transport :tcp)]
+    (case transport
+      :tcp (clojure.rust.net.tcp/connect opts)
+      (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
+
+(defn close
+  "Close a connection map, releasing its socket and channels.
+
+  Closes :out (signals the writer to drain and half-close the write side),
+  closes :in, and aborts the reader/writer tasks via the :resource handle."
+  [conn]
+  (clojure.rust.net.tcp/close conn))

--- a/crates/cljrs-net/src/clojure_rust_net_tcp.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_tcp.cljrs
@@ -1,0 +1,8 @@
+;; clojure.rust.net.tcp — TCP client/server.
+;;
+;; Phase A (client):
+;;   connect  — (connect {:host h :port p}) => promise-chan -> conn-map
+;;   close    — (close conn) => nil
+;;
+;; The native functions are registered by cljrs-net; this file may add
+;; Clojure-level helpers on top as later phases are implemented.

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -49,4 +49,3 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         globals.mark_loaded(NS);
     }
 }
-

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -14,6 +14,8 @@
 
 use std::sync::Arc;
 
+use cljrs_async::load_source;
+
 pub mod tcp;
 
 /// Clojure source for `clojure.rust.net.tcp`.
@@ -48,18 +50,3 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
     }
 }
 
-fn load_source(globals: &Arc<cljrs_env::env::GlobalEnv>, ns: &str, source: &str) {
-    let mut env = cljrs_env::env::Env::new(globals.clone(), ns);
-    let mut parser = cljrs_reader::Parser::new(source.to_string(), format!("<{ns}>"));
-    match parser.parse_all() {
-        Ok(forms) => {
-            for form in forms {
-                let _alloc_frame = cljrs_gc::push_alloc_frame();
-                if let Err(e) = cljrs_interp::eval::eval(&form, &mut env) {
-                    eprintln!("[{ns} warning] {e:?}");
-                }
-            }
-        }
-        Err(e) => eprintln!("[{ns} parse error] {e:?}"),
-    }
-}

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -1,0 +1,65 @@
+//! Networking for clojurust — TCP over core.async channels.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! let globals = cljrs_stdlib::standard_env();
+//! cljrs_async::init(&globals); // channels + executor (required)
+//! cljrs_net::init(&globals);   // networking
+//! ```
+//!
+//! Like `cljrs-async` and `cljrs-io`, requires a Tokio `current_thread` +
+//! `LocalSet` executor running on the calling thread. The CLI links this crate
+//! by default under the `net` feature (on by default, same as `async`).
+
+use std::sync::Arc;
+
+pub mod tcp;
+
+/// Clojure source for `clojure.rust.net.tcp`.
+const NET_TCP_SOURCE: &str = include_str!("clojure_rust_net_tcp.cljrs");
+
+/// Clojure source for the umbrella `clojure.rust.net` namespace.
+const NET_SOURCE: &str = include_str!("clojure_rust_net.cljrs");
+
+pub const NS_TCP: &str = "clojure.rust.net.tcp";
+pub const NS: &str = "clojure.rust.net";
+
+/// Register the networking namespaces.
+///
+/// Calls `cljrs_async::init` internally (idempotent) so callers only need to
+/// call this one function. Requires a running `LocalSet` executor. Idempotent.
+pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
+    cljrs_async::init(globals);
+
+    if !globals.is_loaded(NS_TCP) {
+        globals.get_or_create_ns(NS_TCP);
+        globals.refer_all(NS_TCP, "clojure.core");
+        tcp::register(globals, NS_TCP);
+        load_source(globals, NS_TCP, NET_TCP_SOURCE);
+        globals.mark_loaded(NS_TCP);
+    }
+
+    if !globals.is_loaded(NS) {
+        globals.get_or_create_ns(NS);
+        globals.refer_all(NS, "clojure.core");
+        load_source(globals, NS, NET_SOURCE);
+        globals.mark_loaded(NS);
+    }
+}
+
+fn load_source(globals: &Arc<cljrs_env::env::GlobalEnv>, ns: &str, source: &str) {
+    let mut env = cljrs_env::env::Env::new(globals.clone(), ns);
+    let mut parser = cljrs_reader::Parser::new(source.to_string(), format!("<{ns}>"));
+    match parser.parse_all() {
+        Ok(forms) => {
+            for form in forms {
+                let _alloc_frame = cljrs_gc::push_alloc_frame();
+                if let Err(e) = cljrs_interp::eval::eval(&form, &mut env) {
+                    eprintln!("[{ns} warning] {e:?}");
+                }
+            }
+        }
+        Err(e) => eprintln!("[{ns} parse error] {e:?}"),
+    }
+}

--- a/crates/cljrs-net/src/tcp.rs
+++ b/crates/cljrs-net/src/tcp.rs
@@ -1,0 +1,352 @@
+//! TCP client support for `clojure.rust.net.tcp`.
+//!
+//! Phase A delivers `connect` and `close`. A connection is a map:
+//!
+//! ```clojure
+//! {:in          <chan>   ; byte-array chunks from the peer; closed at EOF
+//!  :out         <chan>   ; put byte-array/string values here to send
+//!  :remote-addr "ip:port"
+//!  :local-addr  "ip:port"
+//!  :resource    <handle>} ; TcpStreamResource — deterministic socket close
+//! ```
+//!
+//! `connect` returns a capacity-1 promise channel that yields the connection
+//! map once the TCP handshake completes, or a `Value::Error` on failure. The
+//! model is identical to `cljrs-io`'s discrete-op shape.
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::task::AbortHandle;
+
+use cljrs_async::channel::CljChannel;
+use cljrs_async::spawn_future;
+use cljrs_env::env::GlobalEnv;
+use cljrs_env::error::EvalResult;
+use cljrs_gc::GcPtr;
+use cljrs_value::{
+    Arity, ExceptionInfo, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle,
+    Value, ValueError, ValueResult, gc_native_object,
+};
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, fn(&[Value]) -> ValueResult<Value>)> = vec![
+        ("connect", Arity::Fixed(1), builtin_connect),
+        ("close", Arity::Fixed(1), builtin_close),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── TcpStreamResource ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct TcpStreamInner {
+    closed: bool,
+    reader_abort: Option<AbortHandle>,
+    writer_abort: Option<AbortHandle>,
+}
+
+/// `Resource` implementation for a TCP stream.
+///
+/// Holds `AbortHandle`s for the reader and writer tasks spawned in `connect`.
+/// `close()` aborts both tasks, which drops the socket halves and closes the FD.
+/// GC never finalises the socket — this `Arc`-backed resource is the sole
+/// cleanup path, matching the design note in `resource.rs`.
+#[derive(Debug)]
+pub struct TcpStreamResource {
+    inner: Arc<Mutex<TcpStreamInner>>,
+}
+
+impl TcpStreamResource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TcpStreamInner {
+                closed: false,
+                reader_abort: None,
+                writer_abort: None,
+            })),
+        }
+    }
+}
+
+impl Resource for TcpStreamResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        if let Some(h) = g.reader_abort.take() {
+            h.abort();
+        }
+        if let Some(h) = g.writer_abort.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "TcpStream"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Channel / value helpers ───────────────────────────────────────────────────
+
+fn make_chan(capacity: usize) -> GcPtr<NativeObjectBox> {
+    gc_native_object(CljChannel::new(capacity))
+}
+
+fn chan_ref(obj: &NativeObjectBox) -> &CljChannel {
+    obj.downcast_ref::<CljChannel>()
+        .expect("net channel NativeObjectBox holds a CljChannel")
+}
+
+fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+fn net_error(msg: impl Into<String>) -> Value {
+    let msg = msg.into();
+    Value::Error(GcPtr::new(ExceptionInfo::new(
+        ValueError::Other(msg.clone()),
+        msg,
+        None,
+        None,
+    )))
+}
+
+async fn chan_put(ch: &GcPtr<NativeObjectBox>, v: Value) -> bool {
+    chan_ref(ch.get()).put(v).await
+}
+
+/// Deliver exactly one value on a capacity-1 promise channel and close it.
+async fn chan_deliver(ch: &GcPtr<NativeObjectBox>, v: Value) {
+    let _ = chan_ref(ch.get()).put(v).await;
+    chan_ref(ch.get()).close();
+}
+
+/// Async take from a channel: yields until a value is available or the channel
+/// closes. Returns `Value::Nil` when the channel is closed and drained.
+async fn chan_take(ch: &GcPtr<NativeObjectBox>) -> Value {
+    chan_ref(ch.get()).take().await
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+// ── Options-map parsing ───────────────────────────────────────────────────────
+
+fn opts_str(opts: &MapValue, key: &str) -> Option<String> {
+    match opts.get(&kw(key))? {
+        Value::Str(s) => Some(s.get().clone()),
+        _ => None,
+    }
+}
+
+fn opts_usize(opts: &MapValue, key: &str) -> Option<usize> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n >= 0 => Some((n as usize).max(1)),
+        _ => None,
+    }
+}
+
+fn opts_port(opts: &MapValue) -> Option<u16> {
+    match opts.get(&kw("port"))? {
+        Value::Long(n) if n > 0 && n <= 65535 => Some(n as u16),
+        _ => None,
+    }
+}
+
+// ── Async tasks ───────────────────────────────────────────────────────────────
+
+/// Read chunks from the socket and put them on `:in`.
+///
+/// Closes `:in` at EOF or on error (after putting the error value). Aborted
+/// via `TcpStreamResource::close` if the user calls `(close conn)`.
+async fn reader_loop(mut read_half: OwnedReadHalf, in_chan: GcPtr<NativeObjectBox>) {
+    let mut buf = vec![0u8; 8192];
+    loop {
+        match read_half.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                if !chan_put(&in_chan, bytes_value(&buf[..n])).await {
+                    break; // consumer closed :in
+                }
+            }
+            Err(e) => {
+                chan_put(&in_chan, net_error(format!("read error: {e}"))).await;
+                break;
+            }
+        }
+    }
+    chan_ref(in_chan.get()).close();
+}
+
+/// Drain `:out` and write each value to the socket.
+///
+/// Accepts `byte-array` and `string` values. Calls `shutdown` on the write
+/// half when `:out` is closed (TCP half-close: FIN without RST). Aborted via
+/// `TcpStreamResource::close` if the user calls `(close conn)`.
+async fn writer_loop(mut write_half: OwnedWriteHalf, out_chan: GcPtr<NativeObjectBox>) {
+    loop {
+        match chan_take(&out_chan).await {
+            Value::Nil => {
+                // :out closed; gracefully half-close the write side.
+                let _ = write_half.shutdown().await;
+                break;
+            }
+            Value::ByteArray(arr) => {
+                let bytes: Vec<u8> = arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                if write_half.write_all(&bytes).await.is_err() {
+                    break;
+                }
+            }
+            Value::Str(s) => {
+                if write_half.write_all(s.get().as_bytes()).await.is_err() {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+// ── Connect implementation ────────────────────────────────────────────────────
+
+/// Initiate a TCP connection and return the promise channel as a `Value`.
+///
+/// Convenience wrapper used by tests and the Clojure `connect` builtin alike.
+pub fn connect_to(host: &str, port: u16, in_buf: usize, out_buf: usize) -> Value {
+    let host = host.to_string();
+    let promise = make_chan(1);
+    let promise_val = Value::NativeObject(promise.clone());
+    spawn_future(async move { do_connect(host, port, in_buf, out_buf, promise).await });
+    promise_val
+}
+
+async fn do_connect(
+    host: String,
+    port: u16,
+    in_buf: usize,
+    out_buf: usize,
+    promise: GcPtr<NativeObjectBox>,
+) -> EvalResult {
+    let addr = format!("{host}:{port}");
+    let stream = match tokio::net::TcpStream::connect(&addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            chan_deliver(&promise, net_error(format!("connect to {addr}: {e}"))).await;
+            return Ok(Value::Nil);
+        }
+    };
+
+    let remote_addr = stream
+        .peer_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+    let local_addr = stream
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+
+    let (read_half, write_half) = stream.into_split();
+
+    let in_chan = make_chan(in_buf);
+    let out_chan = make_chan(out_buf);
+
+    // Build the resource before spawning; keep the inner Arc so we can set the
+    // abort handles after obtaining the JoinHandles from spawn_local.
+    let resource = TcpStreamResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    let r_jh = tokio::task::spawn_local(reader_loop(read_half, in_chan.clone()));
+    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
+
+    let w_jh = tokio::task::spawn_local(writer_loop(write_half, out_chan.clone()));
+    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
+
+    let conn = Value::Map(MapValue::from_pairs(vec![
+        (kw("in"), Value::NativeObject(in_chan)),
+        (kw("out"), Value::NativeObject(out_chan)),
+        (kw("remote-addr"), Value::string(remote_addr)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]));
+
+    chan_deliver(&promise, conn).await;
+    Ok(Value::Nil)
+}
+
+// ── Builtins ──────────────────────────────────────────────────────────────────
+
+/// `(connect {:host h :port p})` — returns a capacity-1 promise channel that
+/// yields the connection map once connected, or a `Value::Error` on failure.
+/// Optional keys: `:in-buf` (default 8), `:out-buf` (default 8).
+fn builtin_connect(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:host str :port long}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let host = opts_str(&opts, "host").ok_or_else(|| ValueError::Other(":host required".into()))?;
+    let port =
+        opts_port(&opts).ok_or_else(|| ValueError::Other(":port required (1-65535)".into()))?;
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+
+    Ok(connect_to(&host, port, in_buf, out_buf))
+}
+
+/// `(close conn)` — close a connection map.
+///
+/// Closes both `:in` and `:out` channels and aborts the reader/writer tasks
+/// via the connection's `:resource` handle, releasing the socket FD.
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let conn = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "connection map",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    // Signal the writer task; it will drain and shutdown the write half.
+    if let Some(Value::NativeObject(obj)) = conn.get(&kw("out")) {
+        chan_ref(obj.get()).close();
+    }
+    // Close :in so any pending takes complete.
+    if let Some(Value::NativeObject(obj)) = conn.get(&kw("in")) {
+        chan_ref(obj.get()).close();
+    }
+    // Abort tasks and release the FD deterministically.
+    if let Some(Value::Resource(handle)) = conn.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}

--- a/crates/cljrs-net/src/tcp.rs
+++ b/crates/cljrs-net/src/tcp.rs
@@ -33,8 +33,10 @@ use cljrs_value::{
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
 pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
-    let fns: Vec<(&str, Arity, fn(&[Value]) -> ValueResult<Value>)> = vec![
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
         ("connect", Arity::Fixed(1), builtin_connect),
         ("close", Arity::Fixed(1), builtin_close),
     ];

--- a/crates/cljrs-net/src/tcp.rs
+++ b/crates/cljrs-net/src/tcp.rs
@@ -21,14 +21,14 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::task::AbortHandle;
 
-use cljrs_async::channel::CljChannel;
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, chan_take, make_chan};
 use cljrs_async::spawn_future;
 use cljrs_env::env::GlobalEnv;
 use cljrs_env::error::EvalResult;
 use cljrs_gc::GcPtr;
 use cljrs_value::{
     Arity, ExceptionInfo, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle,
-    Value, ValueError, ValueResult, gc_native_object,
+    Value, ValueError, ValueResult,
 };
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -107,16 +107,7 @@ impl Resource for TcpStreamResource {
     }
 }
 
-// ── Channel / value helpers ───────────────────────────────────────────────────
-
-fn make_chan(capacity: usize) -> GcPtr<NativeObjectBox> {
-    gc_native_object(CljChannel::new(capacity))
-}
-
-fn chan_ref(obj: &NativeObjectBox) -> &CljChannel {
-    obj.downcast_ref::<CljChannel>()
-        .expect("net channel NativeObjectBox holds a CljChannel")
-}
+// ── Value helpers ─────────────────────────────────────────────────────────────
 
 fn bytes_value(bytes: &[u8]) -> Value {
     let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
@@ -131,22 +122,6 @@ fn net_error(msg: impl Into<String>) -> Value {
         None,
         None,
     )))
-}
-
-async fn chan_put(ch: &GcPtr<NativeObjectBox>, v: Value) -> bool {
-    chan_ref(ch.get()).put(v).await
-}
-
-/// Deliver exactly one value on a capacity-1 promise channel and close it.
-async fn chan_deliver(ch: &GcPtr<NativeObjectBox>, v: Value) {
-    let _ = chan_ref(ch.get()).put(v).await;
-    chan_ref(ch.get()).close();
-}
-
-/// Async take from a channel: yields until a value is available or the channel
-/// closes. Returns `Value::Nil` when the channel is closed and drained.
-async fn chan_take(ch: &GcPtr<NativeObjectBox>) -> Value {
-    chan_ref(ch.get()).take().await
 }
 
 fn kw(name: &str) -> Value {

--- a/crates/cljrs-net/src/tcp.rs
+++ b/crates/cljrs-net/src/tcp.rs
@@ -207,27 +207,30 @@ async fn reader_loop(mut read_half: OwnedReadHalf, in_chan: GcPtr<NativeObjectBo
 /// half when `:out` is closed (TCP half-close: FIN without RST). Aborted via
 /// `TcpStreamResource::close` if the user calls `(close conn)`.
 async fn writer_loop(mut write_half: OwnedWriteHalf, out_chan: GcPtr<NativeObjectBox>) {
-    loop {
-        match chan_take(&out_chan).await {
-            Value::Nil => {
-                // :out closed; gracefully half-close the write side.
-                let _ = write_half.shutdown().await;
-                break;
-            }
-            Value::ByteArray(arr) => {
-                let bytes: Vec<u8> = arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
-                if write_half.write_all(&bytes).await.is_err() {
+    // Nested async block so write errors propagate via `?` rather than
+    // `if err { break }`, keeping each match arm free of collapsible ifs.
+    let _: std::io::Result<()> = async {
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => {
+                    // :out closed; gracefully half-close the write side.
+                    let _ = write_half.shutdown().await;
                     break;
                 }
-            }
-            Value::Str(s) => {
-                if write_half.write_all(s.get().as_bytes()).await.is_err() {
-                    break;
+                Value::ByteArray(arr) => {
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    write_half.write_all(&bytes).await?;
                 }
+                Value::Str(s) => {
+                    write_half.write_all(s.get().as_bytes()).await?;
+                }
+                _ => {}
             }
-            _ => {}
         }
+        Ok(())
     }
+    .await;
 }
 
 // ── Connect implementation ────────────────────────────────────────────────────

--- a/crates/cljrs-net/tests/tcp_client.rs
+++ b/crates/cljrs-net/tests/tcp_client.rs
@@ -1,0 +1,148 @@
+//! Phase A integration tests: TCP client connect / read / write / close.
+//!
+//! Done criterion from networking-plan.md Phase A:
+//!   "a client can connect, (>! out req-bytes), (close! out), and drain :in to EOF."
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use cljrs_async::channel::CljChannel;
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, Value};
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn chan_of(v: &Value) -> &CljChannel {
+    match v {
+        Value::NativeObject(obj) => obj
+            .get()
+            .downcast_ref::<CljChannel>()
+            .expect("expected CljChannel"),
+        other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+    }
+}
+
+fn conn_field(conn: &cljrs_value::MapValue, key: &str) -> Value {
+    conn.get(&Value::keyword(Keyword::simple(key)))
+        .unwrap_or_else(|| panic!("connection map missing :{key}"))
+}
+
+// ── Echo server ───────────────────────────────────────────────────────────────
+
+/// Accept one connection, read until EOF, echo the bytes back, and close.
+async fn run_echo_server(listener: TcpListener) {
+    let (mut stream, _) = listener.accept().await.unwrap();
+    let mut buf = vec![0u8; 4096];
+    let mut received = Vec::new();
+    loop {
+        match stream.read(&mut buf).await.unwrap() {
+            0 => break,
+            n => received.extend_from_slice(&buf[..n]),
+        }
+    }
+    stream.write_all(&received).await.unwrap();
+    // stream drop closes the connection, sending EOF to the client
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Phase A done criterion: connect → put bytes on :out → close! :out → drain :in to EOF.
+#[test]
+fn test_connect_send_recv_close() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Spawn the echo server (uses only Tokio/std types — no LocalSet required).
+        tokio::task::spawn_local(run_echo_server(listener));
+
+        let globals = setup_globals();
+
+        // TCP connect — returns a promise channel.
+        let promise =
+            cljrs_net::tcp::connect_to("127.0.0.1", port, 8, 8);
+
+        // Await the promise channel (drive the LocalSet while waiting).
+        let conn_val = chan_of(&promise).take().await;
+        let conn = match &conn_val {
+            Value::Map(m) => m.clone(),
+            Value::Error(e) => panic!("connect failed: {}", e.get().message()),
+            other => panic!("expected conn map, got {}", other.type_name()),
+        };
+
+        // Verify map keys exist.
+        let in_val = conn_field(&conn, "in");
+        let out_val = conn_field(&conn, "out");
+        let _remote = conn_field(&conn, "remote-addr");
+        let _local_addr = conn_field(&conn, "local-addr");
+        let _resource = conn_field(&conn, "resource");
+
+        let in_ch = chan_of(&in_val);
+        let out_ch = chan_of(&out_val);
+
+        // Put request bytes on :out.
+        let request = b"hello from cljrs-net";
+        let signed: Vec<i8> = request.iter().map(|&b| b as i8).collect();
+        out_ch
+            .put(Value::ByteArray(GcPtr::new(std::sync::Mutex::new(signed))))
+            .await;
+
+        // Close :out — triggers TCP half-close (FIN) after drain.
+        out_ch.close();
+
+        // Drain :in until EOF (Value::Nil from a closed channel).
+        let mut response: Vec<u8> = Vec::new();
+        loop {
+            match in_ch.take().await {
+                Value::Nil => break,
+                Value::ByteArray(arr) => {
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    response.extend_from_slice(&bytes);
+                }
+                Value::Error(e) => panic!("read error: {}", e.get().message()),
+                other => panic!("unexpected value on :in: {}", other.type_name()),
+            }
+        }
+
+        assert_eq!(response, request, "echo server must echo back the same bytes");
+    });
+}
+
+/// Verify that a connection failure delivers `Value::Error` on the promise
+/// channel rather than panicking.
+#[test]
+fn test_connect_failure_delivers_error() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        // Port 1 is privileged and almost certainly not listening.
+        let promise = cljrs_net::tcp::connect_to("127.0.0.1", 1, 8, 8);
+
+        let result = chan_of(&promise).take().await;
+        assert!(
+            matches!(result, Value::Error(_)),
+            "expected Value::Error for refused connection, got {}", result.type_name()
+        );
+    });
+}

--- a/crates/cljrs-net/tests/tcp_client.rs
+++ b/crates/cljrs-net/tests/tcp_client.rs
@@ -70,11 +70,10 @@ fn test_connect_send_recv_close() {
         // Spawn the echo server (uses only Tokio/std types — no LocalSet required).
         tokio::task::spawn_local(run_echo_server(listener));
 
-        let globals = setup_globals();
+        let _globals = setup_globals();
 
         // TCP connect — returns a promise channel.
-        let promise =
-            cljrs_net::tcp::connect_to("127.0.0.1", port, 8, 8);
+        let promise = cljrs_net::tcp::connect_to("127.0.0.1", port, 8, 8);
 
         // Await the promise channel (drive the LocalSet while waiting).
         let conn_val = chan_of(&promise).take().await;
@@ -119,7 +118,10 @@ fn test_connect_send_recv_close() {
             }
         }
 
-        assert_eq!(response, request, "echo server must echo back the same bytes");
+        assert_eq!(
+            response, request,
+            "echo server must echo back the same bytes"
+        );
     });
 }
 
@@ -142,7 +144,8 @@ fn test_connect_failure_delivers_error() {
         let result = chan_of(&promise).take().await;
         assert!(
             matches!(result, Value::Error(_)),
-            "expected Value::Error for refused connection, got {}", result.type_name()
+            "expected Value::Error for refused connection, got {}",
+            result.type_name()
         );
     });
 }

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["async"]
+default = ["async", "net"]
 # Propagate no-gc to all direct dependencies; transitive deps pick it up through their own feature chains.
 no-gc = [
     "cljrs-gc/no-gc",
@@ -19,6 +19,7 @@ no-gc = [
 ]
 enable-rustyline = ["rustyline"]
 async = ["dep:cljrs-async", "dep:cljrs-io", "dep:tokio"]
+net   = ["dep:cljrs-net", "async"]
 
 [[bin]]
 name = "cljrs"
@@ -46,4 +47,5 @@ rustyline   = { workspace = true, optional = true }
 libloading  = { workspace = true }
 cljrs-async = { workspace = true, optional = true }
 cljrs-io    = { workspace = true, optional = true }
+cljrs-net   = { workspace = true, optional = true }
 tokio       = { workspace = true, optional = true }

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -481,6 +481,8 @@ fn setup_globals(
         let init = |g: &Arc<GlobalEnv>| {
             cljrs_async::init(g);
             cljrs_io::init(g);
+            #[cfg(feature = "net")]
+            cljrs_net::init(g);
         };
         match guard.as_ref() {
             Some(drv) => drv.local.block_on(&drv.rt, async { init(&globals) }),


### PR DESCRIPTION
Adds the `cljrs-net` crate (Phase A of networking-plan.md):

- `TcpStreamResource` implementing the `Resource` trait — Arc-backed,
  deterministic close via `AbortHandle`s for reader/writer tasks
- `connect` builtin: `(connect {:host h :port p})` returns a capacity-1
  promise channel that yields a connection map `{:in :out :remote-addr
  :local-addr :resource}` once the TCP handshake completes, or a
  `Value::Error` on failure
- `close` builtin: closes `:in`/`:out` channels and aborts both tasks
- Reader task: chunks socket data into `byte-array` values on `:in`,
  closes `:in` at EOF or error
- Writer task: drains `:out`, writes `byte-array`/string values to the
  socket, calls `shutdown(Write)` when `:out` closes (TCP half-close)
- `clojure.rust.net.tcp` namespace (native + Clojure source)
- `clojure.rust.net` umbrella namespace with transport-agnostic `connect`
  and `close` (defaults to `:transport :tcp`)

Also:
- Adds `pub async fn CljChannel::take()` to `cljrs-async` (public
  counterpart to `put` for use by sibling crates)
- Wires `cljrs_net::init` into the CLI under a default-on `net` feature
- Integration tests: echo-server round-trip + connection-failure error path

https://claude.ai/code/session_0191HKMtgw6d6GhrJY3kPXLS