### PR TITLE
A2: add WorkerPool and pool I/O infrastructure

### DIFF
--- a/crates/cljrs-async/Cargo.toml
+++ b/crates/cljrs-async/Cargo.toml
@@ -17,5 +17,8 @@ cljrs-interp   = { workspace = true }
 tokio          = { workspace = true, features = ["rt", "sync", "time", "macros"] }
 futures-util   = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.3", features = ["futures"] }

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -10,13 +10,12 @@ executor. All Clojure values remain on a single thread, keeping GC pointers (`!S
 
 ## Status
 
-**Phase G (GC safety for the async runtime)** — complete. GC safepoints are integrated at
-cooperative yield points. `async_gc_collect()` is called before every `yield_now().await` in
-`await_value`, and a background GC-service task (spawned by `init`) services GC requests between
-poll cycles. Explicit GC root guards protect `task_future` in `spawn_future`, callee/env in
-`run_async_fn`, and awaited futures/promises in `await_value`.
+**Phase A2 (Send worker pool)** — complete. `WorkerPool` is a singleton multi-thread Tokio runtime
+for `Send`-only byte-level work (TCP/TLS I/O, hashing, compression) that must not block the heap
+thread. Results cross back to the `LocalSet` thread as `Vec<u8>`, `String`, or primitive types over
+oneshot/mpsc channels. On `wasm32`, a stub pool runs futures locally.
 
-Done (Phases A–G):
+Done (Phases A–H, A2):
 
 - Phase A: `init()` registers the async runtime hook with the interpreter.
 - Phase B: `^:async` fn dispatch via the `AsyncRuntime` hook; `eval_async` tree-walker;
@@ -39,6 +38,10 @@ Done (Phases A–G):
   called before each `yield_now().await` in `await_value`. Background GC-service task spawned
   by `init()`. Explicit GC root guards for `task_future` in `spawn_future`, callee/env in
   `run_async_fn`, and awaited futures/promises in `await_value`.
+- Phase A2: `WorkerPool` singleton — multi-thread Tokio runtime for `Send` byte-level tasks
+  (`WorkerPool::global()`, `offload`, `handle`). Pool tasks carry only `Vec<u8>`, `String`, and
+  `Send` channel types; `GcPtr`/`Value` construction is confined to LocalSet bridge tasks.
+  wasm32 stub runs futures locally.
 - Phase H: `<!!` (blocking take) and `>!!` (blocking put) for synchronous / REPL / test
   contexts. Both use `Condvar`-based parking (with a 1 ms poll-interval fallback so they
   remain non-deadlocking when called from the LocalSet executor thread). Errors with a
@@ -123,8 +126,10 @@ blocking bridge is a later phase.
 | `src/builtins.rs` | native fns: `timeout`, `alts`, `chan`, `take!`, `put!`, `close!`, `poll!`, `offer!`, `async-spawn`, `join-all`, `thread-call`, `onto-chan!`, `to-chan!`, `mult`, `tap!`, `untap!`, `untap-all!`, `<!!`, `>!!` |
 | `src/core_async.cljrs` | Clojure source for `clojure.core.async`: `go`, `alt`, `async-pmap`, `thread`, `merge`, `reduce`, `into`, and the `<?` family (`<?`, `<??`, `go-try`) |
 | `src/clojure_rust_error.cljrs` | Clojure source for `clojure.rust.error`: in-band error helpers `error?`, `ok?`, `throw-err` |
+| `src/worker_pool.rs` | `WorkerPool` singleton: multi-thread Tokio runtime (`new_multi_thread`) for `Send` pool tasks; wasm32 stub; `offload` bridges pool results to LocalSet via oneshot; `handle` for direct multi-task spawning |
 | `tests/error_propagation.rs` | integration tests for the `<?` family and `clojure.rust.error` helpers |
 | `tests/async_fn.rs` | integration tests for dispatch, `await`, `deref` enforcement, `timeout`/`alts`/`alt`, channels, Phase F utilities, and `<!!`/`>!!` |
+| `tests/worker_pool.rs` | Phase A2 integration tests: offload, concurrent tasks, handle spawning, LocalSet context, singleton invariant, byte processing round-trip |
 
 ## Public API
 
@@ -136,6 +141,25 @@ pub fn init(globals: &Arc<GlobalEnv>);
 /// Re-exports for sibling native crates (e.g. cljrs-io) that drive their own
 /// work onto the shared LocalSet executor.
 pub use eval_async::{await_value, spawn_future};
+
+pub mod worker_pool {
+    /// Global Send-only worker pool backed by a Tokio multi-thread runtime.
+    /// On wasm32 this is a stub that runs futures locally.
+    pub struct WorkerPool { /* singleton */ }
+    impl WorkerPool {
+        /// Get (or initialize) the global singleton.
+        pub fn global() -> &'static Self;
+
+        /// Offload a Send future to the pool; the returned future can be awaited
+        /// on the LocalSet thread without blocking.
+        pub fn offload<F, T>(&self, f: F) -> impl Future<Output = T> + 'static
+        where F: Future<Output = T> + Send + 'static, T: Send + 'static;
+
+        /// Direct handle to the pool runtime for multi-task spawning (non-wasm only).
+        #[cfg(not(target_arch = "wasm32"))]
+        pub fn handle(&self) -> &tokio::runtime::Handle;
+    }
+}
 
 pub mod eval_async {
     /// Spawn `task` on the current LocalSet and return a `Value::Future` that

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -20,6 +20,7 @@ mod builtins;
 pub mod channel;
 pub mod eval_async;
 mod runtime;
+pub mod worker_pool;
 use runtime::AsyncRuntimeImpl;
 
 // Re-exported so sibling native crates (e.g. `cljrs-io`) can spawn work onto the

--- a/crates/cljrs-async/src/worker_pool.rs
+++ b/crates/cljrs-async/src/worker_pool.rs
@@ -1,0 +1,138 @@
+//! `WorkerPool` — a `Send`-only multi-thread worker pool for byte-level work.
+//!
+//! TCP/TLS I/O, hashing, compression, and similar CPU- or I/O-bound operations
+//! that must not block the heap thread (which runs on a `LocalSet` +
+//! `current_thread` runtime) are offloaded here. Results cross back to the heap
+//! thread as `Send` data (`Vec<u8>`, `String`, oneshot/mpsc messages) rather
+//! than as `GcPtr`/`Value`, which are `!Send`.
+//!
+//! # Key invariant
+//!
+//! Pool tasks **must never hold `GcPtr`, `Value`, or any other GC-heap data**.
+//! The seam between the pool and the heap thread is:
+//! - Pool → heap: `Vec<u8>`, `String`, or plain Rust primitives over oneshot/mpsc.
+//! - Heap → pool: `Vec<u8>` bytes, opaque `Arc`-wrapped config, or plain values.
+//!
+//! All `GcPtr` construction happens on the heap thread (in LocalSet bridge tasks).
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use cljrs_async::worker_pool::WorkerPool;
+//!
+//! // Offload a Send computation; await the result on the heap thread.
+//! let result = WorkerPool::global().offload(async { expensive_hash() }).await;
+//! ```
+
+use std::future::Future;
+use std::sync::OnceLock;
+
+// ── Non-wasm implementation ───────────────────────────────────────────────────
+
+#[cfg(not(target_arch = "wasm32"))]
+mod inner {
+    use std::future::Future;
+    use tokio::runtime::{Handle, Runtime};
+
+    /// Global `Send`-only worker pool backed by a Tokio multi-thread runtime.
+    pub struct WorkerPool {
+        pub(super) rt: Runtime,
+    }
+
+    impl WorkerPool {
+        pub(super) fn new() -> Self {
+            let parallelism = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(2);
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(parallelism)
+                .thread_name("cljrs-worker")
+                .enable_all()
+                .build()
+                .expect("cljrs-async: failed to build worker pool runtime");
+            Self { rt }
+        }
+
+        /// Offload a `Send` future to the pool and return a local future the
+        /// heap thread can await. The output `T` comes back over a oneshot channel
+        /// so no `Send` bound is required on the return site.
+        pub fn offload<F, T>(&self, f: F) -> impl Future<Output = T> + 'static
+        where
+            F: Future<Output = T> + Send + 'static,
+            T: Send + 'static,
+        {
+            let (tx, rx) = tokio::sync::oneshot::channel::<T>();
+            self.rt.spawn(async move {
+                let result = f.await;
+                let _ = tx.send(result);
+            });
+            async move { rx.await.expect("cljrs-async: worker pool task panicked") }
+        }
+
+        /// Direct handle to the pool runtime for multi-task spawning.
+        pub fn handle(&self) -> &Handle {
+            self.rt.handle()
+        }
+    }
+}
+
+// ── wasm32 stub ───────────────────────────────────────────────────────────────
+
+#[cfg(target_arch = "wasm32")]
+mod inner {
+    use std::future::Future;
+
+    /// Stub pool for wasm32: no real pool threads exist, futures run locally.
+    pub struct WorkerPool;
+
+    impl WorkerPool {
+        pub(super) fn new() -> Self {
+            Self
+        }
+
+        /// On wasm32, offload just runs the future locally (no pool threads exist).
+        pub fn offload<F, T>(&self, f: F) -> impl Future<Output = T> + 'static
+        where
+            F: Future<Output = T> + Send + 'static,
+            T: Send + 'static,
+        {
+            f
+        }
+    }
+}
+
+// ── Public re-export ──────────────────────────────────────────────────────────
+
+/// Global `Send`-only worker pool. Use `WorkerPool::global()` to access it.
+pub struct WorkerPool(inner::WorkerPool);
+
+static POOL: OnceLock<WorkerPool> = OnceLock::new();
+
+impl WorkerPool {
+    /// Get (or initialize) the global singleton pool.
+    pub fn global() -> &'static Self {
+        POOL.get_or_init(|| WorkerPool(inner::WorkerPool::new()))
+    }
+
+    /// Offload a `Send` future to the pool and return a `Future` the heap thread
+    /// can await without blocking the `LocalSet` executor.
+    ///
+    /// The returned future is `'static` but not `Send` — it may be polled from
+    /// the `LocalSet` executor thread (via `spawn_local` or direct `.await`).
+    pub fn offload<F, T>(&self, f: F) -> impl Future<Output = T> + 'static
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.0.offload(f)
+    }
+
+    /// Direct handle to the pool runtime for multi-task spawning.
+    ///
+    /// Use this when you need to spawn multiple tasks independently (e.g. a
+    /// pool_reader + pool_writer pair) rather than `offload` a single future.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn handle(&self) -> &tokio::runtime::Handle {
+        self.0.handle()
+    }
+}

--- a/crates/cljrs-async/tests/worker_pool.rs
+++ b/crates/cljrs-async/tests/worker_pool.rs
@@ -23,11 +23,7 @@ fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
 /// A simple Send computation offloaded to the pool returns the correct result.
 #[test]
 fn offload_simple_send_computation() {
-    let result = block_on_local(async {
-        WorkerPool::global()
-            .offload(async { 6u64 * 7 })
-            .await
-    });
+    let result = block_on_local(async { WorkerPool::global().offload(async { 6u64 * 7 }).await });
     assert_eq!(result, 42u64);
 }
 
@@ -87,8 +83,12 @@ fn handle_spawn_sub_tasks() {
         // Use the handle to spawn two tasks and collect via oneshot channels.
         let (tx1, rx1) = tokio::sync::oneshot::channel::<u64>();
         let (tx2, rx2) = tokio::sync::oneshot::channel::<u64>();
-        pool.handle().spawn(async move { let _ = tx1.send(10); });
-        pool.handle().spawn(async move { let _ = tx2.send(32); });
+        pool.handle().spawn(async move {
+            let _ = tx1.send(10);
+        });
+        pool.handle().spawn(async move {
+            let _ = tx2.send(32);
+        });
         let a = rx1.await.unwrap();
         let b = rx2.await.unwrap();
         a + b
@@ -105,9 +105,7 @@ fn offload_from_spawn_local_context() {
     let result = block_on_local(async {
         let (tx, rx) = tokio::sync::oneshot::channel::<u64>();
         tokio::task::spawn_local(async move {
-            let val = WorkerPool::global()
-                .offload(async { 21u64 * 2 })
-                .await;
+            let val = WorkerPool::global().offload(async { 21u64 * 2 }).await;
             let _ = tx.send(val);
         });
         rx.await.unwrap()

--- a/crates/cljrs-async/tests/worker_pool.rs
+++ b/crates/cljrs-async/tests/worker_pool.rs
@@ -1,0 +1,143 @@
+//! Tests for `WorkerPool` — the `Send`-only multi-thread worker pool.
+//!
+//! The harness mirrors real usage: a `current_thread` runtime + `LocalSet`
+//! drives the heap thread, while the pool runs `Send` tasks on separate
+//! worker threads.
+
+use cljrs_async::worker_pool::WorkerPool;
+use tokio::task::LocalSet;
+
+/// Run a `!Send` future on a current-thread LocalSet executor (mirrors how the
+/// heap thread actually runs during normal clojurust operation).
+fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+    let local = LocalSet::new();
+    local.block_on(&rt, f)
+}
+
+// ── Basic offload ─────────────────────────────────────────────────────────────
+
+/// A simple Send computation offloaded to the pool returns the correct result.
+#[test]
+fn offload_simple_send_computation() {
+    let result = block_on_local(async {
+        WorkerPool::global()
+            .offload(async { 6u64 * 7 })
+            .await
+    });
+    assert_eq!(result, 42u64);
+}
+
+/// `offload` works with `String` results (heap-allocated, Send).
+#[test]
+fn offload_returns_string() {
+    let result = block_on_local(async {
+        WorkerPool::global()
+            .offload(async { format!("hello-{}", 99) })
+            .await
+    });
+    assert_eq!(result, "hello-99");
+}
+
+/// A pool task that does a small async sleep still resolves correctly.
+#[test]
+fn offload_with_async_sleep() {
+    let result = block_on_local(async {
+        WorkerPool::global()
+            .offload(async {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                42u32
+            })
+            .await
+    });
+    assert_eq!(result, 42u32);
+}
+
+// ── Concurrent pool tasks ─────────────────────────────────────────────────────
+
+/// Multiple concurrent pool tasks all complete and return distinct results.
+#[test]
+fn multiple_concurrent_pool_tasks() {
+    let results = block_on_local(async {
+        let pool = WorkerPool::global();
+        let futs: Vec<_> = (0u64..8)
+            .map(|i| pool.offload(async move { i * i }))
+            .collect();
+        // Await all in order (join_all pattern via a simple loop).
+        let mut out = Vec::with_capacity(8);
+        for f in futs {
+            out.push(f.await);
+        }
+        out
+    });
+    let expected: Vec<u64> = (0u64..8).map(|i| i * i).collect();
+    assert_eq!(results, expected);
+}
+
+/// Pool tasks can themselves spawn sub-tasks via `handle()` and the results
+/// arrive back on the LocalSet.
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn handle_spawn_sub_tasks() {
+    let result = block_on_local(async {
+        let pool = WorkerPool::global();
+        // Use the handle to spawn two tasks and collect via oneshot channels.
+        let (tx1, rx1) = tokio::sync::oneshot::channel::<u64>();
+        let (tx2, rx2) = tokio::sync::oneshot::channel::<u64>();
+        pool.handle().spawn(async move { let _ = tx1.send(10); });
+        pool.handle().spawn(async move { let _ = tx2.send(32); });
+        let a = rx1.await.unwrap();
+        let b = rx2.await.unwrap();
+        a + b
+    });
+    assert_eq!(result, 42u64);
+}
+
+// ── LocalSet context ──────────────────────────────────────────────────────────
+
+/// The pool is accessible from within a `spawn_local` task (the actual usage
+/// scenario where a LocalSet bridge task offloads work to the pool).
+#[test]
+fn offload_from_spawn_local_context() {
+    let result = block_on_local(async {
+        let (tx, rx) = tokio::sync::oneshot::channel::<u64>();
+        tokio::task::spawn_local(async move {
+            let val = WorkerPool::global()
+                .offload(async { 21u64 * 2 })
+                .await;
+            let _ = tx.send(val);
+        });
+        rx.await.unwrap()
+    });
+    assert_eq!(result, 42u64);
+}
+
+/// `WorkerPool::global()` returns the same singleton on repeated calls.
+#[test]
+fn global_is_singleton() {
+    let p1 = WorkerPool::global() as *const WorkerPool;
+    let p2 = WorkerPool::global() as *const WorkerPool;
+    assert_eq!(p1, p2, "WorkerPool::global() must return the same pointer");
+}
+
+// ── Vec<u8> round-trip (the primary use case) ─────────────────────────────────
+
+/// A pool task that processes `Vec<u8>` data (e.g. hashing/compression) and
+/// returns the result as another `Vec<u8>` to the LocalSet.
+#[test]
+fn offload_byte_processing() {
+    let input = b"hello world".to_vec();
+    let output = block_on_local(async {
+        WorkerPool::global()
+            .offload(async move {
+                // Simulate byte-level work: XOR each byte with 0xFF.
+                input.iter().map(|&b| b ^ 0xFF).collect::<Vec<u8>>()
+            })
+            .await
+    });
+    let expected: Vec<u8> = b"hello world".iter().map(|&b| b ^ 0xFF).collect();
+    assert_eq!(output, expected);
+}

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -14,7 +14,7 @@ cljrs-env      = { workspace = true }
 cljrs-reader   = { workspace = true }
 cljrs-interp   = { workspace = true }
 cljrs-async    = { workspace = true }
-tokio          = { workspace = true, features = ["net", "io-util"] }
+tokio          = { workspace = true, features = ["net", "io-util", "sync"] }
 tokio-rustls   = { version = "0.26", default-features = false, features = ["ring"] }
 rustls         = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-pemfile = "2"

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,19 +2,22 @@
 
 **Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–G implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics).
+**Status**: Phases A–G + A2 implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics, pool-based I/O).
 
 **Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
+
+**Phase A2 — pool-based I/O**: TCP and TLS byte-level I/O (connect, accept loop, TLS handshake, reader, writer) now runs on the `WorkerPool` multi-thread runtime instead of on the `LocalSet` executor thread. The LocalSet bridge tasks (`read_bridge`, `write_bridge`, `local_accept_bridge`) run on the LocalSet and are the only code that touches `GcPtr`/`Value`. This separation ensures the heap thread remains responsive under sustained byte-level traffic. `pool_io.rs` contains the shared pool tasks and bridge helpers. UDP and Unix sockets are not pool-based yet (their I/O is lower-volume).
 
 ## File Layout
 
 | File | Description |
 |---|---|
 | `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, `clojure.rust.net.unix`, and `clojure.rust.net` |
-| `src/tcp.rs` | `TcpStreamResource`, `TcpListenerResource`, connection builder, accept loop, `connect`/`listen`/`close` builtins |
+| `src/pool_io.rs` | Shared pool tasks and bridge helpers: `ReadMsg`, `PoolStreamSetup`, `pool_reader`, `pool_writer`, `read_bridge`, `write_bridge`, `bytes_value`, `net_error` |
+| `src/tcp.rs` | `TcpStreamResource` (Vec<AbortHandle>), `TcpListenerResource` (Vec<AbortHandle>), pool-based connect/accept, `connect`/`listen`/`close` builtins |
 | `src/frame.rs` | `FramerSpec` native object, stateful framers (`LinesFramer`, `DelimiterFramer`, `LengthPrefixedFramer`), `frame`/encode builtins |
 | `src/udp.rs` | `UdpSocketResource`, reader/writer tasks, `socket`/`close` builtins |
-| `src/tls.rs` | `TlsStreamResource`, `TlsListenerResource`, generic reader/writer loops, `build_client_config`, `build_server_config`, `tls_connect_to`/`tls_listen_on`/`connect`/`listen`/`close` builtins |
+| `src/tls.rs` | `TlsStreamResource` (Vec<AbortHandle>), `TlsListenerResource` (Vec<AbortHandle>), pool-based TLS connect/accept, `build_client_config`, `build_server_config`, `tls_connect_to`/`tls_listen_on`/`connect`/`listen`/`close` builtins |
 | `src/unix.rs` | `UnixStreamResource`, `UnixListenerResource` (`close` unlinks path), reader/writer loops, accept loop, `connect`/`listen`/`close` builtins; `#[cfg(unix)]` with non-Unix stubs |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
@@ -185,11 +188,11 @@ pub fn tls::build_server_config(opts: &MapValue) -> ValueResult<Arc<rustls::Serv
 
 ### `TcpStreamResource`
 
-Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks, dropping the socket halves and releasing the FD.
+Implements `cljrs_value::Resource` (Arc-backed). Holds `Vec<AbortHandle>` for the pool reader, pool writer, and LocalSet bridge tasks (4 total). `close()` aborts all handles, dropping the pool socket halves and releasing the FD.
 
 ### `TcpListenerResource`
 
-Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `accept_loop` task. `close()` aborts the task, dropping the `TcpListener` and releasing the listener FD.
+Implements `cljrs_value::Resource` (Arc-backed). Holds `Vec<AbortHandle>` for the pool accept loop and the LocalSet accept bridge (2 total). `close()` aborts all handles, dropping the `TcpListener` and releasing the listener FD.
 
 ### `UdpSocketResource`
 
@@ -197,11 +200,11 @@ Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the re
 
 ### `TlsStreamResource`
 
-Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks (generic over the TLS stream halves). `close()` aborts both tasks, dropping the TLS stream halves and releasing the FD.
+Implements `cljrs_value::Resource` (Arc-backed). Holds `Vec<AbortHandle>` for the pool reader, pool writer, and LocalSet bridge tasks (4 total). `close()` aborts all handles, dropping the TLS stream halves and releasing the FD.
 
 ### `TlsListenerResource`
 
-Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `tls_accept_loop` task. `close()` aborts the task, dropping the `TcpListener` and releasing the listener FD.
+Implements `cljrs_value::Resource` (Arc-backed). Holds `Vec<AbortHandle>` for the pool TLS accept loop and the LocalSet accept bridge (2 total). `close()` aborts all handles, dropping the `TcpListener` and releasing the listener FD.
 
 ### `UnixStreamResource` (`#[cfg(unix)]`)
 
@@ -223,9 +226,11 @@ Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the
  :resource    <TcpStream>}   ; Arc<TcpStreamResource> — call (close conn) to release
 ```
 
-Two tasks are spawned per connection on the `LocalSet`:
-- **reader task** — reads the socket into `byte-array` chunks and puts them on `:in`
-- **writer task** — takes from `:out` and writes to the socket; shuts down the write half when `:out` closes
+Four tasks are spawned per connection (A2 pool model):
+- **pool reader** (pool thread) — reads the socket into `Vec<u8>` chunks and sends `ReadMsg` to the LocalSet bridge
+- **pool writer** (pool thread) — receives `Vec<u8>` from the LocalSet bridge and writes to the socket; shuts down gracefully when the sender is dropped
+- **read bridge** (LocalSet) — converts `ReadMsg` → `Value::ByteArray` and puts on `:in`
+- **write bridge** (LocalSet) — takes from `:out`, converts to `Vec<u8>`, sends to the pool writer
 
 ## Server Model
 
@@ -237,7 +242,7 @@ Two tasks are spawned per connection on the `LocalSet`:
  :resource   <TcpListener>} ; Arc<TcpListenerResource> — call (close server) to stop accepting
 ```
 
-The accept loop runs as a `spawn_local` task. When `:conns` is full, `chan_put` parks the accept loop, applying backpressure all the way to the TCP accept window.
+The accept loop runs on the `WorkerPool` (`pool_accept_loop`). A LocalSet bridge (`local_accept_bridge`) receives the `PoolStreamSetup` for each accepted connection and spawns the read/write bridges. When `:conns` is full, `chan_put` parks the bridge, applying backpressure all the way to the pool accept loop.
 
 ## Usage Example
 

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use cljrs_async::load_source;
 
 pub mod frame;
+mod pool_io;
 pub mod tcp;
 pub mod tls;
 pub mod udp;

--- a/crates/cljrs-net/src/pool_io.rs
+++ b/crates/cljrs-net/src/pool_io.rs
@@ -124,10 +124,7 @@ where
 ///
 /// Closes `in_chan` when the pool reader signals EOF or an error. On error, puts
 /// a `Value::Error` first so the consumer can observe it before the channel closes.
-pub(crate) async fn read_bridge(
-    mut rx: mpsc::Receiver<ReadMsg>,
-    in_chan: GcPtr<NativeObjectBox>,
-) {
+pub(crate) async fn read_bridge(mut rx: mpsc::Receiver<ReadMsg>, in_chan: GcPtr<NativeObjectBox>) {
     while let Some(msg) = rx.recv().await {
         match msg {
             ReadMsg::Data(bytes) => {
@@ -150,16 +147,12 @@ pub(crate) async fn read_bridge(
 ///
 /// Exits when `out_chan` is closed (returns `Value::Nil`). Dropping `tx` signals
 /// the pool writer to shut down.
-pub(crate) async fn write_bridge(
-    out_chan: GcPtr<NativeObjectBox>,
-    tx: mpsc::Sender<Vec<u8>>,
-) {
+pub(crate) async fn write_bridge(out_chan: GcPtr<NativeObjectBox>, tx: mpsc::Sender<Vec<u8>>) {
     loop {
         match chan_take(&out_chan).await {
             Value::Nil => break, // :out channel closed
             Value::ByteArray(arr) => {
-                let bytes: Vec<u8> =
-                    arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                let bytes: Vec<u8> = arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
                 if tx.send(bytes).await.is_err() {
                     break; // pool writer dropped
                 }

--- a/crates/cljrs-net/src/pool_io.rs
+++ b/crates/cljrs-net/src/pool_io.rs
@@ -1,0 +1,177 @@
+//! Shared pool I/O types and async tasks for TCP and TLS.
+//!
+//! # Architecture
+//!
+//! The pool-based I/O model has two layers:
+//!
+//! - **Pool tasks** (`pool_reader`, `pool_writer`): run on the `WorkerPool`
+//!   multi-thread runtime. They only touch `Vec<u8>`, `String`, and
+//!   `mpsc`/`oneshot` channel types — **never `GcPtr` or `Value`**.
+//!
+//! - **LocalSet bridge tasks** (`read_bridge`, `write_bridge`): run on the
+//!   `current_thread` + `LocalSet` executor. They convert between pool bytes
+//!   and Clojure `Value`s, touching `GcPtr<NativeObjectBox>` and `Value` safely.
+//!
+//! The `PoolStreamSetup` struct is the handshake result produced on a pool thread
+//! after a connection is established. It carries only `Send` data; the LocalSet
+//! side reads it via a oneshot and creates Clojure channels from it.
+
+use std::sync::Mutex;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
+
+use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+use cljrs_gc::GcPtr;
+use cljrs_value::{ExceptionInfo, NativeObjectBox, Value, ValueError};
+
+// ── ReadMsg ───────────────────────────────────────────────────────────────────
+
+/// Messages from a pool reader task to the LocalSet read-bridge.
+pub(crate) enum ReadMsg {
+    Data(Vec<u8>),
+    Eof,
+    Error(String),
+}
+
+// ── PoolStreamSetup ───────────────────────────────────────────────────────────
+
+/// Everything the LocalSet needs to know after a pool connection is established.
+///
+/// Produced on a pool thread and sent via oneshot to the LocalSet bridge.
+/// All fields are `Send`; no `GcPtr` or `Value` here.
+pub(crate) struct PoolStreamSetup {
+    pub remote_addr: String,
+    pub local_addr: String,
+    pub read_rx: mpsc::Receiver<ReadMsg>,
+    pub write_tx: mpsc::Sender<Vec<u8>>,
+    pub reader_abort: tokio::task::AbortHandle,
+    pub writer_abort: tokio::task::AbortHandle,
+}
+
+pub(crate) type PoolSetupResult = Result<PoolStreamSetup, String>;
+
+// ── Value helpers ─────────────────────────────────────────────────────────────
+
+/// Wrap a byte slice as a `Value::ByteArray`.
+pub(crate) fn bytes_value(bytes: &[u8]) -> Value {
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
+}
+
+/// Wrap an error message as a `Value::Error`.
+pub(crate) fn net_error(msg: impl Into<String>) -> Value {
+    let msg = msg.into();
+    Value::Error(GcPtr::new(ExceptionInfo::new(
+        ValueError::Other(msg.clone()),
+        msg,
+        None,
+        None,
+    )))
+}
+
+// ── Pool tasks (Send, no GcPtr) ───────────────────────────────────────────────
+
+/// Runs on a pool thread: reads bytes from any `AsyncRead` and sends them as
+/// `ReadMsg` messages to the LocalSet bridge.
+///
+/// Sends `ReadMsg::Eof` at clean EOF or `ReadMsg::Error` on I/O failure, then
+/// the task exits.
+pub(crate) async fn pool_reader<R>(mut reader: R, tx: mpsc::Sender<ReadMsg>)
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let mut buf = vec![0u8; 8192];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => {
+                let _ = tx.send(ReadMsg::Eof).await;
+                break;
+            }
+            Ok(n) => {
+                let chunk = buf[..n].to_vec();
+                if tx.send(ReadMsg::Data(chunk)).await.is_err() {
+                    break; // bridge dropped
+                }
+            }
+            Err(e) => {
+                let _ = tx.send(ReadMsg::Error(format!("read error: {e}"))).await;
+                break;
+            }
+        }
+    }
+}
+
+/// Runs on a pool thread: receives `Vec<u8>` from the LocalSet write-bridge and
+/// writes it to any `AsyncWrite`, shutting down gracefully when the sender drops.
+pub(crate) async fn pool_writer<W>(mut writer: W, mut rx: mpsc::Receiver<Vec<u8>>)
+where
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    while let Some(bytes) = rx.recv().await {
+        if writer.write_all(&bytes).await.is_err() {
+            break;
+        }
+    }
+    // Graceful half-close: drain (sender dropped) then shut down.
+    let _ = writer.shutdown().await;
+}
+
+// ── LocalSet bridge tasks (touch GcPtr / Value) ───────────────────────────────
+
+/// Runs on the LocalSet: bridges pool `ReadMsg` → `Value::ByteArray` →
+/// puts on `in_chan`.
+///
+/// Closes `in_chan` when the pool reader signals EOF or an error. On error, puts
+/// a `Value::Error` first so the consumer can observe it before the channel closes.
+pub(crate) async fn read_bridge(
+    mut rx: mpsc::Receiver<ReadMsg>,
+    in_chan: GcPtr<NativeObjectBox>,
+) {
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            ReadMsg::Data(bytes) => {
+                if !chan_put(&in_chan, bytes_value(&bytes)).await {
+                    break; // consumer closed :in
+                }
+            }
+            ReadMsg::Eof => break,
+            ReadMsg::Error(e) => {
+                chan_put(&in_chan, net_error(e)).await;
+                break;
+            }
+        }
+    }
+    chan_ref(in_chan.get()).close();
+}
+
+/// Runs on the LocalSet: takes `Value`s from `out_chan` → converts to `Vec<u8>`
+/// → sends to the pool writer.
+///
+/// Exits when `out_chan` is closed (returns `Value::Nil`). Dropping `tx` signals
+/// the pool writer to shut down.
+pub(crate) async fn write_bridge(
+    out_chan: GcPtr<NativeObjectBox>,
+    tx: mpsc::Sender<Vec<u8>>,
+) {
+    loop {
+        match chan_take(&out_chan).await {
+            Value::Nil => break, // :out channel closed
+            Value::ByteArray(arr) => {
+                let bytes: Vec<u8> =
+                    arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                if tx.send(bytes).await.is_err() {
+                    break; // pool writer dropped
+                }
+            }
+            Value::Str(s) => {
+                let bytes = s.get().as_bytes().to_vec();
+                if tx.send(bytes).await.is_err() {
+                    break;
+                }
+            }
+            _ => {} // ignore unsupported value types
+        }
+    }
+    // Dropping `tx` here signals pool_writer to flush and shut down.
+}

--- a/crates/cljrs-net/src/tcp.rs
+++ b/crates/cljrs-net/src/tcp.rs
@@ -45,8 +45,8 @@ use cljrs_value::{
 };
 
 use crate::pool_io::{
-    net_error, pool_reader, pool_writer, read_bridge, write_bridge, PoolSetupResult,
-    PoolStreamSetup,
+    PoolSetupResult, PoolStreamSetup, net_error, pool_reader, pool_writer, read_bridge,
+    write_bridge,
 };
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -220,9 +220,7 @@ async fn pool_accept_loop(
     let listener = match TcpListener::from_std(std_listener) {
         Ok(l) => l,
         Err(e) => {
-            let _ = conn_info_tx
-                .send(Err(format!("from_std: {e}")))
-                .await;
+            let _ = conn_info_tx.send(Err(format!("from_std: {e}"))).await;
             return;
         }
     };
@@ -230,9 +228,7 @@ async fn pool_accept_loop(
     loop {
         match listener.accept().await {
             Err(e) => {
-                let _ = conn_info_tx
-                    .send(Err(format!("accept error: {e}")))
-                    .await;
+                let _ = conn_info_tx.send(Err(format!("accept error: {e}"))).await;
                 break;
             }
             Ok((stream, _peer)) => {
@@ -247,8 +243,7 @@ async fn pool_accept_loop(
 
                 let (read_half, write_half) = stream.into_split();
 
-                let (read_tx, read_rx) =
-                    mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+                let (read_tx, read_rx) = mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
                 let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
 
                 let reader_jh = tokio::spawn(pool_reader(read_half, read_tx));
@@ -368,9 +363,12 @@ pub fn listen_on(
     let resource_handle = ResourceHandle::new(resource);
 
     // Spawn accept loop on pool (Send).
-    let pool_jh = WorkerPool::global()
-        .handle()
-        .spawn(pool_accept_loop(std_listener, conn_info_tx, in_buf, out_buf));
+    let pool_jh = WorkerPool::global().handle().spawn(pool_accept_loop(
+        std_listener,
+        conn_info_tx,
+        in_buf,
+        out_buf,
+    ));
 
     // Spawn bridge on LocalSet (!Send, touches GcPtr).
     let bridge_jh = tokio::task::spawn_local(local_accept_bridge(
@@ -437,8 +435,7 @@ async fn do_connect(
                     .unwrap_or_default();
 
                 let (read_half, write_half) = stream.into_split();
-                let (read_tx, read_rx) =
-                    mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+                let (read_tx, read_rx) = mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
                 let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
 
                 let reader_jh = tokio::spawn(pool_reader(read_half, read_tx));

--- a/crates/cljrs-net/src/tcp.rs
+++ b/crates/cljrs-net/src/tcp.rs
@@ -20,23 +20,33 @@
 //!  :local-addr "ip:port"
 //!  :resource   <handle>} ; TcpListenerResource — deterministic listener close
 //! ```
+//!
+//! Phase A2: TCP connect and accept now run on the `WorkerPool` multi-thread
+//! runtime, so byte-level I/O never blocks the heap (`LocalSet`) thread.
+//! `GcPtr`/`Value` construction happens in LocalSet bridge tasks only.
 
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use tokio::net::TcpStream;
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::AbortHandle;
 
-use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, chan_take, make_chan};
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, make_chan};
 use cljrs_async::spawn_future;
+use cljrs_async::worker_pool::WorkerPool;
 use cljrs_env::env::GlobalEnv;
 use cljrs_env::error::EvalResult;
 use cljrs_gc::GcPtr;
 use cljrs_value::{
-    Arity, ExceptionInfo, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle,
-    Value, ValueError, ValueResult,
+    Arity, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle, Value,
+    ValueError, ValueResult,
+};
+
+use crate::pool_io::{
+    net_error, pool_reader, pool_writer, read_bridge, write_bridge, PoolSetupResult,
+    PoolStreamSetup,
 };
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -61,16 +71,15 @@ pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
 #[derive(Debug)]
 struct TcpStreamInner {
     closed: bool,
-    reader_abort: Option<AbortHandle>,
-    writer_abort: Option<AbortHandle>,
+    abort_handles: Vec<AbortHandle>,
 }
 
 /// `Resource` implementation for a TCP stream.
 ///
-/// Holds `AbortHandle`s for the reader and writer tasks spawned in `connect`.
-/// `close()` aborts both tasks, which drops the socket halves and closes the FD.
-/// GC never finalises the socket — this `Arc`-backed resource is the sole
-/// cleanup path, matching the design note in `resource.rs`.
+/// Holds `AbortHandle`s for the pool reader, pool writer, and LocalSet bridge
+/// tasks. `close()` aborts all handles, which drops the pool socket halves and
+/// closes the FD. GC never finalises the socket — this `Arc`-backed resource is
+/// the sole cleanup path.
 #[derive(Debug)]
 pub struct TcpStreamResource {
     inner: Arc<Mutex<TcpStreamInner>>,
@@ -81,8 +90,7 @@ impl TcpStreamResource {
         Self {
             inner: Arc::new(Mutex::new(TcpStreamInner {
                 closed: false,
-                reader_abort: None,
-                writer_abort: None,
+                abort_handles: Vec::new(),
             })),
         }
     }
@@ -95,10 +103,7 @@ impl Resource for TcpStreamResource {
             return Ok(());
         }
         g.closed = true;
-        if let Some(h) = g.reader_abort.take() {
-            h.abort();
-        }
-        if let Some(h) = g.writer_abort.take() {
+        for h in g.abort_handles.drain(..) {
             h.abort();
         }
         Ok(())
@@ -122,13 +127,13 @@ impl Resource for TcpStreamResource {
 #[derive(Debug)]
 struct TcpListenerInner {
     closed: bool,
-    accept_abort: Option<AbortHandle>,
+    abort_handles: Vec<AbortHandle>,
 }
 
 /// `Resource` implementation for a TCP listener.
 ///
-/// Holds the `AbortHandle` for the `accept_loop` task. `close()` aborts the
-/// task, which drops the `TcpListener` and closes the listener FD.
+/// Holds `AbortHandle`s for the pool accept loop and the LocalSet accept bridge.
+/// `close()` aborts all handles, which drops the listener and closes the FD.
 #[derive(Debug)]
 pub struct TcpListenerResource {
     inner: Arc<Mutex<TcpListenerInner>>,
@@ -139,7 +144,7 @@ impl TcpListenerResource {
         Self {
             inner: Arc::new(Mutex::new(TcpListenerInner {
                 closed: false,
-                accept_abort: None,
+                abort_handles: Vec::new(),
             })),
         }
     }
@@ -152,7 +157,7 @@ impl Resource for TcpListenerResource {
             return Ok(());
         }
         g.closed = true;
-        if let Some(h) = g.accept_abort.take() {
+        for h in g.abort_handles.drain(..) {
             h.abort();
         }
         Ok(())
@@ -172,21 +177,6 @@ impl Resource for TcpListenerResource {
 }
 
 // ── Value helpers ─────────────────────────────────────────────────────────────
-
-fn bytes_value(bytes: &[u8]) -> Value {
-    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
-    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
-}
-
-fn net_error(msg: impl Into<String>) -> Value {
-    let msg = msg.into();
-    Value::Error(GcPtr::new(ExceptionInfo::new(
-        ValueError::Other(msg.clone()),
-        msg,
-        None,
-        None,
-    )))
-}
 
 fn kw(name: &str) -> Value {
     Value::keyword(Keyword::simple(name))
@@ -215,114 +205,94 @@ fn opts_port(opts: &MapValue) -> Option<u16> {
     }
 }
 
-// ── Async tasks ───────────────────────────────────────────────────────────────
+// ── Pool tasks (Send, no GcPtr) ───────────────────────────────────────────────
 
-/// Read chunks from the socket and put them on `:in`.
-///
-/// Closes `:in` at EOF or on error (after putting the error value). Aborted
-/// via `TcpStreamResource::close` if the user calls `(close conn)`.
-async fn reader_loop(mut read_half: OwnedReadHalf, in_chan: GcPtr<NativeObjectBox>) {
-    let mut buf = vec![0u8; 8192];
+/// Runs on the pool: accepts connections from `listener`, spawns pool_reader +
+/// pool_writer for each, and sends the `PoolStreamSetup` via `conn_info_tx`.
+/// Exits when the listener FD is closed or an accept error occurs.
+async fn pool_accept_loop(
+    std_listener: std::net::TcpListener,
+    conn_info_tx: mpsc::Sender<PoolSetupResult>,
+    in_buf: usize,
+    out_buf: usize,
+) {
+    // Convert the std listener inside the pool runtime context.
+    let listener = match TcpListener::from_std(std_listener) {
+        Ok(l) => l,
+        Err(e) => {
+            let _ = conn_info_tx
+                .send(Err(format!("from_std: {e}")))
+                .await;
+            return;
+        }
+    };
+
     loop {
-        match read_half.read(&mut buf).await {
-            Ok(0) => break,
-            Ok(n) => {
-                if !chan_put(&in_chan, bytes_value(&buf[..n])).await {
-                    break; // consumer closed :in
-                }
-            }
+        match listener.accept().await {
             Err(e) => {
-                chan_put(&in_chan, net_error(format!("read error: {e}"))).await;
+                let _ = conn_info_tx
+                    .send(Err(format!("accept error: {e}")))
+                    .await;
                 break;
             }
-        }
-    }
-    chan_ref(in_chan.get()).close();
-}
+            Ok((stream, _peer)) => {
+                let remote_addr = stream
+                    .peer_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_default();
+                let local_addr = stream
+                    .local_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_default();
 
-/// Drain `:out` and write each value to the socket.
-///
-/// Accepts `byte-array` and `string` values. Calls `shutdown` on the write
-/// half when `:out` is closed (TCP half-close: FIN without RST). Aborted via
-/// `TcpStreamResource::close` if the user calls `(close conn)`.
-async fn writer_loop(mut write_half: OwnedWriteHalf, out_chan: GcPtr<NativeObjectBox>) {
-    // Nested async block so write errors propagate via `?` rather than
-    // `if err { break }`, keeping each match arm free of collapsible ifs.
-    let _: std::io::Result<()> = async {
-        loop {
-            match chan_take(&out_chan).await {
-                Value::Nil => {
-                    // :out closed; gracefully half-close the write side.
-                    let _ = write_half.shutdown().await;
+                let (read_half, write_half) = stream.into_split();
+
+                let (read_tx, read_rx) =
+                    mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+                let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
+
+                let reader_jh = tokio::spawn(pool_reader(read_half, read_tx));
+                let writer_jh = tokio::spawn(pool_writer(write_half, write_rx));
+
+                let setup = PoolStreamSetup {
+                    remote_addr,
+                    local_addr,
+                    read_rx,
+                    write_tx,
+                    reader_abort: reader_jh.abort_handle(),
+                    writer_abort: writer_jh.abort_handle(),
+                };
+
+                if conn_info_tx.send(Ok(setup)).await.is_err() {
+                    // LocalSet bridge dropped; abort the just-spawned tasks.
+                    reader_jh.abort();
+                    writer_jh.abort();
                     break;
                 }
-                Value::ByteArray(arr) => {
-                    let bytes: Vec<u8> =
-                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
-                    write_half.write_all(&bytes).await?;
-                }
-                Value::Str(s) => {
-                    write_half.write_all(s.get().as_bytes()).await?;
-                }
-                _ => {}
             }
         }
-        Ok(())
     }
-    .await;
 }
 
-// ── Connection builder ────────────────────────────────────────────────────────
+// ── LocalSet bridge (touches GcPtr / Value) ───────────────────────────────────
 
-fn make_connection(stream: TcpStream, in_buf: usize, out_buf: usize) -> Value {
-    let remote_addr = stream
-        .peer_addr()
-        .map(|a| a.to_string())
-        .unwrap_or_default();
-    let local_addr = stream
-        .local_addr()
-        .map(|a| a.to_string())
-        .unwrap_or_default();
-    let (read_half, write_half) = stream.into_split();
-    let in_chan = make_chan(in_buf);
-    let out_chan = make_chan(out_buf);
-    let resource = TcpStreamResource::new();
-    let shared_inner = resource.inner.clone();
-    let resource_handle = ResourceHandle::new(resource);
-    let r_jh = tokio::task::spawn_local(reader_loop(read_half, in_chan.clone()));
-    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
-    let w_jh = tokio::task::spawn_local(writer_loop(write_half, out_chan.clone()));
-    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
-    Value::Map(MapValue::from_pairs(vec![
-        (kw("in"), Value::NativeObject(in_chan)),
-        (kw("out"), Value::NativeObject(out_chan)),
-        (kw("remote-addr"), Value::string(remote_addr)),
-        (kw("local-addr"), Value::string(local_addr)),
-        (kw("resource"), Value::Resource(resource_handle)),
-    ]))
-}
-
-// ── Accept loop ───────────────────────────────────────────────────────────────
-
-/// Accept connections from `listener` and put each connection map on `conns_chan`.
-///
-/// Exits when the listener returns an error (e.g. the FD is closed by aborting
-/// this task) or when the consumer closes `conns_chan`. After exiting, closes
-/// `conns_chan` so consumers see EOF.
-async fn accept_loop(
-    listener: tokio::net::TcpListener,
+/// Runs on the LocalSet: receives `PoolSetupResult` from the pool accept loop,
+/// creates Clojure channels + bridges for each new connection, and puts the
+/// connection map on `conns_chan`.
+async fn local_accept_bridge(
+    mut conn_info_rx: mpsc::Receiver<PoolSetupResult>,
     conns_chan: GcPtr<NativeObjectBox>,
     in_buf: usize,
     out_buf: usize,
 ) {
-    loop {
-        match listener.accept().await {
+    while let Some(result) = conn_info_rx.recv().await {
+        match result {
             Err(e) => {
-                chan_put(&conns_chan, net_error(format!("accept error: {e}"))).await;
+                chan_put(&conns_chan, net_error(e)).await;
                 break;
             }
-            Ok((stream, _)) => {
-                let conn = make_connection(stream, in_buf, out_buf);
+            Ok(setup) => {
+                let conn = make_tcp_connection_from_setup(setup, in_buf, out_buf);
                 if !chan_put(&conns_chan, conn).await {
                     break; // consumer closed :conns
                 }
@@ -332,11 +302,43 @@ async fn accept_loop(
     chan_ref(conns_chan.get()).close();
 }
 
+/// Build a connection map + resource from a `PoolStreamSetup`, spawning LocalSet
+/// bridge tasks. Called on the LocalSet thread.
+fn make_tcp_connection_from_setup(setup: PoolStreamSetup, in_buf: usize, out_buf: usize) -> Value {
+    let in_chan = make_chan(in_buf);
+    let out_chan = make_chan(out_buf);
+    let resource = TcpStreamResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    // Bridge tasks: run on LocalSet, touch GcPtr.
+    let rb_jh = tokio::task::spawn_local(read_bridge(setup.read_rx, in_chan.clone()));
+    let wb_jh = tokio::task::spawn_local(write_bridge(out_chan.clone(), setup.write_tx));
+
+    {
+        let mut g = shared_inner.lock().unwrap();
+        g.abort_handles.push(setup.reader_abort);
+        g.abort_handles.push(setup.writer_abort);
+        g.abort_handles.push(rb_jh.abort_handle());
+        g.abort_handles.push(wb_jh.abort_handle());
+    }
+
+    Value::Map(MapValue::from_pairs(vec![
+        (kw("in"), Value::NativeObject(in_chan)),
+        (kw("out"), Value::NativeObject(out_chan)),
+        (kw("remote-addr"), Value::string(setup.remote_addr)),
+        (kw("local-addr"), Value::string(setup.local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]))
+}
+
 // ── Listen implementation ─────────────────────────────────────────────────────
 
 /// Bind a TCP listener on `host:port` and return a server map.
 ///
-/// Convenience wrapper used by tests and the Clojure `listen` builtin alike.
+/// The accept loop runs on the `WorkerPool`; a LocalSet bridge delivers
+/// connection maps onto `conns_chan`. Convenience wrapper used by tests and the
+/// Clojure `listen` builtin alike.
 pub fn listen_on(
     host: &str,
     port: u16,
@@ -346,28 +348,43 @@ pub fn listen_on(
 ) -> ValueResult<Value> {
     let addr = format!("{host}:{port}");
 
-    // Bind synchronously (std), then convert to Tokio (requires runtime context).
+    // Bind synchronously (std) so we get the local_addr immediately.
     let std_listener = std::net::TcpListener::bind(&addr)
         .map_err(|e| ValueError::Other(format!("listen on {addr}: {e}")))?;
     std_listener
         .set_nonblocking(true)
         .map_err(|e| ValueError::Other(format!("set_nonblocking: {e}")))?;
-    let listener = tokio::net::TcpListener::from_std(std_listener)
-        .map_err(|e| ValueError::Other(format!("from_std: {e}")))?;
 
-    let local_addr = listener
+    let local_addr = std_listener
         .local_addr()
         .map(|a| a.to_string())
         .unwrap_or_default();
 
+    let (conn_info_tx, conn_info_rx) = mpsc::channel::<PoolSetupResult>(conns_buf.max(1));
     let conns_chan = make_chan(conns_buf);
 
     let resource = TcpListenerResource::new();
     let shared_inner = resource.inner.clone();
     let resource_handle = ResourceHandle::new(resource);
 
-    let jh = tokio::task::spawn_local(accept_loop(listener, conns_chan.clone(), in_buf, out_buf));
-    shared_inner.lock().unwrap().accept_abort = Some(jh.abort_handle());
+    // Spawn accept loop on pool (Send).
+    let pool_jh = WorkerPool::global()
+        .handle()
+        .spawn(pool_accept_loop(std_listener, conn_info_tx, in_buf, out_buf));
+
+    // Spawn bridge on LocalSet (!Send, touches GcPtr).
+    let bridge_jh = tokio::task::spawn_local(local_accept_bridge(
+        conn_info_rx,
+        conns_chan.clone(),
+        in_buf,
+        out_buf,
+    ));
+
+    {
+        let mut g = shared_inner.lock().unwrap();
+        g.abort_handles.push(pool_jh.abort_handle());
+        g.abort_handles.push(bridge_jh.abort_handle());
+    }
 
     Ok(Value::Map(MapValue::from_pairs(vec![
         (kw("conns"), Value::NativeObject(conns_chan)),
@@ -380,7 +397,9 @@ pub fn listen_on(
 
 /// Initiate a TCP connection and return the promise channel as a `Value`.
 ///
-/// Convenience wrapper used by tests and the Clojure `connect` builtin alike.
+/// The TCP connect and I/O tasks run on the `WorkerPool`; bridge tasks run on
+/// the LocalSet. Convenience wrapper used by tests and the Clojure `connect`
+/// builtin alike.
 pub fn connect_to(host: &str, port: u16, in_buf: usize, out_buf: usize) -> Value {
     let host = host.to_string();
     let promise = make_chan(1);
@@ -397,14 +416,59 @@ async fn do_connect(
     promise: GcPtr<NativeObjectBox>,
 ) -> EvalResult {
     let addr = format!("{host}:{port}");
-    let stream = match tokio::net::TcpStream::connect(&addr).await {
-        Ok(s) => s,
-        Err(e) => {
-            chan_deliver(&promise, net_error(format!("connect to {addr}: {e}"))).await;
-            return Ok(Value::Nil);
+
+    // Channel for the pool → LocalSet handshake.
+    let (setup_tx, setup_rx) = oneshot::channel::<PoolSetupResult>();
+
+    // Spawn the entire TCP connect + I/O pump on the pool (Send).
+    WorkerPool::global().handle().spawn(async move {
+        match TcpStream::connect(&addr).await {
+            Err(e) => {
+                let _ = setup_tx.send(Err(format!("connect to {addr}: {e}")));
+            }
+            Ok(stream) => {
+                let remote_addr = stream
+                    .peer_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_default();
+                let local_addr = stream
+                    .local_addr()
+                    .map(|a| a.to_string())
+                    .unwrap_or_default();
+
+                let (read_half, write_half) = stream.into_split();
+                let (read_tx, read_rx) =
+                    mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+                let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
+
+                let reader_jh = tokio::spawn(pool_reader(read_half, read_tx));
+                let writer_jh = tokio::spawn(pool_writer(write_half, write_rx));
+
+                let _ = setup_tx.send(Ok(PoolStreamSetup {
+                    remote_addr,
+                    local_addr,
+                    read_rx,
+                    write_tx,
+                    reader_abort: reader_jh.abort_handle(),
+                    writer_abort: writer_jh.abort_handle(),
+                }));
+            }
         }
-    };
-    chan_deliver(&promise, make_connection(stream, in_buf, out_buf)).await;
+    });
+
+    // Await the setup result back on the LocalSet (not blocking the thread).
+    match setup_rx.await {
+        Err(_) => {
+            chan_deliver(&promise, net_error("pool task dropped")).await;
+        }
+        Ok(Err(e)) => {
+            chan_deliver(&promise, net_error(e)).await;
+        }
+        Ok(Ok(setup)) => {
+            let conn = make_tcp_connection_from_setup(setup, in_buf, out_buf);
+            chan_deliver(&promise, conn).await;
+        }
+    }
     Ok(Value::Nil)
 }
 
@@ -435,8 +499,8 @@ fn builtin_connect(args: &[Value]) -> ValueResult<Value> {
 
 /// `(close conn)` — close a connection map.
 ///
-/// Closes both `:in` and `:out` channels and aborts the reader/writer tasks
-/// via the connection's `:resource` handle, releasing the socket FD.
+/// Closes both `:in` and `:out` channels and aborts all I/O tasks via the
+/// connection's `:resource` handle, releasing the socket FD.
 fn builtin_close(args: &[Value]) -> ValueResult<Value> {
     let conn = match args.first() {
         Some(Value::Map(m)) => m.clone(),
@@ -448,7 +512,7 @@ fn builtin_close(args: &[Value]) -> ValueResult<Value> {
         }
     };
 
-    // Signal the writer task; it will drain and shutdown the write half.
+    // Signal the writer task; it will drain and shutdown the write side.
     if let Some(Value::NativeObject(obj)) = conn.get(&kw("out")) {
         chan_ref(obj.get()).close();
     }

--- a/crates/cljrs-net/src/tls.rs
+++ b/crates/cljrs-net/src/tls.rs
@@ -21,6 +21,11 @@
 //!  :local-addr "ip:port"
 //!  :resource   <handle>} ; TlsListenerResource — deterministic listener close
 //! ```
+//!
+//! Phase A2: TCP connect, TLS handshake, and I/O tasks all run on the
+//! `WorkerPool` multi-thread runtime.  `GcPtr`/`Value` construction happens in
+//! LocalSet bridge tasks only.  `TlsStream<TcpStream>: Send` because
+//! `ClientConnection`/`ServerConnection: Send`.
 
 use std::any::Any;
 use std::io::BufReader;
@@ -29,18 +34,26 @@ use std::sync::{Arc, Mutex};
 use rustls::ClientConfig;
 use rustls::ServerConfig;
 use rustls::pki_types::ServerName;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::AbortHandle;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
-use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, chan_take, make_chan};
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, make_chan};
 use cljrs_async::spawn_future;
+use cljrs_async::worker_pool::WorkerPool;
 use cljrs_env::env::GlobalEnv;
 use cljrs_env::error::EvalResult;
 use cljrs_gc::GcPtr;
 use cljrs_value::{
-    Arity, ExceptionInfo, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle,
-    Value, ValueError, ValueResult,
+    Arity, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle, Value,
+    ValueError, ValueResult,
+};
+
+use crate::pool_io::{
+    net_error, pool_reader, pool_writer, read_bridge, write_bridge, PoolSetupResult,
+    PoolStreamSetup,
 };
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -65,14 +78,14 @@ pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
 #[derive(Debug)]
 struct TlsStreamInner {
     closed: bool,
-    reader_abort: Option<AbortHandle>,
-    writer_abort: Option<AbortHandle>,
+    abort_handles: Vec<AbortHandle>,
 }
 
 /// `Resource` implementation for a TLS stream.
 ///
-/// Holds `AbortHandle`s for the reader and writer tasks spawned in `connect`.
-/// `close()` aborts both tasks, which drops the socket halves and closes the FD.
+/// Holds `AbortHandle`s for the pool reader, pool writer, and LocalSet bridge
+/// tasks. `close()` aborts all handles, which drops the socket halves and
+/// closes the FD.
 #[derive(Debug)]
 pub struct TlsStreamResource {
     inner: Arc<Mutex<TlsStreamInner>>,
@@ -83,8 +96,7 @@ impl TlsStreamResource {
         Self {
             inner: Arc::new(Mutex::new(TlsStreamInner {
                 closed: false,
-                reader_abort: None,
-                writer_abort: None,
+                abort_handles: Vec::new(),
             })),
         }
     }
@@ -97,10 +109,7 @@ impl Resource for TlsStreamResource {
             return Ok(());
         }
         g.closed = true;
-        if let Some(h) = g.reader_abort.take() {
-            h.abort();
-        }
-        if let Some(h) = g.writer_abort.take() {
+        for h in g.abort_handles.drain(..) {
             h.abort();
         }
         Ok(())
@@ -124,13 +133,13 @@ impl Resource for TlsStreamResource {
 #[derive(Debug)]
 struct TlsListenerInner {
     closed: bool,
-    accept_abort: Option<AbortHandle>,
+    abort_handles: Vec<AbortHandle>,
 }
 
 /// `Resource` implementation for a TLS listener.
 ///
-/// Holds the `AbortHandle` for the `tls_accept_loop` task. `close()` aborts the
-/// task, which drops the `TcpListener` and closes the listener FD.
+/// Holds `AbortHandle`s for the pool accept loop and the LocalSet accept bridge.
+/// `close()` aborts all handles, which drops the listener and closes the FD.
 #[derive(Debug)]
 pub struct TlsListenerResource {
     inner: Arc<Mutex<TlsListenerInner>>,
@@ -141,7 +150,7 @@ impl TlsListenerResource {
         Self {
             inner: Arc::new(Mutex::new(TlsListenerInner {
                 closed: false,
-                accept_abort: None,
+                abort_handles: Vec::new(),
             })),
         }
     }
@@ -154,7 +163,7 @@ impl Resource for TlsListenerResource {
             return Ok(());
         }
         g.closed = true;
-        if let Some(h) = g.accept_abort.take() {
+        for h in g.abort_handles.drain(..) {
             h.abort();
         }
         Ok(())
@@ -174,21 +183,6 @@ impl Resource for TlsListenerResource {
 }
 
 // ── Value helpers ─────────────────────────────────────────────────────────────
-
-fn bytes_value(bytes: &[u8]) -> Value {
-    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
-    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
-}
-
-fn net_error(msg: impl Into<String>) -> Value {
-    let msg = msg.into();
-    Value::Error(GcPtr::new(ExceptionInfo::new(
-        ValueError::Other(msg.clone()),
-        msg,
-        None,
-        None,
-    )))
-}
 
 fn kw(name: &str) -> Value {
     Value::keyword(Keyword::simple(name))
@@ -241,93 +235,136 @@ fn opts_string_vec(opts: &MapValue, key: &str) -> Option<Vec<String>> {
     }
 }
 
-// ── Async tasks (generic — used by both client and server connections) ─────────
+// ── Pool tasks (Send, no GcPtr) ───────────────────────────────────────────────
 
-/// Read chunks from the TLS stream and put them on `:in`.
-///
-/// Closes `:in` at EOF or on error. Aborted via `TlsStreamResource::close`.
-async fn tls_reader_loop<R>(mut reader: R, in_chan: GcPtr<NativeObjectBox>)
-where
-    R: tokio::io::AsyncRead + Unpin + 'static,
-{
-    let mut buf = vec![0u8; 8192];
-    loop {
-        match reader.read(&mut buf).await {
-            Ok(0) => break,
-            Ok(n) => {
-                if !chan_put(&in_chan, bytes_value(&buf[..n])).await {
-                    break; // consumer closed :in
-                }
-            }
-            Err(e) => {
-                chan_put(&in_chan, net_error(format!("read error: {e}"))).await;
-                break;
-            }
-        }
-    }
-    chan_ref(in_chan.get()).close();
-}
-
-/// Drain `:out` and write each value to the TLS stream.
-///
-/// Accepts `byte-array` and `string` values. Shuts down write side when `:out`
-/// is closed. Aborted via `TlsStreamResource::close`.
-async fn tls_writer_loop<W>(mut writer: W, out_chan: GcPtr<NativeObjectBox>)
-where
-    W: tokio::io::AsyncWrite + Unpin + 'static,
-{
-    let _: std::io::Result<()> = async {
-        loop {
-            match chan_take(&out_chan).await {
-                Value::Nil => {
-                    // :out closed; gracefully half-close the write side.
-                    let _ = writer.shutdown().await;
-                    break;
-                }
-                Value::ByteArray(arr) => {
-                    let bytes: Vec<u8> =
-                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
-                    writer.write_all(&bytes).await?;
-                }
-                Value::Str(s) => {
-                    writer.write_all(s.get().as_bytes()).await?;
-                }
-                _ => {}
-            }
-        }
-        Ok(())
-    }
-    .await;
-}
-
-// ── Connection builder (generic) ──────────────────────────────────────────────
-
-fn make_tls_connection<R, W>(
-    reader: R,
-    writer: W,
-    remote_addr: String,
-    local_addr: String,
+/// Runs on the pool: accepts TCP connections, performs TLS handshake on the
+/// pool, splits the TLS stream, spawns pool_reader + pool_writer, and sends
+/// the `PoolStreamSetup` via `conn_info_tx`.
+async fn pool_tls_accept_loop(
+    std_listener: std::net::TcpListener,
+    acceptor: TlsAcceptor,
+    conn_info_tx: mpsc::Sender<PoolSetupResult>,
     in_buf: usize,
     out_buf: usize,
-) -> Value
-where
-    R: tokio::io::AsyncRead + Unpin + 'static,
-    W: tokio::io::AsyncWrite + Unpin + 'static,
-{
+) {
+    // Convert std listener inside pool runtime context.
+    let listener = match TcpListener::from_std(std_listener) {
+        Ok(l) => l,
+        Err(e) => {
+            let _ = conn_info_tx
+                .send(Err(format!("from_std: {e}")))
+                .await;
+            return;
+        }
+    };
+
+    let local_addr = listener
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_default();
+
+    loop {
+        match listener.accept().await {
+            Err(e) => {
+                let _ = conn_info_tx
+                    .send(Err(format!("accept error: {e}")))
+                    .await;
+                break;
+            }
+            Ok((tcp_stream, peer_addr)) => {
+                let remote_addr = peer_addr.to_string();
+                let local_addr_conn = local_addr.clone();
+                let acceptor = acceptor.clone();
+                let conn_info_tx = conn_info_tx.clone();
+
+                // Spawn per-connection TLS handshake as a separate pool task.
+                tokio::spawn(async move {
+                    let tls_stream = match acceptor.accept(tcp_stream).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            let _ = conn_info_tx
+                                .send(Err(format!("TLS handshake: {e}")))
+                                .await;
+                            return;
+                        }
+                    };
+
+                    let (read_half, write_half) = tokio::io::split(tls_stream);
+                    let (read_tx, read_rx) =
+                        mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+                    let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
+
+                    let reader_jh = tokio::spawn(pool_reader(read_half, read_tx));
+                    let writer_jh = tokio::spawn(pool_writer(write_half, write_rx));
+
+                    let setup = PoolStreamSetup {
+                        remote_addr,
+                        local_addr: local_addr_conn,
+                        read_rx,
+                        write_tx,
+                        reader_abort: reader_jh.abort_handle(),
+                        writer_abort: writer_jh.abort_handle(),
+                    };
+                    let _ = conn_info_tx.send(Ok(setup)).await;
+                });
+            }
+        }
+    }
+}
+
+// ── LocalSet bridge (touches GcPtr / Value) ───────────────────────────────────
+
+/// Runs on the LocalSet: receives `PoolSetupResult` from the pool accept loop,
+/// creates Clojure channels + bridges for each new connection, and puts the
+/// connection map on `conns_chan`.
+async fn local_tls_accept_bridge(
+    mut conn_info_rx: mpsc::Receiver<PoolSetupResult>,
+    conns_chan: GcPtr<NativeObjectBox>,
+    in_buf: usize,
+    out_buf: usize,
+) {
+    while let Some(result) = conn_info_rx.recv().await {
+        match result {
+            Err(e) => {
+                chan_put(&conns_chan, net_error(e)).await;
+                break;
+            }
+            Ok(setup) => {
+                let conn = make_tls_connection_from_setup(setup, in_buf, out_buf);
+                if !chan_put(&conns_chan, conn).await {
+                    break; // consumer closed :conns
+                }
+            }
+        }
+    }
+    chan_ref(conns_chan.get()).close();
+}
+
+/// Build a TLS connection map + resource from a `PoolStreamSetup`, spawning
+/// LocalSet bridge tasks. Called on the LocalSet thread.
+fn make_tls_connection_from_setup(setup: PoolStreamSetup, in_buf: usize, out_buf: usize) -> Value {
     let in_chan = make_chan(in_buf);
     let out_chan = make_chan(out_buf);
     let resource = TlsStreamResource::new();
     let shared_inner = resource.inner.clone();
     let resource_handle = ResourceHandle::new(resource);
-    let r_jh = tokio::task::spawn_local(tls_reader_loop(reader, in_chan.clone()));
-    shared_inner.lock().unwrap().reader_abort = Some(r_jh.abort_handle());
-    let w_jh = tokio::task::spawn_local(tls_writer_loop(writer, out_chan.clone()));
-    shared_inner.lock().unwrap().writer_abort = Some(w_jh.abort_handle());
+
+    let rb_jh = tokio::task::spawn_local(read_bridge(setup.read_rx, in_chan.clone()));
+    let wb_jh = tokio::task::spawn_local(write_bridge(out_chan.clone(), setup.write_tx));
+
+    {
+        let mut g = shared_inner.lock().unwrap();
+        g.abort_handles.push(setup.reader_abort);
+        g.abort_handles.push(setup.writer_abort);
+        g.abort_handles.push(rb_jh.abort_handle());
+        g.abort_handles.push(wb_jh.abort_handle());
+    }
+
     Value::Map(MapValue::from_pairs(vec![
         (kw("in"), Value::NativeObject(in_chan)),
         (kw("out"), Value::NativeObject(out_chan)),
-        (kw("remote-addr"), Value::string(remote_addr)),
-        (kw("local-addr"), Value::string(local_addr)),
+        (kw("remote-addr"), Value::string(setup.remote_addr)),
+        (kw("local-addr"), Value::string(setup.local_addr)),
         (kw("resource"), Value::Resource(resource_handle)),
     ]))
 }
@@ -489,6 +526,9 @@ fn load_private_key(path: &str) -> ValueResult<rustls::pki_types::PrivateKeyDer<
 // ── Connect implementation ────────────────────────────────────────────────────
 
 /// Initiate a TLS connection and return the promise channel as a `Value`.
+///
+/// TCP connect + TLS handshake + I/O tasks run on the `WorkerPool`; bridge
+/// tasks run on the LocalSet.
 pub fn tls_connect_to(
     host: &str,
     port: u16,
@@ -499,7 +539,9 @@ pub fn tls_connect_to(
     let host = host.to_string();
     let promise = make_chan(1);
     let promise_val = Value::NativeObject(promise.clone());
-    spawn_future(async move { do_tls_connect(host, port, config, in_buf, out_buf, promise).await });
+    spawn_future(async move {
+        do_tls_connect(host, port, config, in_buf, out_buf, promise).await
+    });
     promise_val
 }
 
@@ -513,105 +555,86 @@ async fn do_tls_connect(
 ) -> EvalResult {
     let addr = format!("{host}:{port}");
 
-    // TCP connect
-    let tcp_stream = match tokio::net::TcpStream::connect(&addr).await {
-        Ok(s) => s,
-        Err(e) => {
-            chan_deliver(&promise, net_error(format!("connect to {addr}: {e}"))).await;
-            return Ok(Value::Nil);
-        }
-    };
+    // Channel for pool → LocalSet handshake.
+    let (setup_tx, setup_rx) = oneshot::channel::<PoolSetupResult>();
 
-    let remote_addr = tcp_stream
-        .peer_addr()
-        .map(|a| a.to_string())
-        .unwrap_or_default();
-    let local_addr = tcp_stream
-        .local_addr()
-        .map(|a| a.to_string())
-        .unwrap_or_default();
-
-    // TLS handshake
-    let server_name = match ServerName::try_from(host.as_str()) {
-        Ok(n) => n.to_owned(),
-        Err(e) => {
-            chan_deliver(
-                &promise,
-                net_error(format!("invalid SNI hostname {host}: {e}")),
-            )
-            .await;
-            return Ok(Value::Nil);
-        }
-    };
-
-    let connector = TlsConnector::from(config);
-    let tls_stream = match connector.connect(server_name, tcp_stream).await {
-        Ok(s) => s,
-        Err(e) => {
-            chan_deliver(&promise, net_error(format!("TLS handshake: {e}"))).await;
-            return Ok(Value::Nil);
-        }
-    };
-
-    let (reader, writer) = tokio::io::split(tls_stream);
-    let conn = make_tls_connection(reader, writer, remote_addr, local_addr, in_buf, out_buf);
-    chan_deliver(&promise, conn).await;
-    Ok(Value::Nil)
-}
-
-// ── Accept loop ───────────────────────────────────────────────────────────────
-
-/// Accept TLS connections and put each connection map on `conns_chan`.
-async fn tls_accept_loop(
-    listener: tokio::net::TcpListener,
-    acceptor: TlsAcceptor,
-    conns_chan: GcPtr<NativeObjectBox>,
-    in_buf: usize,
-    out_buf: usize,
-) {
-    loop {
-        match listener.accept().await {
+    // Spawn entire TLS connect + I/O pump on pool (Send).
+    WorkerPool::global().handle().spawn(async move {
+        // TCP connect
+        let tcp_stream = match TcpStream::connect(&addr).await {
+            Ok(s) => s,
             Err(e) => {
-                chan_put(&conns_chan, net_error(format!("accept error: {e}"))).await;
-                break;
+                let _ = setup_tx.send(Err(format!("connect to {addr}: {e}")));
+                return;
             }
-            Ok((tcp_stream, peer_addr)) => {
-                let remote_addr = peer_addr.to_string();
-                let local_addr = listener
-                    .local_addr()
-                    .map(|a| a.to_string())
-                    .unwrap_or_default();
-                let acceptor = acceptor.clone();
-                let conns_chan_clone = conns_chan.clone();
-                tokio::task::spawn_local(async move {
-                    let tls_stream = match acceptor.accept(tcp_stream).await {
-                        Ok(s) => s,
-                        Err(e) => {
-                            chan_put(&conns_chan_clone, net_error(format!("TLS handshake: {e}")))
-                                .await;
-                            return;
-                        }
-                    };
-                    let (reader, writer) = tokio::io::split(tls_stream);
-                    let conn = make_tls_connection(
-                        reader,
-                        writer,
-                        remote_addr,
-                        local_addr,
-                        in_buf,
-                        out_buf,
-                    );
-                    chan_put(&conns_chan_clone, conn).await;
-                });
+        };
+
+        let remote_addr = tcp_stream
+            .peer_addr()
+            .map(|a| a.to_string())
+            .unwrap_or_default();
+        let local_addr = tcp_stream
+            .local_addr()
+            .map(|a| a.to_string())
+            .unwrap_or_default();
+
+        // TLS handshake
+        let server_name = match ServerName::try_from(host.as_str()) {
+            Ok(n) => n.to_owned(),
+            Err(e) => {
+                let _ = setup_tx.send(Err(format!("invalid SNI hostname {host}: {e}")));
+                return;
             }
+        };
+
+        let connector = TlsConnector::from(config);
+        let tls_stream = match connector.connect(server_name, tcp_stream).await {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = setup_tx.send(Err(format!("TLS handshake: {e}")));
+                return;
+            }
+        };
+
+        let (read_half, write_half) = tokio::io::split(tls_stream);
+        let (read_tx, read_rx) = mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+        let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
+
+        let reader_jh = tokio::spawn(pool_reader(read_half, read_tx));
+        let writer_jh = tokio::spawn(pool_writer(write_half, write_rx));
+
+        let _ = setup_tx.send(Ok(PoolStreamSetup {
+            remote_addr,
+            local_addr,
+            read_rx,
+            write_tx,
+            reader_abort: reader_jh.abort_handle(),
+            writer_abort: writer_jh.abort_handle(),
+        }));
+    });
+
+    // Await the setup result back on the LocalSet.
+    match setup_rx.await {
+        Err(_) => {
+            chan_deliver(&promise, net_error("pool task dropped")).await;
+        }
+        Ok(Err(e)) => {
+            chan_deliver(&promise, net_error(e)).await;
+        }
+        Ok(Ok(setup)) => {
+            let conn = make_tls_connection_from_setup(setup, in_buf, out_buf);
+            chan_deliver(&promise, conn).await;
         }
     }
-    chan_ref(conns_chan.get()).close();
+    Ok(Value::Nil)
 }
 
 // ── Listen implementation ─────────────────────────────────────────────────────
 
 /// Bind a TLS listener on `host:port` and return a server map.
+///
+/// The accept loop and TLS handshakes run on the `WorkerPool`; a LocalSet bridge
+/// delivers connection maps onto `conns_chan`.
 pub fn tls_listen_on(
     host: &str,
     port: u16,
@@ -622,20 +645,19 @@ pub fn tls_listen_on(
 ) -> ValueResult<Value> {
     let addr = format!("{host}:{port}");
 
-    // Bind synchronously (std), then convert to Tokio.
+    // Bind synchronously (std) so we get the local_addr immediately.
     let std_listener = std::net::TcpListener::bind(&addr)
         .map_err(|e| ValueError::Other(format!("listen on {addr}: {e}")))?;
     std_listener
         .set_nonblocking(true)
         .map_err(|e| ValueError::Other(format!("set_nonblocking: {e}")))?;
-    let listener = tokio::net::TcpListener::from_std(std_listener)
-        .map_err(|e| ValueError::Other(format!("from_std: {e}")))?;
 
-    let local_addr = listener
+    let local_addr = std_listener
         .local_addr()
         .map(|a| a.to_string())
         .unwrap_or_default();
 
+    let (conn_info_tx, conn_info_rx) = mpsc::channel::<PoolSetupResult>(conns_buf.max(1));
     let conns_chan = make_chan(conns_buf);
     let acceptor = TlsAcceptor::from(config);
 
@@ -643,14 +665,30 @@ pub fn tls_listen_on(
     let shared_inner = resource.inner.clone();
     let resource_handle = ResourceHandle::new(resource);
 
-    let jh = tokio::task::spawn_local(tls_accept_loop(
-        listener,
-        acceptor,
+    // Spawn accept loop on pool (Send).
+    let pool_jh = WorkerPool::global()
+        .handle()
+        .spawn(pool_tls_accept_loop(
+            std_listener,
+            acceptor,
+            conn_info_tx,
+            in_buf,
+            out_buf,
+        ));
+
+    // Spawn bridge on LocalSet (!Send, touches GcPtr).
+    let bridge_jh = tokio::task::spawn_local(local_tls_accept_bridge(
+        conn_info_rx,
         conns_chan.clone(),
         in_buf,
         out_buf,
     ));
-    shared_inner.lock().unwrap().accept_abort = Some(jh.abort_handle());
+
+    {
+        let mut g = shared_inner.lock().unwrap();
+        g.abort_handles.push(pool_jh.abort_handle());
+        g.abort_handles.push(bridge_jh.abort_handle());
+    }
 
     Ok(Value::Map(MapValue::from_pairs(vec![
         (kw("conns"), Value::NativeObject(conns_chan)),

--- a/crates/cljrs-net/src/tls.rs
+++ b/crates/cljrs-net/src/tls.rs
@@ -52,8 +52,8 @@ use cljrs_value::{
 };
 
 use crate::pool_io::{
-    net_error, pool_reader, pool_writer, read_bridge, write_bridge, PoolSetupResult,
-    PoolStreamSetup,
+    PoolSetupResult, PoolStreamSetup, net_error, pool_reader, pool_writer, read_bridge,
+    write_bridge,
 };
 
 // ── Public entry point ────────────────────────────────────────────────────────
@@ -251,9 +251,7 @@ async fn pool_tls_accept_loop(
     let listener = match TcpListener::from_std(std_listener) {
         Ok(l) => l,
         Err(e) => {
-            let _ = conn_info_tx
-                .send(Err(format!("from_std: {e}")))
-                .await;
+            let _ = conn_info_tx.send(Err(format!("from_std: {e}"))).await;
             return;
         }
     };
@@ -266,9 +264,7 @@ async fn pool_tls_accept_loop(
     loop {
         match listener.accept().await {
             Err(e) => {
-                let _ = conn_info_tx
-                    .send(Err(format!("accept error: {e}")))
-                    .await;
+                let _ = conn_info_tx.send(Err(format!("accept error: {e}"))).await;
                 break;
             }
             Ok((tcp_stream, peer_addr)) => {
@@ -282,9 +278,7 @@ async fn pool_tls_accept_loop(
                     let tls_stream = match acceptor.accept(tcp_stream).await {
                         Ok(s) => s,
                         Err(e) => {
-                            let _ = conn_info_tx
-                                .send(Err(format!("TLS handshake: {e}")))
-                                .await;
+                            let _ = conn_info_tx.send(Err(format!("TLS handshake: {e}"))).await;
                             return;
                         }
                     };
@@ -539,9 +533,7 @@ pub fn tls_connect_to(
     let host = host.to_string();
     let promise = make_chan(1);
     let promise_val = Value::NativeObject(promise.clone());
-    spawn_future(async move {
-        do_tls_connect(host, port, config, in_buf, out_buf, promise).await
-    });
+    spawn_future(async move { do_tls_connect(host, port, config, in_buf, out_buf, promise).await });
     promise_val
 }
 
@@ -666,15 +658,13 @@ pub fn tls_listen_on(
     let resource_handle = ResourceHandle::new(resource);
 
     // Spawn accept loop on pool (Send).
-    let pool_jh = WorkerPool::global()
-        .handle()
-        .spawn(pool_tls_accept_loop(
-            std_listener,
-            acceptor,
-            conn_info_tx,
-            in_buf,
-            out_buf,
-        ));
+    let pool_jh = WorkerPool::global().handle().spawn(pool_tls_accept_loop(
+        std_listener,
+        acceptor,
+        conn_info_tx,
+        in_buf,
+        out_buf,
+    ));
 
     // Spawn bridge on LocalSet (!Send, touches GcPtr).
     let bridge_jh = tokio::task::spawn_local(local_tls_accept_bridge(


### PR DESCRIPTION
- cljrs-async/src/worker_pool.rs: WorkerPool singleton backed by a
  Tokio multi-thread runtime; offload<F,T>() bridges Send futures from
  the heap (LocalSet) thread to pool threads via oneshot channels;
  handle() exposes the runtime for multi-task spawning; wasm32 stub
  runs futures locally
- cljrs-async/src/lib.rs: pub mod worker_pool
- cljrs-async/Cargo.toml: add rt-multi-thread tokio feature (non-wasm)
- cljrs-net/src/pool_io.rs: ReadMsg enum, PoolStreamSetup struct,
  pool_reader/pool_writer (run on pool, no GcPtr), read_bridge/
  write_bridge (run on LocalSet, create Value::ByteArray from bytes),
  bytes_value/net_error helpers shared by tcp.rs and tls.rs
- cljrs-net/src/lib.rs: mod pool_io
- cljrs-net/Cargo.toml: add sync tokio feature for mpsc/oneshot

https://claude.ai/code/session_018YTurjgpFqq3ge2idDc413