### PR TITLE
feat(net): implement Phase D — UDP datagram sockets

### DIFF
--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–C implemented (TCP client + server + framing). Phases D–F (UDP, TLS, Unix) are stubs.
+**Status**: Phases A–D implemented (TCP client + server + framing + UDP datagrams). Phases E–F (TLS, Unix) are stubs.
 
 **Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
 
@@ -10,15 +10,18 @@
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, and `clojure.rust.net` |
+| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, and `clojure.rust.net` |
 | `src/tcp.rs` | `TcpStreamResource`, `TcpListenerResource`, connection builder, accept loop, `connect`/`listen`/`close` builtins |
 | `src/frame.rs` | `FramerSpec` native object, stateful framers (`LinesFramer`, `DelimiterFramer`, `LengthPrefixedFramer`), `frame`/encode builtins |
+| `src/udp.rs` | `UdpSocketResource`, reader/writer tasks, `socket`/`close` builtins |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
+| `src/clojure_rust_net_udp.cljrs` | Clojure source for `clojure.rust.net.udp`; usage examples |
 | `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net` |
 | `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
 | `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |
 | `tests/framing.rs` | Phase C integration tests (lines + length-prefixed end-to-end, framer unit tests) |
+| `tests/udp.rs` | Phase D integration tests (echo round-trip, multiple senders, close) |
 
 ## Public API
 
@@ -75,12 +78,24 @@
 (close x)                 ;; dispatches on :conns key: server → listen-close, else → close
 ```
 
+### `clojure.rust.net.udp`
+
+```clojure
+(socket {:port 9000})
+;; => {:in <chan> :out <chan> :local-addr "0.0.0.0:9000" :resource h}
+;;    :in yields {:data <byte-array> :addr "ip:port"} per received datagram
+;;    put {:data <byte-array> :addr "ip:port"} on :out to send
+
+(close sock)  ;; => nil — closes :in/:out and aborts reader/writer tasks
+```
+
 ### Rust
 
 ```rust
 pub fn init(globals: &Arc<GlobalEnv>)
 pub fn tcp::connect_to(host: &str, port: u16, in_buf: usize, out_buf: usize) -> Value
 pub fn tcp::listen_on(host: &str, port: u16, conns_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
+pub fn udp::socket_on(host: &str, port: u16, in_buf: usize, out_buf: usize) -> ValueResult<Value>
 pub fn frame::frame_channel(in_chan: GcPtr<NativeObjectBox>, spec: FramerSpec, out_buf: usize) -> GcPtr<NativeObjectBox>
 pub fn frame::encode_line(s: &str) -> Value
 pub fn frame::encode_length_prefixed(data: &[u8], prefix_len: usize, big_endian: bool) -> Value
@@ -95,6 +110,10 @@ Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the re
 ### `TcpListenerResource`
 
 Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `accept_loop` task. `close()` aborts the task, dropping the `TcpListener` and releasing the listener FD.
+
+### `UdpSocketResource`
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks; once they finish the `Arc<UdpSocket>` drops and the FD is released.
 
 ## Connection Model
 

--- a/crates/cljrs-net/src/clojure_rust_net.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net.cljrs
@@ -1,6 +1,7 @@
 ;; clojure.rust.net — umbrella networking namespace.
 
 (require 'clojure.rust.net.tcp)
+(require 'clojure.rust.net.udp)
 
 (defn connect
   "Connect to a remote host. Returns a promise channel that yields a connection
@@ -45,13 +46,31 @@
   [handler opts]
   (clojure.rust.net.tcp/start-server handler opts))
 
-(defn close
-  "Close a connection or server map, releasing its socket and channels.
+(defn socket
+  "Create a UDP datagram socket. Returns a socket map:
+  {:in <chan> :out <chan> :local-addr str :resource handle}
 
-  For connections: closes :out (signals writer to drain and half-close the write
-  side), closes :in, and aborts reader/writer tasks via the :resource handle.
-  For servers: stops the accept loop, closes the listener FD, and closes :conns."
+  :in yields {:data <byte-array> :addr \"ip:port\"} for each received datagram.
+  Put {:data <byte-array> :addr \"ip:port\"} maps on :out to send datagrams.
+
+  Opts:
+    :port    integer (required, 1-65535)
+    :host    string (default \"0.0.0.0\")
+    :in-buf  channel buffer depth for :in (default 8)
+    :out-buf channel buffer depth for :out (default 8)"
+  [opts]
+  (clojure.rust.net.udp/socket opts))
+
+(defn close
+  "Close a connection, server, or UDP socket map, releasing its socket and channels.
+
+  For TCP connections (:remote-addr present): closes :out (signals writer to drain
+  and half-close), closes :in, and aborts reader/writer tasks via :resource.
+  For TCP servers (:conns present): stops the accept loop, closes the listener FD,
+  and closes :conns.
+  For UDP sockets: closes :in, :out, and aborts reader/writer tasks via :resource."
   [x]
   (cond
-    (contains? x :conns) (clojure.rust.net.tcp/listen-close x)
-    :else                (clojure.rust.net.tcp/close x)))
+    (contains? x :conns)       (clojure.rust.net.tcp/listen-close x)
+    (contains? x :remote-addr) (clojure.rust.net.tcp/close x)
+    :else                      (clojure.rust.net.udp/close x)))

--- a/crates/cljrs-net/src/clojure_rust_net_udp.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_udp.cljrs
@@ -1,0 +1,29 @@
+;; clojure.rust.net.udp — UDP datagram sockets.
+;;
+;; A UDP socket is a map:
+;;   {:in          <chan>   ; yields {:data <byte-array> :addr "ip:port"}
+;;    :out         <chan>   ; put {:data <byte-array> :addr "ip:port"}
+;;    :local-addr  "ip:port"
+;;    :resource    <handle>}
+;;
+;; Native builtins (registered from Rust):
+;;   socket  — (socket {:port p}) => socket-map
+;;   close   — (close sock) => nil
+;;
+;; Usage:
+;;
+;;   ;; Echo responder
+;;   (let [s (clojure.rust.net.udp/socket {:port 9000})]
+;;     (clojure.core.async/go
+;;       (loop []
+;;         (when-let [{:keys [data addr]} (await (clojure.core.async/take! (:in s)))]
+;;           (await (clojure.core.async/put! (:out s) {:data data :addr addr}))
+;;           (recur))))
+;;     s)
+;;
+;;   ;; Send a datagram
+;;   (await (clojure.core.async/put! (:out s) {:data some-bytes :addr "1.2.3.4:5000"}))
+;;
+;;   ;; Receive a datagram
+;;   (let [{:keys [data addr]} (await (clojure.core.async/take! (:in s)))]
+;;     (println "got" (count data) "bytes from" addr))

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -1,4 +1,4 @@
-//! Networking for clojurust — TCP over core.async channels.
+//! Networking for clojurust — TCP, UDP over core.async channels.
 //!
 //! # Usage
 //!
@@ -18,6 +18,7 @@ use cljrs_async::load_source;
 
 pub mod frame;
 pub mod tcp;
+pub mod udp;
 
 /// Clojure source for `clojure.rust.net.tcp`.
 const NET_TCP_SOURCE: &str = include_str!("clojure_rust_net_tcp.cljrs");
@@ -28,9 +29,13 @@ const NET_SOURCE: &str = include_str!("clojure_rust_net.cljrs");
 /// Clojure source for `clojure.rust.net.frame`.
 const NET_FRAME_SOURCE: &str = include_str!("clojure_rust_net_frame.cljrs");
 
+/// Clojure source for `clojure.rust.net.udp`.
+const NET_UDP_SOURCE: &str = include_str!("clojure_rust_net_udp.cljrs");
+
 pub const NS_TCP: &str = "clojure.rust.net.tcp";
 pub const NS: &str = "clojure.rust.net";
 pub const NS_FRAME: &str = "clojure.rust.net.frame";
+pub const NS_UDP: &str = "clojure.rust.net.udp";
 
 /// Register the networking namespaces.
 ///
@@ -53,6 +58,14 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         frame::register(globals, NS_FRAME);
         load_source(globals, NS_FRAME, NET_FRAME_SOURCE);
         globals.mark_loaded(NS_FRAME);
+    }
+
+    if !globals.is_loaded(NS_UDP) {
+        globals.get_or_create_ns(NS_UDP);
+        globals.refer_all(NS_UDP, "clojure.core");
+        udp::register(globals, NS_UDP);
+        load_source(globals, NS_UDP, NET_UDP_SOURCE);
+        globals.mark_loaded(NS_UDP);
     }
 
     if !globals.is_loaded(NS) {

--- a/crates/cljrs-net/src/udp.rs
+++ b/crates/cljrs-net/src/udp.rs
@@ -190,16 +190,13 @@ async fn writer_loop(socket: Arc<UdpSocket>, out_chan: GcPtr<NativeObjectBox>) {
             Value::Map(m) => {
                 let data = m.get(&kw("data"));
                 let addr = m.get(&kw("addr"));
-                match (data, addr) {
-                    (Some(Value::ByteArray(arr)), Some(Value::Str(addr_str))) => {
-                        let bytes: Vec<u8> =
-                            arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
-                        let addr_str = addr_str.get().clone();
-                        if let Ok(addr) = addr_str.parse::<SocketAddr>() {
-                            let _ = socket.send_to(&bytes, addr).await;
-                        }
+                if let (Some(Value::ByteArray(arr)), Some(Value::Str(addr_str))) = (data, addr) {
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    let addr_str = addr_str.get().clone();
+                    if let Ok(addr) = addr_str.parse::<SocketAddr>() {
+                        let _ = socket.send_to(&bytes, addr).await;
                     }
-                    _ => {}
                 }
             }
             _ => {}

--- a/crates/cljrs-net/src/udp.rs
+++ b/crates/cljrs-net/src/udp.rs
@@ -1,0 +1,304 @@
+//! UDP datagram socket support for `clojure.rust.net.udp`.
+//!
+//! A UDP socket is a map:
+//!
+//! ```clojure
+//! {:in          <chan>   ; yields {:data <byte-array> :addr "ip:port"}
+//!  :out         <chan>   ; put {:data <byte-array> :addr "ip:port"}
+//!  :local-addr  "ip:port"
+//!  :resource    <handle>} ; UdpSocketResource — deterministic socket close
+//! ```
+//!
+//! `socket` returns the socket map immediately (bind is synchronous). Reader
+//! and writer tasks are spawned on the `LocalSet`.
+
+use std::any::Any;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use tokio::net::UdpSocket;
+use tokio::task::AbortHandle;
+
+use cljrs_async::channel::{chan_put, chan_ref, chan_take, make_chan};
+use cljrs_env::env::GlobalEnv;
+use cljrs_gc::GcPtr;
+use cljrs_value::{
+    Arity, ExceptionInfo, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle,
+    Value, ValueError, ValueResult,
+};
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        ("socket", Arity::Fixed(1), builtin_socket),
+        ("close", Arity::Fixed(1), builtin_close),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── UdpSocketResource ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct UdpSocketInner {
+    closed: bool,
+    reader_abort: Option<AbortHandle>,
+    writer_abort: Option<AbortHandle>,
+}
+
+/// `Resource` implementation for a UDP socket.
+///
+/// Holds `AbortHandle`s for the reader and writer tasks spawned in `socket_on`.
+/// `close()` aborts both tasks, which drops the `Arc<UdpSocket>` they hold and
+/// releases the FD once both tasks are gone. GC never finalises the socket —
+/// this `Arc`-backed resource is the sole cleanup path.
+#[derive(Debug)]
+pub struct UdpSocketResource {
+    inner: Arc<Mutex<UdpSocketInner>>,
+}
+
+impl UdpSocketResource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(UdpSocketInner {
+                closed: false,
+                reader_abort: None,
+                writer_abort: None,
+            })),
+        }
+    }
+}
+
+impl Resource for UdpSocketResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        if let Some(h) = g.reader_abort.take() {
+            h.abort();
+        }
+        if let Some(h) = g.writer_abort.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "UdpSocket"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Value helpers ─────────────────────────────────────────────────────────────
+
+fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+fn net_error(msg: impl Into<String>) -> Value {
+    let msg = msg.into();
+    Value::Error(GcPtr::new(ExceptionInfo::new(
+        ValueError::Other(msg.clone()),
+        msg,
+        None,
+        None,
+    )))
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn make_datagram(bytes: &[u8], addr: &str) -> Value {
+    Value::Map(MapValue::from_pairs(vec![
+        (kw("data"), bytes_value(bytes)),
+        (kw("addr"), Value::string(addr.to_string())),
+    ]))
+}
+
+// ── Options-map parsing ───────────────────────────────────────────────────────
+
+fn opts_str(opts: &MapValue, key: &str) -> Option<String> {
+    match opts.get(&kw(key))? {
+        Value::Str(s) => Some(s.get().clone()),
+        _ => None,
+    }
+}
+
+fn opts_usize(opts: &MapValue, key: &str) -> Option<usize> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n >= 0 => Some((n as usize).max(1)),
+        _ => None,
+    }
+}
+
+fn opts_port(opts: &MapValue) -> Option<u16> {
+    match opts.get(&kw("port"))? {
+        Value::Long(n) if n > 0 && n <= 65535 => Some(n as u16),
+        _ => None,
+    }
+}
+
+// ── Async tasks ───────────────────────────────────────────────────────────────
+
+/// Read datagrams from the socket and put `{:data :addr}` maps onto `:in`.
+///
+/// Closes `:in` on error (after putting the error value) or when aborted
+/// via `UdpSocketResource::close`.
+async fn reader_loop(socket: Arc<UdpSocket>, in_chan: GcPtr<NativeObjectBox>) {
+    let mut buf = vec![0u8; 65536];
+    loop {
+        match socket.recv_from(&mut buf).await {
+            Ok((n, peer_addr)) => {
+                let datagram = make_datagram(&buf[..n], &peer_addr.to_string());
+                if !chan_put(&in_chan, datagram).await {
+                    break; // consumer closed :in
+                }
+            }
+            Err(e) => {
+                chan_put(&in_chan, net_error(format!("recv_from error: {e}"))).await;
+                break;
+            }
+        }
+    }
+    chan_ref(in_chan.get()).close();
+}
+
+/// Drain `:out` and send each `{:data :addr}` map as a datagram.
+///
+/// Exits when `:out` closes (channel yields `nil`). Aborted via
+/// `UdpSocketResource::close` if the user calls `(close sock)`.
+async fn writer_loop(socket: Arc<UdpSocket>, out_chan: GcPtr<NativeObjectBox>) {
+    loop {
+        match chan_take(&out_chan).await {
+            Value::Nil => break,
+            Value::Map(m) => {
+                let data = m.get(&kw("data"));
+                let addr = m.get(&kw("addr"));
+                match (data, addr) {
+                    (Some(Value::ByteArray(arr)), Some(Value::Str(addr_str))) => {
+                        let bytes: Vec<u8> =
+                            arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                        let addr_str = addr_str.get().clone();
+                        if let Ok(addr) = addr_str.parse::<SocketAddr>() {
+                            let _ = socket.send_to(&bytes, addr).await;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+// ── Socket builder ────────────────────────────────────────────────────────────
+
+/// Bind a UDP socket on `host:port` and return a socket map.
+///
+/// Convenience wrapper used by tests and the Clojure `socket` builtin alike.
+pub fn socket_on(host: &str, port: u16, in_buf: usize, out_buf: usize) -> ValueResult<Value> {
+    let addr = format!("{host}:{port}");
+
+    // Bind synchronously (std), then convert to Tokio (requires runtime context).
+    let std_socket = std::net::UdpSocket::bind(&addr)
+        .map_err(|e| ValueError::Other(format!("bind {addr}: {e}")))?;
+    std_socket
+        .set_nonblocking(true)
+        .map_err(|e| ValueError::Other(format!("set_nonblocking: {e}")))?;
+    let socket = tokio::net::UdpSocket::from_std(std_socket)
+        .map_err(|e| ValueError::Other(format!("from_std: {e}")))?;
+
+    let local_addr = socket
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+
+    let socket = Arc::new(socket);
+    let in_chan = make_chan(in_buf);
+    let out_chan = make_chan(out_buf);
+
+    let resource = UdpSocketResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    let r_jh = tokio::task::spawn_local(reader_loop(socket.clone(), in_chan.clone()));
+    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
+    let w_jh = tokio::task::spawn_local(writer_loop(socket, out_chan.clone()));
+    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
+
+    Ok(Value::Map(MapValue::from_pairs(vec![
+        (kw("in"), Value::NativeObject(in_chan)),
+        (kw("out"), Value::NativeObject(out_chan)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ])))
+}
+
+// ── Builtins ──────────────────────────────────────────────────────────────────
+
+/// `(socket {:port p})` — bind a UDP socket and return a socket map.
+///
+/// `:in` yields `{:data <byte-array> :addr "ip:port"}` maps for each received
+/// datagram. Put `{:data <byte-array> :addr "ip:port"}` maps on `:out` to send.
+/// Optional keys: `:host` (default `"0.0.0.0"`), `:in-buf` (default 8),
+/// `:out-buf` (default 8).
+fn builtin_socket(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:port long}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let host = opts_str(&opts, "host").unwrap_or_else(|| "0.0.0.0".to_string());
+    let port =
+        opts_port(&opts).ok_or_else(|| ValueError::Other(":port required (1-65535)".into()))?;
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+
+    socket_on(&host, port, in_buf, out_buf)
+}
+
+/// `(close sock)` — close a UDP socket map, releasing the FD and aborting tasks.
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let sock = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "UDP socket map {:in ch :out ch :resource handle}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::NativeObject(obj)) = sock.get(&kw("in")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::NativeObject(obj)) = sock.get(&kw("out")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::Resource(handle)) = sock.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}

--- a/crates/cljrs-net/tests/udp.rs
+++ b/crates/cljrs-net/tests/udp.rs
@@ -55,7 +55,12 @@ fn test_udp_echo_round_trip() {
             Value::Str(s) => s.get().clone(),
             other => panic!("expected str :local-addr, got {}", other.type_name()),
         };
-        let server_port: u16 = server_local_addr.split(':').last().unwrap().parse().unwrap();
+        let server_port: u16 = server_local_addr
+            .split(':')
+            .last()
+            .unwrap()
+            .parse()
+            .unwrap();
 
         let server_in = as_chan(&map_get(&server_map, "in"));
         let server_out = as_chan(&map_get(&server_map, "out"));
@@ -83,10 +88,7 @@ fn test_udp_echo_round_trip() {
         let payload = b"phase D udp echo test";
         let signed: Vec<i8> = payload.iter().map(|&b| b as i8).collect();
         let send_dgram = Value::Map(MapValue::from_pairs(vec![
-            (
-                kw("data"),
-                Value::ByteArray(GcPtr::new(Mutex::new(signed))),
-            ),
+            (kw("data"), Value::ByteArray(GcPtr::new(Mutex::new(signed)))),
             (
                 kw("addr"),
                 Value::string(format!("127.0.0.1:{server_port}")),
@@ -100,13 +102,8 @@ fn test_udp_echo_round_trip() {
                 // Verify echoed payload matches.
                 match dgram.get(&kw("data")) {
                     Some(Value::ByteArray(arr)) => {
-                        let received: Vec<u8> = arr
-                            .get()
-                            .lock()
-                            .unwrap()
-                            .iter()
-                            .map(|&b| b as u8)
-                            .collect();
+                        let received: Vec<u8> =
+                            arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
                         assert_eq!(received, payload, "echoed payload must match");
                     }
                     other => panic!(
@@ -162,8 +159,7 @@ fn test_close_socket_closes_in() {
     local.block_on(&rt, async {
         let _globals = setup_globals();
 
-        let sock_val =
-            cljrs_net::udp::socket_on("127.0.0.1", 0, 8, 8).expect("socket failed");
+        let sock_val = cljrs_net::udp::socket_on("127.0.0.1", 0, 8, 8).expect("socket failed");
         let sock_map = match sock_val {
             Value::Map(m) => m,
             other => panic!("expected socket map, got {}", other.type_name()),

--- a/crates/cljrs-net/tests/udp.rs
+++ b/crates/cljrs-net/tests/udp.rs
@@ -1,0 +1,307 @@
+//! Phase D integration tests: UDP datagram sockets — echo round-trip.
+//!
+//! Done criterion from networking-plan.md Phase D:
+//!   "a UDP echo responder round-trips datagrams with correct :addr."
+
+use std::sync::{Arc, Mutex};
+
+use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn map_get(map: &MapValue, key: &str) -> Value {
+    map.get(&kw(key))
+        .unwrap_or_else(|| panic!("map missing :{key}"))
+}
+
+fn as_chan(v: &Value) -> GcPtr<NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => obj.clone(),
+        other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+    }
+}
+
+/// Phase D done criterion: echo responder round-trips datagrams with correct :addr.
+#[test]
+fn test_udp_echo_round_trip() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        // Create server socket (port 0 = OS-assigned).
+        let server_val =
+            cljrs_net::udp::socket_on("127.0.0.1", 0, 8, 8).expect("server socket failed");
+        let server_map = match server_val {
+            Value::Map(m) => m,
+            other => panic!("expected socket map, got {}", other.type_name()),
+        };
+
+        let server_local_addr = match map_get(&server_map, "local-addr") {
+            Value::Str(s) => s.get().clone(),
+            other => panic!("expected str :local-addr, got {}", other.type_name()),
+        };
+        let server_port: u16 = server_local_addr.split(':').last().unwrap().parse().unwrap();
+
+        let server_in = as_chan(&map_get(&server_map, "in"));
+        let server_out = as_chan(&map_get(&server_map, "out"));
+
+        // Create client socket (port 0 = OS-assigned).
+        let client_val =
+            cljrs_net::udp::socket_on("127.0.0.1", 0, 8, 8).expect("client socket failed");
+        let client_map = match client_val {
+            Value::Map(m) => m,
+            other => panic!("expected socket map, got {}", other.type_name()),
+        };
+
+        let client_in = as_chan(&map_get(&client_map, "in"));
+        let client_out = as_chan(&map_get(&client_map, "out"));
+
+        // Spawn a one-shot echo handler: take one datagram from :in and echo it to :out.
+        // The datagram's :addr field is the sender's address, so send_to goes back to them.
+        tokio::task::spawn_local(async move {
+            if let Value::Map(dgram) = chan_take(&server_in).await {
+                chan_put(&server_out, Value::Map(dgram)).await;
+            }
+        });
+
+        // Client sends a datagram to the server.
+        let payload = b"phase D udp echo test";
+        let signed: Vec<i8> = payload.iter().map(|&b| b as i8).collect();
+        let send_dgram = Value::Map(MapValue::from_pairs(vec![
+            (
+                kw("data"),
+                Value::ByteArray(GcPtr::new(Mutex::new(signed))),
+            ),
+            (
+                kw("addr"),
+                Value::string(format!("127.0.0.1:{server_port}")),
+            ),
+        ]));
+        chan_put(&client_out, send_dgram).await;
+
+        // Client receives the echoed datagram.
+        match chan_take(&client_in).await {
+            Value::Map(dgram) => {
+                // Verify echoed payload matches.
+                match dgram.get(&kw("data")) {
+                    Some(Value::ByteArray(arr)) => {
+                        let received: Vec<u8> = arr
+                            .get()
+                            .lock()
+                            .unwrap()
+                            .iter()
+                            .map(|&b| b as u8)
+                            .collect();
+                        assert_eq!(received, payload, "echoed payload must match");
+                    }
+                    other => panic!(
+                        "expected :data byte-array, got {:?}",
+                        other.map(|v| v.type_name())
+                    ),
+                }
+                // Verify :addr is the server's address (echo came from the server socket).
+                match dgram.get(&kw("addr")) {
+                    Some(Value::Str(s)) => {
+                        let addr = s.get();
+                        let echo_port: u16 = addr.split(':').last().unwrap().parse().unwrap();
+                        assert_eq!(
+                            echo_port, server_port,
+                            ":addr port must be server's port; got {addr}"
+                        );
+                    }
+                    other => panic!(
+                        "expected :addr string, got {:?}",
+                        other.map(|v| v.type_name())
+                    ),
+                }
+            }
+            Value::Error(e) => panic!("received error: {}", e.get().message()),
+            other => panic!("expected datagram map, got {}", other.type_name()),
+        }
+
+        // Clean up.
+        match map_get(&server_map, "resource") {
+            Value::Resource(handle) => {
+                let _ = handle.close();
+            }
+            _ => panic!("expected server resource"),
+        }
+        match map_get(&client_map, "resource") {
+            Value::Resource(handle) => {
+                let _ = handle.close();
+            }
+            _ => panic!("expected client resource"),
+        }
+    });
+}
+
+/// Closing a socket's resource and :in channel makes a pending take yield nil.
+#[test]
+fn test_close_socket_closes_in() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let sock_val =
+            cljrs_net::udp::socket_on("127.0.0.1", 0, 8, 8).expect("socket failed");
+        let sock_map = match sock_val {
+            Value::Map(m) => m,
+            other => panic!("expected socket map, got {}", other.type_name()),
+        };
+
+        let in_chan = as_chan(&map_get(&sock_map, "in"));
+
+        // Abort reader/writer tasks via the resource handle.
+        match map_get(&sock_map, "resource") {
+            Value::Resource(handle) => {
+                let _ = handle.close();
+            }
+            _ => panic!("expected resource"),
+        }
+        // Abort does not automatically close the channel; close it explicitly.
+        chan_ref(in_chan.get()).close();
+
+        let val = chan_take(&in_chan).await;
+        assert!(
+            matches!(val, Value::Nil),
+            "expected nil from closed :in, got {}",
+            val.type_name()
+        );
+    });
+}
+
+/// Multiple datagrams from different senders are received with correct :addr fields.
+#[test]
+fn test_udp_multiple_senders() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        // One server, two clients.
+        let server_val =
+            cljrs_net::udp::socket_on("127.0.0.1", 0, 16, 8).expect("server socket failed");
+        let server_map = match server_val {
+            Value::Map(m) => m,
+            other => panic!("expected socket map, got {}", other.type_name()),
+        };
+        let server_port: u16 = match map_get(&server_map, "local-addr") {
+            Value::Str(s) => s.get().split(':').last().unwrap().parse().unwrap(),
+            _ => panic!("expected str :local-addr"),
+        };
+        let server_in = as_chan(&map_get(&server_map, "in"));
+
+        let client_a_val =
+            cljrs_net::udp::socket_on("127.0.0.1", 0, 8, 8).expect("client A failed");
+        let client_a_map = match client_a_val {
+            Value::Map(m) => m,
+            _ => panic!("expected socket map"),
+        };
+        let client_a_port: u16 = match map_get(&client_a_map, "local-addr") {
+            Value::Str(s) => s.get().split(':').last().unwrap().parse().unwrap(),
+            _ => panic!("expected str"),
+        };
+        let client_a_out = as_chan(&map_get(&client_a_map, "out"));
+
+        let client_b_val =
+            cljrs_net::udp::socket_on("127.0.0.1", 0, 8, 8).expect("client B failed");
+        let client_b_map = match client_b_val {
+            Value::Map(m) => m,
+            _ => panic!("expected socket map"),
+        };
+        let client_b_port: u16 = match map_get(&client_b_map, "local-addr") {
+            Value::Str(s) => s.get().split(':').last().unwrap().parse().unwrap(),
+            _ => panic!("expected str"),
+        };
+        let client_b_out = as_chan(&map_get(&client_b_map, "out"));
+
+        // Client A sends "from-a".
+        let signed_a: Vec<i8> = b"from-a".iter().map(|&b| b as i8).collect();
+        chan_put(
+            &client_a_out,
+            Value::Map(MapValue::from_pairs(vec![
+                (
+                    kw("data"),
+                    Value::ByteArray(GcPtr::new(Mutex::new(signed_a))),
+                ),
+                (
+                    kw("addr"),
+                    Value::string(format!("127.0.0.1:{server_port}")),
+                ),
+            ])),
+        )
+        .await;
+
+        // Client B sends "from-b".
+        let signed_b: Vec<i8> = b"from-b".iter().map(|&b| b as i8).collect();
+        chan_put(
+            &client_b_out,
+            Value::Map(MapValue::from_pairs(vec![
+                (
+                    kw("data"),
+                    Value::ByteArray(GcPtr::new(Mutex::new(signed_b))),
+                ),
+                (
+                    kw("addr"),
+                    Value::string(format!("127.0.0.1:{server_port}")),
+                ),
+            ])),
+        )
+        .await;
+
+        // Server receives two datagrams; each must carry the correct sender port.
+        let mut received_ports: Vec<u16> = Vec::new();
+        for _ in 0..2 {
+            match chan_take(&server_in).await {
+                Value::Map(dgram) => match dgram.get(&kw("addr")) {
+                    Some(Value::Str(s)) => {
+                        let p: u16 = s.get().split(':').last().unwrap().parse().unwrap();
+                        received_ports.push(p);
+                    }
+                    _ => panic!("expected :addr string"),
+                },
+                other => panic!("expected datagram map, got {}", other.type_name()),
+            }
+        }
+
+        assert!(
+            received_ports.contains(&client_a_port),
+            "must see client A's port {client_a_port}; got {received_ports:?}"
+        );
+        assert!(
+            received_ports.contains(&client_b_port),
+            "must see client B's port {client_b_port}; got {received_ports:?}"
+        );
+
+        // Clean up.
+        for map in [&server_map, &client_a_map, &client_b_map] {
+            if let Value::Resource(handle) = map_get(map, "resource") {
+                let _ = handle.close();
+            }
+        }
+    });
+}


### PR DESCRIPTION
Adds clojure.rust.net.udp: a UDP socket is a map {:in :out :local-addr
:resource} where :in yields {:data <byte-array> :addr "ip:port"} datagrams
and :out accepts the same shape for sending. One Arc<UdpSocket> is shared
between the reader (recv_from) and writer (send_to) tasks, both spawned on
the LocalSet. UdpSocketResource holds AbortHandles for deterministic close.

The umbrella clojure.rust.net gains a socket fn and dispatches close to
udp/close for socket maps (no :remote-addr), keeping TCP connections and
UDP sockets distinct.

Three integration tests in tests/udp.rs cover: echo round-trip with correct
:addr verification, close-closes-:in, and multiple senders with distinct
:addr fields.

https://claude.ai/code/session_012khL5v5PP86zUF6b8ydXFx