### PR TITLE
feat(net): implement Phase B — TCP server (listen, start-server, close)

### DIFF
--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,49 +2,70 @@
 
 **Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phase A implemented (TCP client: `connect`, `close`). Phases B–F (server, framing, UDP, TLS, Unix) are stubs.
+**Status**: Phases A–B implemented (TCP client + server). Phases C–F (framing, UDP, TLS, Unix) are stubs.
 
-**Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. Higher-level protocols are higher-order functions over those channels.
+**Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels.
 
 ## File Layout
 
 | File | Description |
 |---|---|
 | `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp` and `clojure.rust.net` |
-| `src/tcp.rs` | `TcpStreamResource`, `connect`, `close`, reader/writer tasks |
-| `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp` |
+| `src/tcp.rs` | `TcpStreamResource`, `TcpListenerResource`, connection builder, accept loop, `connect`/`listen`/`close` builtins |
+| `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net` |
+| `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
+| `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |
 
 ## Public API
 
 ### `clojure.rust.net.tcp`
 
 ```clojure
+;; Phase A — client
 (connect {:host "example.com" :port 80})
 ;; => promise-chan — yields {:in ch :out ch :remote-addr str :local-addr str :resource h}
 ;;    or Value::Error on failure
 
-(close conn)  ;; => nil — closes :in/:out channels and aborts tasks
+(close conn)         ;; => nil — closes :in/:out and aborts reader/writer tasks
+
+;; Phase B — server
+(listen {:port 8080})
+;; => {:conns <chan> :local-addr "0.0.0.0:8080" :resource h}
+;;    :conns yields a connection map per accepted socket; closed when listener closes
+
+(listen-close server) ;; => nil — stops accept loop, closes :conns
+
+(start-server handler {:port 8080})
+;; => server-map — spawns go-loop that calls (handler conn) for each accepted conn
 ```
 
 ### `clojure.rust.net` (umbrella)
 
 ```clojure
-(connect opts)  ;; delegates to tcp/connect; :transport key (default :tcp)
-(close conn)    ;; delegates to tcp/close
+(connect opts)            ;; delegates to tcp/connect; :transport key (default :tcp)
+(listen opts)             ;; delegates to tcp/listen; :transport key (default :tcp)
+(start-server handler opts) ;; delegates to tcp/start-server
+(close x)                 ;; dispatches on :conns key: server → listen-close, else → close
 ```
 
 ### Rust
 
 ```rust
 pub fn init(globals: &Arc<GlobalEnv>)
+pub fn tcp::connect_to(host: &str, port: u16, in_buf: usize, out_buf: usize) -> Value
+pub fn tcp::listen_on(host: &str, port: u16, conns_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
 ```
 
-Registers `clojure.rust.net.tcp` and `clojure.rust.net`. Calls `cljrs_async::init` internally. Idempotent.
+`init` registers both namespaces, calling `cljrs_async::init` internally. Idempotent.
 
 ### `TcpStreamResource`
 
-Implements `cljrs_value::Resource` (Arc-backed, `Send + Sync`). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks, dropping the `OwnedReadHalf`/`OwnedWriteHalf` and releasing the file descriptor.
+Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks, dropping the socket halves and releasing the FD.
+
+### `TcpListenerResource`
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `accept_loop` task. `close()` aborts the task, dropping the `TcpListener` and releasing the listener FD.
 
 ## Connection Model
 
@@ -62,18 +83,44 @@ Two tasks are spawned per connection on the `LocalSet`:
 - **reader task** — reads the socket into `byte-array` chunks and puts them on `:in`
 - **writer task** — takes from `:out` and writes to the socket; shuts down the write half when `:out` closes
 
+## Server Model
+
+`listen` binds synchronously (std socket → Tokio listener) and returns a server map:
+
+```clojure
+{:conns      <chan>          ; yields a connection map per accepted socket; closed at listener close
+ :local-addr "ip:port"
+ :resource   <TcpListener>} ; Arc<TcpListenerResource> — call (close server) to stop accepting
+```
+
+The accept loop runs as a `spawn_local` task. When `:conns` is full, `chan_put` parks the accept loop, applying backpressure all the way to the TCP accept window.
+
 ## Usage Example
 
 ```clojure
-(require '[clojure.core.async :refer [<!! >!! close!]])
-(require '[clojure.rust.net.tcp :as tcp])
+(require '[clojure.rust.net :as net])
+(require '[clojure.core.async :refer [go <!! close!]])
 
-(let [conn (<!! (tcp/connect {:host "example.com" :port 80}))]
-  (>!! (:out conn) (.getBytes "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"))
-  (close! (:out conn))
-  (loop []
-    (when-let [chunk (<!! (:in conn))]
-      (print (String. (byte-array (map #(bit-and % 0xff) chunk))))
-      (recur)))
-  (tcp/close conn))
+;; Echo server
+(let [server (net/listen {:port 8080})]
+  (go (loop []
+        (when-let [conn (<! (:conns server))]
+          (go (loop []
+                (when-let [chunk (<! (:in conn))]
+                  (>! (:out conn) chunk)
+                  (recur)))
+              (close! (:out conn)))
+          (recur))))
+  ;; ... later ...
+  (net/close server))
+
+;; Or with start-server sugar:
+(net/start-server
+  (fn [conn]
+    (go (loop []
+          (when-let [chunk (<! (:in conn))]
+            (>! (:out conn) chunk)
+            (recur)))
+        (close! (:out conn))))
+  {:port 8080})
 ```

--- a/crates/cljrs-net/src/clojure_rust_net.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net.cljrs
@@ -1,8 +1,4 @@
 ;; clojure.rust.net — umbrella networking namespace.
-;;
-;; Delegates to the transport-specific namespaces. For Phase A only TCP is
-;; implemented; later phases add :unix and :tls transports behind the same
-;; connect/listen/close API.
 
 (require 'clojure.rust.net.tcp)
 
@@ -23,10 +19,39 @@
       :tcp (clojure.rust.net.tcp/connect opts)
       (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
 
-(defn close
-  "Close a connection map, releasing its socket and channels.
+(defn listen
+  "Listen on a TCP port. Returns a server map {:conns <chan> :local-addr str :resource handle}.
+  The :conns channel yields a connection map for each accepted socket; it closes when the
+  listener closes. Bounded :conns buffer applies accept backpressure.
 
-  Closes :out (signals the writer to drain and half-close the write side),
-  closes :in, and aborts the reader/writer tasks via the :resource handle."
-  [conn]
-  (clojure.rust.net.tcp/close conn))
+  Opts:
+    :port       integer (required, 1-65535)
+    :host       string (default \"0.0.0.0\")
+    :transport  :tcp (default) — future: :unix, :tls
+    :conns-buf  buffer depth for :conns (default 8)
+    :in-buf     per-connection :in buffer (default 8)
+    :out-buf    per-connection :out buffer (default 8)"
+  [opts]
+  (let [transport (get opts :transport :tcp)]
+    (case transport
+      :tcp (clojure.rust.net.tcp/listen opts)
+      (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
+
+(defn start-server
+  "Start a TCP server, calling handler for each accepted connection.
+  Sugar over listen: spawns a go-loop that drains :conns and calls handler.
+  Returns the server map. The handler runs synchronously in the accept loop —
+  use (go ...) inside it to avoid blocking new accepts."
+  [handler opts]
+  (clojure.rust.net.tcp/start-server handler opts))
+
+(defn close
+  "Close a connection or server map, releasing its socket and channels.
+
+  For connections: closes :out (signals writer to drain and half-close the write
+  side), closes :in, and aborts reader/writer tasks via the :resource handle.
+  For servers: stops the accept loop, closes the listener FD, and closes :conns."
+  [x]
+  (cond
+    (contains? x :conns) (clojure.rust.net.tcp/listen-close x)
+    :else                (clojure.rust.net.tcp/close x)))

--- a/crates/cljrs-net/src/clojure_rust_net_tcp.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_tcp.cljrs
@@ -1,8 +1,34 @@
 ;; clojure.rust.net.tcp — TCP client/server.
 ;;
 ;; Phase A (client):
-;;   connect  — (connect {:host h :port p}) => promise-chan -> conn-map
-;;   close    — (close conn) => nil
+;;   connect      — (connect {:host h :port p}) => promise-chan -> conn-map
+;;   close        — (close conn) => nil
 ;;
-;; The native functions are registered by cljrs-net; this file may add
-;; Clojure-level helpers on top as later phases are implemented.
+;; Phase B (server):
+;;   listen       — (listen {:port p}) => {:conns ch :local-addr str :resource h}
+;;   listen-close — (listen-close server) => nil
+;;   start-server — (start-server handler opts) => server-map
+
+(defn start-server
+  "Start a TCP server with `handler` called for each accepted connection.
+  Returns the server map {:conns <chan> :local-addr str :resource handle}.
+
+  `handler` is called with a connection map for each accepted connection.
+  Use (go ...) inside the handler to avoid blocking new accepts.
+
+  Opts (same as listen):
+    :port       integer (required, 1-65535)
+    :host       string (default \"0.0.0.0\")
+    :conns-buf  buffer depth for :conns (default 8)
+    :in-buf     per-connection :in buffer (default 8)
+    :out-buf    per-connection :out buffer (default 8)"
+  [handler opts]
+  (let [server (clojure.rust.net.tcp/listen opts)
+        conns  (:conns server)]
+    (clojure.core.async/go
+      (loop []
+        (let [conn (await (clojure.core.async/take! conns))]
+          (when (some? conn)
+            (handler conn)
+            (recur)))))
+    server))

--- a/crates/cljrs-net/src/tcp.rs
+++ b/crates/cljrs-net/src/tcp.rs
@@ -1,4 +1,4 @@
-//! TCP client support for `clojure.rust.net.tcp`.
+//! TCP client/server support for `clojure.rust.net.tcp`.
 //!
 //! Phase A delivers `connect` and `close`. A connection is a map:
 //!
@@ -11,13 +11,21 @@
 //! ```
 //!
 //! `connect` returns a capacity-1 promise channel that yields the connection
-//! map once the TCP handshake completes, or a `Value::Error` on failure. The
-//! model is identical to `cljrs-io`'s discrete-op shape.
+//! map once the TCP handshake completes, or a `Value::Error` on failure.
+//!
+//! Phase B adds `listen` and `listen-close`. A server map is:
+//!
+//! ```clojure
+//! {:conns      <chan>   ; yields a connection map for each accepted socket
+//!  :local-addr "ip:port"
+//!  :resource   <handle>} ; TcpListenerResource — deterministic listener close
+//! ```
 
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::task::AbortHandle;
 
@@ -39,6 +47,8 @@ pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
     let fns: Vec<(&str, Arity, Builtin)> = vec![
         ("connect", Arity::Fixed(1), builtin_connect),
         ("close", Arity::Fixed(1), builtin_close),
+        ("listen", Arity::Fixed(1), builtin_listen),
+        ("listen-close", Arity::Fixed(1), builtin_listen_close),
     ];
     for (name, arity, func) in fns {
         let nf = NativeFn::new(name, arity, func);
@@ -100,6 +110,60 @@ impl Resource for TcpStreamResource {
 
     fn resource_type(&self) -> &'static str {
         "TcpStream"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── TcpListenerResource ───────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct TcpListenerInner {
+    closed: bool,
+    accept_abort: Option<AbortHandle>,
+}
+
+/// `Resource` implementation for a TCP listener.
+///
+/// Holds the `AbortHandle` for the `accept_loop` task. `close()` aborts the
+/// task, which drops the `TcpListener` and closes the listener FD.
+#[derive(Debug)]
+pub struct TcpListenerResource {
+    inner: Arc<Mutex<TcpListenerInner>>,
+}
+
+impl TcpListenerResource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TcpListenerInner {
+                closed: false,
+                accept_abort: None,
+            })),
+        }
+    }
+}
+
+impl Resource for TcpListenerResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        if let Some(h) = g.accept_abort.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "TcpListener"
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -208,6 +272,110 @@ async fn writer_loop(mut write_half: OwnedWriteHalf, out_chan: GcPtr<NativeObjec
     .await;
 }
 
+// ── Connection builder ────────────────────────────────────────────────────────
+
+fn make_connection(stream: TcpStream, in_buf: usize, out_buf: usize) -> Value {
+    let remote_addr = stream
+        .peer_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+    let local_addr = stream
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+    let (read_half, write_half) = stream.into_split();
+    let in_chan = make_chan(in_buf);
+    let out_chan = make_chan(out_buf);
+    let resource = TcpStreamResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+    let r_jh = tokio::task::spawn_local(reader_loop(read_half, in_chan.clone()));
+    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
+    let w_jh = tokio::task::spawn_local(writer_loop(write_half, out_chan.clone()));
+    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
+    Value::Map(MapValue::from_pairs(vec![
+        (kw("in"), Value::NativeObject(in_chan)),
+        (kw("out"), Value::NativeObject(out_chan)),
+        (kw("remote-addr"), Value::string(remote_addr)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]))
+}
+
+// ── Accept loop ───────────────────────────────────────────────────────────────
+
+/// Accept connections from `listener` and put each connection map on `conns_chan`.
+///
+/// Exits when the listener returns an error (e.g. the FD is closed by aborting
+/// this task) or when the consumer closes `conns_chan`. After exiting, closes
+/// `conns_chan` so consumers see EOF.
+async fn accept_loop(
+    listener: tokio::net::TcpListener,
+    conns_chan: GcPtr<NativeObjectBox>,
+    in_buf: usize,
+    out_buf: usize,
+) {
+    loop {
+        match listener.accept().await {
+            Err(e) => {
+                chan_put(&conns_chan, net_error(format!("accept error: {e}"))).await;
+                break;
+            }
+            Ok((stream, _)) => {
+                let conn = make_connection(stream, in_buf, out_buf);
+                if !chan_put(&conns_chan, conn).await {
+                    break; // consumer closed :conns
+                }
+            }
+        }
+    }
+    chan_ref(conns_chan.get()).close();
+}
+
+// ── Listen implementation ─────────────────────────────────────────────────────
+
+/// Bind a TCP listener on `host:port` and return a server map.
+///
+/// Convenience wrapper used by tests and the Clojure `listen` builtin alike.
+pub fn listen_on(
+    host: &str,
+    port: u16,
+    conns_buf: usize,
+    in_buf: usize,
+    out_buf: usize,
+) -> ValueResult<Value> {
+    let addr = format!("{host}:{port}");
+
+    // Bind synchronously (std), then convert to Tokio (requires runtime context).
+    let std_listener = std::net::TcpListener::bind(&addr)
+        .map_err(|e| ValueError::Other(format!("listen on {addr}: {e}")))?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| ValueError::Other(format!("set_nonblocking: {e}")))?;
+    let listener = tokio::net::TcpListener::from_std(std_listener)
+        .map_err(|e| ValueError::Other(format!("from_std: {e}")))?;
+
+    let local_addr = listener
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+
+    let conns_chan = make_chan(conns_buf);
+
+    let resource = TcpListenerResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    let jh = tokio::task::spawn_local(accept_loop(listener, conns_chan.clone(), in_buf, out_buf));
+    shared_inner.lock().unwrap().accept_abort = Some(jh.abort_handle());
+
+    Ok(Value::Map(MapValue::from_pairs(vec![
+        (kw("conns"), Value::NativeObject(conns_chan)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ])))
+}
+
 // ── Connect implementation ────────────────────────────────────────────────────
 
 /// Initiate a TCP connection and return the promise channel as a `Value`.
@@ -236,42 +404,7 @@ async fn do_connect(
             return Ok(Value::Nil);
         }
     };
-
-    let remote_addr = stream
-        .peer_addr()
-        .map(|a| a.to_string())
-        .unwrap_or_default();
-    let local_addr = stream
-        .local_addr()
-        .map(|a| a.to_string())
-        .unwrap_or_default();
-
-    let (read_half, write_half) = stream.into_split();
-
-    let in_chan = make_chan(in_buf);
-    let out_chan = make_chan(out_buf);
-
-    // Build the resource before spawning; keep the inner Arc so we can set the
-    // abort handles after obtaining the JoinHandles from spawn_local.
-    let resource = TcpStreamResource::new();
-    let shared_inner = resource.inner.clone();
-    let resource_handle = ResourceHandle::new(resource);
-
-    let r_jh = tokio::task::spawn_local(reader_loop(read_half, in_chan.clone()));
-    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
-
-    let w_jh = tokio::task::spawn_local(writer_loop(write_half, out_chan.clone()));
-    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
-
-    let conn = Value::Map(MapValue::from_pairs(vec![
-        (kw("in"), Value::NativeObject(in_chan)),
-        (kw("out"), Value::NativeObject(out_chan)),
-        (kw("remote-addr"), Value::string(remote_addr)),
-        (kw("local-addr"), Value::string(local_addr)),
-        (kw("resource"), Value::Resource(resource_handle)),
-    ]));
-
-    chan_deliver(&promise, conn).await;
+    chan_deliver(&promise, make_connection(stream, in_buf, out_buf)).await;
     Ok(Value::Nil)
 }
 
@@ -326,6 +459,55 @@ fn builtin_close(args: &[Value]) -> ValueResult<Value> {
     // Abort tasks and release the FD deterministically.
     if let Some(Value::Resource(handle)) = conn.get(&kw("resource")) {
         let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}
+
+/// `(listen {:port p})` — bind a TCP listener and return a server map.
+///
+/// The `:conns` channel yields a connection map for each accepted socket and
+/// is closed when the listener closes. Optional keys: `:host` (default
+/// `"0.0.0.0"`), `:conns-buf` (default 8), `:in-buf` (default 8), `:out-buf`
+/// (default 8).
+fn builtin_listen(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:port long}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let host = opts_str(&opts, "host").unwrap_or_else(|| "0.0.0.0".to_string());
+    let port =
+        opts_port(&opts).ok_or_else(|| ValueError::Other(":port required (1-65535)".into()))?;
+    let conns_buf = opts_usize(&opts, "conns-buf").unwrap_or(8);
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+
+    listen_on(&host, port, conns_buf, in_buf, out_buf)
+}
+
+/// `(listen-close server)` — stop the accept loop and close the `:conns` channel.
+fn builtin_listen_close(args: &[Value]) -> ValueResult<Value> {
+    let server = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "server map {:conns ch :resource handle}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::Resource(handle)) = server.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+    if let Some(Value::NativeObject(obj)) = server.get(&kw("conns")) {
+        chan_ref(obj.get()).close();
     }
 
     Ok(Value::Nil)

--- a/crates/cljrs-net/tests/tcp_server.rs
+++ b/crates/cljrs-net/tests/tcp_server.rs
@@ -1,0 +1,173 @@
+//! Phase B integration tests: TCP server — listen + accept loop round-trips bytes.
+//!
+//! Done criterion from networking-plan.md Phase B:
+//!   "an echo server built from listen + go round-trips bytes from a connect client."
+
+use std::sync::Arc;
+
+use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, NativeObjectBox, Value};
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn map_get(map: &cljrs_value::MapValue, key: &str) -> Value {
+    map.get(&kw(key))
+        .unwrap_or_else(|| panic!("map missing :{key}"))
+}
+
+fn as_chan(v: &Value) -> GcPtr<NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => obj.clone(),
+        other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+    }
+}
+
+/// Phase B done criterion: echo server from `listen_on` + accept handler round-trips bytes.
+#[test]
+fn test_listen_echo_round_trip() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        // Start the server (port 0 = OS-assigned).
+        let server_val =
+            cljrs_net::tcp::listen_on("127.0.0.1", 0, 8, 8, 8).expect("listen_on failed");
+        let server_map = match server_val {
+            Value::Map(m) => m,
+            other => panic!("expected server map, got {}", other.type_name()),
+        };
+
+        // Extract the port from :local-addr ("127.0.0.1:PORT").
+        let local_addr = match map_get(&server_map, "local-addr") {
+            Value::Str(s) => s.get().clone(),
+            other => panic!("expected str :local-addr, got {}", other.type_name()),
+        };
+        let port: u16 = local_addr.split(':').last().unwrap().parse().unwrap();
+
+        let conns_ch = as_chan(&map_get(&server_map, "conns"));
+
+        // Spawn a one-shot echo handler: accept one connection, echo all bytes.
+        let conns_for_handler = conns_ch.clone();
+        tokio::task::spawn_local(async move {
+            let conn_val = chan_take(&conns_for_handler).await;
+            let conn = match conn_val {
+                Value::Map(m) => m,
+                other => panic!("handler got non-map from :conns: {}", other.type_name()),
+            };
+
+            let in_ch = as_chan(&map_get(&conn, "in"));
+            let out_ch = as_chan(&map_get(&conn, "out"));
+
+            loop {
+                match chan_take(&in_ch).await {
+                    Value::Nil => break,
+                    val => {
+                        chan_put(&out_ch, val).await;
+                    }
+                }
+            }
+            chan_ref(out_ch.get()).close();
+        });
+
+        // Connect a client.
+        let promise = cljrs_net::tcp::connect_to("127.0.0.1", port, 8, 8);
+        let conn_val = chan_take(&as_chan(&promise)).await;
+        let conn = match conn_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("connect failed: {}", e.get().message()),
+            other => panic!("expected conn map, got {}", other.type_name()),
+        };
+
+        let out_ch = as_chan(&map_get(&conn, "out"));
+        let in_ch = as_chan(&map_get(&conn, "in"));
+
+        // Send a request and half-close the write side.
+        let request = b"phase B echo test";
+        let signed: Vec<i8> = request.iter().map(|&b| b as i8).collect();
+        chan_put(
+            &out_ch,
+            Value::ByteArray(GcPtr::new(std::sync::Mutex::new(signed))),
+        )
+        .await;
+        chan_ref(out_ch.get()).close();
+
+        // Drain :in until EOF, collecting the echoed bytes.
+        let mut response: Vec<u8> = Vec::new();
+        loop {
+            match chan_take(&in_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(arr) => {
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    response.extend_from_slice(&bytes);
+                }
+                Value::Error(e) => panic!("read error: {}", e.get().message()),
+                other => panic!("unexpected value on :in: {}", other.type_name()),
+            }
+        }
+
+        assert_eq!(response, request, "echo server must return the same bytes");
+
+        // Close the server listener.
+        match map_get(&server_map, "resource") {
+            Value::Resource(handle) => {
+                let _ = handle.close();
+            }
+            other => panic!("expected resource, got {}", other.type_name()),
+        }
+    });
+}
+
+/// Closing the server closes :conns so consumers see nil.
+#[test]
+fn test_close_server_closes_conns() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let server_val =
+            cljrs_net::tcp::listen_on("127.0.0.1", 0, 8, 8, 8).expect("listen_on failed");
+        let server_map = match server_val {
+            Value::Map(m) => m,
+            other => panic!("expected server map, got {}", other.type_name()),
+        };
+
+        let conns_ch = as_chan(&map_get(&server_map, "conns"));
+
+        // Close the server (abort accept loop + close :conns).
+        match map_get(&server_map, "resource") {
+            Value::Resource(handle) => {
+                let _ = handle.close();
+            }
+            _ => panic!("expected resource"),
+        }
+        chan_ref(conns_ch.get()).close();
+
+        // A take on the closed :conns must yield nil immediately.
+        let val = chan_take(&conns_ch).await;
+        assert!(
+            matches!(val, Value::Nil),
+            "expected nil from closed :conns, got {}",
+            val.type_name()
+        );
+    });
+}


### PR DESCRIPTION
Adds the server primitive described in networking-plan.md Phase B:
`listen` returns {:conns <chan> :local-addr str :resource handle} where
:conns yields a connection map per accepted socket; `start-server` is
go-loop sugar; `close` dispatches on server vs connection maps.

- TcpListenerResource (Resource, AbortHandle for accept_loop task)
- accept_loop: backpressure-aware accept loop; chan_put parks when :conns full
- listen_on: synchronous std bind → Tokio conversion; public for tests
- Refactored do_connect to share make_connection helper with accept_loop
- start-server Clojure fn in clojure.rust.net.tcp
- listen + start-server + dispatch close in clojure.rust.net umbrella
- Phase B integration tests: echo round-trip + server close

https://claude.ai/code/session_01YKweWKtpKLjH5H1XkXKoV6