### PR TITLE
feat(net): implement Phase C — framing (lines, length-prefixed, by-delimiter)

### DIFF
--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -18,4 +18,7 @@ tokio          = { workspace = true, features = ["net", "io-util"] }
 
 [dev-dependencies]
 cljrs-stdlib   = { workspace = true }
+cljrs-interp   = { workspace = true }
+cljrs-reader   = { workspace = true }
+cljrs-env      = { workspace = true }
 tokio          = { workspace = true, features = ["net", "io-util", "sync"] }

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,20 +2,23 @@
 
 **Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–B implemented (TCP client + server). Phases C–F (framing, UDP, TLS, Unix) are stubs.
+**Status**: Phases A–C implemented (TCP client + server + framing). Phases D–F (UDP, TLS, Unix) are stubs.
 
-**Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels.
+**Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
 
 ## File Layout
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp` and `clojure.rust.net` |
+| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, and `clojure.rust.net` |
 | `src/tcp.rs` | `TcpStreamResource`, `TcpListenerResource`, connection builder, accept loop, `connect`/`listen`/`close` builtins |
+| `src/frame.rs` | `FramerSpec` native object, stateful framers (`LinesFramer`, `DelimiterFramer`, `LengthPrefixedFramer`), `frame`/encode builtins |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
+| `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
 | `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net` |
 | `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
 | `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |
+| `tests/framing.rs` | Phase C integration tests (lines + length-prefixed end-to-end, framer unit tests) |
 
 ## Public API
 
@@ -40,6 +43,29 @@
 ;; => server-map — spawns go-loop that calls (handler conn) for each accepted conn
 ```
 
+### `clojure.rust.net.frame`
+
+```clojure
+;; Decoder specs — pass to `frame`
+(lines)                              ; => FramerSpec — split on \n, emit strings
+(by-delimiter b)                     ; => FramerSpec — split on byte b, emit byte-arrays
+(length-prefixed {:bytes 4 :endian :big})  ; => FramerSpec — N-byte length prefix, emit byte-arrays
+
+;; Main framing helper
+(frame in-chan spec)                 ; => out-chan of decoded messages
+(frame in-chan spec out-buf)         ; => out-chan with custom buffer depth
+
+;; Encode helpers (write / outgoing direction)
+(lines-encode str)                   ; => byte-array (UTF-8 + \n)
+(length-prefixed-encode ba opts)     ; => byte-array (N-byte header prepended to ba)
+
+;; Pipe-fn helper (Clojure source)
+(pipe-map in-chan f)                 ; => out-chan — async map over channel values
+(pipe-map in-chan f out-buf)
+```
+
+`frame` spawns a `LocalSet` background task that reads byte-arrays from `in-chan`, feeds them through the stateful framer, and puts complete frames on the returned output channel. Errors from `in-chan` are forwarded in-band; the output channel closes at EOF or on error.
+
 ### `clojure.rust.net` (umbrella)
 
 ```clojure
@@ -55,9 +81,12 @@
 pub fn init(globals: &Arc<GlobalEnv>)
 pub fn tcp::connect_to(host: &str, port: u16, in_buf: usize, out_buf: usize) -> Value
 pub fn tcp::listen_on(host: &str, port: u16, conns_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
+pub fn frame::frame_channel(in_chan: GcPtr<NativeObjectBox>, spec: FramerSpec, out_buf: usize) -> GcPtr<NativeObjectBox>
+pub fn frame::encode_line(s: &str) -> Value
+pub fn frame::encode_length_prefixed(data: &[u8], prefix_len: usize, big_endian: bool) -> Value
 ```
 
-`init` registers both namespaces, calling `cljrs_async::init` internally. Idempotent.
+`init` registers all three namespaces, calling `cljrs_async::init` internally. Idempotent.
 
 ### `TcpStreamResource`
 
@@ -123,4 +152,67 @@ The accept loop runs as a `spawn_local` task. When `:conns` is full, `chan_put` 
             (recur)))
         (close! (:out conn))))
   {:port 8080})
+```
+
+## Framing Model (Phase C)
+
+`frame` turns a raw `:in` byte-stream channel into a channel of application messages by
+piping chunks through a stateful framer. The framer handles TCP segmentation: chunks
+can be split across frame boundaries or contain multiple frames.
+
+```clojure
+(require '[clojure.rust.net.frame :as frame])
+
+;; Line-protocol server: read \n-delimited strings
+(net/start-server
+  (fn [conn]
+    (let [lines (frame/frame (:in conn) (frame/lines))]
+      (go (loop []
+            (when-let [line (<! lines)]
+              (println "got line:" line)
+              ;; echo back
+              (>! (:out conn) (frame/lines-encode line))
+              (recur)))
+          (close! (:out conn)))))
+  {:port 8080})
+
+;; Length-prefixed protocol: 4-byte big-endian length header
+(net/start-server
+  (fn [conn]
+    (let [msgs (frame/frame (:in conn) (frame/length-prefixed {:bytes 4}))]
+      (go (loop []
+            (when-let [msg (<! msgs)]
+              ;; msg is a byte-array of exactly the declared length
+              (>! (:out conn) (frame/length-prefixed-encode msg {:bytes 4}))
+              (recur)))
+          (close! (:out conn)))))
+  {:port 9090})
+```
+
+### Stateful framers
+
+| Spec | Input | Output | Notes |
+|---|---|---|---|
+| `(lines)` | `byte-array` chunks | `string` per line | strips `\r`, emits partial final line at EOF |
+| `(by-delimiter b)` | `byte-array` chunks | `byte-array` per frame | `b` is excluded from frames |
+| `(length-prefixed {:bytes n})` | `byte-array` chunks | `byte-array` per frame | N-byte big-endian (default) or little-endian length header; partial frame at EOF discarded |
+
+### Encode helpers
+
+| Function | Returns |
+|---|---|
+| `(lines-encode str)` | `byte-array` — UTF-8 bytes of `str` followed by `\n` |
+| `(length-prefixed-encode ba opts)` | `byte-array` — N-byte length header prepended to `ba` |
+
+### Pipe-fn pattern
+
+For protocols that need async logic (request/response correlation, lookups), use
+a `(fn [in-chan] -> out-chan)` that spawns a `go-loop`. The `pipe-map` helper
+in this namespace covers the simple map-over-channel case:
+
+```clojure
+;; Transform each decoded message asynchronously
+(let [msgs   (frame/frame (:in conn) (frame/lines))
+      parsed (frame/pipe-map msgs parse-json)]
+  ...)
 ```

--- a/crates/cljrs-net/src/clojure_rust_net_frame.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_frame.cljrs
@@ -4,11 +4,43 @@
 ;;   lines              — (lines) => framer-spec
 ;;   by-delimiter       — (by-delimiter b) => framer-spec
 ;;   length-prefixed    — (length-prefixed {:bytes n :endian :big}) => framer-spec
-;;   frame              — (frame in-chan spec) => out-chan of messages
+;;   frame              — (frame in-chan spec-or-fn) => out-chan of messages
 ;;   lines-encode       — (lines-encode str) => byte-array (UTF-8 + \n)
 ;;   length-prefixed-encode — (length-prefixed-encode ba opts) => byte-array (header + data)
 ;;
-;; Usage — decode side:
+;; The `frame` function accepts either:
+;;   - A native framer spec ((lines), (by-delimiter b), (length-prefixed opts))
+;;   - A Clojure pipe function (fn [in-chan] -> out-chan)
+;;
+;; This means new framers can be written entirely in Clojure without touching
+;; any Rust code:
+;;
+;;   (defn crlf-framer [in-chan]
+;;     "Decode a CRLF line protocol."
+;;     (let [out (clojure.core.async/chan 8)]
+;;       (clojure.core.async/go
+;;         (loop [buf ""]
+;;           (let [chunk (await (clojure.core.async/take! in-chan))]
+;;             (if (nil? chunk)
+;;               (do
+;;                 (when (seq buf) (await (clojure.core.async/put! out buf)))
+;;                 (clojure.core.async/close! out))
+;;               (let [s (String. chunk "UTF-8")
+;;                     combined (str buf s)]
+;;                 (loop [s combined]
+;;                   (let [pos (.indexOf s "\r\n")]
+;;                     (if (neg? pos)
+;;                       (recur combined)  ;; no complete line yet, wait for more
+;;                       (do
+;;                         (await (clojure.core.async/put! out (subs s 0 pos)))
+;;                         (recur (subs s (+ pos 2))))))))))))
+;;       out))
+;;
+;;   ;; Use it just like a native framer spec:
+;;   (let [msgs (frame (:in conn) crlf-framer)]
+;;     (go-loop [] (when-let [m (<! msgs)] (handle m) (recur))))
+;;
+;; Usage — native specs:
 ;;
 ;;   (let [msgs (frame (:in conn) (lines))]
 ;;     (go-loop []
@@ -23,24 +55,6 @@
 ;;
 ;;   ;; Length-prefixed protocol:
 ;;   (>! (:out conn) (length-prefixed-encode msg-bytes {:bytes 4}))
-;;
-;; Pipe-fn pattern
-;; ───────────────
-;; A "pipe-fn" is a (fn [in-chan] -> out-chan) that spawns a go-loop.
-;; Use when you need async logic (e.g. request/response correlation) that a
-;; pure stateful framer can't express:
-;;
-;;   (defn my-pipe [in-chan]
-;;     (let [out (clojure.core.async/chan 8)]
-;;       (clojure.core.async/go
-;;         (loop []
-;;           (let [v (await (clojure.core.async/take! in-chan))]
-;;             (if (nil? v)
-;;               (clojure.core.async/close! out)
-;;               (do
-;;                 (await (clojure.core.async/put! out (transform v)))
-;;                 (recur))))))
-;;       out))
 
 (defn pipe-map
   "Create a new channel that contains the result of applying `f` to each value

--- a/crates/cljrs-net/src/clojure_rust_net_frame.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_frame.cljrs
@@ -1,0 +1,71 @@
+;; clojure.rust.net.frame — framing transducers and pipe-fns.
+;;
+;; Native primitives registered from Rust:
+;;   lines              — (lines) => framer-spec
+;;   by-delimiter       — (by-delimiter b) => framer-spec
+;;   length-prefixed    — (length-prefixed {:bytes n :endian :big}) => framer-spec
+;;   frame              — (frame in-chan spec) => out-chan of messages
+;;   lines-encode       — (lines-encode str) => byte-array (UTF-8 + \n)
+;;   length-prefixed-encode — (length-prefixed-encode ba opts) => byte-array (header + data)
+;;
+;; Usage — decode side:
+;;
+;;   (let [msgs (frame (:in conn) (lines))]
+;;     (go-loop []
+;;       (when-let [m (<! msgs)]
+;;         (handle m)
+;;         (recur))))
+;;
+;; Usage — encode side:
+;;
+;;   ;; Line protocol:
+;;   (>! (:out conn) (lines-encode "hello"))
+;;
+;;   ;; Length-prefixed protocol:
+;;   (>! (:out conn) (length-prefixed-encode msg-bytes {:bytes 4}))
+;;
+;; Pipe-fn pattern
+;; ───────────────
+;; A "pipe-fn" is a (fn [in-chan] -> out-chan) that spawns a go-loop.
+;; Use when you need async logic (e.g. request/response correlation) that a
+;; pure stateful framer can't express:
+;;
+;;   (defn my-pipe [in-chan]
+;;     (let [out (clojure.core.async/chan 8)]
+;;       (clojure.core.async/go
+;;         (loop []
+;;           (let [v (await (clojure.core.async/take! in-chan))]
+;;             (if (nil? v)
+;;               (clojure.core.async/close! out)
+;;               (do
+;;                 (await (clojure.core.async/put! out (transform v)))
+;;                 (recur))))))
+;;       out))
+
+(defn pipe-map
+  "Create a new channel that contains the result of applying `f` to each value
+  from `in-chan`. Closes when `in-chan` closes. Errors on `in-chan` are forwarded
+  unchanged. `out-buf` controls the output channel buffer depth (default 8).
+
+  This is the async pipe-fn pattern: (fn [in-chan] -> out-chan)."
+  ([in-chan f]
+   (pipe-map in-chan f 8))
+  ([in-chan f out-buf]
+   (let [out (clojure.core.async/chan out-buf)]
+     (clojure.core.async/go
+       (loop []
+         (let [v (await (clojure.core.async/take! in-chan))]
+           (cond
+             (nil? v)
+             (clojure.core.async/close! out)
+
+             (clojure.rust.error/error? v)
+             (do
+               (await (clojure.core.async/put! out v))
+               (clojure.core.async/close! out))
+
+             :else
+             (do
+               (await (clojure.core.async/put! out (f v)))
+               (recur))))))
+     out)))

--- a/crates/cljrs-net/src/frame.rs
+++ b/crates/cljrs-net/src/frame.rs
@@ -501,9 +501,7 @@ fn builtin_frame(args: &[Value]) -> ValueResult<Value> {
 
         other => Err(ValueError::WrongType {
             expected: "framer spec (lines, by-delimiter, length-prefixed) or pipe function",
-            got: other
-                .map(|v| v.type_name().to_string())
-                .unwrap_or_default(),
+            got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
         }),
     }
 }

--- a/crates/cljrs-net/src/frame.rs
+++ b/crates/cljrs-net/src/frame.rs
@@ -1,0 +1,589 @@
+//! Framing layer for `clojure.rust.net.frame` — Phase C of the networking plan.
+//!
+//! Stateful framers reassemble TCP byte-array chunks into application messages.
+//! The primary API is the `frame` function, which pipes an input channel through
+//! a framer spec into a new output channel:
+//!
+//! ```clojure
+//! (let [msgs (frame (:in conn) (lines))]
+//!   (go-loop [] (when-let [m (<! msgs)] (handle m) (recur))))
+//!
+//! (let [msgs (frame (:in conn) (length-prefixed {:bytes 4 :endian :big}))]
+//!   ...)
+//! ```
+//!
+//! Framer specs are created by `(lines)`, `(by-delimiter b)`, and
+//! `(length-prefixed opts)` and consumed by `frame`.
+//!
+//! Encode direction helpers produce framed byte-arrays for the write side:
+//! - `(lines-encode str)` → `byte-array` (UTF-8 + `\n`)
+//! - `(length-prefixed-encode byte-array opts)` → `byte-array` (N-byte header + data)
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use cljrs_async::channel::{chan_put, chan_ref, make_chan};
+use cljrs_env::env::GlobalEnv;
+use cljrs_gc::{GcPtr, MarkVisitor, Trace};
+use cljrs_value::{
+    Arity, ExceptionInfo, Keyword, MapValue, NativeFn, NativeObject, NativeObjectBox, Value,
+    ValueError, ValueResult, gc_native_object,
+};
+
+// ── Public entry point ─────────────────────────────────────────────────────────
+
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        // Decoder specs
+        ("lines", Arity::Fixed(0), builtin_lines),
+        ("by-delimiter", Arity::Fixed(1), builtin_by_delimiter),
+        ("length-prefixed", Arity::Fixed(1), builtin_length_prefixed),
+        // Pipe: in-chan + spec → out-chan of messages
+        ("frame", Arity::Variadic { min: 2 }, builtin_frame),
+        // Encode helpers (write side)
+        ("lines-encode", Arity::Fixed(1), builtin_lines_encode),
+        (
+            "length-prefixed-encode",
+            Arity::Fixed(2),
+            builtin_length_prefixed_encode,
+        ),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── FramerSpec NativeObject ────────────────────────────────────────────────────
+
+const FRAMER_TAG: &str = "FramerSpec";
+
+#[derive(Clone, Debug)]
+pub enum FramerKind {
+    Lines,
+    Delimiter(u8),
+    LengthPrefixed { prefix_len: usize, big_endian: bool },
+}
+
+/// Native object that describes a framing algorithm. Created by `(lines)`,
+/// `(by-delimiter b)`, or `(length-prefixed opts)` and consumed by `frame`.
+#[derive(Clone, Debug)]
+pub struct FramerSpec {
+    pub kind: FramerKind,
+    /// Default output channel buffer depth (overridden by the optional 3rd arg to `frame`).
+    pub out_buf: usize,
+}
+
+impl Trace for FramerSpec {
+    fn trace(&self, _visitor: &mut MarkVisitor) {}
+}
+
+impl NativeObject for FramerSpec {
+    fn type_tag(&self) -> &str {
+        FRAMER_TAG
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Stateful framer trait + implementations ────────────────────────────────────
+
+/// A stateful byte-stream framer. `feed` accepts a chunk and returns any
+/// complete frames; `finish` flushes any partial frame at EOF (may return `None`
+/// if the protocol requires a clean frame boundary).
+trait Framer {
+    fn feed(&mut self, bytes: &[u8]) -> Vec<Value>;
+    fn finish(&mut self) -> Option<Value>;
+}
+
+// ── Lines framer ──────────────────────────────────────────────────────────────
+
+/// Splits on `\n`, strips trailing `\r`, emits `Value::Str` per line.
+struct LinesFramer {
+    buf: Vec<u8>,
+}
+
+impl LinesFramer {
+    fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+}
+
+impl Framer for LinesFramer {
+    fn feed(&mut self, bytes: &[u8]) -> Vec<Value> {
+        let mut frames = Vec::new();
+        self.buf.extend_from_slice(bytes);
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let mut line: Vec<u8> = self.buf.drain(..pos).collect();
+            self.buf.remove(0); // consume the '\n'
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            let s = String::from_utf8_lossy(&line).into_owned();
+            frames.push(Value::string(s));
+        }
+        frames
+    }
+
+    fn finish(&mut self) -> Option<Value> {
+        if self.buf.is_empty() {
+            return None;
+        }
+        let mut line = std::mem::take(&mut self.buf);
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+        let s = String::from_utf8_lossy(&line).into_owned();
+        Some(Value::string(s))
+    }
+}
+
+// ── Delimiter framer ──────────────────────────────────────────────────────────
+
+/// Splits on a single delimiter byte, emits `byte-array` frames (delimiter excluded).
+struct DelimiterFramer {
+    delim: u8,
+    buf: Vec<u8>,
+}
+
+impl DelimiterFramer {
+    fn new(delim: u8) -> Self {
+        Self {
+            delim,
+            buf: Vec::new(),
+        }
+    }
+}
+
+impl Framer for DelimiterFramer {
+    fn feed(&mut self, bytes: &[u8]) -> Vec<Value> {
+        let mut frames = Vec::new();
+        self.buf.extend_from_slice(bytes);
+        while let Some(pos) = self.buf.iter().position(|&b| b == self.delim) {
+            let frame: Vec<u8> = self.buf.drain(..pos).collect();
+            self.buf.remove(0); // consume the delimiter
+            frames.push(bytes_value(&frame));
+        }
+        frames
+    }
+
+    fn finish(&mut self) -> Option<Value> {
+        if self.buf.is_empty() {
+            return None;
+        }
+        let frame = std::mem::take(&mut self.buf);
+        Some(bytes_value(&frame))
+    }
+}
+
+// ── Length-prefixed framer ────────────────────────────────────────────────────
+
+#[derive(PartialEq)]
+enum LpState {
+    Header,
+    Body(usize),
+}
+
+/// Reads an N-byte big- or little-endian length header, then reads that many body
+/// bytes and emits a `byte-array` frame. Handles chunks that span multiple frames
+/// or that split a header/body boundary.
+struct LengthPrefixedFramer {
+    prefix_len: usize,
+    big_endian: bool,
+    buf: Vec<u8>,
+    state: LpState,
+}
+
+impl LengthPrefixedFramer {
+    fn new(prefix_len: usize, big_endian: bool) -> Self {
+        Self {
+            prefix_len,
+            big_endian,
+            buf: Vec::new(),
+            state: LpState::Header,
+        }
+    }
+
+    fn parse_length(&self, header: &[u8]) -> usize {
+        let mut n: u64 = 0;
+        if self.big_endian {
+            for &b in header {
+                n = (n << 8) | (b as u64);
+            }
+        } else {
+            for &b in header.iter().rev() {
+                n = (n << 8) | (b as u64);
+            }
+        }
+        n as usize
+    }
+}
+
+impl Framer for LengthPrefixedFramer {
+    fn feed(&mut self, bytes: &[u8]) -> Vec<Value> {
+        let mut frames = Vec::new();
+        self.buf.extend_from_slice(bytes);
+        loop {
+            match self.state {
+                LpState::Header => {
+                    if self.buf.len() < self.prefix_len {
+                        break;
+                    }
+                    let header: Vec<u8> = self.buf.drain(..self.prefix_len).collect();
+                    let body_len = self.parse_length(&header);
+                    self.state = LpState::Body(body_len);
+                }
+                LpState::Body(body_len) => {
+                    if self.buf.len() < body_len {
+                        break;
+                    }
+                    let body: Vec<u8> = self.buf.drain(..body_len).collect();
+                    frames.push(bytes_value(&body));
+                    self.state = LpState::Header;
+                }
+            }
+        }
+        frames
+    }
+
+    fn finish(&mut self) -> Option<Value> {
+        // A partial frame at EOF is a protocol error; discard silently.
+        None
+    }
+}
+
+// ── Value helpers ──────────────────────────────────────────────────────────────
+
+fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+fn frame_error(msg: impl Into<String>) -> Value {
+    let msg = msg.into();
+    Value::Error(GcPtr::new(ExceptionInfo::new(
+        ValueError::Other(msg.clone()),
+        msg,
+        None,
+        None,
+    )))
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn get_bytes(v: &Value) -> Option<Vec<u8>> {
+    match v {
+        Value::ByteArray(arr) => Some(arr.get().lock().unwrap().iter().map(|&b| b as u8).collect()),
+        _ => None,
+    }
+}
+
+fn parse_prefix_opts(opts: &MapValue) -> (usize, bool) {
+    let prefix_len = match opts.get(&kw("bytes")) {
+        Some(Value::Long(n)) if n > 0 && n <= 8 => n as usize,
+        _ => 4,
+    };
+    let big_endian = opts
+        .get(&kw("endian"))
+        .map(|v| v != kw("little"))
+        .unwrap_or(true);
+    (prefix_len, big_endian)
+}
+
+// ── Framer async pipe task ─────────────────────────────────────────────────────
+
+/// Reads from `in_chan`, feeds bytes through `framer`, and puts complete frames
+/// on `out_chan`. Propagates `Value::Error` in-band and closes `out_chan` at EOF
+/// or on error, exactly matching the `cljrs-io` streaming channel contract.
+async fn framer_task(
+    in_chan: GcPtr<NativeObjectBox>,
+    out_chan: GcPtr<NativeObjectBox>,
+    mut framer: Box<dyn Framer>,
+) {
+    'outer: loop {
+        let val = chan_ref(in_chan.get()).take().await;
+        match val {
+            Value::Nil => {
+                // EOF: flush any trailing partial frame, then close.
+                if let Some(frame) = framer.finish() {
+                    chan_put(&out_chan, frame).await;
+                }
+                break;
+            }
+            Value::Error(_) => {
+                // Propagate error in-band then close.
+                chan_put(&out_chan, val).await;
+                break;
+            }
+            Value::ByteArray(_) => {
+                if let Some(bytes) = get_bytes(&val) {
+                    for frame in framer.feed(&bytes) {
+                        if !chan_put(&out_chan, frame).await {
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+            other => {
+                chan_put(
+                    &out_chan,
+                    frame_error(format!(
+                        "frame: unexpected value on :in (expected byte-array, got {})",
+                        other.type_name()
+                    )),
+                )
+                .await;
+                break;
+            }
+        }
+    }
+    chan_ref(out_chan.get()).close();
+}
+
+// ── Builtin functions ──────────────────────────────────────────────────────────
+
+/// `(lines)` — return a framer spec that splits byte-array chunks on `\n` and
+/// emits a `string` per line (strips trailing `\r`). Pass to `frame`.
+fn builtin_lines(_args: &[Value]) -> ValueResult<Value> {
+    let spec = FramerSpec {
+        kind: FramerKind::Lines,
+        out_buf: 8,
+    };
+    Ok(Value::NativeObject(gc_native_object(spec)))
+}
+
+/// `(by-delimiter b)` — return a framer spec that splits on byte `b` (0-255)
+/// and emits a `byte-array` per frame (delimiter excluded). Pass to `frame`.
+fn builtin_by_delimiter(args: &[Value]) -> ValueResult<Value> {
+    let delim = match args.first() {
+        Some(Value::Long(n)) if *n >= 0 && *n <= 255 => *n as u8,
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "byte (long 0-255)",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let spec = FramerSpec {
+        kind: FramerKind::Delimiter(delim),
+        out_buf: 8,
+    };
+    Ok(Value::NativeObject(gc_native_object(spec)))
+}
+
+/// `(length-prefixed {:bytes n :endian :big})` — return a framer spec that
+/// reads an N-byte (default 4) big-endian length header, then emits a
+/// `byte-array` of exactly that many bytes. Pass to `frame`.
+///
+/// Options:
+///   `:bytes`  — prefix width in bytes: 1, 2, 4 (default), or 8
+///   `:endian` — `:big` (default) or `:little`
+fn builtin_length_prefixed(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:bytes n}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let (prefix_len, big_endian) = parse_prefix_opts(&opts);
+    let spec = FramerSpec {
+        kind: FramerKind::LengthPrefixed {
+            prefix_len,
+            big_endian,
+        },
+        out_buf: 8,
+    };
+    Ok(Value::NativeObject(gc_native_object(spec)))
+}
+
+/// `(frame in-chan framer-spec)` / `(frame in-chan framer-spec out-buf)` —
+/// pipe `in-chan` through the framer and return a new channel that emits
+/// complete application messages (strings or byte-arrays depending on the spec).
+///
+/// Spawns a background task on the `LocalSet` that reads byte-array chunks from
+/// `in-chan`, feeds them through the stateful framer, and puts complete frames
+/// on the output channel. The output channel closes when `in-chan` closes (EOF)
+/// or when an error is propagated.
+///
+/// The optional `out-buf` argument controls the output channel's buffer depth
+/// (default 8).
+fn builtin_frame(args: &[Value]) -> ValueResult<Value> {
+    let in_chan = match args.first() {
+        Some(Value::NativeObject(obj)) if obj.get().type_tag() == "Channel" => obj.clone(),
+        Some(Value::NativeObject(obj)) => {
+            return Err(ValueError::Other(format!(
+                "frame: first argument must be a channel, got native object type '{}'",
+                obj.get().type_tag()
+            )));
+        }
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "channel",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let spec = match args.get(1) {
+        Some(Value::NativeObject(obj)) => match obj.get().downcast_ref::<FramerSpec>() {
+            Some(s) => s.clone(),
+            None => {
+                return Err(ValueError::Other(format!(
+                    "frame: second argument must be a framer spec (lines/by-delimiter/length-prefixed), \
+                     got native object type '{}'",
+                    obj.get().type_tag()
+                )));
+            }
+        },
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "framer spec (lines, by-delimiter, or length-prefixed)",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let out_buf = match args.get(2) {
+        Some(Value::Long(n)) if *n > 0 => *n as usize,
+        None | Some(Value::Nil) => spec.out_buf,
+        Some(other) => {
+            return Err(ValueError::WrongType {
+                expected: "positive long (out-buf)",
+                got: other.type_name().to_string(),
+            });
+        }
+    };
+
+    let out_chan = make_chan(out_buf);
+    let out_val = Value::NativeObject(out_chan.clone());
+
+    let framer: Box<dyn Framer> = match spec.kind {
+        FramerKind::Lines => Box::new(LinesFramer::new()),
+        FramerKind::Delimiter(d) => Box::new(DelimiterFramer::new(d)),
+        FramerKind::LengthPrefixed {
+            prefix_len,
+            big_endian,
+        } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian)),
+    };
+
+    tokio::task::spawn_local(framer_task(in_chan, out_chan, framer));
+
+    Ok(out_val)
+}
+
+/// `(lines-encode str)` — encode a string for a line protocol by appending `\n`.
+/// Returns a `byte-array` of the UTF-8 bytes followed by `\n`.
+fn builtin_lines_encode(args: &[Value]) -> ValueResult<Value> {
+    let s = match args.first() {
+        Some(Value::Str(s)) => s.get().clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "string",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let mut bytes: Vec<u8> = s.into_bytes();
+    bytes.push(b'\n');
+    Ok(bytes_value(&bytes))
+}
+
+/// `(length-prefixed-encode byte-array opts)` — prepend an N-byte length header
+/// to `byte-array`. Same options as `length-prefixed`: `:bytes` (default 4),
+/// `:endian` (default `:big`).
+///
+/// Returns a new `byte-array` of `[header || data]`.
+fn builtin_length_prefixed_encode(args: &[Value]) -> ValueResult<Value> {
+    let data: Vec<u8> = match args.first() {
+        Some(Value::ByteArray(arr)) => arr.get().lock().unwrap().iter().map(|&b| b as u8).collect(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "byte-array",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let (prefix_len, big_endian) = match args.get(1) {
+        Some(Value::Map(m)) => parse_prefix_opts(m),
+        None | Some(Value::Nil) => (4, true),
+        Some(other) => {
+            return Err(ValueError::WrongType {
+                expected: "map {:bytes n :endian :big/:little}",
+                got: other.type_name().to_string(),
+            });
+        }
+    };
+
+    let len = data.len() as u64;
+    let header: Vec<u8> = if big_endian {
+        (0..prefix_len)
+            .rev()
+            .map(|i| ((len >> (i * 8)) & 0xFF) as u8)
+            .collect()
+    } else {
+        (0..prefix_len)
+            .map(|i| ((len >> (i * 8)) & 0xFF) as u8)
+            .collect()
+    };
+
+    let mut result = header;
+    result.extend_from_slice(&data);
+    Ok(bytes_value(&result))
+}
+
+// ── Public Rust API for tests ─────────────────────────────────────────────────
+
+/// Pipe `in_chan` through the given `FramerSpec`, returning the output channel.
+/// Convenience wrapper for tests and other Rust consumers.
+pub fn frame_channel(
+    in_chan: GcPtr<NativeObjectBox>,
+    spec: FramerSpec,
+    out_buf: usize,
+) -> GcPtr<NativeObjectBox> {
+    let out_chan = make_chan(out_buf);
+    let framer: Box<dyn Framer> = match spec.kind {
+        FramerKind::Lines => Box::new(LinesFramer::new()),
+        FramerKind::Delimiter(d) => Box::new(DelimiterFramer::new(d)),
+        FramerKind::LengthPrefixed {
+            prefix_len,
+            big_endian,
+        } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian)),
+    };
+    tokio::task::spawn_local(framer_task(in_chan, out_chan.clone(), framer));
+    out_chan
+}
+
+/// Encode a string for the line protocol (appends `\n`).
+pub fn encode_line(s: &str) -> Value {
+    let mut bytes: Vec<u8> = s.as_bytes().to_vec();
+    bytes.push(b'\n');
+    bytes_value(&bytes)
+}
+
+/// Encode a byte slice for the length-prefixed protocol (prepends N-byte header).
+pub fn encode_length_prefixed(data: &[u8], prefix_len: usize, big_endian: bool) -> Value {
+    let len = data.len() as u64;
+    let header: Vec<u8> = if big_endian {
+        (0..prefix_len)
+            .rev()
+            .map(|i| ((len >> (i * 8)) & 0xFF) as u8)
+            .collect()
+    } else {
+        (0..prefix_len)
+            .map(|i| ((len >> (i * 8)) & 0xFF) as u8)
+            .collect()
+    };
+    let mut result = header;
+    result.extend_from_slice(data);
+    bytes_value(&result)
+}

--- a/crates/cljrs-net/src/frame.rs
+++ b/crates/cljrs-net/src/frame.rs
@@ -23,6 +23,7 @@ use std::any::Any;
 use std::sync::{Arc, Mutex};
 
 use cljrs_async::channel::{chan_put, chan_ref, make_chan};
+use cljrs_env::callback::invoke;
 use cljrs_env::env::GlobalEnv;
 use cljrs_gc::{GcPtr, MarkVisitor, Trace};
 use cljrs_value::{
@@ -405,21 +406,30 @@ fn builtin_length_prefixed(args: &[Value]) -> ValueResult<Value> {
     Ok(Value::NativeObject(gc_native_object(spec)))
 }
 
-/// `(frame in-chan framer-spec)` / `(frame in-chan framer-spec out-buf)` —
-/// pipe `in-chan` through the framer and return a new channel that emits
-/// complete application messages (strings or byte-arrays depending on the spec).
+/// `(frame in-chan framer)` — pipe `in-chan` through a framer and return a new
+/// channel of decoded messages.
 ///
-/// Spawns a background task on the `LocalSet` that reads byte-array chunks from
-/// `in-chan`, feeds them through the stateful framer, and puts complete frames
-/// on the output channel. The output channel closes when `in-chan` closes (EOF)
-/// or when an error is propagated.
+/// `framer` may be either:
 ///
-/// The optional `out-buf` argument controls the output channel's buffer depth
-/// (default 8).
+/// - A **native framer spec** created by `(lines)`, `(by-delimiter b)`, or
+///   `(length-prefixed opts)`. Spawns a `LocalSet` background task that feeds
+///   byte-array chunks through the stateful framer and puts complete frames on
+///   the output channel. The optional third argument `out-buf` controls the
+///   output channel buffer depth (default 8).
+///
+/// - A **Clojure pipe function** `(fn [in-chan] -> out-chan)`. `frame` calls
+///   `(f in-chan)` and returns the result. The function is responsible for
+///   spawning a `go`-loop that reads from `in-chan` and puts decoded values on
+///   the channel it returns. This lets framers be written entirely in Clojure.
+///   The `out-buf` argument is ignored for pipe functions.
+///
+/// Both forms compose: `frame` returns a channel, so framers can be stacked.
 fn builtin_frame(args: &[Value]) -> ValueResult<Value> {
-    let in_chan = match args.first() {
-        Some(Value::NativeObject(obj)) if obj.get().type_tag() == "Channel" => obj.clone(),
-        Some(Value::NativeObject(obj)) => {
+    // Validate the first argument: must be a channel.
+    let in_chan_val = args.first().cloned().unwrap_or(Value::Nil);
+    let in_chan = match &in_chan_val {
+        Value::NativeObject(obj) if obj.get().type_tag() == "Channel" => obj.clone(),
+        Value::NativeObject(obj) => {
             return Err(ValueError::Other(format!(
                 "frame: first argument must be a channel, got native object type '{}'",
                 obj.get().type_tag()
@@ -428,56 +438,74 @@ fn builtin_frame(args: &[Value]) -> ValueResult<Value> {
         other => {
             return Err(ValueError::WrongType {
                 expected: "channel",
-                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
-            });
-        }
-    };
-
-    let spec = match args.get(1) {
-        Some(Value::NativeObject(obj)) => match obj.get().downcast_ref::<FramerSpec>() {
-            Some(s) => s.clone(),
-            None => {
-                return Err(ValueError::Other(format!(
-                    "frame: second argument must be a framer spec (lines/by-delimiter/length-prefixed), \
-                     got native object type '{}'",
-                    obj.get().type_tag()
-                )));
-            }
-        },
-        other => {
-            return Err(ValueError::WrongType {
-                expected: "framer spec (lines, by-delimiter, or length-prefixed)",
-                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
-            });
-        }
-    };
-
-    let out_buf = match args.get(2) {
-        Some(Value::Long(n)) if *n > 0 => *n as usize,
-        None | Some(Value::Nil) => spec.out_buf,
-        Some(other) => {
-            return Err(ValueError::WrongType {
-                expected: "positive long (out-buf)",
                 got: other.type_name().to_string(),
             });
         }
     };
 
-    let out_chan = make_chan(out_buf);
-    let out_val = Value::NativeObject(out_chan.clone());
+    match args.get(1) {
+        // ── Clojure pipe-fn path ───────────────────────────────────────────────
+        // Any Clojure-callable is treated as a pipe-fn: (f in-chan) → out-chan.
+        // The function is responsible for spawning a go-loop and returning the
+        // output channel. The `out-buf` argument is unused on this path.
+        Some(
+            f @ (Value::Fn(_)
+            | Value::NativeFunction(_)
+            | Value::MultiFn(_)
+            | Value::ProtocolFn(_)
+            | Value::BoundFn(_)
+            | Value::Var(_)
+            | Value::WithMeta(_, _)),
+        ) => invoke(f, vec![in_chan_val]),
 
-    let framer: Box<dyn Framer> = match spec.kind {
-        FramerKind::Lines => Box::new(LinesFramer::new()),
-        FramerKind::Delimiter(d) => Box::new(DelimiterFramer::new(d)),
-        FramerKind::LengthPrefixed {
-            prefix_len,
-            big_endian,
-        } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian)),
-    };
+        // ── Native FramerSpec path (lines/by-delimiter/length-prefixed) ────────
+        Some(Value::NativeObject(obj)) => {
+            let spec = obj
+                .get()
+                .downcast_ref::<FramerSpec>()
+                .ok_or_else(|| {
+                    ValueError::Other(format!(
+                        "frame: second argument must be a framer spec or a pipe function, \
+                         got native object type '{}'",
+                        obj.get().type_tag()
+                    ))
+                })?
+                .clone();
 
-    tokio::task::spawn_local(framer_task(in_chan, out_chan, framer));
+            let out_buf = match args.get(2) {
+                Some(Value::Long(n)) if *n > 0 => *n as usize,
+                None | Some(Value::Nil) => spec.out_buf,
+                Some(other) => {
+                    return Err(ValueError::WrongType {
+                        expected: "positive long (out-buf)",
+                        got: other.type_name().to_string(),
+                    });
+                }
+            };
 
-    Ok(out_val)
+            let out_chan = make_chan(out_buf);
+            let out_val = Value::NativeObject(out_chan.clone());
+
+            let framer: Box<dyn Framer> = match spec.kind {
+                FramerKind::Lines => Box::new(LinesFramer::new()),
+                FramerKind::Delimiter(d) => Box::new(DelimiterFramer::new(d)),
+                FramerKind::LengthPrefixed {
+                    prefix_len,
+                    big_endian,
+                } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian)),
+            };
+
+            tokio::task::spawn_local(framer_task(in_chan, out_chan, framer));
+            Ok(out_val)
+        }
+
+        other => Err(ValueError::WrongType {
+            expected: "framer spec (lines, by-delimiter, length-prefixed) or pipe function",
+            got: other
+                .map(|v| v.type_name().to_string())
+                .unwrap_or_default(),
+        }),
+    }
 }
 
 /// `(lines-encode str)` — encode a string for a line protocol by appending `\n`.

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use cljrs_async::load_source;
 
+pub mod frame;
 pub mod tcp;
 
 /// Clojure source for `clojure.rust.net.tcp`.
@@ -24,8 +25,12 @@ const NET_TCP_SOURCE: &str = include_str!("clojure_rust_net_tcp.cljrs");
 /// Clojure source for the umbrella `clojure.rust.net` namespace.
 const NET_SOURCE: &str = include_str!("clojure_rust_net.cljrs");
 
+/// Clojure source for `clojure.rust.net.frame`.
+const NET_FRAME_SOURCE: &str = include_str!("clojure_rust_net_frame.cljrs");
+
 pub const NS_TCP: &str = "clojure.rust.net.tcp";
 pub const NS: &str = "clojure.rust.net";
+pub const NS_FRAME: &str = "clojure.rust.net.frame";
 
 /// Register the networking namespaces.
 ///
@@ -40,6 +45,14 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         tcp::register(globals, NS_TCP);
         load_source(globals, NS_TCP, NET_TCP_SOURCE);
         globals.mark_loaded(NS_TCP);
+    }
+
+    if !globals.is_loaded(NS_FRAME) {
+        globals.get_or_create_ns(NS_FRAME);
+        globals.refer_all(NS_FRAME, "clojure.core");
+        frame::register(globals, NS_FRAME);
+        load_source(globals, NS_FRAME, NET_FRAME_SOURCE);
+        globals.mark_loaded(NS_FRAME);
     }
 
     if !globals.is_loaded(NS) {

--- a/crates/cljrs-net/tests/framing.rs
+++ b/crates/cljrs-net/tests/framing.rs
@@ -1,0 +1,409 @@
+//! Phase C integration tests: framing — line protocol and length-prefixed protocol.
+//!
+//! Done criterion from networking-plan.md Phase C:
+//!   "a line-protocol and a length-prefixed-frame protocol both work end-to-end
+//!   over a TCP connection, built purely from `frame` + transducers."
+
+use std::sync::{Arc, Mutex};
+
+use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, Value};
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn map_get(map: &cljrs_value::MapValue, key: &str) -> Value {
+    map.get(&kw(key))
+        .unwrap_or_else(|| panic!("map missing :{key}"))
+}
+
+fn as_chan(v: &Value) -> GcPtr<cljrs_value::NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => obj.clone(),
+        other => panic!("expected channel, got {}", other.type_name()),
+    }
+}
+
+fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+fn string_of(v: Value) -> String {
+    match v {
+        Value::Str(s) => s.get().clone(),
+        other => panic!("expected string, got {}", other.type_name()),
+    }
+}
+
+fn bytes_of(v: Value) -> Vec<u8> {
+    match v {
+        Value::ByteArray(arr) => arr.get().lock().unwrap().iter().map(|&b| b as u8).collect(),
+        other => panic!("expected byte-array, got {}", other.type_name()),
+    }
+}
+
+// ── Helper: connect client + server ──────────────────────────────────────────
+
+/// Start a server on a free port, connect a client, and return
+/// `(server_conn_map, client_conn_map)`.
+async fn setup_connection() -> (cljrs_value::MapValue, cljrs_value::MapValue) {
+    let server_val = cljrs_net::tcp::listen_on("127.0.0.1", 0, 8, 8, 8).expect("listen_on failed");
+    let server_map = match server_val {
+        Value::Map(m) => m,
+        other => panic!("expected server map, got {}", other.type_name()),
+    };
+
+    let local_addr = match map_get(&server_map, "local-addr") {
+        Value::Str(s) => s.get().clone(),
+        other => panic!("expected str :local-addr, got {}", other.type_name()),
+    };
+    let port: u16 = local_addr.split(':').last().unwrap().parse().unwrap();
+
+    // Start connecting — the promise resolves once the server accepts.
+    let promise = cljrs_net::tcp::connect_to("127.0.0.1", port, 8, 8);
+    let promise_chan = as_chan(&promise);
+
+    // Accept the connection on the server side.
+    let conns_ch = as_chan(&map_get(&server_map, "conns"));
+    let server_conn = match chan_take(&conns_ch).await {
+        Value::Map(m) => m,
+        other => panic!("expected conn map from :conns, got {}", other.type_name()),
+    };
+
+    // Await the client side.
+    let client_conn = match chan_take(&promise_chan).await {
+        Value::Map(m) => m,
+        Value::Error(e) => panic!("connect failed: {}", e.get().message()),
+        other => panic!("expected conn map, got {}", other.type_name()),
+    };
+
+    (server_conn, client_conn)
+}
+
+// ── Phase C / line protocol ────────────────────────────────────────────────────
+
+/// Phase C done criterion (lines): send line-encoded messages from client,
+/// decode them on the server with `frame` + `lines`, verify the decoded strings.
+#[test]
+fn test_line_protocol_end_to_end() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let (server_conn, client_conn) = setup_connection().await;
+
+        let server_in = as_chan(&map_get(&server_conn, "in"));
+        let server_out = as_chan(&map_get(&server_conn, "out"));
+
+        // Attach a lines framer to the server's :in channel.
+        let lines_spec = cljrs_net::frame::FramerSpec {
+            kind: cljrs_net::frame::FramerKind::Lines,
+            out_buf: 8,
+        };
+        let msg_chan = cljrs_net::frame::frame_channel(server_in, lines_spec, 8);
+
+        let client_out = as_chan(&map_get(&client_conn, "out"));
+        let client_in = as_chan(&map_get(&client_conn, "in"));
+
+        // Send three lines from the client (each UTF-8 + '\n').
+        let messages = vec!["hello", "world", "from cljrs-net"];
+        for msg in &messages {
+            chan_put(&client_out, cljrs_net::frame::encode_line(msg)).await;
+        }
+        // Half-close the client write side → server :in sees EOF.
+        chan_ref(client_out.get()).close();
+
+        // Server: read three decoded strings from the framed channel.
+        let mut received: Vec<String> = Vec::new();
+        loop {
+            match chan_take(&msg_chan).await {
+                Value::Nil => break,
+                v @ Value::Str(_) => received.push(string_of(v)),
+                Value::Error(e) => panic!("frame error: {}", e.get().message()),
+                other => panic!("unexpected value from framer: {}", other.type_name()),
+            }
+        }
+        assert_eq!(received, messages, "decoded lines must match sent messages");
+
+        // Echo them back line-encoded so we can verify the wire round-trip.
+        for msg in &received {
+            chan_put(&server_out, cljrs_net::frame::encode_line(msg)).await;
+        }
+        chan_ref(server_out.get()).close();
+
+        // Client: drain raw :in and verify the response bytes equal re-encoded lines.
+        let mut raw_response: Vec<u8> = Vec::new();
+        loop {
+            match chan_take(&client_in).await {
+                Value::Nil => break,
+                v @ Value::ByteArray(_) => raw_response.extend_from_slice(&bytes_of(v)),
+                Value::Error(e) => panic!("client read error: {}", e.get().message()),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        let expected: String = messages.iter().map(|m| format!("{m}\n")).collect();
+        assert_eq!(
+            raw_response,
+            expected.as_bytes(),
+            "echoed response must match line-encoded originals"
+        );
+    });
+}
+
+// ── Phase C / length-prefixed protocol ───────────────────────────────────────
+
+/// Phase C done criterion (length-prefixed): send length-prefixed messages from
+/// client, decode them on the server with `frame` + `length-prefixed`, verify
+/// round-trip.
+#[test]
+fn test_length_prefixed_protocol_end_to_end() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let (server_conn, client_conn) = setup_connection().await;
+
+        let server_in = as_chan(&map_get(&server_conn, "in"));
+        let server_out = as_chan(&map_get(&server_conn, "out"));
+
+        // Attach a 4-byte big-endian length-prefixed framer to the server's :in.
+        let lp_spec = cljrs_net::frame::FramerSpec {
+            kind: cljrs_net::frame::FramerKind::LengthPrefixed {
+                prefix_len: 4,
+                big_endian: true,
+            },
+            out_buf: 8,
+        };
+        let msg_chan = cljrs_net::frame::frame_channel(server_in, lp_spec, 8);
+
+        let client_out = as_chan(&map_get(&client_conn, "out"));
+        let client_in = as_chan(&map_get(&client_conn, "in"));
+
+        // Send three messages (each prefixed with a 4-byte big-endian length).
+        let payloads: Vec<&[u8]> = vec![b"ping", b"hello world", b"length-prefixed test"];
+        for payload in &payloads {
+            let framed = cljrs_net::frame::encode_length_prefixed(payload, 4, true);
+            chan_put(&client_out, framed).await;
+        }
+        chan_ref(client_out.get()).close();
+
+        // Server: read three decoded byte-arrays.
+        let mut received: Vec<Vec<u8>> = Vec::new();
+        loop {
+            match chan_take(&msg_chan).await {
+                Value::Nil => break,
+                v @ Value::ByteArray(_) => received.push(bytes_of(v)),
+                Value::Error(e) => panic!("frame error: {}", e.get().message()),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        let expected_payloads: Vec<Vec<u8>> = payloads.iter().map(|p| p.to_vec()).collect();
+        assert_eq!(
+            received, expected_payloads,
+            "decoded payloads must match sent payloads"
+        );
+
+        // Echo back length-prefixed and verify the wire format on the client.
+        for payload in &received {
+            chan_put(
+                &server_out,
+                cljrs_net::frame::encode_length_prefixed(payload, 4, true),
+            )
+            .await;
+        }
+        chan_ref(server_out.get()).close();
+
+        let mut raw_response: Vec<u8> = Vec::new();
+        loop {
+            match chan_take(&client_in).await {
+                Value::Nil => break,
+                v @ Value::ByteArray(_) => raw_response.extend_from_slice(&bytes_of(v)),
+                Value::Error(e) => panic!("client read error: {}", e.get().message()),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+
+        let mut expected_wire: Vec<u8> = Vec::new();
+        for payload in &payloads {
+            let len = payload.len() as u32;
+            expected_wire.extend_from_slice(&len.to_be_bytes());
+            expected_wire.extend_from_slice(payload);
+        }
+        assert_eq!(
+            raw_response, expected_wire,
+            "echoed response must match length-prefixed wire format"
+        );
+    });
+}
+
+// ── Framer unit tests (no TCP) ────────────────────────────────────────────────
+
+/// Lines framer: partial chunks must be reassembled correctly.
+#[test]
+fn test_lines_framer_partial_chunks() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let in_chan = cljrs_async::channel::make_chan(8);
+        let spec = cljrs_net::frame::FramerSpec {
+            kind: cljrs_net::frame::FramerKind::Lines,
+            out_buf: 8,
+        };
+        let out_chan = cljrs_net::frame::frame_channel(in_chan.clone(), spec, 8);
+
+        // Split "hello\nworld\n" across three chunks.
+        chan_put(&in_chan, bytes_value(b"hel")).await;
+        chan_put(&in_chan, bytes_value(b"lo\nwo")).await;
+        chan_put(&in_chan, bytes_value(b"rld\n")).await;
+        chan_ref(in_chan.get()).close();
+
+        let mut lines: Vec<String> = Vec::new();
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => break,
+                v @ Value::Str(_) => lines.push(string_of(v)),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        assert_eq!(lines, vec!["hello", "world"]);
+    });
+}
+
+/// Length-prefixed framer: multiple frames coalesced in a single TCP chunk.
+#[test]
+fn test_length_prefixed_framer_coalesced_chunks() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let in_chan = cljrs_async::channel::make_chan(8);
+        let spec = cljrs_net::frame::FramerSpec {
+            kind: cljrs_net::frame::FramerKind::LengthPrefixed {
+                prefix_len: 4,
+                big_endian: true,
+            },
+            out_buf: 8,
+        };
+        let out_chan = cljrs_net::frame::frame_channel(in_chan.clone(), spec, 8);
+
+        // Two frames in one chunk.
+        let mut wire: Vec<u8> = Vec::new();
+        for payload in [b"abc" as &[u8], b"de"] {
+            let len = payload.len() as u32;
+            wire.extend_from_slice(&len.to_be_bytes());
+            wire.extend_from_slice(payload);
+        }
+        chan_put(&in_chan, bytes_value(&wire)).await;
+        chan_ref(in_chan.get()).close();
+
+        let mut frames: Vec<Vec<u8>> = Vec::new();
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => break,
+                v @ Value::ByteArray(_) => frames.push(bytes_of(v)),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        assert_eq!(frames, vec![b"abc".to_vec(), b"de".to_vec()]);
+    });
+}
+
+/// By-delimiter framer: split on null byte, partial chunks.
+#[test]
+fn test_delimiter_framer_null_byte() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let in_chan = cljrs_async::channel::make_chan(8);
+        let spec = cljrs_net::frame::FramerSpec {
+            kind: cljrs_net::frame::FramerKind::Delimiter(0u8),
+            out_buf: 8,
+        };
+        let out_chan = cljrs_net::frame::frame_channel(in_chan.clone(), spec, 8);
+
+        // Two frames separated by \0, delivered in one chunk.
+        chan_put(&in_chan, bytes_value(b"frame1\x00frame2\x00")).await;
+        chan_ref(in_chan.get()).close();
+
+        let mut frames: Vec<Vec<u8>> = Vec::new();
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => break,
+                v @ Value::ByteArray(_) => frames.push(bytes_of(v)),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        assert_eq!(frames, vec![b"frame1".to_vec(), b"frame2".to_vec()]);
+    });
+}
+
+/// Lines framer: last line without trailing newline is emitted at EOF.
+#[test]
+fn test_lines_framer_no_trailing_newline() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let in_chan = cljrs_async::channel::make_chan(8);
+        let spec = cljrs_net::frame::FramerSpec {
+            kind: cljrs_net::frame::FramerKind::Lines,
+            out_buf: 8,
+        };
+        let out_chan = cljrs_net::frame::frame_channel(in_chan.clone(), spec, 8);
+
+        // "first\nsecond" — second line has no trailing newline.
+        chan_put(&in_chan, bytes_value(b"first\nsecond")).await;
+        chan_ref(in_chan.get()).close();
+
+        let mut lines: Vec<String> = Vec::new();
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => break,
+                v @ Value::Str(_) => lines.push(string_of(v)),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        assert_eq!(lines, vec!["first", "second"]);
+    });
+}

--- a/crates/cljrs-net/tests/framing.rs
+++ b/crates/cljrs-net/tests/framing.rs
@@ -433,10 +433,7 @@ fn test_clojure_pipe_fn_as_framer() {
         // Build an input channel and bind it by name for the Clojure expression.
         let in_chan = cljrs_async::channel::make_chan(8);
         env.push_frame();
-        env.bind(
-            Arc::from("test-in"),
-            Value::NativeObject(in_chan.clone()),
-        );
+        env.bind(Arc::from("test-in"), Value::NativeObject(in_chan.clone()));
 
         // A Clojure identity pipe-fn: reads from ch, puts each value on out, closes at EOF.
         // Written entirely in Clojure — no Rust framer involved.

--- a/crates/cljrs-net/tests/framing.rs
+++ b/crates/cljrs-net/tests/framing.rs
@@ -7,7 +7,9 @@
 use std::sync::{Arc, Mutex};
 
 use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+use cljrs_env::env::Env;
 use cljrs_gc::GcPtr;
+use cljrs_reader::Parser;
 use cljrs_value::{Keyword, Value};
 
 fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
@@ -405,5 +407,83 @@ fn test_lines_framer_no_trailing_newline() {
             }
         }
         assert_eq!(lines, vec!["first", "second"]);
+    });
+}
+
+// ── Clojure pipe-fn as framer ─────────────────────────────────────────────────
+
+/// `frame` accepts a Clojure `(fn [in-chan] -> out-chan)` as the second argument.
+/// The function is called with `in-chan` and its return value (the output channel)
+/// is returned by `frame`. This lets framers be written entirely in Clojure
+/// without any Rust involvement.
+#[test]
+fn test_clojure_pipe_fn_as_framer() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let globals = setup_globals();
+
+        // Env in the frame namespace so `frame`, `chan`, `go`, etc. resolve.
+        let mut env = Env::new(globals.clone(), "clojure.rust.net.frame");
+
+        // Build an input channel and bind it by name for the Clojure expression.
+        let in_chan = cljrs_async::channel::make_chan(8);
+        env.push_frame();
+        env.bind(
+            Arc::from("test-in"),
+            Value::NativeObject(in_chan.clone()),
+        );
+
+        // A Clojure identity pipe-fn: reads from ch, puts each value on out, closes at EOF.
+        // Written entirely in Clojure — no Rust framer involved.
+        let src = r#"
+            (let [pipe (fn [ch]
+                         (let [out (clojure.core.async/chan 8)]
+                           (clojure.core.async/go
+                             (loop []
+                               (let [v (await (clojure.core.async/take! ch))]
+                                 (if (nil? v)
+                                   (clojure.core.async/close! out)
+                                   (do
+                                     (await (clojure.core.async/put! out v))
+                                     (recur))))))
+                           out))]
+              (frame test-in pipe))
+        "#;
+
+        let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+        let forms = parser.parse_all().expect("parse error");
+        let out_chan_val = cljrs_interp::eval::eval(forms.last().unwrap(), &mut env)
+            .expect("eval error: frame with Clojure pipe-fn failed");
+
+        let out_chan = as_chan(&out_chan_val);
+
+        // Feed two byte-arrays into the input channel.
+        let payload1 = bytes_value(b"hello");
+        let payload2 = bytes_value(b"world");
+        chan_put(&in_chan, payload1).await;
+        chan_put(&in_chan, payload2).await;
+        chan_ref(in_chan.get()).close();
+
+        // Drain the output channel and verify the same byte-arrays come out.
+        let mut received: Vec<Vec<u8>> = Vec::new();
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => break,
+                v @ Value::ByteArray(_) => received.push(bytes_of(v)),
+                Value::Error(e) => panic!("pipe-fn error: {}", e.get().message()),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+
+        assert_eq!(
+            received,
+            vec![b"hello".to_vec(), b"world".to_vec()],
+            "Clojure pipe-fn must relay all values and close the output channel at EOF"
+        );
     });
 }


### PR DESCRIPTION
Adds `clojure.rust.net.frame` with stateful framers that reassemble TCP
byte-stream chunks into application messages:

- `(lines)` — split on `\n`, emit strings (strips `\r`, flushes partial
  line at EOF)
- `(by-delimiter b)` — split on a delimiter byte, emit byte-arrays
- `(length-prefixed {:bytes n :endian :big})` — N-byte length header,
  emit byte-array frames; handles chunks spanning frame or header
  boundaries and coalesced frames in a single chunk

The `frame` function pipes an input channel through a FramerSpec and
returns a new channel of decoded messages, spawning a background
`spawn_local` task that drives the conversion. Errors from `:in` are
forwarded in-band; the output channel closes at EOF or on error.

Encode helpers for the write side:
- `(lines-encode str)` → byte-array (UTF-8 + `\n`)
- `(length-prefixed-encode ba opts)` → byte-array (header || data)

Clojure source adds `pipe-map` — the async pipe-fn pattern:
`(fn [in-chan] -> out-chan)` for protocols needing async transforms.

Phase C done criterion met: line-protocol and length-prefixed-frame
protocols work end-to-end over TCP connections (6 new tests covering
both end-to-end and framer unit cases: partial chunks, coalesced frames,
delimiter splitting, no-trailing-newline EOF flush).

https://claude.ai/code/session_018q6v43yXUZohRAG9atA793