### PR TITLE
Implement Phase F: Unix-domain stream sockets (clojure.rust.net.unix)

### DIFF
--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–E implemented (TCP client + server + framing + UDP datagrams + TLS client/server). Phase F (Unix sockets) is a stub.
+**Status**: Phases A–F implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets).
 
 **Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
 
@@ -10,21 +10,24 @@
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, and `clojure.rust.net` |
+| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, `clojure.rust.net.unix`, and `clojure.rust.net` |
 | `src/tcp.rs` | `TcpStreamResource`, `TcpListenerResource`, connection builder, accept loop, `connect`/`listen`/`close` builtins |
 | `src/frame.rs` | `FramerSpec` native object, stateful framers (`LinesFramer`, `DelimiterFramer`, `LengthPrefixedFramer`), `frame`/encode builtins |
 | `src/udp.rs` | `UdpSocketResource`, reader/writer tasks, `socket`/`close` builtins |
 | `src/tls.rs` | `TlsStreamResource`, `TlsListenerResource`, generic reader/writer loops, `build_client_config`, `build_server_config`, `tls_connect_to`/`tls_listen_on`/`connect`/`listen`/`close` builtins |
+| `src/unix.rs` | `UnixStreamResource`, `UnixListenerResource` (`close` unlinks path), reader/writer loops, accept loop, `connect`/`listen`/`close` builtins; `#[cfg(unix)]` with non-Unix stubs |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
 | `src/clojure_rust_net_udp.cljrs` | Clojure source for `clojure.rust.net.udp`; usage examples |
 | `src/clojure_rust_net_tls.cljrs` | Clojure source for `clojure.rust.net.tls`; `start-server` sugar |
-| `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net`; dispatches on `:transport` |
+| `src/clojure_rust_net_unix.cljrs` | Clojure source for `clojure.rust.net.unix`; `start-server` sugar |
+| `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net`; dispatches on `:transport` (`:tcp`, `:tls`, `:unix`) |
 | `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
 | `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |
 | `tests/framing.rs` | Phase C integration tests (lines + length-prefixed end-to-end, framer unit tests) |
 | `tests/udp.rs` | Phase D integration tests (echo round-trip, multiple senders, close) |
 | `tests/tls.rs` | Phase E integration tests (TLS echo round-trip with rcgen self-signed cert, connect failure) |
+| `tests/unix.rs` | Phase F integration tests (Unix echo round-trip, listener unlinks path, stale socket removal) |
 
 ## Public API
 
@@ -98,13 +101,38 @@
 ;; => server-map — spawns go-loop that calls (handler conn) for each accepted TLS conn
 ```
 
+### `clojure.rust.net.unix`
+
+Unix-domain stream sockets. `#[cfg(unix)]` — only on Unix targets; non-Unix
+builds register stub functions that throw "not supported on this platform".
+
+```clojure
+;; Phase F — Unix client
+(connect {:path "/tmp/app.sock"})
+;; => promise-chan — yields {:in ch :out ch :remote-addr str :local-addr str :resource h}
+;;    :remote-addr / :local-addr are filesystem paths (empty for unnamed sockets)
+;; Optional keys: :in-buf, :out-buf (default 8)
+
+(close conn)         ;; => nil — closes :in/:out and aborts reader/writer tasks
+
+;; Phase F — Unix server
+(listen {:path "/tmp/app.sock"})
+;; => {:conns <chan> :local-addr "/tmp/app.sock" :resource h}
+;;    (close server) also unlinks the socket file
+
+(listen-close server) ;; => nil — stops accept loop, unlinks socket path, closes :conns
+
+(start-server handler {:path "/tmp/app.sock"})
+;; => server-map — spawns go-loop that calls (handler conn) for each accepted conn
+```
+
 ### `clojure.rust.net` (umbrella)
 
 ```clojure
-(connect opts)            ;; delegates to tcp/connect; :transport key (default :tcp)
-(listen opts)             ;; delegates to tcp/listen; :transport key (default :tcp)
-(start-server handler opts) ;; delegates to tcp/start-server
-(close x)                 ;; dispatches on :conns key: server → listen-close, else → close
+(connect opts)            ;; :transport key selects :tcp (default), :tls, or :unix
+(listen opts)             ;; :transport key selects :tcp (default), :tls, or :unix
+(start-server handler opts) ;; :transport key selects :tcp (default), :tls, or :unix
+(close x)                 ;; dispatches on map shape: :conns → server close, :remote-addr → conn close, else → udp close
 ```
 
 ### `clojure.rust.net.udp`
@@ -132,6 +160,8 @@ pub fn tls::tls_connect_to(host: &str, port: u16, config: Arc<rustls::ClientConf
 pub fn tls::tls_listen_on(host: &str, port: u16, config: Arc<rustls::ServerConfig>, conns_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
 pub fn tls::build_client_config(opts: &MapValue) -> ValueResult<Arc<rustls::ClientConfig>>
 pub fn tls::build_server_config(opts: &MapValue) -> ValueResult<Arc<rustls::ServerConfig>>
+#[cfg(unix)] pub fn unix::connect_to(path: &str, in_buf: usize, out_buf: usize) -> Value
+#[cfg(unix)] pub fn unix::listen_on(path: &str, conns_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
 ```
 
 `init` registers all three namespaces, calling `cljrs_async::init` internally. Idempotent.
@@ -155,6 +185,14 @@ Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the re
 ### `TlsListenerResource`
 
 Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `tls_accept_loop` task. `close()` aborts the task, dropping the `TcpListener` and releasing the listener FD.
+
+### `UnixStreamResource` (`#[cfg(unix)]`)
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks, dropping the Unix stream halves and releasing the FD.
+
+### `UnixListenerResource` (`#[cfg(unix)]`)
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `accept_loop` task and the socket's filesystem `path`. `close()` aborts the task and **unlinks the socket path** via `std::fs::remove_file`, so the next `listen_on` on the same path does not get EADDRINUSE. `listen_on` also pre-unlinks any stale socket file before binding.
 
 ## Connection Model
 

--- a/crates/cljrs-net/src/clojure_rust_net.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net.cljrs
@@ -3,6 +3,7 @@
 (require 'clojure.rust.net.tcp)
 (require 'clojure.rust.net.tls)
 (require 'clojure.rust.net.udp)
+(require 'clojure.rust.net.unix)
 
 (defn connect
   "Connect to a remote host. Returns a promise channel that yields a connection
@@ -10,44 +11,56 @@
   the handshake completes, or a Value::Error on failure.
 
   Opts:
-    :host          string (required)
-    :port          integer (required, 1-65535)
-    :transport     :tcp (default), :tls
+    :host          string (required for :tcp/:tls)
+    :port          integer (required for :tcp/:tls, 1-65535)
+    :path          string (required for :unix)
+    :transport     :tcp (default), :tls, :unix
     :in-buf        channel buffer depth for :in (default 8)
     :out-buf       channel buffer depth for :out (default 8)"
   [opts]
   (let [transport (get opts :transport :tcp)]
     (case transport
-      :tcp (clojure.rust.net.tcp/connect opts)
-      :tls (clojure.rust.net.tls/connect opts)
+      :tcp  (clojure.rust.net.tcp/connect opts)
+      :tls  (clojure.rust.net.tls/connect opts)
+      :unix (clojure.rust.net.unix/connect opts)
       (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
 
 (defn listen
-  "Listen on a TCP port. Returns a server map {:conns <chan> :local-addr str :resource handle}.
-  The :conns channel yields a connection map for each accepted socket; it closes when the
-  listener closes. Bounded :conns buffer applies accept backpressure.
+  "Listen for incoming connections. Returns a server map
+  {:conns <chan> :local-addr str :resource handle}.
+  The :conns channel yields a connection map for each accepted socket; it closes
+  when the listener closes. Bounded :conns buffer applies accept backpressure.
 
   Opts:
-    :port       integer (required, 1-65535)
-    :host       string (default \"0.0.0.0\")
-    :transport  :tcp (default), :tls
+    :port       integer (required for :tcp/:tls, 1-65535)
+    :host       string (default \"0.0.0.0\", :tcp/:tls only)
+    :path       string (required for :unix)
+    :transport  :tcp (default), :tls, :unix
     :conns-buf  buffer depth for :conns (default 8)
     :in-buf     per-connection :in buffer (default 8)
     :out-buf    per-connection :out buffer (default 8)"
   [opts]
   (let [transport (get opts :transport :tcp)]
     (case transport
-      :tcp (clojure.rust.net.tcp/listen opts)
-      :tls (clojure.rust.net.tls/listen opts)
+      :tcp  (clojure.rust.net.tcp/listen opts)
+      :tls  (clojure.rust.net.tls/listen opts)
+      :unix (clojure.rust.net.unix/listen opts)
       (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
 
 (defn start-server
-  "Start a TCP server, calling handler for each accepted connection.
+  "Start a server, calling handler for each accepted connection.
   Sugar over listen: spawns a go-loop that drains :conns and calls handler.
   Returns the server map. The handler runs synchronously in the accept loop —
-  use (go ...) inside it to avoid blocking new accepts."
+  use (go ...) inside it to avoid blocking new accepts.
+
+  :transport key selects the transport (:tcp default, :tls, :unix)."
   [handler opts]
-  (clojure.rust.net.tcp/start-server handler opts))
+  (let [transport (get opts :transport :tcp)]
+    (case transport
+      :tcp  (clojure.rust.net.tcp/start-server handler opts)
+      :tls  (clojure.rust.net.tls/start-server handler opts)
+      :unix (clojure.rust.net.unix/start-server handler opts)
+      (throw (ex-info (str "unsupported transport: " transport) {:transport transport})))))
 
 (defn socket
   "Create a UDP datagram socket. Returns a socket map:
@@ -67,10 +80,11 @@
 (defn close
   "Close a connection, server, or UDP socket map, releasing its socket and channels.
 
-  For TCP connections (:remote-addr present): closes :out (signals writer to drain
-  and half-close), closes :in, and aborts reader/writer tasks via :resource.
-  For TCP servers (:conns present): stops the accept loop, closes the listener FD,
-  and closes :conns.
+  For stream connections (:remote-addr present — TCP, Unix, TLS): closes :out
+  (signals writer to drain and half-close), closes :in, and aborts reader/writer
+  tasks via :resource.
+  For servers (:conns present — TCP, Unix, TLS): stops the accept loop, closes
+  the listener FD (Unix listeners also unlink the socket path), and closes :conns.
   For UDP sockets: closes :in, :out, and aborts reader/writer tasks via :resource."
   [x]
   (cond

--- a/crates/cljrs-net/src/clojure_rust_net_unix.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_unix.cljrs
@@ -1,0 +1,45 @@
+;; clojure.rust.net.unix — Unix-domain stream sockets.
+;;
+;; Only available on Unix targets. On non-Unix targets all functions throw
+;; a "not supported on this platform" error.
+;;
+;; Native builtins (registered from Rust, #[cfg(unix)]):
+;;   connect      — (connect {:path "/tmp/app.sock"}) => promise-chan -> conn-map
+;;   close        — (close conn) => nil
+;;   listen       — (listen {:path "/tmp/app.sock"}) => {:conns ch :local-addr str :resource h}
+;;   listen-close — (listen-close server) => nil
+;;
+;; Connection map (same shape as TCP):
+;;   {:in          <chan>   ; byte-array chunks; closed at EOF
+;;    :out         <chan>   ; put byte-array/string values here
+;;    :remote-addr "..."   ; peer path, or empty for unnamed peers
+;;    :local-addr  "..."   ; local path, or empty for unnamed sockets
+;;    :resource    <handle>}
+;;
+;; Server map (same shape as TCP):
+;;   {:conns      <chan>   ; yields connection maps; closed when listener closes
+;;    :local-addr "..."   ; socket file path
+;;    :resource   <handle>}  ; close() unlinks the socket path
+
+(defn start-server
+  "Start a Unix-socket server with `handler` called for each accepted connection.
+  Returns the server map {:conns <chan> :local-addr str :resource handle}.
+
+  `handler` is called with a connection map for each accepted connection.
+  Use (go ...) inside the handler to avoid blocking new accepts.
+
+  Opts:
+    :path       string (required) — filesystem path for the socket file
+    :conns-buf  buffer depth for :conns (default 8)
+    :in-buf     per-connection :in buffer (default 8)
+    :out-buf    per-connection :out buffer (default 8)"
+  [handler opts]
+  (let [server (clojure.rust.net.unix/listen opts)
+        conns  (:conns server)]
+    (clojure.core.async/go
+      (loop []
+        (let [conn (await (clojure.core.async/take! conns))]
+          (when (some? conn)
+            (handler conn)
+            (recur)))))
+    server))

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -1,4 +1,4 @@
-//! Networking for clojurust — TCP, UDP over core.async channels.
+//! Networking for clojurust — TCP, Unix, UDP, TLS over core.async channels.
 //!
 //! # Usage
 //!
@@ -20,6 +20,7 @@ pub mod frame;
 pub mod tcp;
 pub mod tls;
 pub mod udp;
+pub mod unix;
 
 /// Clojure source for `clojure.rust.net.tcp`.
 const NET_TCP_SOURCE: &str = include_str!("clojure_rust_net_tcp.cljrs");
@@ -36,11 +37,15 @@ const NET_UDP_SOURCE: &str = include_str!("clojure_rust_net_udp.cljrs");
 /// Clojure source for `clojure.rust.net.tls`.
 const NET_TLS_SOURCE: &str = include_str!("clojure_rust_net_tls.cljrs");
 
+/// Clojure source for `clojure.rust.net.unix`.
+const NET_UNIX_SOURCE: &str = include_str!("clojure_rust_net_unix.cljrs");
+
 pub const NS_TCP: &str = "clojure.rust.net.tcp";
 pub const NS: &str = "clojure.rust.net";
 pub const NS_FRAME: &str = "clojure.rust.net.frame";
 pub const NS_UDP: &str = "clojure.rust.net.udp";
 pub const NS_TLS: &str = "clojure.rust.net.tls";
+pub const NS_UNIX: &str = "clojure.rust.net.unix";
 
 /// Register the networking namespaces.
 ///
@@ -79,6 +84,14 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         tls::register(globals, NS_TLS);
         load_source(globals, NS_TLS, NET_TLS_SOURCE);
         globals.mark_loaded(NS_TLS);
+    }
+
+    if !globals.is_loaded(NS_UNIX) {
+        globals.get_or_create_ns(NS_UNIX);
+        globals.refer_all(NS_UNIX, "clojure.core");
+        unix::register(globals, NS_UNIX);
+        load_source(globals, NS_UNIX, NET_UNIX_SOURCE);
+        globals.mark_loaded(NS_UNIX);
     }
 
     if !globals.is_loaded(NS) {

--- a/crates/cljrs-net/src/unix.rs
+++ b/crates/cljrs-net/src/unix.rs
@@ -445,8 +445,7 @@ fn builtin_connect(args: &[Value]) -> ValueResult<Value> {
             });
         }
     };
-    let path =
-        opts_str(&opts, "path").ok_or_else(|| ValueError::Other(":path required".into()))?;
+    let path = opts_str(&opts, "path").ok_or_else(|| ValueError::Other(":path required".into()))?;
     let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
     let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
     Ok(connect_to(&path, in_buf, out_buf))
@@ -492,8 +491,7 @@ fn builtin_listen(args: &[Value]) -> ValueResult<Value> {
             });
         }
     };
-    let path =
-        opts_str(&opts, "path").ok_or_else(|| ValueError::Other(":path required".into()))?;
+    let path = opts_str(&opts, "path").ok_or_else(|| ValueError::Other(":path required".into()))?;
     let conns_buf = opts_usize(&opts, "conns-buf").unwrap_or(8);
     let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
     let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);

--- a/crates/cljrs-net/src/unix.rs
+++ b/crates/cljrs-net/src/unix.rs
@@ -1,0 +1,552 @@
+//! Unix-domain stream socket support for `clojure.rust.net.unix`.
+//!
+//! `#[cfg(unix)]` — full implementation on Unix targets (Linux, macOS, etc.).
+//! On non-Unix targets every registered function returns a clear
+//! "not supported on this platform" error.
+//!
+//! Connection shape (identical to TCP):
+//! ```clojure
+//! {:in          <chan>   ; byte-array chunks; closed at EOF
+//!  :out         <chan>   ; put byte-array/string values here
+//!  :remote-addr "..."   ; peer socket path, or empty for unnamed peers
+//!  :local-addr  "..."   ; local socket path, or empty for unnamed sockets
+//!  :resource    <handle>}  ; UnixStreamResource — deterministic close
+//! ```
+//!
+//! Server shape (identical to TCP):
+//! ```clojure
+//! {:conns      <chan>     ; yields a connection map per accepted socket
+//!  :local-addr "..."     ; socket file path
+//!  :resource   <handle>} ; UnixListenerResource — close() unlinks the path
+//! ```
+
+use std::sync::Arc;
+
+use cljrs_env::env::GlobalEnv;
+use cljrs_gc::GcPtr;
+use cljrs_value::{Arity, NativeFn, Value, ValueError, ValueResult};
+
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        ("connect", Arity::Fixed(1), builtin_connect),
+        ("close", Arity::Fixed(1), builtin_close),
+        ("listen", Arity::Fixed(1), builtin_listen),
+        ("listen-close", Arity::Fixed(1), builtin_listen_close),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── Unix target ───────────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+use std::{any::Any, sync::Mutex};
+
+#[cfg(unix)]
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, chan_take, make_chan};
+#[cfg(unix)]
+use cljrs_async::spawn_future;
+#[cfg(unix)]
+use cljrs_env::error::EvalResult;
+#[cfg(unix)]
+use cljrs_value::{ExceptionInfo, Keyword, MapValue, NativeObjectBox, Resource, ResourceHandle};
+#[cfg(unix)]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(unix)]
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+#[cfg(unix)]
+use tokio::task::AbortHandle;
+
+// ── Value helpers (unix only) ─────────────────────────────────────────────────
+
+#[cfg(unix)]
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+#[cfg(unix)]
+fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+#[cfg(unix)]
+fn net_error(msg: impl Into<String>) -> Value {
+    let msg = msg.into();
+    Value::Error(GcPtr::new(ExceptionInfo::new(
+        ValueError::Other(msg.clone()),
+        msg,
+        None,
+        None,
+    )))
+}
+
+#[cfg(unix)]
+fn opts_str(opts: &MapValue, key: &str) -> Option<String> {
+    match opts.get(&kw(key))? {
+        Value::Str(s) => Some(s.get().clone()),
+        _ => None,
+    }
+}
+
+#[cfg(unix)]
+fn opts_usize(opts: &MapValue, key: &str) -> Option<usize> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n >= 0 => Some((n as usize).max(1)),
+        _ => None,
+    }
+}
+
+// ── UnixStreamResource ────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct UnixStreamInner {
+    closed: bool,
+    reader_abort: Option<AbortHandle>,
+    writer_abort: Option<AbortHandle>,
+}
+
+/// `Resource` for a Unix-domain stream connection.
+///
+/// Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both,
+/// which drops the socket halves and releases the FD. The GC never finalises the
+/// socket — this Arc-backed resource is the sole cleanup path.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct UnixStreamResource {
+    inner: Arc<Mutex<UnixStreamInner>>,
+}
+
+#[cfg(unix)]
+impl UnixStreamResource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(UnixStreamInner {
+                closed: false,
+                reader_abort: None,
+                writer_abort: None,
+            })),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Resource for UnixStreamResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        if let Some(h) = g.reader_abort.take() {
+            h.abort();
+        }
+        if let Some(h) = g.writer_abort.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "UnixStream"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── UnixListenerResource ──────────────────────────────────────────────────────
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct UnixListenerInner {
+    closed: bool,
+    accept_abort: Option<AbortHandle>,
+    path: std::path::PathBuf,
+}
+
+/// `Resource` for a Unix-domain socket listener.
+///
+/// Holds the `AbortHandle` for the accept-loop task. `close()` aborts the task
+/// and **unlinks the socket path** from the filesystem, so a subsequent `listen`
+/// on the same path succeeds without EADDRINUSE.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct UnixListenerResource {
+    inner: Arc<Mutex<UnixListenerInner>>,
+}
+
+#[cfg(unix)]
+impl UnixListenerResource {
+    fn new(path: std::path::PathBuf) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(UnixListenerInner {
+                closed: false,
+                accept_abort: None,
+                path,
+            })),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Resource for UnixListenerResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        if let Some(h) = g.accept_abort.take() {
+            h.abort();
+        }
+        // Unlink the socket file; ignore error if already gone.
+        let _ = std::fs::remove_file(&g.path);
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "UnixListener"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Async tasks ───────────────────────────────────────────────────────────────
+
+/// Read chunks from the socket and put them on `:in`.
+///
+/// Closes `:in` at EOF or on error (after putting the error value). Aborted via
+/// `UnixStreamResource::close` when the user calls `(close conn)`.
+#[cfg(unix)]
+async fn reader_loop(mut read_half: OwnedReadHalf, in_chan: GcPtr<NativeObjectBox>) {
+    let mut buf = vec![0u8; 8192];
+    loop {
+        match read_half.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                if !chan_put(&in_chan, bytes_value(&buf[..n])).await {
+                    break; // consumer closed :in
+                }
+            }
+            Err(e) => {
+                chan_put(&in_chan, net_error(format!("unix read error: {e}"))).await;
+                break;
+            }
+        }
+    }
+    chan_ref(in_chan.get()).close();
+}
+
+/// Drain `:out` and write each value to the socket.
+///
+/// Accepts `byte-array` and `string` values. Calls `shutdown` on the write half
+/// when `:out` is closed (half-close: FIN without RST). Aborted via
+/// `UnixStreamResource::close` when the user calls `(close conn)`.
+#[cfg(unix)]
+async fn writer_loop(mut write_half: OwnedWriteHalf, out_chan: GcPtr<NativeObjectBox>) {
+    let _: std::io::Result<()> = async {
+        loop {
+            match chan_take(&out_chan).await {
+                Value::Nil => {
+                    let _ = write_half.shutdown().await;
+                    break;
+                }
+                Value::ByteArray(arr) => {
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    write_half.write_all(&bytes).await?;
+                }
+                Value::Str(s) => {
+                    write_half.write_all(s.get().as_bytes()).await?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+    .await;
+}
+
+// ── Connection builder ────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+fn make_connection(stream: tokio::net::UnixStream, in_buf: usize, out_buf: usize) -> Value {
+    let remote_addr = stream
+        .peer_addr()
+        .ok()
+        .and_then(|a| a.as_pathname().map(|p| p.to_string_lossy().into_owned()))
+        .unwrap_or_default();
+    let local_addr = stream
+        .local_addr()
+        .ok()
+        .and_then(|a| a.as_pathname().map(|p| p.to_string_lossy().into_owned()))
+        .unwrap_or_default();
+    let (read_half, write_half) = stream.into_split();
+    let in_chan = make_chan(in_buf);
+    let out_chan = make_chan(out_buf);
+    let resource = UnixStreamResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+    let r_jh = tokio::task::spawn_local(reader_loop(read_half, in_chan.clone()));
+    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
+    let w_jh = tokio::task::spawn_local(writer_loop(write_half, out_chan.clone()));
+    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
+    Value::Map(MapValue::from_pairs(vec![
+        (kw("in"), Value::NativeObject(in_chan)),
+        (kw("out"), Value::NativeObject(out_chan)),
+        (kw("remote-addr"), Value::string(remote_addr)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]))
+}
+
+// ── Accept loop ───────────────────────────────────────────────────────────────
+
+/// Accept connections from `listener` and put each connection map on `conns_chan`.
+///
+/// Exits on accept error or when the consumer closes `conns_chan`. Closes
+/// `conns_chan` after exiting so consumers see EOF.
+#[cfg(unix)]
+async fn accept_loop(
+    listener: tokio::net::UnixListener,
+    conns_chan: GcPtr<NativeObjectBox>,
+    in_buf: usize,
+    out_buf: usize,
+) {
+    loop {
+        match listener.accept().await {
+            Err(e) => {
+                chan_put(&conns_chan, net_error(format!("unix accept error: {e}"))).await;
+                break;
+            }
+            Ok((stream, _)) => {
+                let conn = make_connection(stream, in_buf, out_buf);
+                if !chan_put(&conns_chan, conn).await {
+                    break; // consumer closed :conns
+                }
+            }
+        }
+    }
+    chan_ref(conns_chan.get()).close();
+}
+
+// ── Public Rust API ───────────────────────────────────────────────────────────
+
+/// Connect to the Unix-domain socket at `path`. Returns a capacity-1 promise
+/// channel that yields the connection map once connected, or a `Value::Error`
+/// on failure.
+#[cfg(unix)]
+pub fn connect_to(path: &str, in_buf: usize, out_buf: usize) -> Value {
+    let path = path.to_string();
+    let promise = make_chan(1);
+    let promise_val = Value::NativeObject(promise.clone());
+    spawn_future(async move { do_connect(path, in_buf, out_buf, promise).await });
+    promise_val
+}
+
+#[cfg(unix)]
+async fn do_connect(
+    path: String,
+    in_buf: usize,
+    out_buf: usize,
+    promise: GcPtr<NativeObjectBox>,
+) -> EvalResult {
+    let stream = match tokio::net::UnixStream::connect(&path).await {
+        Ok(s) => s,
+        Err(e) => {
+            chan_deliver(&promise, net_error(format!("unix connect to {path}: {e}"))).await;
+            return Ok(Value::Nil);
+        }
+    };
+    chan_deliver(&promise, make_connection(stream, in_buf, out_buf)).await;
+    Ok(Value::Nil)
+}
+
+/// Bind a Unix listener at `path` and return a server map.
+///
+/// Removes any existing socket file at `path` before binding so that a
+/// server restart after a crash does not get EADDRINUSE.
+///
+/// Convenience function used by tests and the Clojure `listen` builtin alike.
+#[cfg(unix)]
+pub fn listen_on(
+    path: &str,
+    conns_buf: usize,
+    in_buf: usize,
+    out_buf: usize,
+) -> ValueResult<Value> {
+    let path_buf = std::path::PathBuf::from(path);
+
+    // Remove any stale socket file; ignore errors (file may not exist).
+    let _ = std::fs::remove_file(&path_buf);
+
+    // Bind synchronously (std), then wrap as tokio (requires runtime context).
+    let std_listener = std::os::unix::net::UnixListener::bind(&path_buf)
+        .map_err(|e| ValueError::Other(format!("unix listen on {path}: {e}")))?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| ValueError::Other(format!("set_nonblocking: {e}")))?;
+    let listener = tokio::net::UnixListener::from_std(std_listener)
+        .map_err(|e| ValueError::Other(format!("from_std: {e}")))?;
+
+    let local_addr = listener
+        .local_addr()
+        .ok()
+        .and_then(|a| a.as_pathname().map(|p| p.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| path.to_string());
+
+    let conns_chan = make_chan(conns_buf);
+    let resource = UnixListenerResource::new(path_buf);
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    let jh = tokio::task::spawn_local(accept_loop(listener, conns_chan.clone(), in_buf, out_buf));
+    shared_inner.lock().unwrap().accept_abort = Some(jh.abort_handle());
+
+    Ok(Value::Map(MapValue::from_pairs(vec![
+        (kw("conns"), Value::NativeObject(conns_chan)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ])))
+}
+
+// ── Builtins — unix ───────────────────────────────────────────────────────────
+
+/// `(connect {:path "/tmp/app.sock"})` — returns a capacity-1 promise channel
+/// that yields the connection map once connected, or a `Value::Error` on failure.
+/// Optional keys: `:in-buf` (default 8), `:out-buf` (default 8).
+#[cfg(unix)]
+fn builtin_connect(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:path str}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let path =
+        opts_str(&opts, "path").ok_or_else(|| ValueError::Other(":path required".into()))?;
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+    Ok(connect_to(&path, in_buf, out_buf))
+}
+
+/// `(close conn)` — close a Unix-socket connection map.
+#[cfg(unix)]
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let conn = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "connection map",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    if let Some(Value::NativeObject(obj)) = conn.get(&kw("out")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::NativeObject(obj)) = conn.get(&kw("in")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::Resource(handle)) = conn.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+    Ok(Value::Nil)
+}
+
+/// `(listen {:path "/tmp/app.sock"})` — bind a Unix listener and return a server map.
+///
+/// The `:conns` channel yields a connection map for each accepted socket and is
+/// closed when the listener closes. Optional keys: `:conns-buf` (default 8),
+/// `:in-buf` (default 8), `:out-buf` (default 8).
+#[cfg(unix)]
+fn builtin_listen(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:path str}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let path =
+        opts_str(&opts, "path").ok_or_else(|| ValueError::Other(":path required".into()))?;
+    let conns_buf = opts_usize(&opts, "conns-buf").unwrap_or(8);
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+    listen_on(&path, conns_buf, in_buf, out_buf)
+}
+
+/// `(listen-close server)` — stop the accept loop and close the `:conns` channel.
+#[cfg(unix)]
+fn builtin_listen_close(args: &[Value]) -> ValueResult<Value> {
+    let server = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "server map {:conns ch :resource handle}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    if let Some(Value::Resource(handle)) = server.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+    if let Some(Value::NativeObject(obj)) = server.get(&kw("conns")) {
+        chan_ref(obj.get()).close();
+    }
+    Ok(Value::Nil)
+}
+
+// ── Builtins — non-unix stubs ─────────────────────────────────────────────────
+
+#[cfg(not(unix))]
+fn builtin_connect(_args: &[Value]) -> ValueResult<Value> {
+    Err(ValueError::Other(
+        "clojure.rust.net.unix: Unix domain sockets are not supported on this platform".into(),
+    ))
+}
+
+#[cfg(not(unix))]
+fn builtin_close(_args: &[Value]) -> ValueResult<Value> {
+    Err(ValueError::Other(
+        "clojure.rust.net.unix: Unix domain sockets are not supported on this platform".into(),
+    ))
+}
+
+#[cfg(not(unix))]
+fn builtin_listen(_args: &[Value]) -> ValueResult<Value> {
+    Err(ValueError::Other(
+        "clojure.rust.net.unix: Unix domain sockets are not supported on this platform".into(),
+    ))
+}
+
+#[cfg(not(unix))]
+fn builtin_listen_close(_args: &[Value]) -> ValueResult<Value> {
+    Err(ValueError::Other(
+        "clojure.rust.net.unix: Unix domain sockets are not supported on this platform".into(),
+    ))
+}

--- a/crates/cljrs-net/tests/framing.rs
+++ b/crates/cljrs-net/tests/framing.rs
@@ -68,7 +68,7 @@ async fn setup_connection() -> (cljrs_value::MapValue, cljrs_value::MapValue) {
         Value::Str(s) => s.get().clone(),
         other => panic!("expected str :local-addr, got {}", other.type_name()),
     };
-    let port: u16 = local_addr.split(':').last().unwrap().parse().unwrap();
+    let port: u16 = local_addr.split(':').next_back().unwrap().parse().unwrap();
 
     // Start connecting — the promise resolves once the server accepts.
     let promise = cljrs_net::tcp::connect_to("127.0.0.1", port, 8, 8);

--- a/crates/cljrs-net/tests/tcp_server.rs
+++ b/crates/cljrs-net/tests/tcp_server.rs
@@ -56,7 +56,7 @@ fn test_listen_echo_round_trip() {
             Value::Str(s) => s.get().clone(),
             other => panic!("expected str :local-addr, got {}", other.type_name()),
         };
-        let port: u16 = local_addr.split(':').last().unwrap().parse().unwrap();
+        let port: u16 = local_addr.split(':').next_back().unwrap().parse().unwrap();
 
         let conns_ch = as_chan(&map_get(&server_map, "conns"));
 

--- a/crates/cljrs-net/tests/tls.rs
+++ b/crates/cljrs-net/tests/tls.rs
@@ -93,7 +93,7 @@ fn test_tls_echo_round_trip() {
             Value::Str(s) => s.get().clone(),
             other => panic!("expected str :local-addr, got {}", other.type_name()),
         };
-        let port: u16 = local_addr.split(':').last().unwrap().parse().unwrap();
+        let port: u16 = local_addr.split(':').next_back().unwrap().parse().unwrap();
 
         let conns_ch = as_chan(&map_get(&server_map, "conns"));
 

--- a/crates/cljrs-net/tests/udp.rs
+++ b/crates/cljrs-net/tests/udp.rs
@@ -57,7 +57,7 @@ fn test_udp_echo_round_trip() {
         };
         let server_port: u16 = server_local_addr
             .split(':')
-            .last()
+            .next_back()
             .unwrap()
             .parse()
             .unwrap();
@@ -115,7 +115,7 @@ fn test_udp_echo_round_trip() {
                 match dgram.get(&kw("addr")) {
                     Some(Value::Str(s)) => {
                         let addr = s.get();
-                        let echo_port: u16 = addr.split(':').last().unwrap().parse().unwrap();
+                        let echo_port: u16 = addr.split(':').next_back().unwrap().parse().unwrap();
                         assert_eq!(
                             echo_port, server_port,
                             ":addr port must be server's port; got {addr}"
@@ -206,7 +206,7 @@ fn test_udp_multiple_senders() {
             other => panic!("expected socket map, got {}", other.type_name()),
         };
         let server_port: u16 = match map_get(&server_map, "local-addr") {
-            Value::Str(s) => s.get().split(':').last().unwrap().parse().unwrap(),
+            Value::Str(s) => s.get().split(':').next_back().unwrap().parse().unwrap(),
             _ => panic!("expected str :local-addr"),
         };
         let server_in = as_chan(&map_get(&server_map, "in"));
@@ -218,7 +218,7 @@ fn test_udp_multiple_senders() {
             _ => panic!("expected socket map"),
         };
         let client_a_port: u16 = match map_get(&client_a_map, "local-addr") {
-            Value::Str(s) => s.get().split(':').last().unwrap().parse().unwrap(),
+            Value::Str(s) => s.get().split(':').next_back().unwrap().parse().unwrap(),
             _ => panic!("expected str"),
         };
         let client_a_out = as_chan(&map_get(&client_a_map, "out"));
@@ -230,7 +230,7 @@ fn test_udp_multiple_senders() {
             _ => panic!("expected socket map"),
         };
         let client_b_port: u16 = match map_get(&client_b_map, "local-addr") {
-            Value::Str(s) => s.get().split(':').last().unwrap().parse().unwrap(),
+            Value::Str(s) => s.get().split(':').next_back().unwrap().parse().unwrap(),
             _ => panic!("expected str"),
         };
         let client_b_out = as_chan(&map_get(&client_b_map, "out"));
@@ -275,7 +275,7 @@ fn test_udp_multiple_senders() {
             match chan_take(&server_in).await {
                 Value::Map(dgram) => match dgram.get(&kw("addr")) {
                     Some(Value::Str(s)) => {
-                        let p: u16 = s.get().split(':').last().unwrap().parse().unwrap();
+                        let p: u16 = s.get().split(':').next_back().unwrap().parse().unwrap();
                         received_ports.push(p);
                     }
                     _ => panic!("expected :addr string"),

--- a/crates/cljrs-net/tests/unix.rs
+++ b/crates/cljrs-net/tests/unix.rs
@@ -1,0 +1,258 @@
+//! Phase F integration tests: Unix-domain stream sockets — echo round-trip.
+//!
+//! Done criterion from networking-plan.md Phase F:
+//!   "a Unix-socket echo server round-trips with a Unix-socket client."
+//!
+//! All tests are `#[cfg(unix)]`; on non-Unix targets this file compiles to an
+//! empty module.
+
+#[cfg(unix)]
+mod unix_tests {
+    use std::sync::Arc;
+
+    use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+    use cljrs_gc::GcPtr;
+    use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
+
+    fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+        let globals = cljrs_stdlib::standard_env();
+        cljrs_net::init(&globals);
+        globals
+    }
+
+    fn kw(name: &str) -> Value {
+        Value::keyword(Keyword::simple(name))
+    }
+
+    fn map_get(map: &MapValue, key: &str) -> Value {
+        map.get(&kw(key))
+            .unwrap_or_else(|| panic!("map missing :{key}"))
+    }
+
+    fn as_chan(v: &Value) -> GcPtr<NativeObjectBox> {
+        match v {
+            Value::NativeObject(obj) => obj.clone(),
+            other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+        }
+    }
+
+    /// Unique socket path per test — PID + suffix avoids collisions in parallel runs.
+    fn sock(suffix: &str) -> String {
+        format!("/tmp/cljrs_net_unix_{}_{suffix}.sock", std::process::id())
+    }
+
+    // ── Phase F done criterion ────────────────────────────────────────────────
+
+    /// Echo server built from `listen_on` + accept handler round-trips bytes.
+    #[test]
+    fn test_unix_echo_round_trip() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let local = tokio::task::LocalSet::new();
+
+        local.block_on(&rt, async {
+            let _globals = setup_globals();
+
+            let path = sock("echo");
+
+            let server_val =
+                cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
+            let server_map = match server_val {
+                Value::Map(m) => m,
+                other => panic!("expected server map, got {}", other.type_name()),
+            };
+
+            let conns_ch = as_chan(&map_get(&server_map, "conns"));
+
+            // Spawn a one-shot echo handler.
+            let conns_for_handler = conns_ch.clone();
+            tokio::task::spawn_local(async move {
+                let conn_val = chan_take(&conns_for_handler).await;
+                let conn = match conn_val {
+                    Value::Map(m) => m,
+                    other => panic!("handler got non-map from :conns: {}", other.type_name()),
+                };
+                let in_ch = as_chan(&map_get(&conn, "in"));
+                let out_ch = as_chan(&map_get(&conn, "out"));
+                loop {
+                    match chan_take(&in_ch).await {
+                        Value::Nil => break,
+                        val => {
+                            chan_put(&out_ch, val).await;
+                        }
+                    }
+                }
+                chan_ref(out_ch.get()).close();
+            });
+
+            // Connect a client.
+            let promise = cljrs_net::unix::connect_to(&path, 8, 8);
+            let conn_val = chan_take(&as_chan(&promise)).await;
+            let conn = match conn_val {
+                Value::Map(m) => m,
+                Value::Error(e) => panic!("connect failed: {}", e.get().message()),
+                other => panic!("expected conn map, got {}", other.type_name()),
+            };
+
+            let out_ch = as_chan(&map_get(&conn, "out"));
+            let in_ch = as_chan(&map_get(&conn, "in"));
+
+            // Send request and half-close the write side.
+            let request = b"phase F unix socket echo test";
+            let signed: Vec<i8> = request.iter().map(|&b| b as i8).collect();
+            chan_put(
+                &out_ch,
+                Value::ByteArray(GcPtr::new(std::sync::Mutex::new(signed))),
+            )
+            .await;
+            chan_ref(out_ch.get()).close();
+
+            // Drain :in until EOF, collecting echoed bytes.
+            let mut response: Vec<u8> = Vec::new();
+            loop {
+                match chan_take(&in_ch).await {
+                    Value::Nil => break,
+                    Value::ByteArray(arr) => {
+                        let bytes: Vec<u8> =
+                            arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                        response.extend_from_slice(&bytes);
+                    }
+                    Value::Error(e) => panic!("read error: {}", e.get().message()),
+                    other => panic!("unexpected value on :in: {}", other.type_name()),
+                }
+            }
+
+            assert_eq!(response, request, "echo server must return the same bytes");
+
+            // Close the listener; this also unlinks the socket path.
+            match map_get(&server_map, "resource") {
+                Value::Resource(handle) => {
+                    let _ = handle.close();
+                }
+                other => panic!("expected resource, got {}", other.type_name()),
+            }
+        });
+    }
+
+    // ── Server lifecycle ──────────────────────────────────────────────────────
+
+    /// Closing the server resource closes :conns so consumers see nil.
+    #[test]
+    fn test_close_unix_server_closes_conns() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let local = tokio::task::LocalSet::new();
+
+        local.block_on(&rt, async {
+            let _globals = setup_globals();
+
+            let path = sock("close_conns");
+
+            let server_val =
+                cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
+            let server_map = match server_val {
+                Value::Map(m) => m,
+                other => panic!("expected server map, got {}", other.type_name()),
+            };
+
+            let conns_ch = as_chan(&map_get(&server_map, "conns"));
+
+            match map_get(&server_map, "resource") {
+                Value::Resource(handle) => {
+                    let _ = handle.close();
+                }
+                _ => panic!("expected resource"),
+            }
+            chan_ref(conns_ch.get()).close();
+
+            let val = chan_take(&conns_ch).await;
+            assert!(
+                matches!(val, Value::Nil),
+                "expected nil from closed :conns, got {}",
+                val.type_name()
+            );
+        });
+    }
+
+    /// `UnixListenerResource::close` unlinks the socket path from the filesystem.
+    #[test]
+    fn test_unix_listener_unlinks_path() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let local = tokio::task::LocalSet::new();
+
+        local.block_on(&rt, async {
+            let _globals = setup_globals();
+
+            let path = sock("unlink");
+
+            let server_val =
+                cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
+            let server_map = match server_val {
+                Value::Map(m) => m,
+                _ => panic!("expected server map"),
+            };
+
+            assert!(
+                std::path::Path::new(&path).exists(),
+                "socket file must exist while listener is open"
+            );
+
+            match map_get(&server_map, "resource") {
+                Value::Resource(handle) => {
+                    let _ = handle.close();
+                }
+                _ => panic!("expected resource"),
+            }
+
+            // Allow the abort to propagate.
+            tokio::task::yield_now().await;
+
+            assert!(
+                !std::path::Path::new(&path).exists(),
+                "socket file must be unlinked after listener close"
+            );
+        });
+    }
+
+    /// `listen_on` on a path where a stale socket file exists succeeds (pre-unlinks).
+    #[test]
+    fn test_listen_on_removes_stale_socket() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let local = tokio::task::LocalSet::new();
+
+        local.block_on(&rt, async {
+            let _globals = setup_globals();
+
+            let path = sock("stale");
+
+            // Create a stale socket file without a listening server.
+            std::fs::write(&path, b"").expect("create stale file");
+            assert!(std::path::Path::new(&path).exists());
+
+            // listen_on should remove it and bind successfully.
+            let server_val = cljrs_net::unix::listen_on(&path, 8, 8, 8)
+                .expect("listen_on should succeed despite stale socket");
+            let server_map = match server_val {
+                Value::Map(m) => m,
+                other => panic!("expected server map, got {}", other.type_name()),
+            };
+
+            match map_get(&server_map, "resource") {
+                Value::Resource(handle) => {
+                    let _ = handle.close();
+                }
+                _ => panic!("expected resource"),
+            }
+        });
+    }
+}

--- a/crates/cljrs-net/tests/unix.rs
+++ b/crates/cljrs-net/tests/unix.rs
@@ -57,8 +57,7 @@ mod unix_tests {
 
             let path = sock("echo");
 
-            let server_val =
-                cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
+            let server_val = cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
             let server_map = match server_val {
                 Value::Map(m) => m,
                 other => panic!("expected server map, got {}", other.type_name()),
@@ -152,8 +151,7 @@ mod unix_tests {
 
             let path = sock("close_conns");
 
-            let server_val =
-                cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
+            let server_val = cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
             let server_map = match server_val {
                 Value::Map(m) => m,
                 other => panic!("expected server map, got {}", other.type_name()),
@@ -192,8 +190,7 @@ mod unix_tests {
 
             let path = sock("unlink");
 
-            let server_val =
-                cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
+            let server_val = cljrs_net::unix::listen_on(&path, 8, 8, 8).expect("listen_on failed");
             let server_map = match server_val {
                 Value::Map(m) => m,
                 _ => panic!("expected server map"),


### PR DESCRIPTION
Adds `clojure.rust.net.unix` — channel-oriented Unix domain sockets with the
same `{:in :out :remote-addr :local-addr :resource}` connection shape as TCP.

- `unix.rs`: `UnixStreamResource` and `UnixListenerResource` (Arc-backed);
  `UnixListenerResource::close` unlinks the socket path from the filesystem.
  `listen_on` pre-removes any stale socket before binding, so server restarts
  never get EADDRINUSE. Reader/writer loops mirror TCP exactly. Non-Unix targets
  get stub builtins that return a clear "not supported" error.
- `clojure_rust_net_unix.cljrs`: `start-server` sugar identical in shape to
  the TCP version.
- `lib.rs`: registers `clojure.rust.net.unix` (before the umbrella namespace).
- `clojure_rust_net.cljrs`: adds `:unix` transport case to `connect`, `listen`,
  and `start-server`; updates `close` docstring to mention Unix.
- `tests/unix.rs`: four `#[cfg(unix)]` tests — echo round-trip (Phase F done
  criterion), server-close-closes-conns, listener-unlinks-path, and
  listen-on-removes-stale-socket.
- `README.md`: updated status, file layout, public API, and resource type docs.

https://claude.ai/code/session_01RkWizt9kQHUEy9GNnRXrNM