### PR TITLE
B2: copy boundary — structured-clone for cross-isolate value transfer

### DIFF
--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -44,6 +44,13 @@ Done (Phases A–H, A2, B1):
 - Phase B1: `Isolate` type — per-isolate OS thread with independent GC heap (`ISOLATE_HEAP`
   thread-local), `current_thread` Tokio runtime, and `LocalSet`. GC collections are fully
   parallel and independent; no cross-isolate STW coordination.
+- Phase B2: `isolate_channel` — cross-isolate copy boundary. `IsolateSender::send` serializes
+  a `Value` to a `Send + Sync` wire form (`SerializedValue`, defined in `cljrs-value::clone`);
+  `IsolateReceiver::recv`/`try_recv` deserializes it into the receiver's GC heap. Non-shareable
+  values (mutable state, closures, native resources) are rejected at send time with a typed
+  `CloneError`. The sender may be cloned (multi-producer); the receiver must stay on its isolate
+  thread (single-consumer). `GcPtr`'s `!Send` bound makes pointer-sharing a compile error —
+  the channel is the only sanctioned crossing point.
 - Phase H: `<!!` (blocking take) and `>!!` (blocking put) for synchronous / REPL / test
   contexts. Both use `Condvar`-based parking (with a 1 ms poll-interval fallback so they
   remain non-deadlocking when called from the LocalSet executor thread). Errors with a
@@ -129,6 +136,7 @@ blocking bridge is a later phase.
 | `src/core_async.cljrs` | Clojure source for `clojure.core.async`: `go`, `alt`, `async-pmap`, `thread`, `merge`, `reduce`, `into`, and the `<?` family (`<?`, `<??`, `go-try`) |
 | `src/clojure_rust_error.cljrs` | Clojure source for `clojure.rust.error`: in-band error helpers `error?`, `ok?`, `throw-err` |
 | `src/isolate.rs` | `Isolate` — per-isolate execution context: dedicated OS thread, `current_thread` Tokio runtime + `LocalSet`, and independent GC heap (thread-local). `Isolate::spawn` initializes GC state and runs the entry-point future |
+| `src/isolate_channel.rs` | `IsolateSender` / `IsolateReceiver` / `isolate_channel()` — cross-isolate copy boundary (Phase B2): structured-clone of `Value` through a `SerializedValue` wire form over a tokio unbounded MPSC channel |
 | `src/worker_pool.rs` | `WorkerPool` singleton: multi-thread Tokio runtime (`new_multi_thread`) for `Send` pool tasks; wasm32 stub; `offload` bridges pool results to LocalSet via oneshot; `handle` for direct multi-task spawning |
 | `tests/error_propagation.rs` | integration tests for the `<?` family and `clojure.rust.error` helpers |
 | `tests/async_fn.rs` | integration tests for dispatch, `await`, `deref` enforcement, `timeout`/`alts`/`alt`, channels, Phase F utilities, and `<!!`/`>!!` |
@@ -186,6 +194,31 @@ pub mod worker_pool {
         #[cfg(not(target_arch = "wasm32"))]
         pub fn handle(&self) -> &tokio::runtime::Handle;
     }
+}
+
+pub mod isolate_channel {
+    /// Sending end of a cross-isolate channel (cloneable, Send).
+    #[derive(Clone)]
+    pub struct IsolateSender;
+    impl IsolateSender {
+        /// Serialize `v` and enqueue it. Returns CloneError for non-shareable values
+        /// or if the receiver has been dropped.
+        pub fn send(&self, v: &Value) -> Result<(), CloneError>;
+    }
+
+    /// Receiving end of a cross-isolate channel. Must remain on the destination
+    /// isolate thread so `deserialize` allocates into the correct GC heap.
+    pub struct IsolateReceiver;
+    impl IsolateReceiver {
+        /// Async receive: deserialize the next value into the current isolate's heap.
+        /// Returns `None` when all senders have been dropped.
+        pub async fn recv(&mut self) -> Option<Value>;
+        /// Non-blocking receive attempt. Returns `None` if the channel is empty.
+        pub fn try_recv(&mut self) -> Option<Value>;
+    }
+
+    /// Create a linked `(IsolateSender, IsolateReceiver)` pair.
+    pub fn isolate_channel() -> (IsolateSender, IsolateReceiver);
 }
 
 pub mod eval_async {

--- a/crates/cljrs-async/src/isolate_channel.rs
+++ b/crates/cljrs-async/src/isolate_channel.rs
@@ -1,0 +1,312 @@
+//! Cross-isolate channel — the copy boundary for Phase B2.
+//!
+//! A cross-isolate channel transfers `Value`s between two isolates by
+//! **structured-cloning** them at the boundary:
+//!
+//! 1. The sender calls `IsolateSender::send`, which calls `serialize` to produce
+//!    a `SerializedValue` (a `Send + Sync` owned intermediate).
+//! 2. The serialized form travels over a `tokio::sync::mpsc` channel (which is
+//!    `Send` when the item type is `Send`).
+//! 3. The receiver calls `IsolateReceiver::recv` (async) or
+//!    `IsolateReceiver::try_recv` (non-blocking), which calls `deserialize` to
+//!    allocate a fresh `Value` in the *current* isolate's GC heap.
+//!
+//! `GcPtr` is `!Send`, so the compiler prevents accidentally sharing a pointer
+//! across the boundary. The only crossing mechanism is this channel.
+//!
+//! Non-shareable values (`Resource`, `Atom`, mutable state, closures) are
+//! rejected at `send` time with a [`CloneError`] rather than a panic.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! let (tx, rx) = isolate_channel();
+//!
+//! // Isolate A sends
+//! tx.send(&Value::Long(42)).unwrap();
+//!
+//! // Isolate B receives (inside its LocalSet)
+//! let v = rx_clone.recv().await.unwrap();
+//! assert_eq!(v, Value::Long(42));
+//! ```
+
+use cljrs_value::Value;
+use cljrs_value::clone::{CloneError, SerializedValue, deserialize, serialize};
+
+/// Sending end of a cross-isolate channel. Cloneable — multiple senders are
+/// allowed. All methods are synchronous and cheap (just serialization + channel
+/// push).
+#[derive(Clone)]
+pub struct IsolateSender {
+    tx: tokio::sync::mpsc::UnboundedSender<SerializedValue>,
+}
+
+/// Receiving end of a cross-isolate channel. Must live on the destination
+/// isolate's thread so that `deserialize` allocates into the right GC heap.
+pub struct IsolateReceiver {
+    rx: tokio::sync::mpsc::UnboundedReceiver<SerializedValue>,
+}
+
+// IsolateSender is Send because SerializedValue: Send.
+// IsolateReceiver is also Send (tokio guarantees this when the item is Send);
+// it must be moved to the destination thread before use.
+
+/// Create a linked `(IsolateSender, IsolateReceiver)` pair.
+///
+/// The sender may be cloned and used from any thread or isolate. The receiver
+/// must be moved to the destination isolate *before* any `recv` call so that
+/// deserialized `GcPtr`s are allocated in the correct heap.
+pub fn isolate_channel() -> (IsolateSender, IsolateReceiver) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    (IsolateSender { tx }, IsolateReceiver { rx })
+}
+
+impl IsolateSender {
+    /// Serialize `v` and enqueue it for the receiving isolate.
+    ///
+    /// Returns `Err(CloneError::NotShareable { .. })` if `v` contains a
+    /// non-shareable type (mutable state, closures, native resources).
+    /// Returns `Err(CloneError::Disconnected)` if the receiver has been dropped.
+    pub fn send(&self, v: &Value) -> Result<(), CloneError> {
+        let sv = serialize(v)?;
+        self.tx.send(sv).map_err(|_| CloneError::Disconnected)
+    }
+}
+
+impl IsolateReceiver {
+    /// Asynchronously receive the next value, deserializing it into the current
+    /// isolate's GC heap. Returns `None` when all senders have been dropped.
+    pub async fn recv(&mut self) -> Option<Value> {
+        self.rx.recv().await.map(deserialize)
+    }
+
+    /// Non-blocking receive attempt. Returns `None` if the channel is currently
+    /// empty or all senders have been dropped.
+    pub fn try_recv(&mut self) -> Option<Value> {
+        self.rx.try_recv().ok().map(deserialize)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::isolate::Isolate;
+    use cljrs_gc::GcPtr;
+    use cljrs_value::{Keyword, MapValue, PersistentList, PersistentVector};
+    use std::sync::Arc;
+
+    // Values are !Send (GcPtr contains NonNull).  All value creation must happen
+    // *inside* an Isolate::spawn future body, not in a captured outer variable.
+    // Assertions are also done inside the receiving isolate; panics propagate via
+    // JoinHandle::join().unwrap().
+
+    #[test]
+    fn nil_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("nil-sender").spawn(move || async move {
+            tx.send(&Value::Nil).unwrap();
+        });
+        let hr = Isolate::new("nil-receiver").spawn(move || async move {
+            let mut rx = rx;
+            assert_eq!(rx.recv().await.unwrap(), Value::Nil);
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    #[test]
+    fn long_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("long-sender").spawn(move || async move {
+            tx.send(&Value::Long(123)).unwrap();
+        });
+        let hr = Isolate::new("long-receiver").spawn(move || async move {
+            let mut rx = rx;
+            assert_eq!(rx.recv().await.unwrap(), Value::Long(123));
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    #[test]
+    fn string_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("str-sender").spawn(move || async move {
+            tx.send(&Value::string("hello across isolates")).unwrap();
+        });
+        let hr = Isolate::new("str-receiver").spawn(move || async move {
+            let mut rx = rx;
+            assert_eq!(
+                rx.recv().await.unwrap(),
+                Value::string("hello across isolates")
+            );
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    #[test]
+    fn keyword_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("kw-sender").spawn(move || async move {
+            tx.send(&Value::keyword(Keyword::qualified("clojure.core", "map")))
+                .unwrap();
+        });
+        let hr = Isolate::new("kw-receiver").spawn(move || async move {
+            let mut rx = rx;
+            assert_eq!(
+                rx.recv().await.unwrap(),
+                Value::keyword(Keyword::qualified("clojure.core", "map"))
+            );
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    #[test]
+    fn vector_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("vec-sender").spawn(move || async move {
+            let v = Value::Vector(GcPtr::new(PersistentVector::from_iter([
+                Value::Long(1),
+                Value::Long(2),
+                Value::string("three"),
+            ])));
+            tx.send(&v).unwrap();
+        });
+        let hr = Isolate::new("vec-receiver").spawn(move || async move {
+            let mut rx = rx;
+            let got = rx.recv().await.unwrap();
+            let expected = Value::Vector(GcPtr::new(PersistentVector::from_iter([
+                Value::Long(1),
+                Value::Long(2),
+                Value::string("three"),
+            ])));
+            assert_eq!(got, expected);
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    #[test]
+    fn map_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("map-sender").spawn(move || async move {
+            let v = Value::Map(MapValue::from_pairs(vec![
+                (Value::keyword(Keyword::simple("a")), Value::Long(1)),
+                (Value::keyword(Keyword::simple("b")), Value::string("two")),
+            ]));
+            tx.send(&v).unwrap();
+        });
+        let hr = Isolate::new("map-receiver").spawn(move || async move {
+            let mut rx = rx;
+            let got = rx.recv().await.unwrap();
+            let expected = Value::Map(MapValue::from_pairs(vec![
+                (Value::keyword(Keyword::simple("a")), Value::Long(1)),
+                (Value::keyword(Keyword::simple("b")), Value::string("two")),
+            ]));
+            assert_eq!(got, expected);
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    #[test]
+    fn list_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("list-sender").spawn(move || async move {
+            let v = Value::List(GcPtr::new(PersistentList::from_iter([
+                Value::Bool(true),
+                Value::Nil,
+                Value::Long(-7),
+            ])));
+            tx.send(&v).unwrap();
+        });
+        let hr = Isolate::new("list-receiver").spawn(move || async move {
+            let mut rx = rx;
+            let got = rx.recv().await.unwrap();
+            let expected = Value::List(GcPtr::new(PersistentList::from_iter([
+                Value::Bool(true),
+                Value::Nil,
+                Value::Long(-7),
+            ])));
+            assert_eq!(got, expected);
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    #[test]
+    fn resource_rejected_at_boundary() {
+        let (tx, _rx) = isolate_channel();
+        let h = Isolate::new("resource-sender").spawn(move || async move {
+            use cljrs_value::resource::ResourceHandle;
+            use std::any::Any;
+            #[derive(Debug)]
+            struct FakeResource;
+            impl cljrs_value::resource::Resource for FakeResource {
+                fn resource_type(&self) -> &'static str {
+                    "fake"
+                }
+                fn close(&self) -> cljrs_value::ValueResult<()> {
+                    Ok(())
+                }
+                fn is_closed(&self) -> bool {
+                    false
+                }
+                fn as_any(&self) -> &dyn Any {
+                    self
+                }
+            }
+            let r = Value::Resource(ResourceHandle(Arc::new(FakeResource)));
+            assert!(matches!(tx.send(&r), Err(CloneError::NotShareable { .. })));
+        });
+        h.join().unwrap();
+    }
+
+    #[test]
+    fn atom_rejected_at_boundary() {
+        let (tx, _rx) = isolate_channel();
+        let h = Isolate::new("atom-sender").spawn(move || async move {
+            let a = Value::Atom(GcPtr::new(cljrs_value::Atom::new(Value::Nil)));
+            assert!(matches!(tx.send(&a), Err(CloneError::NotShareable { .. })));
+        });
+        h.join().unwrap();
+    }
+
+    /// Two isolates allocate independently; the receiver's heap is unaffected
+    /// by the sender's heap. Verifies cross-isolate copy (not shared pointer).
+    #[test]
+    fn receiver_heap_is_independent() {
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let (tx, rx) = isolate_channel();
+
+        let b1 = barrier.clone();
+        let hs = Isolate::new("b2-sender").spawn(move || async move {
+            // Allocate 30 boxed i64s on the sender's heap.
+            let _vals: Vec<_> = (0_i64..30).map(|i| GcPtr::new(i)).collect();
+            // Send a shareable value to the receiver.
+            tx.send(&Value::Long(999)).unwrap();
+            b1.wait();
+            // Sender heap has exactly 30 objects.
+            assert_eq!(cljrs_gc::HEAP.count(), 30);
+        });
+
+        let b2 = barrier.clone();
+        let hr = Isolate::new("b2-receiver").spawn(move || async move {
+            let mut rx = rx;
+            // Allocate 50 objects on the receiver's heap before receiving.
+            let _vals: Vec<_> = (0_i64..50).map(|i| GcPtr::new(i)).collect();
+            let v = rx.recv().await.unwrap();
+            b2.wait();
+            // Long is inlined (no GcPtr), so count stays at 50.
+            assert_eq!(cljrs_gc::HEAP.count(), 50);
+            assert_eq!(v, Value::Long(999));
+        });
+
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+}

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -20,6 +20,7 @@ mod builtins;
 pub mod channel;
 pub mod eval_async;
 pub mod isolate;
+pub mod isolate_channel;
 mod runtime;
 pub mod worker_pool;
 use runtime::AsyncRuntimeImpl;

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -20,13 +20,14 @@ standard library on top of them.
 ```
 src/
   lib.rs                         — module declarations and re-exports
+  clone.rs                       — SerializedValue (Send+Sync wire form), CloneError, serialize/deserialize for cross-isolate copy boundary (Phase B2)
   error.rs                       — ValueError enum, ValueResult<T> alias
   hash.rs                        — ClojureHash trait, Murmur3 helpers, JVM-compatible hash_string
   keyword.rs                     — Keyword { namespace, name }
   symbol.rs                      — Symbol { namespace, name }
   native_object.rs               — NativeObject trait, NativeObjectBox wrapper, gc_native_object helper (Phase 9 interop)
   types.rs                       — Var, Atom, Namespace, NativeFn, CljxFn, Thunk, LazySeq, CljxCons, Protocol, ProtocolFn, ProtocolMethod, MultiFn, Volatile, Delay, CljxPromise, CljxFuture, Agent
-  value.rs                       — Value enum (incl. NativeObject variant), MapValue, TypeInstance, pr_str, PartialEq, ClojureHash, std::hash::Hash
+  value.rs                       — Value enum (incl. NativeObject variant), MapValue, SetValue, TypeInstance, pr_str, PartialEq, ClojureHash, std::hash::Hash
   collections/
     mod.rs                       — re-exports all collection types
     array_map.rs                 — PersistentArrayMap (≤8 entries, linear scan)
@@ -294,6 +295,38 @@ pub struct MultiFn {
     pub default_dispatch: String,  // normally ":default"
 }
 ```
+
+### `clone` — isolate copy boundary (Phase B2)
+
+```rust
+/// A Send + Sync intermediate representation for cross-isolate transfer.
+/// All heap data is owned (no GcPtr); safe to move across thread boundaries.
+pub enum SerializedValue { Nil, Bool(bool), Long(i64), /* … */ }
+
+/// Reason a value cannot cross an isolate boundary.
+pub enum CloneError {
+    NotShareable { type_name: &'static str },
+    Disconnected,
+}
+
+/// Convert a Value to SerializedValue.  Returns CloneError for mutable state,
+/// closures, native resources, and other non-shareable types.
+pub fn serialize(v: &Value) -> Result<SerializedValue, CloneError>;
+
+/// Allocate a fresh Value in the *current* GC heap from a SerializedValue.
+/// Infallible — non-shareable types are rejected at serialize time.
+pub fn deserialize(sv: SerializedValue) -> Value;
+```
+
+Shareable types: all scalars, strings, BigInt/BigDecimal/Ratio, Symbol/Keyword,
+all persistent collections, TypeInstance records, Error chains, primitive and
+object arrays, lazy sequences (realized first), WithMeta/Reduced wrappers.
+
+Non-shareable (returns `CloneError`): Atom, Var, Volatile, Promise, Future,
+Agent (mutable state); Fn, BoundFn, NativeFn, Macro, ProtocolFn, MultiFn
+(closures with isolate-local captures); Namespace, Protocol (global singletons);
+Resource, NativeObject (isolate-bound handles); TransientMap/Set/Vector;
+unforced Delay; Matcher.
 
 ### Dependencies
 

--- a/crates/cljrs-value/src/clone.rs
+++ b/crates/cljrs-value/src/clone.rs
@@ -1,0 +1,744 @@
+//! Structured-clone boundary between isolates (Phase B2).
+//!
+//! `serialize` converts a `Value` to a `Send + Sync` intermediate form;
+//! `deserialize` allocates a fresh copy into the *current* isolate's GC heap.
+//! Non-shareable values (mutable state, closures, native resources) produce a
+//! [`CloneError`] so the compiler — not a runtime panic — enforces the boundary.
+//!
+//! The round-trip is:
+//!
+//! ```text
+//! isolate A: Value → serialize → SerializedValue   (Send) ──► thread boundary
+//! isolate B:                      SerializedValue → deserialize → Value
+//! ```
+//!
+//! ## What is shareable
+//!
+//! - All scalar immediates: `Nil`, `Bool`, `Long`, `Double`, `Char`, `Uuid`
+//! - Heap-allocated *data* values: `Str`, `BigInt`, `BigDecimal`, `Ratio`,
+//!   `Pattern` (source only), `Symbol`, `Keyword`
+//! - All persistent collections: `List`, `Vector`, `Map`, `Set`, `Queue`, `Cons`
+//! - Primitive and object arrays (snapshot of current contents)
+//! - `TypeInstance` records (fields cloned recursively)
+//! - `Error` (message + data + cause chain, `Thrown` value cloned recursively)
+//! - Lazy sequences: **realized** first; the realized value is then cloned
+//! - `WithMeta`, `Reduced` wrappers (inner value + meta cloned recursively)
+//!
+//! ## What is *not* shareable (returns `CloneError`)
+//!
+//! - `Atom`, `Var`, `Volatile`, `Promise`, `Future`, `Agent`  (mutable state)
+//! - `Fn`, `BoundFn`, `Macro`, `NativeFunction`, `ProtocolFn`, `MultiFn`
+//!   (closures capture isolate-local `GcPtr`s)
+//! - `Namespace`, `Protocol`  (global singletons managed elsewhere)
+//! - `Resource`, `NativeObject`  (isolate-bound OS handles / native objects)
+//! - `TransientMap`, `TransientSet`, `TransientVector`  (isolate-local transients)
+//! - `Delay` whose thunk has not yet been forced  (thunk is isolate-local)
+//! - `Matcher`  (regex engine state tied to one execution context)
+
+use std::sync::Arc;
+
+use num_bigint::BigInt;
+
+use crate::collections::{PersistentHashSet, PersistentVector, SortedMap, SortedSet};
+use crate::error::ValueError;
+use crate::types::DelayState;
+use crate::{Keyword, MapValue, PersistentList, PersistentQueue, SetValue, Symbol, Value};
+use cljrs_gc::GcPtr;
+
+// ── Error ────────────────────────────────────────────────────────────────────
+
+/// Reason a value cannot cross an isolate boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CloneError {
+    /// The value holds isolate-local state that cannot be serialized.
+    NotShareable {
+        /// Clojure type name (matches `Value::type_name()`).
+        type_name: &'static str,
+    },
+    /// The channel's receiver side has been dropped.
+    Disconnected,
+}
+
+impl std::fmt::Display for CloneError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CloneError::NotShareable { type_name } => {
+                write!(
+                    f,
+                    "value of type `{type_name}` cannot cross an isolate boundary"
+                )
+            }
+            CloneError::Disconnected => write!(f, "isolate channel is disconnected"),
+        }
+    }
+}
+
+impl std::error::Error for CloneError {}
+
+fn not_shareable(type_name: &'static str) -> CloneError {
+    CloneError::NotShareable { type_name }
+}
+
+// ── Wire form ─────────────────────────────────────────────────────────────────
+
+/// Send + Sync intermediate form produced by `serialize` and consumed by
+/// `deserialize`. All heap data is owned (no `GcPtr`), so it is safe to move
+/// across thread boundaries.
+#[derive(Clone, Debug)]
+pub enum SerializedValue {
+    // Scalars
+    Nil,
+    Bool(bool),
+    Long(i64),
+    Double(f64),
+    BigInt(BigInt),
+    BigDecimal(bigdecimal::BigDecimal),
+    Ratio(num_rational::Ratio<BigInt>),
+    Char(char),
+    Str(String),
+    Uuid(u128),
+    /// Regex stored as source string; recompiled on deserialize.
+    Pattern(String),
+
+    // Identifiers
+    Symbol {
+        namespace: Option<Arc<str>>,
+        name: Arc<str>,
+        version: Option<Arc<str>>,
+    },
+    Keyword {
+        namespace: Option<Arc<str>>,
+        name: Arc<str>,
+    },
+
+    // Collections
+    List(Vec<SerializedValue>),
+    Vector(Vec<SerializedValue>),
+    ArrayMap(Vec<(SerializedValue, SerializedValue)>),
+    HashMap(Vec<(SerializedValue, SerializedValue)>),
+    SortedMap(Vec<(SerializedValue, SerializedValue)>),
+    HashSet(Vec<SerializedValue>),
+    SortedSet(Vec<SerializedValue>),
+    Queue(Vec<SerializedValue>),
+    Cons {
+        head: Box<SerializedValue>,
+        tail: Box<SerializedValue>,
+    },
+
+    // Records
+    TypeInstance {
+        type_tag: Arc<str>,
+        fields: Vec<(SerializedValue, SerializedValue)>,
+    },
+
+    // Errors
+    Error(Box<SerializedError>),
+
+    // Primitive arrays (snapshot of current contents)
+    BooleanArray(Vec<bool>),
+    ByteArray(Vec<i8>),
+    ShortArray(Vec<i16>),
+    IntArray(Vec<i32>),
+    LongArray(Vec<i64>),
+    FloatArray(Vec<f32>),
+    DoubleArray(Vec<f64>),
+    CharArray(Vec<char>),
+    ObjectArray(Vec<SerializedValue>),
+
+    // Wrappers
+    WithMeta {
+        value: Box<SerializedValue>,
+        meta: Box<SerializedValue>,
+    },
+    Reduced(Box<SerializedValue>),
+}
+
+// Compile-time Send + Sync assertions.
+const _: () = {
+    const fn _assert_send<T: Send + Sync>() {}
+    let _ = _assert_send::<SerializedValue>;
+};
+
+/// Serialized form of [`crate::error::ExceptionInfo`].
+#[derive(Clone, Debug)]
+pub struct SerializedError {
+    pub kind: SerializedErrorKind,
+    pub message: String,
+    pub data: Option<Vec<(SerializedValue, SerializedValue)>>,
+    pub cause: Option<Box<SerializedError>>,
+}
+
+/// Mirrors [`ValueError`] with `Value` replaced by `SerializedValue`.
+#[derive(Clone, Debug)]
+pub enum SerializedErrorKind {
+    WrongType {
+        expected: &'static str,
+        got: String,
+    },
+    IndexOutOfBounds {
+        idx: usize,
+        count: usize,
+    },
+    ArityError {
+        name: String,
+        expected: String,
+        got: usize,
+    },
+    NotCallable {
+        value: String,
+    },
+    OddMap {
+        count: usize,
+    },
+    Unsupported,
+    Other(String),
+    OutOfRange,
+    TransientAlreadyPersisted,
+    Parse,
+    Thrown(Box<SerializedValue>),
+}
+
+// ── serialize ─────────────────────────────────────────────────────────────────
+
+/// Serialize a `Value` into a `Send + Sync` wire form suitable for crossing an
+/// isolate boundary. Returns [`CloneError`] for non-shareable values.
+pub fn serialize(v: &Value) -> Result<SerializedValue, CloneError> {
+    match v {
+        // ── Wrappers ──
+        Value::WithMeta(inner, meta) => Ok(SerializedValue::WithMeta {
+            value: Box::new(serialize(inner)?),
+            meta: Box::new(serialize(meta)?),
+        }),
+        Value::Reduced(inner) => Ok(SerializedValue::Reduced(Box::new(serialize(inner)?))),
+
+        // ── Scalars ──
+        Value::Nil => Ok(SerializedValue::Nil),
+        Value::Bool(b) => Ok(SerializedValue::Bool(*b)),
+        Value::Long(n) => Ok(SerializedValue::Long(*n)),
+        Value::Double(d) => Ok(SerializedValue::Double(*d)),
+        Value::Char(c) => Ok(SerializedValue::Char(*c)),
+        Value::Uuid(u) => Ok(SerializedValue::Uuid(*u)),
+
+        Value::BigInt(p) => Ok(SerializedValue::BigInt(p.get().clone())),
+        Value::BigDecimal(p) => Ok(SerializedValue::BigDecimal(p.get().clone())),
+        Value::Ratio(p) => Ok(SerializedValue::Ratio(p.get().clone())),
+        Value::Str(p) => Ok(SerializedValue::Str(p.get().clone())),
+        Value::Pattern(p) => Ok(SerializedValue::Pattern(p.get().as_str().to_owned())),
+
+        // ── Identifiers ──
+        Value::Symbol(p) => {
+            let s = p.get();
+            Ok(SerializedValue::Symbol {
+                namespace: s.namespace.clone(),
+                name: s.name.clone(),
+                version: s.version.clone(),
+            })
+        }
+        Value::Keyword(p) => {
+            let k = p.get();
+            Ok(SerializedValue::Keyword {
+                namespace: k.namespace.clone(),
+                name: k.name.clone(),
+            })
+        }
+
+        // ── Collections ──
+        Value::List(p) => {
+            let items: Result<Vec<_>, _> = p.get().iter().map(serialize).collect();
+            Ok(SerializedValue::List(items?))
+        }
+        Value::Vector(p) => {
+            let items: Result<Vec<_>, _> = p.get().iter().map(serialize).collect();
+            Ok(SerializedValue::Vector(items?))
+        }
+        Value::Map(m) => serialize_map(m),
+        Value::Set(s) => serialize_set(s),
+        Value::Queue(p) => {
+            let items: Result<Vec<_>, _> = p.get().iter().map(serialize).collect();
+            Ok(SerializedValue::Queue(items?))
+        }
+        Value::Cons(p) => {
+            let c = p.get();
+            Ok(SerializedValue::Cons {
+                head: Box::new(serialize(&c.head)?),
+                tail: Box::new(serialize(&c.tail)?),
+            })
+        }
+
+        // ── Records ──
+        Value::TypeInstance(p) => {
+            let ti = p.get();
+            let fields = serialize_map_pairs(&ti.fields)?;
+            Ok(SerializedValue::TypeInstance {
+                type_tag: ti.type_tag.clone(),
+                fields,
+            })
+        }
+
+        // ── Errors ──
+        Value::Error(p) => Ok(SerializedValue::Error(Box::new(serialize_error(p.get())?))),
+
+        // ── Primitive arrays (snapshot) ──
+        Value::BooleanArray(p) => Ok(SerializedValue::BooleanArray(
+            p.get().lock().unwrap().clone(),
+        )),
+        Value::ByteArray(p) => Ok(SerializedValue::ByteArray(p.get().lock().unwrap().clone())),
+        Value::ShortArray(p) => Ok(SerializedValue::ShortArray(p.get().lock().unwrap().clone())),
+        Value::IntArray(p) => Ok(SerializedValue::IntArray(p.get().lock().unwrap().clone())),
+        Value::LongArray(p) => Ok(SerializedValue::LongArray(p.get().lock().unwrap().clone())),
+        Value::FloatArray(p) => Ok(SerializedValue::FloatArray(p.get().lock().unwrap().clone())),
+        Value::DoubleArray(p) => Ok(SerializedValue::DoubleArray(
+            p.get().lock().unwrap().clone(),
+        )),
+        Value::CharArray(p) => Ok(SerializedValue::CharArray(p.get().lock().unwrap().clone())),
+        Value::ObjectArray(p) => {
+            let guard = p.get().0.lock().unwrap();
+            let items: Result<Vec<_>, _> = guard.iter().map(serialize).collect();
+            Ok(SerializedValue::ObjectArray(items?))
+        }
+
+        // ── Lazy sequences: realize first ──
+        Value::LazySeq(p) => serialize(&p.get().realize()),
+
+        // ── Delay: force if already realized, else error ──
+        Value::Delay(p) => {
+            let state = p.get().state.lock().unwrap();
+            if let DelayState::Forced(v) = &*state {
+                serialize(v)
+            } else {
+                Err(not_shareable("delay"))
+            }
+        }
+
+        // ── Non-shareable ──
+        Value::Resource(_) => Err(not_shareable("resource")),
+        Value::NativeObject(_) => Err(not_shareable("native-object")),
+        Value::Matcher(_) => Err(not_shareable("matcher")),
+
+        Value::Fn(_) | Value::Macro(_) => Err(not_shareable("fn")),
+        Value::BoundFn(_) => Err(not_shareable("fn")),
+        Value::NativeFunction(_) => Err(not_shareable("fn")),
+        Value::ProtocolFn(_) => Err(not_shareable("fn")),
+        Value::MultiFn(_) => Err(not_shareable("fn")),
+
+        Value::Var(_) => Err(not_shareable("var")),
+        Value::Atom(_) => Err(not_shareable("atom")),
+        Value::Volatile(_) => Err(not_shareable("volatile")),
+        Value::Promise(_) => Err(not_shareable("promise")),
+        Value::Future(_) => Err(not_shareable("future")),
+        Value::Agent(_) => Err(not_shareable("agent")),
+
+        Value::Namespace(_) => Err(not_shareable("namespace")),
+        Value::Protocol(_) => Err(not_shareable("protocol")),
+
+        Value::TransientMap(_) => Err(not_shareable("transient-map")),
+        Value::TransientSet(_) => Err(not_shareable("transient-set")),
+        Value::TransientVector(_) => Err(not_shareable("transient-vector")),
+    }
+}
+
+fn serialize_map(m: &MapValue) -> Result<SerializedValue, CloneError> {
+    let pairs = serialize_map_pairs(m)?;
+    Ok(match m {
+        MapValue::Array(_) => SerializedValue::ArrayMap(pairs),
+        MapValue::Hash(_) => SerializedValue::HashMap(pairs),
+        MapValue::Sorted(_) => SerializedValue::SortedMap(pairs),
+    })
+}
+
+fn serialize_map_pairs(
+    m: &MapValue,
+) -> Result<Vec<(SerializedValue, SerializedValue)>, CloneError> {
+    let mut pairs = Vec::with_capacity(m.count());
+    let mut err: Option<CloneError> = None;
+    m.for_each(|k, v| {
+        if err.is_some() {
+            return;
+        }
+        match (serialize(k), serialize(v)) {
+            (Ok(sk), Ok(sv)) => pairs.push((sk, sv)),
+            (Err(e), _) | (_, Err(e)) => err = Some(e),
+        }
+    });
+    if let Some(e) = err { Err(e) } else { Ok(pairs) }
+}
+
+fn serialize_set(s: &SetValue) -> Result<SerializedValue, CloneError> {
+    let items: Result<Vec<_>, _> = s.iter().map(serialize).collect();
+    Ok(match s {
+        SetValue::Hash(_) => SerializedValue::HashSet(items?),
+        SetValue::Sorted(_) => SerializedValue::SortedSet(items?),
+    })
+}
+
+fn serialize_error(e: &crate::error::ExceptionInfo) -> Result<SerializedError, CloneError> {
+    let kind = match &e.error {
+        ValueError::WrongType { expected, got } => SerializedErrorKind::WrongType {
+            expected,
+            got: got.clone(),
+        },
+        ValueError::IndexOutOfBounds { idx, count } => SerializedErrorKind::IndexOutOfBounds {
+            idx: *idx,
+            count: *count,
+        },
+        ValueError::ArityError {
+            name,
+            expected,
+            got,
+        } => SerializedErrorKind::ArityError {
+            name: name.clone(),
+            expected: expected.clone(),
+            got: *got,
+        },
+        ValueError::NotCallable { value } => SerializedErrorKind::NotCallable {
+            value: value.clone(),
+        },
+        ValueError::OddMap { count } => SerializedErrorKind::OddMap { count: *count },
+        ValueError::Unsupported => SerializedErrorKind::Unsupported,
+        ValueError::Other(s) => SerializedErrorKind::Other(s.clone()),
+        ValueError::OutOfRange => SerializedErrorKind::OutOfRange,
+        ValueError::TransientAlreadyPersisted => SerializedErrorKind::TransientAlreadyPersisted,
+        ValueError::Parse => SerializedErrorKind::Parse,
+        ValueError::Thrown(v) => SerializedErrorKind::Thrown(Box::new(serialize(v)?)),
+    };
+
+    let data = e.data.as_ref().map(serialize_map_pairs).transpose()?;
+
+    let cause = e
+        .cause
+        .as_ref()
+        .map(|c| serialize_error(c.get()).map(Box::new))
+        .transpose()?;
+
+    Ok(SerializedError {
+        kind,
+        message: e.message.clone(),
+        data,
+        cause,
+    })
+}
+
+// ── deserialize ───────────────────────────────────────────────────────────────
+
+/// Deserialize a wire form into a fresh `Value` allocated in the *current*
+/// isolate's GC heap. Infallible: all non-shareable values are rejected at
+/// `serialize` time, so nothing in `SerializedValue` requires runtime checks.
+pub fn deserialize(sv: SerializedValue) -> Value {
+    match sv {
+        SerializedValue::WithMeta { value, meta } => {
+            Value::WithMeta(Box::new(deserialize(*value)), Box::new(deserialize(*meta)))
+        }
+        SerializedValue::Reduced(inner) => Value::Reduced(Box::new(deserialize(*inner))),
+
+        SerializedValue::Nil => Value::Nil,
+        SerializedValue::Bool(b) => Value::Bool(b),
+        SerializedValue::Long(n) => Value::Long(n),
+        SerializedValue::Double(d) => Value::Double(d),
+        SerializedValue::Char(c) => Value::Char(c),
+        SerializedValue::Uuid(u) => Value::Uuid(u),
+
+        SerializedValue::BigInt(n) => Value::BigInt(GcPtr::new(n)),
+        SerializedValue::BigDecimal(d) => Value::BigDecimal(GcPtr::new(d)),
+        SerializedValue::Ratio(r) => Value::Ratio(GcPtr::new(r)),
+        SerializedValue::Str(s) => Value::Str(GcPtr::new(s)),
+        SerializedValue::Pattern(src) => Value::Pattern(GcPtr::new(
+            regex::Regex::new(&src).expect("pattern was valid at serialize time"),
+        )),
+
+        SerializedValue::Symbol {
+            namespace,
+            name,
+            version,
+        } => Value::Symbol(GcPtr::new(Symbol {
+            namespace,
+            name,
+            version,
+        })),
+        SerializedValue::Keyword { namespace, name } => {
+            Value::Keyword(GcPtr::new(Keyword { namespace, name }))
+        }
+
+        SerializedValue::List(items) => Value::List(GcPtr::new(PersistentList::from_iter(
+            items.into_iter().map(deserialize),
+        ))),
+        SerializedValue::Vector(items) => Value::Vector(GcPtr::new(PersistentVector::from_iter(
+            items.into_iter().map(deserialize),
+        ))),
+        SerializedValue::ArrayMap(pairs) => Value::Map(MapValue::from_pairs(
+            pairs
+                .into_iter()
+                .map(|(k, v)| (deserialize(k), deserialize(v)))
+                .collect(),
+        )),
+        SerializedValue::HashMap(pairs) => Value::Map(MapValue::from_pairs(
+            pairs
+                .into_iter()
+                .map(|(k, v)| (deserialize(k), deserialize(v)))
+                .collect(),
+        )),
+        SerializedValue::SortedMap(pairs) => {
+            // Rebuild as a sorted map through the standard sorted-map path.
+            let items: Vec<(Value, Value)> = pairs
+                .into_iter()
+                .map(|(k, v)| (deserialize(k), deserialize(v)))
+                .collect();
+            let sm = SortedMap::from_pairs(items);
+            Value::Map(MapValue::Sorted(GcPtr::new(sm)))
+        }
+        SerializedValue::HashSet(items) => {
+            let mut hs = PersistentHashSet::empty();
+            for item in items.into_iter().map(deserialize) {
+                hs = hs.conj(item);
+            }
+            Value::Set(SetValue::Hash(GcPtr::new(hs)))
+        }
+        SerializedValue::SortedSet(items) => {
+            let mut ss = SortedSet::empty();
+            for item in items.into_iter().map(deserialize) {
+                ss = ss.conj(item);
+            }
+            Value::Set(SetValue::Sorted(GcPtr::new(ss)))
+        }
+        SerializedValue::Queue(items) => {
+            let mut q = PersistentQueue::empty();
+            for item in items.into_iter().map(deserialize) {
+                q = q.conj(item);
+            }
+            Value::Queue(GcPtr::new(q))
+        }
+        SerializedValue::Cons { head, tail } => {
+            use crate::types::CljxCons;
+            Value::Cons(GcPtr::new(CljxCons {
+                head: deserialize(*head),
+                tail: deserialize(*tail),
+            }))
+        }
+
+        SerializedValue::TypeInstance { type_tag, fields } => {
+            use crate::value::TypeInstance;
+            let pairs: Vec<(Value, Value)> = fields
+                .into_iter()
+                .map(|(k, v)| (deserialize(k), deserialize(v)))
+                .collect();
+            Value::TypeInstance(GcPtr::new(TypeInstance {
+                type_tag,
+                fields: MapValue::from_pairs(pairs),
+            }))
+        }
+
+        SerializedValue::Error(se) => Value::Error(GcPtr::new(deserialize_error(*se))),
+
+        SerializedValue::BooleanArray(v) => {
+            Value::BooleanArray(GcPtr::new(std::sync::Mutex::new(v)))
+        }
+        SerializedValue::ByteArray(v) => Value::ByteArray(GcPtr::new(std::sync::Mutex::new(v))),
+        SerializedValue::ShortArray(v) => Value::ShortArray(GcPtr::new(std::sync::Mutex::new(v))),
+        SerializedValue::IntArray(v) => Value::IntArray(GcPtr::new(std::sync::Mutex::new(v))),
+        SerializedValue::LongArray(v) => Value::LongArray(GcPtr::new(std::sync::Mutex::new(v))),
+        SerializedValue::FloatArray(v) => Value::FloatArray(GcPtr::new(std::sync::Mutex::new(v))),
+        SerializedValue::DoubleArray(v) => Value::DoubleArray(GcPtr::new(std::sync::Mutex::new(v))),
+        SerializedValue::CharArray(v) => Value::CharArray(GcPtr::new(std::sync::Mutex::new(v))),
+        SerializedValue::ObjectArray(items) => {
+            use crate::value::ObjectArray;
+            Value::ObjectArray(GcPtr::new(ObjectArray::new(
+                items.into_iter().map(deserialize).collect(),
+            )))
+        }
+    }
+}
+
+fn deserialize_error(se: SerializedError) -> crate::error::ExceptionInfo {
+    let error = match se.kind {
+        SerializedErrorKind::WrongType { expected, got } => ValueError::WrongType { expected, got },
+        SerializedErrorKind::IndexOutOfBounds { idx, count } => {
+            ValueError::IndexOutOfBounds { idx, count }
+        }
+        SerializedErrorKind::ArityError {
+            name,
+            expected,
+            got,
+        } => ValueError::ArityError {
+            name,
+            expected,
+            got,
+        },
+        SerializedErrorKind::NotCallable { value } => ValueError::NotCallable { value },
+        SerializedErrorKind::OddMap { count } => ValueError::OddMap { count },
+        SerializedErrorKind::Unsupported => ValueError::Unsupported,
+        SerializedErrorKind::Other(s) => ValueError::Other(s),
+        SerializedErrorKind::OutOfRange => ValueError::OutOfRange,
+        SerializedErrorKind::TransientAlreadyPersisted => ValueError::TransientAlreadyPersisted,
+        SerializedErrorKind::Parse => ValueError::Parse,
+        SerializedErrorKind::Thrown(sv) => ValueError::Thrown(deserialize(*sv)),
+    };
+
+    let data = se.data.map(|pairs| {
+        MapValue::from_pairs(
+            pairs
+                .into_iter()
+                .map(|(k, v)| (deserialize(k), deserialize(v)))
+                .collect(),
+        )
+    });
+
+    let cause = se.cause.map(|c| GcPtr::new(deserialize_error(*c)));
+
+    crate::error::ExceptionInfo::new(error, se.message, data, cause)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(v: &Value) -> Value {
+        deserialize(serialize(v).expect("serialize"))
+    }
+
+    #[test]
+    fn scalars_roundtrip() {
+        assert_eq!(roundtrip(&Value::Nil), Value::Nil);
+        assert_eq!(roundtrip(&Value::Bool(true)), Value::Bool(true));
+        assert_eq!(roundtrip(&Value::Long(42)), Value::Long(42));
+        assert_eq!(roundtrip(&Value::Char('x')), Value::Char('x'));
+        assert_eq!(roundtrip(&Value::Uuid(12345)), Value::Uuid(12345));
+    }
+
+    #[test]
+    fn string_roundtrip() {
+        let v = Value::string("hello, world");
+        assert_eq!(roundtrip(&v), v);
+    }
+
+    #[test]
+    fn keyword_roundtrip() {
+        let v = Value::keyword(Keyword::simple("foo"));
+        assert_eq!(roundtrip(&v), v);
+        let v2 = Value::keyword(Keyword::qualified("clojure.core", "map"));
+        assert_eq!(roundtrip(&v2), v2);
+    }
+
+    #[test]
+    fn symbol_roundtrip() {
+        let v = Value::symbol(Symbol::simple("my-fn"));
+        assert_eq!(roundtrip(&v), v);
+    }
+
+    #[test]
+    fn list_roundtrip() {
+        let v = Value::List(GcPtr::new(PersistentList::from_iter([
+            Value::Long(1),
+            Value::Long(2),
+            Value::Long(3),
+        ])));
+        assert_eq!(roundtrip(&v), v);
+    }
+
+    #[test]
+    fn vector_roundtrip() {
+        let v = Value::Vector(GcPtr::new(PersistentVector::from_iter([
+            Value::string("a"),
+            Value::Bool(false),
+            Value::Nil,
+        ])));
+        assert_eq!(roundtrip(&v), v);
+    }
+
+    #[test]
+    fn nested_map_roundtrip() {
+        let inner = Value::Vector(GcPtr::new(PersistentVector::from_iter([Value::Long(1)])));
+        let v = MapValue::from_pairs(vec![(Value::keyword(Keyword::simple("k")), inner)]);
+        let v = Value::Map(v);
+        assert_eq!(roundtrip(&v), v);
+    }
+
+    #[test]
+    fn resource_not_shareable() {
+        use crate::resource::ResourceHandle;
+        use std::any::Any;
+        use std::sync::Arc;
+        #[derive(Debug)]
+        struct FakeResource;
+        impl crate::resource::Resource for FakeResource {
+            fn resource_type(&self) -> &'static str {
+                "fake"
+            }
+            fn close(&self) -> crate::error::ValueResult<()> {
+                Ok(())
+            }
+            fn is_closed(&self) -> bool {
+                false
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+        let r = Value::Resource(ResourceHandle(Arc::new(FakeResource)));
+        assert!(matches!(
+            serialize(&r),
+            Err(CloneError::NotShareable {
+                type_name: "resource"
+            })
+        ));
+    }
+
+    #[test]
+    fn atom_not_shareable() {
+        use crate::types::Atom;
+        let a = Value::Atom(GcPtr::new(Atom::new(Value::Nil)));
+        assert!(matches!(
+            serialize(&a),
+            Err(CloneError::NotShareable { type_name: "atom" })
+        ));
+    }
+
+    #[test]
+    fn fn_not_shareable() {
+        use crate::types::{Arity, CljxFn, NativeFn};
+        let nf = Value::NativeFunction(GcPtr::new(NativeFn::new("test", Arity::Fixed(0), |_| {
+            Ok(Value::Nil)
+        })));
+        assert!(matches!(
+            serialize(&nf),
+            Err(CloneError::NotShareable { type_name: "fn" })
+        ));
+    }
+
+    #[test]
+    fn lazy_seq_realized_roundtrip() {
+        use crate::types::{LazySeq, Thunk};
+        struct DoneThunk;
+        impl std::fmt::Debug for DoneThunk {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "DoneThunk")
+            }
+        }
+        impl cljrs_gc::Trace for DoneThunk {
+            fn trace(&self, _: &mut cljrs_gc::MarkVisitor) {}
+        }
+        impl Thunk for DoneThunk {
+            fn force(&self) -> Result<Value, String> {
+                Ok(Value::Long(99))
+            }
+        }
+        let ls = LazySeq::new(Box::new(DoneThunk));
+        let _ = ls.realize(); // force it
+        let v = Value::LazySeq(GcPtr::new(ls));
+        assert_eq!(roundtrip(&v), Value::Long(99));
+    }
+
+    #[test]
+    fn with_meta_roundtrip() {
+        let v = Value::Long(7).with_meta(Value::Map(MapValue::empty()));
+        let rt = roundtrip(&v);
+        // WithMeta strips for equality, so unwrap and check inner
+        assert_eq!(rt, Value::Long(7));
+    }
+
+    #[test]
+    fn reduced_roundtrip() {
+        let v = Value::Reduced(Box::new(Value::Long(55)));
+        assert_eq!(roundtrip(&v), Value::Reduced(Box::new(Value::Long(55))));
+    }
+}

--- a/crates/cljrs-value/src/lib.rs
+++ b/crates/cljrs-value/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::arc_with_non_send_sync)]
+pub mod clone;
 pub mod collections;
 pub mod error;
 pub mod hash;
@@ -25,4 +26,4 @@ pub use types::{
     DelayState, FutureState, LazySeq, MultiFn, Namespace, NativeFn, NativeFnFunc, NativeFnPtr,
     Protocol, ProtocolFn, ProtocolMethod, Thunk, Var, Volatile,
 };
-pub use value::{MapValue, ObjectArray, TypeInstance, Value};
+pub use value::{MapValue, ObjectArray, SetValue, TypeInstance, Value};


### PR DESCRIPTION
Adds `cljrs_value::clone` with `SerializedValue` (Send+Sync wire form),
`serialize` and `deserialize`, and `CloneError` for non-shareable types.
Adds `cljrs_async::isolate_channel` with `IsolateSender`/`IsolateReceiver`
and `isolate_channel()` constructor backed by a tokio unbounded MPSC channel.

All data values (scalars, persistent collections, records, arrays, lazy
sequences, errors) round-trip cleanly. Mutable state (Atom, Var, Future,
Agent, Volatile, Promise), closures (Fn, NativeFn, MultiFn, ProtocolFn),
namespaces, native resources, and transients return CloneError::NotShareable
at send time. GcPtr's !Send bound makes pointer-sharing a compile error —
the channel is the only sanctioned crossing point.

23 new tests: 13 in cljrs-value::clone (round-trip + rejection), 10 in
cljrs-async::isolate_channel (data types, rejection, heap independence).

https://claude.ai/code/session_017ASvim3t76F9QGMpdmgro7