### PR TITLE
Add TLS dependencies to cljrs-net for Phase E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,7 +551,13 @@ dependencies = [
  "cljrs-stdlib",
  "cljrs-types",
  "cljrs-value",
+ "rcgen",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -630,7 +642,7 @@ dependencies = [
  "cljrs-types",
  "cljrs-value",
  "console_error_panic_hook",
- "getrandom",
+ "getrandom 0.4.2",
  "tokio",
  "uuid",
  "wasm-bindgen",
@@ -667,6 +679,22 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -854,6 +882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1006,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1286,6 +1334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,10 +1393,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1362,6 +1432,12 @@ dependencies = [
  "heapless",
  "serde",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -1414,7 +1490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
@@ -1423,6 +1499,19 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
 
 [[package]]
 name = "regalloc2"
@@ -1466,6 +1555,20 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rpds"
@@ -1523,6 +1626,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,10 +1708,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1638,7 +1828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1661,6 +1851,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -1720,7 +1916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1776,6 +1972,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +2014,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1901,6 +2126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,7 +2143,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2060,10 +2291,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2308,6 +2566,21 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -15,10 +15,16 @@ cljrs-reader   = { workspace = true }
 cljrs-interp   = { workspace = true }
 cljrs-async    = { workspace = true }
 tokio          = { workspace = true, features = ["net", "io-util"] }
+tokio-rustls   = { version = "0.26", default-features = false, features = ["ring"] }
+rustls         = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile = "2"
+webpki-roots   = "0.26"
+rustls-native-certs = "0.8"
 
 [dev-dependencies]
 cljrs-stdlib   = { workspace = true }
 cljrs-interp   = { workspace = true }
 cljrs-reader   = { workspace = true }
 cljrs-env      = { workspace = true }
-tokio          = { workspace = true, features = ["net", "io-util", "sync"] }
+tokio          = { workspace = true, features = ["net", "io-util", "sync", "rt-multi-thread", "macros"] }
+rcgen          = "0.13"

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–D implemented (TCP client + server + framing + UDP datagrams). Phases E–F (TLS, Unix) are stubs.
+**Status**: Phases A–E implemented (TCP client + server + framing + UDP datagrams + TLS client/server). Phase F (Unix sockets) is a stub.
 
 **Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
 
@@ -10,18 +10,21 @@
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, and `clojure.rust.net` |
+| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, and `clojure.rust.net` |
 | `src/tcp.rs` | `TcpStreamResource`, `TcpListenerResource`, connection builder, accept loop, `connect`/`listen`/`close` builtins |
 | `src/frame.rs` | `FramerSpec` native object, stateful framers (`LinesFramer`, `DelimiterFramer`, `LengthPrefixedFramer`), `frame`/encode builtins |
 | `src/udp.rs` | `UdpSocketResource`, reader/writer tasks, `socket`/`close` builtins |
+| `src/tls.rs` | `TlsStreamResource`, `TlsListenerResource`, generic reader/writer loops, `build_client_config`, `build_server_config`, `tls_connect_to`/`tls_listen_on`/`connect`/`listen`/`close` builtins |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
 | `src/clojure_rust_net_udp.cljrs` | Clojure source for `clojure.rust.net.udp`; usage examples |
-| `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net` |
+| `src/clojure_rust_net_tls.cljrs` | Clojure source for `clojure.rust.net.tls`; `start-server` sugar |
+| `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net`; dispatches on `:transport` |
 | `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
 | `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |
 | `tests/framing.rs` | Phase C integration tests (lines + length-prefixed end-to-end, framer unit tests) |
 | `tests/udp.rs` | Phase D integration tests (echo round-trip, multiple senders, close) |
+| `tests/tls.rs` | Phase E integration tests (TLS echo round-trip with rcgen self-signed cert, connect failure) |
 
 ## Public API
 
@@ -69,6 +72,32 @@
 
 `frame` spawns a `LocalSet` background task that reads byte-arrays from `in-chan`, feeds them through the stateful framer, and puts complete frames on the returned output channel. Errors from `in-chan` are forwarded in-band; the output channel closes at EOF or on error.
 
+### `clojure.rust.net.tls`
+
+```clojure
+;; Phase E — TLS client
+(connect {:host "example.com" :port 443})
+;; => promise-chan — yields {:in ch :out ch :remote-addr str :local-addr str :resource h}
+;;    or Value::Error on failure
+;; Optional keys: :roots (:webpki default, :system, or "path/to/ca.pem")
+;;                :insecure-skip-verify true (skip cert verification — for testing only)
+;;                :alpn ["h2" "http/1.1"]
+;;                :in-buf, :out-buf (default 8)
+
+(close conn)         ;; => nil — closes :in/:out and aborts reader/writer tasks
+
+;; Phase E — TLS server
+(listen {:port 8443 :cert "cert.pem" :key "key.pem"})
+;; => {:conns <chan> :local-addr "0.0.0.0:8443" :resource h}
+;;    :conns yields a connection map per accepted TLS socket; closed when listener closes
+;; Optional keys: :host (default "0.0.0.0"), :alpn [...], :conns-buf, :in-buf, :out-buf
+
+(listen-close server) ;; => nil — stops accept loop, closes :conns
+
+(start-server handler {:port 8443 :cert "cert.pem" :key "key.pem"})
+;; => server-map — spawns go-loop that calls (handler conn) for each accepted TLS conn
+```
+
 ### `clojure.rust.net` (umbrella)
 
 ```clojure
@@ -99,6 +128,10 @@ pub fn udp::socket_on(host: &str, port: u16, in_buf: usize, out_buf: usize) -> V
 pub fn frame::frame_channel(in_chan: GcPtr<NativeObjectBox>, spec: FramerSpec, out_buf: usize) -> GcPtr<NativeObjectBox>
 pub fn frame::encode_line(s: &str) -> Value
 pub fn frame::encode_length_prefixed(data: &[u8], prefix_len: usize, big_endian: bool) -> Value
+pub fn tls::tls_connect_to(host: &str, port: u16, config: Arc<rustls::ClientConfig>, in_buf: usize, out_buf: usize) -> Value
+pub fn tls::tls_listen_on(host: &str, port: u16, config: Arc<rustls::ServerConfig>, conns_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
+pub fn tls::build_client_config(opts: &MapValue) -> ValueResult<Arc<rustls::ClientConfig>>
+pub fn tls::build_server_config(opts: &MapValue) -> ValueResult<Arc<rustls::ServerConfig>>
 ```
 
 `init` registers all three namespaces, calling `cljrs_async::init` internally. Idempotent.
@@ -114,6 +147,14 @@ Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the
 ### `UdpSocketResource`
 
 Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks; once they finish the `Arc<UdpSocket>` drops and the FD is released.
+
+### `TlsStreamResource`
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks (generic over the TLS stream halves). `close()` aborts both tasks, dropping the TLS stream halves and releasing the FD.
+
+### `TlsListenerResource`
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `tls_accept_loop` task. `close()` aborts the task, dropping the `TcpListener` and releasing the listener FD.
 
 ## Connection Model
 

--- a/crates/cljrs-net/src/clojure_rust_net.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net.cljrs
@@ -1,6 +1,7 @@
 ;; clojure.rust.net — umbrella networking namespace.
 
 (require 'clojure.rust.net.tcp)
+(require 'clojure.rust.net.tls)
 (require 'clojure.rust.net.udp)
 
 (defn connect
@@ -11,13 +12,14 @@
   Opts:
     :host          string (required)
     :port          integer (required, 1-65535)
-    :transport     :tcp (default) — future: :unix, :tls
+    :transport     :tcp (default), :tls
     :in-buf        channel buffer depth for :in (default 8)
     :out-buf       channel buffer depth for :out (default 8)"
   [opts]
   (let [transport (get opts :transport :tcp)]
     (case transport
       :tcp (clojure.rust.net.tcp/connect opts)
+      :tls (clojure.rust.net.tls/connect opts)
       (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
 
 (defn listen
@@ -28,7 +30,7 @@
   Opts:
     :port       integer (required, 1-65535)
     :host       string (default \"0.0.0.0\")
-    :transport  :tcp (default) — future: :unix, :tls
+    :transport  :tcp (default), :tls
     :conns-buf  buffer depth for :conns (default 8)
     :in-buf     per-connection :in buffer (default 8)
     :out-buf    per-connection :out buffer (default 8)"
@@ -36,6 +38,7 @@
   (let [transport (get opts :transport :tcp)]
     (case transport
       :tcp (clojure.rust.net.tcp/listen opts)
+      :tls (clojure.rust.net.tls/listen opts)
       (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
 
 (defn start-server

--- a/crates/cljrs-net/src/clojure_rust_net_tls.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_tls.cljrs
@@ -1,0 +1,32 @@
+;; clojure.rust.net.tls — TLS client/server.
+;;
+;; Phase E (TLS):
+;;   connect      — (connect {:host h :port p}) => promise-chan -> conn-map
+;;   close        — (close conn) => nil
+;;   listen       — (listen {:port p :cert "cert.pem" :key "key.pem"}) => server-map
+;;   listen-close — (listen-close server) => nil
+;;   start-server — (start-server handler opts) => server-map
+
+(defn start-server
+  "Start a TLS server with `handler` called for each accepted connection.
+  Returns the server map {:conns <chan> :local-addr str :resource handle}.
+
+  Opts (same as listen):
+    :port     integer (required, 1-65535)
+    :cert     path to PEM certificate file (required)
+    :key      path to PEM private key file (required)
+    :host     string (default \"0.0.0.0\")
+    :alpn     vector of ALPN protocol strings
+    :conns-buf  buffer depth for :conns (default 8)
+    :in-buf     per-connection :in buffer (default 8)
+    :out-buf    per-connection :out buffer (default 8)"
+  [handler opts]
+  (let [server (clojure.rust.net.tls/listen opts)
+        conns  (:conns server)]
+    (clojure.core.async/go
+      (loop []
+        (let [conn (await (clojure.core.async/take! conns))]
+          (when (some? conn)
+            (handler conn)
+            (recur)))))
+    server))

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -18,6 +18,7 @@ use cljrs_async::load_source;
 
 pub mod frame;
 pub mod tcp;
+pub mod tls;
 pub mod udp;
 
 /// Clojure source for `clojure.rust.net.tcp`.
@@ -32,10 +33,14 @@ const NET_FRAME_SOURCE: &str = include_str!("clojure_rust_net_frame.cljrs");
 /// Clojure source for `clojure.rust.net.udp`.
 const NET_UDP_SOURCE: &str = include_str!("clojure_rust_net_udp.cljrs");
 
+/// Clojure source for `clojure.rust.net.tls`.
+const NET_TLS_SOURCE: &str = include_str!("clojure_rust_net_tls.cljrs");
+
 pub const NS_TCP: &str = "clojure.rust.net.tcp";
 pub const NS: &str = "clojure.rust.net";
 pub const NS_FRAME: &str = "clojure.rust.net.frame";
 pub const NS_UDP: &str = "clojure.rust.net.udp";
+pub const NS_TLS: &str = "clojure.rust.net.tls";
 
 /// Register the networking namespaces.
 ///
@@ -66,6 +71,14 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         udp::register(globals, NS_UDP);
         load_source(globals, NS_UDP, NET_UDP_SOURCE);
         globals.mark_loaded(NS_UDP);
+    }
+
+    if !globals.is_loaded(NS_TLS) {
+        globals.get_or_create_ns(NS_TLS);
+        globals.refer_all(NS_TLS, "clojure.core");
+        tls::register(globals, NS_TLS);
+        load_source(globals, NS_TLS, NET_TLS_SOURCE);
+        globals.mark_loaded(NS_TLS);
     }
 
     if !globals.is_loaded(NS) {

--- a/crates/cljrs-net/src/tls.rs
+++ b/crates/cljrs-net/src/tls.rs
@@ -468,9 +468,7 @@ pub fn build_server_config(opts: &MapValue) -> ValueResult<Arc<ServerConfig>> {
 
 // ── Cert/key loaders ──────────────────────────────────────────────────────────
 
-fn load_certs(
-    path: &str,
-) -> ValueResult<Vec<rustls::pki_types::CertificateDer<'static>>> {
+fn load_certs(path: &str) -> ValueResult<Vec<rustls::pki_types::CertificateDer<'static>>> {
     let file =
         std::fs::File::open(path).map_err(|e| ValueError::Other(format!("open {path}: {e}")))?;
     let mut reader = BufReader::new(file);
@@ -501,9 +499,7 @@ pub fn tls_connect_to(
     let host = host.to_string();
     let promise = make_chan(1);
     let promise_val = Value::NativeObject(promise.clone());
-    spawn_future(async move {
-        do_tls_connect(host, port, config, in_buf, out_buf, promise).await
-    });
+    spawn_future(async move { do_tls_connect(host, port, config, in_buf, out_buf, promise).await });
     promise_val
 }
 
@@ -591,11 +587,8 @@ async fn tls_accept_loop(
                     let tls_stream = match acceptor.accept(tcp_stream).await {
                         Ok(s) => s,
                         Err(e) => {
-                            chan_put(
-                                &conns_chan_clone,
-                                net_error(format!("TLS handshake: {e}")),
-                            )
-                            .await;
+                            chan_put(&conns_chan_clone, net_error(format!("TLS handshake: {e}")))
+                                .await;
                             return;
                         }
                     };

--- a/crates/cljrs-net/src/tls.rs
+++ b/crates/cljrs-net/src/tls.rs
@@ -1,0 +1,761 @@
+//! TLS client/server support for `clojure.rust.net.tls`.
+//!
+//! Phase E delivers TLS on top of TCP, producing the **identical** connection
+//! shape as `clojure.rust.net.tcp`:
+//!
+//! ```clojure
+//! {:in          <chan>   ; byte-array chunks from the peer; closed at EOF
+//!  :out         <chan>   ; put byte-array/string values here to send
+//!  :remote-addr "ip:port"
+//!  :local-addr  "ip:port"
+//!  :resource    <handle>} ; TlsStreamResource — deterministic socket close
+//! ```
+//!
+//! `connect` returns a capacity-1 promise channel that yields the connection
+//! map once the TLS handshake completes, or a `Value::Error` on failure.
+//!
+//! The server map is:
+//!
+//! ```clojure
+//! {:conns      <chan>   ; yields a connection map for each accepted socket
+//!  :local-addr "ip:port"
+//!  :resource   <handle>} ; TlsListenerResource — deterministic listener close
+//! ```
+
+use std::any::Any;
+use std::io::BufReader;
+use std::sync::{Arc, Mutex};
+
+use rustls::ClientConfig;
+use rustls::ServerConfig;
+use rustls::pki_types::ServerName;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::task::AbortHandle;
+use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, chan_take, make_chan};
+use cljrs_async::spawn_future;
+use cljrs_env::env::GlobalEnv;
+use cljrs_env::error::EvalResult;
+use cljrs_gc::GcPtr;
+use cljrs_value::{
+    Arity, ExceptionInfo, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle,
+    Value, ValueError, ValueResult,
+};
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        ("connect", Arity::Fixed(1), builtin_connect),
+        ("close", Arity::Fixed(1), builtin_close),
+        ("listen", Arity::Fixed(1), builtin_listen),
+        ("listen-close", Arity::Fixed(1), builtin_listen_close),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── TlsStreamResource ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct TlsStreamInner {
+    closed: bool,
+    reader_abort: Option<AbortHandle>,
+    writer_abort: Option<AbortHandle>,
+}
+
+/// `Resource` implementation for a TLS stream.
+///
+/// Holds `AbortHandle`s for the reader and writer tasks spawned in `connect`.
+/// `close()` aborts both tasks, which drops the socket halves and closes the FD.
+#[derive(Debug)]
+pub struct TlsStreamResource {
+    inner: Arc<Mutex<TlsStreamInner>>,
+}
+
+impl TlsStreamResource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TlsStreamInner {
+                closed: false,
+                reader_abort: None,
+                writer_abort: None,
+            })),
+        }
+    }
+}
+
+impl Resource for TlsStreamResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        if let Some(h) = g.reader_abort.take() {
+            h.abort();
+        }
+        if let Some(h) = g.writer_abort.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "TlsStream"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── TlsListenerResource ───────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct TlsListenerInner {
+    closed: bool,
+    accept_abort: Option<AbortHandle>,
+}
+
+/// `Resource` implementation for a TLS listener.
+///
+/// Holds the `AbortHandle` for the `tls_accept_loop` task. `close()` aborts the
+/// task, which drops the `TcpListener` and closes the listener FD.
+#[derive(Debug)]
+pub struct TlsListenerResource {
+    inner: Arc<Mutex<TlsListenerInner>>,
+}
+
+impl TlsListenerResource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TlsListenerInner {
+                closed: false,
+                accept_abort: None,
+            })),
+        }
+    }
+}
+
+impl Resource for TlsListenerResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        if let Some(h) = g.accept_abort.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "TlsListener"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Value helpers ─────────────────────────────────────────────────────────────
+
+fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+fn net_error(msg: impl Into<String>) -> Value {
+    let msg = msg.into();
+    Value::Error(GcPtr::new(ExceptionInfo::new(
+        ValueError::Other(msg.clone()),
+        msg,
+        None,
+        None,
+    )))
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+// ── Options-map parsing ───────────────────────────────────────────────────────
+
+fn opts_str(opts: &MapValue, key: &str) -> Option<String> {
+    match opts.get(&kw(key))? {
+        Value::Str(s) => Some(s.get().clone()),
+        _ => None,
+    }
+}
+
+fn opts_usize(opts: &MapValue, key: &str) -> Option<usize> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n >= 0 => Some((n as usize).max(1)),
+        _ => None,
+    }
+}
+
+fn opts_port(opts: &MapValue) -> Option<u16> {
+    match opts.get(&kw("port"))? {
+        Value::Long(n) if n > 0 && n <= 65535 => Some(n as u16),
+        _ => None,
+    }
+}
+
+fn opts_bool(opts: &MapValue, key: &str) -> Option<bool> {
+    match opts.get(&kw(key))? {
+        Value::Bool(b) => Some(b),
+        _ => None,
+    }
+}
+
+fn opts_string_vec(opts: &MapValue, key: &str) -> Option<Vec<String>> {
+    match opts.get(&kw(key))? {
+        Value::Vector(v) => {
+            let items: Vec<String> = v
+                .get()
+                .iter()
+                .filter_map(|val| match val {
+                    Value::Str(s) => Some(s.get().clone()),
+                    _ => None,
+                })
+                .collect();
+            Some(items)
+        }
+        _ => None,
+    }
+}
+
+// ── Async tasks (generic — used by both client and server connections) ─────────
+
+/// Read chunks from the TLS stream and put them on `:in`.
+///
+/// Closes `:in` at EOF or on error. Aborted via `TlsStreamResource::close`.
+async fn tls_reader_loop<R>(mut reader: R, in_chan: GcPtr<NativeObjectBox>)
+where
+    R: tokio::io::AsyncRead + Unpin + 'static,
+{
+    let mut buf = vec![0u8; 8192];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                if !chan_put(&in_chan, bytes_value(&buf[..n])).await {
+                    break; // consumer closed :in
+                }
+            }
+            Err(e) => {
+                chan_put(&in_chan, net_error(format!("read error: {e}"))).await;
+                break;
+            }
+        }
+    }
+    chan_ref(in_chan.get()).close();
+}
+
+/// Drain `:out` and write each value to the TLS stream.
+///
+/// Accepts `byte-array` and `string` values. Shuts down write side when `:out`
+/// is closed. Aborted via `TlsStreamResource::close`.
+async fn tls_writer_loop<W>(mut writer: W, out_chan: GcPtr<NativeObjectBox>)
+where
+    W: tokio::io::AsyncWrite + Unpin + 'static,
+{
+    let _: std::io::Result<()> = async {
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => {
+                    // :out closed; gracefully half-close the write side.
+                    let _ = writer.shutdown().await;
+                    break;
+                }
+                Value::ByteArray(arr) => {
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    writer.write_all(&bytes).await?;
+                }
+                Value::Str(s) => {
+                    writer.write_all(s.get().as_bytes()).await?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+    .await;
+}
+
+// ── Connection builder (generic) ──────────────────────────────────────────────
+
+fn make_tls_connection<R, W>(
+    reader: R,
+    writer: W,
+    remote_addr: String,
+    local_addr: String,
+    in_buf: usize,
+    out_buf: usize,
+) -> Value
+where
+    R: tokio::io::AsyncRead + Unpin + 'static,
+    W: tokio::io::AsyncWrite + Unpin + 'static,
+{
+    let in_chan = make_chan(in_buf);
+    let out_chan = make_chan(out_buf);
+    let resource = TlsStreamResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+    let r_jh = tokio::task::spawn_local(tls_reader_loop(reader, in_chan.clone()));
+    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
+    let w_jh = tokio::task::spawn_local(tls_writer_loop(writer, out_chan.clone()));
+    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
+    Value::Map(MapValue::from_pairs(vec![
+        (kw("in"), Value::NativeObject(in_chan)),
+        (kw("out"), Value::NativeObject(out_chan)),
+        (kw("remote-addr"), Value::string(remote_addr)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]))
+}
+
+// ── SkipCertVerification ──────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct SkipCertVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl rustls::client::danger::ServerCertVerifier for SkipCertVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+// ── Client config builder ─────────────────────────────────────────────────────
+
+pub fn build_client_config(opts: &MapValue) -> ValueResult<Arc<ClientConfig>> {
+    let insecure = opts_bool(opts, "insecure-skip-verify").unwrap_or(false);
+
+    let mut config = if insecure {
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        ClientConfig::builder_with_provider(provider.clone())
+            .with_safe_default_protocol_versions()
+            .map_err(|e| ValueError::Other(format!("TLS protocol versions: {e}")))?
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(SkipCertVerification(provider)))
+            .with_no_client_auth()
+    } else {
+        let mut root_store = rustls::RootCertStore::empty();
+
+        // Determine root source
+        let roots_val = opts.get(&kw("roots"));
+        match &roots_val {
+            None => {
+                // Default: webpki roots
+                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            }
+            Some(Value::Keyword(kw_val)) if kw_val.get().name.as_ref() == "webpki" => {
+                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            }
+            Some(Value::Keyword(kw_val)) if kw_val.get().name.as_ref() == "system" => {
+                let native_certs = rustls_native_certs::load_native_certs();
+                for cert in native_certs.certs {
+                    root_store.add(cert).ok();
+                }
+            }
+            Some(Value::Str(s)) => {
+                // Load PEM certs from file path
+                let certs = load_certs(s.get())?;
+                for cert in certs {
+                    root_store
+                        .add(cert)
+                        .map_err(|e| ValueError::Other(format!("add cert: {e}")))?;
+                }
+            }
+            _ => {
+                // Fall back to webpki roots for unknown values
+                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            }
+        }
+
+        ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth()
+    };
+
+    // ALPN
+    if let Some(alpn) = opts_string_vec(opts, "alpn") {
+        config.alpn_protocols = alpn.into_iter().map(|s| s.into_bytes()).collect();
+    }
+
+    Ok(Arc::new(config))
+}
+
+// ── Server config builder ─────────────────────────────────────────────────────
+
+pub fn build_server_config(opts: &MapValue) -> ValueResult<Arc<ServerConfig>> {
+    let cert_path =
+        opts_str(opts, "cert").ok_or_else(|| ValueError::Other(":cert required".into()))?;
+    let key_path =
+        opts_str(opts, "key").ok_or_else(|| ValueError::Other(":key required".into()))?;
+
+    let certs = load_certs(&cert_path)?;
+    let key = load_private_key(&key_path)?;
+
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| ValueError::Other(format!("server cert/key error: {e}")))?;
+
+    // ALPN
+    if let Some(alpn) = opts_string_vec(opts, "alpn") {
+        config.alpn_protocols = alpn.into_iter().map(|s| s.into_bytes()).collect();
+    }
+
+    Ok(Arc::new(config))
+}
+
+// ── Cert/key loaders ──────────────────────────────────────────────────────────
+
+fn load_certs(
+    path: &str,
+) -> ValueResult<Vec<rustls::pki_types::CertificateDer<'static>>> {
+    let file =
+        std::fs::File::open(path).map_err(|e| ValueError::Other(format!("open {path}: {e}")))?;
+    let mut reader = BufReader::new(file);
+    rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| ValueError::Other(format!("read certs from {path}: {e}")))
+}
+
+fn load_private_key(path: &str) -> ValueResult<rustls::pki_types::PrivateKeyDer<'static>> {
+    let file =
+        std::fs::File::open(path).map_err(|e| ValueError::Other(format!("open {path}: {e}")))?;
+    let mut reader = BufReader::new(file);
+    rustls_pemfile::private_key(&mut reader)
+        .map_err(|e| ValueError::Other(format!("read key from {path}: {e}")))?
+        .ok_or_else(|| ValueError::Other(format!("no private key found in {path}")))
+}
+
+// ── Connect implementation ────────────────────────────────────────────────────
+
+/// Initiate a TLS connection and return the promise channel as a `Value`.
+pub fn tls_connect_to(
+    host: &str,
+    port: u16,
+    config: Arc<ClientConfig>,
+    in_buf: usize,
+    out_buf: usize,
+) -> Value {
+    let host = host.to_string();
+    let promise = make_chan(1);
+    let promise_val = Value::NativeObject(promise.clone());
+    spawn_future(async move {
+        do_tls_connect(host, port, config, in_buf, out_buf, promise).await
+    });
+    promise_val
+}
+
+async fn do_tls_connect(
+    host: String,
+    port: u16,
+    config: Arc<ClientConfig>,
+    in_buf: usize,
+    out_buf: usize,
+    promise: GcPtr<NativeObjectBox>,
+) -> EvalResult {
+    let addr = format!("{host}:{port}");
+
+    // TCP connect
+    let tcp_stream = match tokio::net::TcpStream::connect(&addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            chan_deliver(&promise, net_error(format!("connect to {addr}: {e}"))).await;
+            return Ok(Value::Nil);
+        }
+    };
+
+    let remote_addr = tcp_stream
+        .peer_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+    let local_addr = tcp_stream
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+
+    // TLS handshake
+    let server_name = match ServerName::try_from(host.as_str()) {
+        Ok(n) => n.to_owned(),
+        Err(e) => {
+            chan_deliver(
+                &promise,
+                net_error(format!("invalid SNI hostname {host}: {e}")),
+            )
+            .await;
+            return Ok(Value::Nil);
+        }
+    };
+
+    let connector = TlsConnector::from(config);
+    let tls_stream = match connector.connect(server_name, tcp_stream).await {
+        Ok(s) => s,
+        Err(e) => {
+            chan_deliver(&promise, net_error(format!("TLS handshake: {e}"))).await;
+            return Ok(Value::Nil);
+        }
+    };
+
+    let (reader, writer) = tokio::io::split(tls_stream);
+    let conn = make_tls_connection(reader, writer, remote_addr, local_addr, in_buf, out_buf);
+    chan_deliver(&promise, conn).await;
+    Ok(Value::Nil)
+}
+
+// ── Accept loop ───────────────────────────────────────────────────────────────
+
+/// Accept TLS connections and put each connection map on `conns_chan`.
+async fn tls_accept_loop(
+    listener: tokio::net::TcpListener,
+    acceptor: TlsAcceptor,
+    conns_chan: GcPtr<NativeObjectBox>,
+    in_buf: usize,
+    out_buf: usize,
+) {
+    loop {
+        match listener.accept().await {
+            Err(e) => {
+                chan_put(&conns_chan, net_error(format!("accept error: {e}"))).await;
+                break;
+            }
+            Ok((tcp_stream, peer_addr)) => {
+                let remote_addr = peer_addr.to_string();
+                let local_addr = listener
+                    .local_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_default();
+                let acceptor = acceptor.clone();
+                let conns_chan_clone = conns_chan.clone();
+                tokio::task::spawn_local(async move {
+                    let tls_stream = match acceptor.accept(tcp_stream).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            chan_put(
+                                &conns_chan_clone,
+                                net_error(format!("TLS handshake: {e}")),
+                            )
+                            .await;
+                            return;
+                        }
+                    };
+                    let (reader, writer) = tokio::io::split(tls_stream);
+                    let conn = make_tls_connection(
+                        reader,
+                        writer,
+                        remote_addr,
+                        local_addr,
+                        in_buf,
+                        out_buf,
+                    );
+                    chan_put(&conns_chan_clone, conn).await;
+                });
+            }
+        }
+    }
+    chan_ref(conns_chan.get()).close();
+}
+
+// ── Listen implementation ─────────────────────────────────────────────────────
+
+/// Bind a TLS listener on `host:port` and return a server map.
+pub fn tls_listen_on(
+    host: &str,
+    port: u16,
+    config: Arc<ServerConfig>,
+    conns_buf: usize,
+    in_buf: usize,
+    out_buf: usize,
+) -> ValueResult<Value> {
+    let addr = format!("{host}:{port}");
+
+    // Bind synchronously (std), then convert to Tokio.
+    let std_listener = std::net::TcpListener::bind(&addr)
+        .map_err(|e| ValueError::Other(format!("listen on {addr}: {e}")))?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| ValueError::Other(format!("set_nonblocking: {e}")))?;
+    let listener = tokio::net::TcpListener::from_std(std_listener)
+        .map_err(|e| ValueError::Other(format!("from_std: {e}")))?;
+
+    let local_addr = listener
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+
+    let conns_chan = make_chan(conns_buf);
+    let acceptor = TlsAcceptor::from(config);
+
+    let resource = TlsListenerResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    let jh = tokio::task::spawn_local(tls_accept_loop(
+        listener,
+        acceptor,
+        conns_chan.clone(),
+        in_buf,
+        out_buf,
+    ));
+    shared_inner.lock().unwrap().accept_abort = Some(jh.abort_handle());
+
+    Ok(Value::Map(MapValue::from_pairs(vec![
+        (kw("conns"), Value::NativeObject(conns_chan)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ])))
+}
+
+// ── Builtins ──────────────────────────────────────────────────────────────────
+
+/// `(connect {:host h :port p :cert "ca.pem"})` — returns a promise channel.
+fn builtin_connect(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:host str :port long}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let host = opts_str(&opts, "host").ok_or_else(|| ValueError::Other(":host required".into()))?;
+    let port =
+        opts_port(&opts).ok_or_else(|| ValueError::Other(":port required (1-65535)".into()))?;
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+
+    let config = build_client_config(&opts)?;
+    Ok(tls_connect_to(&host, port, config, in_buf, out_buf))
+}
+
+/// `(close conn)` — close a TLS connection map.
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let conn = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "connection map",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::NativeObject(obj)) = conn.get(&kw("out")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::NativeObject(obj)) = conn.get(&kw("in")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::Resource(handle)) = conn.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}
+
+/// `(listen {:port p :cert "cert.pem" :key "key.pem"})` — bind a TLS listener.
+fn builtin_listen(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:port long :cert str :key str}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let host = opts_str(&opts, "host").unwrap_or_else(|| "0.0.0.0".to_string());
+    let port =
+        opts_port(&opts).ok_or_else(|| ValueError::Other(":port required (1-65535)".into()))?;
+    let conns_buf = opts_usize(&opts, "conns-buf").unwrap_or(8);
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+
+    let config = build_server_config(&opts)?;
+    tls_listen_on(&host, port, config, conns_buf, in_buf, out_buf)
+}
+
+/// `(listen-close server)` — stop the accept loop and close the `:conns` channel.
+fn builtin_listen_close(args: &[Value]) -> ValueResult<Value> {
+    let server = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "server map {:conns ch :resource handle}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::Resource(handle)) = server.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+    if let Some(Value::NativeObject(obj)) = server.get(&kw("conns")) {
+        chan_ref(obj.get()).close();
+    }
+
+    Ok(Value::Nil)
+}

--- a/crates/cljrs-net/tests/tls.rs
+++ b/crates/cljrs-net/tests/tls.rs
@@ -1,0 +1,216 @@
+//! Phase E integration tests: TLS client + server — echo round-trip and error path.
+//!
+//! Done criterion from networking-plan.md Phase E:
+//!   "TLS client and server round-trip bytes over an encrypted channel."
+
+use std::sync::Arc;
+
+use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn map_get(map: &MapValue, key: &str) -> Value {
+    map.get(&kw(key))
+        .unwrap_or_else(|| panic!("map missing :{key}"))
+}
+
+fn as_chan(v: &Value) -> GcPtr<NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => obj.clone(),
+        other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+    }
+}
+
+/// Write cert and key PEM strings to temp files; return (cert_path, key_path).
+fn write_temp_pem(cert_pem: &str, key_pem: &str) -> (String, String) {
+    let dir = std::env::temp_dir();
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    let cert_path = dir
+        .join(format!("cljrs_tls_test_cert_{unique}.pem"))
+        .to_string_lossy()
+        .into_owned();
+    let key_path = dir
+        .join(format!("cljrs_tls_test_key_{unique}.pem"))
+        .to_string_lossy()
+        .into_owned();
+    std::fs::write(&cert_path, cert_pem).expect("write cert pem");
+    std::fs::write(&key_path, key_pem).expect("write key pem");
+    (cert_path, key_path)
+}
+
+/// Phase E done criterion: TLS echo server from `tls_listen_on` + client round-trips bytes.
+#[test]
+fn test_tls_echo_round_trip() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        // Generate a self-signed certificate for "localhost".
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("rcgen cert generation failed");
+        let cert_pem = cert.cert.pem();
+        let key_pem = cert.key_pair.serialize_pem();
+
+        // Write PEM files to temp dir.
+        let (cert_path, key_path) = write_temp_pem(&cert_pem, &key_pem);
+
+        // Build server config from PEM files.
+        let server_opts = cljrs_value::MapValue::from_pairs(vec![
+            (kw("cert"), Value::string(cert_path.clone())),
+            (kw("key"), Value::string(key_path.clone())),
+        ]);
+        let server_config = cljrs_net::tls::build_server_config(&server_opts)
+            .expect("build_server_config failed");
+
+        // Start the TLS listener (port 0 = OS-assigned).
+        let server_val = cljrs_net::tls::tls_listen_on("127.0.0.1", 0, server_config, 8, 8, 8)
+            .expect("tls_listen_on failed");
+        let server_map = match server_val {
+            Value::Map(m) => m,
+            other => panic!("expected server map, got {}", other.type_name()),
+        };
+
+        // Extract port from :local-addr.
+        let local_addr = match map_get(&server_map, "local-addr") {
+            Value::Str(s) => s.get().clone(),
+            other => panic!("expected str :local-addr, got {}", other.type_name()),
+        };
+        let port: u16 = local_addr.split(':').last().unwrap().parse().unwrap();
+
+        let conns_ch = as_chan(&map_get(&server_map, "conns"));
+
+        // Spawn a one-shot echo handler.
+        let conns_for_handler = conns_ch.clone();
+        tokio::task::spawn_local(async move {
+            let conn_val = chan_take(&conns_for_handler).await;
+            let conn = match conn_val {
+                Value::Map(m) => m,
+                Value::Error(e) => panic!("handler got error from :conns: {}", e.get().message()),
+                other => panic!("handler got non-map from :conns: {}", other.type_name()),
+            };
+
+            let in_ch = as_chan(&map_get(&conn, "in"));
+            let out_ch = as_chan(&map_get(&conn, "out"));
+
+            loop {
+                match chan_take(&in_ch).await {
+                    Value::Nil => break,
+                    val => {
+                        chan_put(&out_ch, val).await;
+                    }
+                }
+            }
+            chan_ref(out_ch.get()).close();
+        });
+
+        // Build insecure client config (accepts self-signed cert).
+        let client_opts = cljrs_value::MapValue::from_pairs(vec![(
+            kw("insecure-skip-verify"),
+            Value::Bool(true),
+        )]);
+        let client_config = cljrs_net::tls::build_client_config(&client_opts)
+            .expect("build_client_config failed");
+
+        // Connect the TLS client.
+        let promise = cljrs_net::tls::tls_connect_to("localhost", port, client_config, 8, 8);
+        let conn_val = chan_take(&as_chan(&promise)).await;
+        let conn = match conn_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("TLS connect failed: {}", e.get().message()),
+            other => panic!("expected conn map, got {}", other.type_name()),
+        };
+
+        let out_ch = as_chan(&map_get(&conn, "out"));
+        let in_ch = as_chan(&map_get(&conn, "in"));
+
+        // Send a request and half-close the write side.
+        let request = b"phase E TLS echo test";
+        let signed: Vec<i8> = request.iter().map(|&b| b as i8).collect();
+        chan_put(
+            &out_ch,
+            Value::ByteArray(GcPtr::new(std::sync::Mutex::new(signed))),
+        )
+        .await;
+        chan_ref(out_ch.get()).close();
+
+        // Drain :in until EOF, collecting the echoed bytes.
+        let mut response: Vec<u8> = Vec::new();
+        loop {
+            match chan_take(&in_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(arr) => {
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    response.extend_from_slice(&bytes);
+                }
+                Value::Error(e) => panic!("read error: {}", e.get().message()),
+                other => panic!("unexpected value on :in: {}", other.type_name()),
+            }
+        }
+
+        assert_eq!(response, request, "TLS echo server must return the same bytes");
+
+        // Cleanup temp files.
+        let _ = std::fs::remove_file(&cert_path);
+        let _ = std::fs::remove_file(&key_path);
+
+        // Close the server listener.
+        match map_get(&server_map, "resource") {
+            Value::Resource(handle) => {
+                let _ = handle.close();
+            }
+            other => panic!("expected resource, got {}", other.type_name()),
+        }
+    });
+}
+
+/// A TLS connection attempt to a port that isn't listening must yield Value::Error.
+#[test]
+fn test_tls_connect_failure() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        // Build a minimal client config (insecure to avoid cert issues — we
+        // won't get that far anyway since there's no server).
+        let client_opts = cljrs_value::MapValue::from_pairs(vec![(
+            kw("insecure-skip-verify"),
+            Value::Bool(true),
+        )]);
+        let client_config = cljrs_net::tls::build_client_config(&client_opts)
+            .expect("build_client_config failed");
+
+        // Port 1 is privileged and almost certainly not listening.
+        let promise = cljrs_net::tls::tls_connect_to("127.0.0.1", 1, client_config, 8, 8);
+
+        let result = chan_take(&as_chan(&promise)).await;
+        assert!(
+            matches!(result, Value::Error(_)),
+            "expected Value::Error for refused TLS connection, got {}",
+            result.type_name()
+        );
+    });
+}

--- a/crates/cljrs-net/tests/tls.rs
+++ b/crates/cljrs-net/tests/tls.rs
@@ -77,8 +77,8 @@ fn test_tls_echo_round_trip() {
             (kw("cert"), Value::string(cert_path.clone())),
             (kw("key"), Value::string(key_path.clone())),
         ]);
-        let server_config = cljrs_net::tls::build_server_config(&server_opts)
-            .expect("build_server_config failed");
+        let server_config =
+            cljrs_net::tls::build_server_config(&server_opts).expect("build_server_config failed");
 
         // Start the TLS listener (port 0 = OS-assigned).
         let server_val = cljrs_net::tls::tls_listen_on("127.0.0.1", 0, server_config, 8, 8, 8)
@@ -126,8 +126,8 @@ fn test_tls_echo_round_trip() {
             kw("insecure-skip-verify"),
             Value::Bool(true),
         )]);
-        let client_config = cljrs_net::tls::build_client_config(&client_opts)
-            .expect("build_client_config failed");
+        let client_config =
+            cljrs_net::tls::build_client_config(&client_opts).expect("build_client_config failed");
 
         // Connect the TLS client.
         let promise = cljrs_net::tls::tls_connect_to("localhost", port, client_config, 8, 8);
@@ -166,7 +166,10 @@ fn test_tls_echo_round_trip() {
             }
         }
 
-        assert_eq!(response, request, "TLS echo server must return the same bytes");
+        assert_eq!(
+            response, request,
+            "TLS echo server must return the same bytes"
+        );
 
         // Cleanup temp files.
         let _ = std::fs::remove_file(&cert_path);
@@ -200,8 +203,8 @@ fn test_tls_connect_failure() {
             kw("insecure-skip-verify"),
             Value::Bool(true),
         )]);
-        let client_config = cljrs_net::tls::build_client_config(&client_opts)
-            .expect("build_client_config failed");
+        let client_config =
+            cljrs_net::tls::build_client_config(&client_opts).expect("build_client_config failed");
 
         // Port 1 is privileged and almost certainly not listening.
         let promise = cljrs_net::tls::tls_connect_to("127.0.0.1", 1, client_config, 8, 8);


### PR DESCRIPTION
Adds tokio-rustls, rustls (ring backend), rustls-pemfile, webpki-roots,
and rustls-native-certs as dependencies for Phase E TLS implementation.
Adds rcgen as a dev-dependency for generating test certificates.

https://claude.ai/code/session_01WJ8aAMv2Zx12XxMemE2Rwd