### PR TITLE
B3: shared static arena for code, keywords, and blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "archery"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +616,7 @@ dependencies = [
 name = "cljrs-value"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "bigdecimal",
  "cljrs-gc",
  "cljrs-reader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ serde        = "1.0.228"
 postcard     = "1.1.3"
 rustyline    = "18.0.0"
 libloading   = "0.8"
+arc-swap     = "1"
 
 # Cranelift compiler backend (all crates must be at the same version)
 cranelift-codegen  = "0.129.1"

--- a/crates/cljrs-gc/README.md
+++ b/crates/cljrs-gc/README.md
@@ -9,7 +9,8 @@ fixed **64 MB** soft limit instead of consulting total system RAM.
 
 **Phase:** 8.1 (GcVisitor + Trace infrastructure) + 8.2 (GcBox/GcHeap
 raw-pointer implementation) — implemented.  `no-gc` mode (Phases 1–8 of
-`docs/no-gc-plan.md`) — implemented.
+`docs/no-gc-plan.md`) — implemented.  B3 (`StaticGcPtr`, `static_alloc`) —
+implemented.
 
 ---
 
@@ -120,10 +121,37 @@ impl<T: Trace + 'static> Clone for GcPtr<T> { /* O(1) raw-pointer copy */ }
 impl<T: Trace + 'static> Drop  for GcPtr<T> { /* no-op */ }
 ```
 
-### Free functions (no-gc only)
+### `StaticGcPtr<T: 'static>` (always available — Phase B3)
+
+Program-lifetime pointer safe to share across isolate threads.  Backed by the
+global `StaticArena` (in `no-gc` builds) or `Box::leak` (in GC builds).
+Unlike `GcPtr`, it wraps `*const T` directly (no `GcBox` header) and is
+`Send + Sync`.
 
 ```rust
-// debug_assertions only:
+pub struct StaticGcPtr<T: 'static>(NonNull<T>);
+
+impl<T: 'static> StaticGcPtr<T> {
+    pub fn get(&self) -> &T
+    pub fn ptr_eq(a: &Self, b: &Self) -> bool
+}
+impl<T: 'static> Clone for StaticGcPtr<T> { /* O(1) NonNull copy */ }
+
+/// Allocate `value` as program-lifetime memory.
+/// no-gc: StaticArena bump-alloc; GC: Box::leak.
+pub fn static_alloc<T: 'static>(value: T) -> StaticGcPtr<T>;
+```
+
+### Free functions
+
+```rust
+// always:
+pub fn static_alloc<T: 'static>(value: T) -> StaticGcPtr<T>;
+
+// no-gc only:
+pub fn static_arena() -> &'static StaticArena;
+
+// no-gc + debug_assertions only:
 pub fn is_static_addr(addr: usize) -> bool;  // checks the StaticArena chunk registry
 ```
 

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -374,6 +374,69 @@ impl<T: Trace + 'static> Drop for GcPtr<T> {
 }
 
 // =============================================================================
+// StaticGcPtr — Send+Sync pointer to program-lifetime data
+// =============================================================================
+
+/// A raw pointer to a value that lives for the entire program lifetime.
+///
+/// Backed by the global `StaticArena` (in `no-gc` builds) or by `Box::leak`
+/// (in GC builds).  Either way the pointee is never freed and never moved, so
+/// it is safe to share across isolate threads.
+///
+/// `StaticGcPtr<T>` wraps `*const T` — it does **not** involve a `GcBox`
+/// header — so it is independent of the GC build mode and carries no GC
+/// overhead.
+pub struct StaticGcPtr<T: 'static>(NonNull<T>);
+
+// SAFETY: program-lifetime allocations are never moved, freed, or mutated
+// after the initial write.  The stored types (Keyword, Symbol, …) are
+// themselves `Sync` (no unsynchronised interior mutability).
+unsafe impl<T: 'static> Send for StaticGcPtr<T> {}
+unsafe impl<T: 'static> Sync for StaticGcPtr<T> {}
+
+impl<T: 'static> StaticGcPtr<T> {
+    /// Borrow the contained value.
+    pub fn get(&self) -> &T {
+        // SAFETY: pointer is program-lifetime, always valid.
+        unsafe { self.0.as_ref() }
+    }
+
+    /// Pointer equality: `true` iff both `StaticGcPtr`s point to the exact
+    /// same allocation (i.e. the same interned entry).
+    pub fn ptr_eq(a: &Self, b: &Self) -> bool {
+        a.0 == b.0
+    }
+}
+
+impl<T: 'static> Clone for StaticGcPtr<T> {
+    fn clone(&self) -> Self {
+        StaticGcPtr(self.0)
+    }
+}
+
+impl<T: 'static + std::fmt::Debug> std::fmt::Debug for StaticGcPtr<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unsafe { self.0.as_ref().fmt(f) }
+    }
+}
+
+/// Allocate `value` as program-lifetime memory and return a [`StaticGcPtr`].
+///
+/// In `no-gc` builds the allocation comes from the global bump-allocated
+/// `StaticArena` (never freed, no GC header overhead).  In GC builds
+/// `Box::leak` is used instead — the memory lives until the process exits.
+pub fn static_alloc<T: 'static>(value: T) -> StaticGcPtr<T> {
+    #[cfg(feature = "no-gc")]
+    {
+        static_arena::static_alloc_val(value)
+    }
+    #[cfg(not(feature = "no-gc"))]
+    {
+        StaticGcPtr(NonNull::from(Box::leak(Box::new(value))))
+    }
+}
+
+// =============================================================================
 // Full GC implementation (default build)
 // =============================================================================
 

--- a/crates/cljrs-gc/src/static_arena.rs
+++ b/crates/cljrs-gc/src/static_arena.rs
@@ -124,6 +124,20 @@ impl StaticArena {
         GcPtr(unsafe { NonNull::new_unchecked(gc_box) })
     }
 
+    /// Allocate `value` directly (no `GcBox` wrapper) and return a
+    /// [`StaticGcPtr`].
+    ///
+    /// Use this when the caller needs a `Send + Sync` program-lifetime pointer
+    /// but does **not** need `GcPtr` interoperability — e.g. keyword/symbol
+    /// intern tables.  The allocation is never freed.
+    pub fn alloc_val<T: 'static>(&self, value: T) -> crate::StaticGcPtr<T> {
+        let layout = std::alloc::Layout::new::<T>();
+        let raw = self.inner.lock().unwrap().alloc_raw(layout) as *mut T;
+        // SAFETY: raw is properly aligned and sized for T.
+        unsafe { std::ptr::write(raw, value) };
+        crate::StaticGcPtr(unsafe { NonNull::new_unchecked(raw) })
+    }
+
     /// Return `true` if `addr` was allocated by this arena.
     ///
     /// Used by debug-mode provenance assertions to distinguish static-arena
@@ -139,6 +153,13 @@ static STATIC_ARENA: OnceLock<StaticArena> = OnceLock::new();
 /// Return the global static arena singleton.
 pub fn static_arena() -> &'static StaticArena {
     STATIC_ARENA.get_or_init(StaticArena::new)
+}
+
+/// Allocate `value` into the global static arena (no `GcBox` wrapper) and
+/// return a [`StaticGcPtr`].  Convenience wrapper around
+/// `static_arena().alloc_val(value)`.
+pub fn static_alloc_val<T: 'static>(value: T) -> crate::StaticGcPtr<T> {
+    static_arena().alloc_val(value)
 }
 
 /// Return `true` if the raw pointer address was allocated by the static arena.

--- a/crates/cljrs-value/Cargo.toml
+++ b/crates/cljrs-value/Cargo.toml
@@ -21,3 +21,4 @@ thiserror    = { workspace = true }
 rpds         = { workspace = true }
 uuid         = { workspace = true }
 regex        = { workspace = true }
+arc-swap     = { workspace = true }

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -2,7 +2,7 @@
 
 Core runtime values and persistent collections for clojurust.
 
-**Phase:** 3 (collections/Value) + 4 (CljxFn, Namespace) + 5 (LazySeq, CljxCons) + 6 (Protocol, ProtocolFn, MultiFn) + 7 (Volatile, Delay, CljxPromise, CljxFuture, Agent) + 6-ext (TypeInstance for defrecord/reify) — implemented.
+**Phase:** 3 (collections/Value) + 4 (CljxFn, Namespace) + 5 (LazySeq, CljxCons) + 6 (Protocol, ProtocolFn, MultiFn) + 7 (Volatile, Delay, CljxPromise, CljxFuture, Agent) + 6-ext (TypeInstance for defrecord/reify) + B2 (structured-clone boundary) + B3 (shared static arena: intern tables, SharedValue, SharedAtom, ByteBlob) — implemented.
 
 ---
 
@@ -20,14 +20,16 @@ standard library on top of them.
 ```
 src/
   lib.rs                         — module declarations and re-exports
-  clone.rs                       — SerializedValue (Send+Sync wire form), CloneError, serialize/deserialize for cross-isolate copy boundary (Phase B2)
+  clone.rs                       — SerializedValue (Send+Sync wire form), CloneError, serialize/deserialize for cross-isolate copy boundary (Phase B2); handles SharedAtom/ByteBlob pass-through (B3)
   error.rs                       — ValueError enum, ValueResult<T> alias
   hash.rs                        — ClojureHash trait, Murmur3 helpers, JVM-compatible hash_string
+  intern.rs                      — (Phase B3) global keyword/symbol intern tables backed by StaticGcPtr; intern_keyword, intern_symbol
   keyword.rs                     — Keyword { namespace, name }
+  shared.rs                      — (Phase B3) SharedValue enum, SharedAtom (Arc<ArcSwap<SharedValue>>), promote/demote; PromoteError
   symbol.rs                      — Symbol { namespace, name }
   native_object.rs               — NativeObject trait, NativeObjectBox wrapper, gc_native_object helper (Phase 9 interop)
   types.rs                       — Var, Atom, Namespace, NativeFn, CljxFn, Thunk, LazySeq, CljxCons, Protocol, ProtocolFn, ProtocolMethod, MultiFn, Volatile, Delay, CljxPromise, CljxFuture, Agent
-  value.rs                       — Value enum (incl. NativeObject variant), MapValue, SetValue, TypeInstance, pr_str, PartialEq, ClojureHash, std::hash::Hash
+  value.rs                       — Value enum (incl. SharedAtom, ByteBlob variants), MapValue, SetValue, TypeInstance, pr_str, PartialEq, ClojureHash, std::hash::Hash
   collections/
     mod.rs                       — re-exports all collection types
     array_map.rs                 — PersistentArrayMap (≤8 entries, linear scan)
@@ -75,6 +77,8 @@ pub enum Value {
     // Runtime objects
     Var(GcPtr<Var>),
     Atom(GcPtr<Atom>),
+    SharedAtom(Arc<SharedAtom>),       // cross-isolate mutable ref (Phase B3)
+    ByteBlob(Arc<[u8]>),               // refcounted immutable byte buffer (Phase B3)
     Namespace(GcPtr<Namespace>),
     NativeFn(GcPtr<NativeFn>),
     CljxFn(GcPtr<CljxFn>),
@@ -113,6 +117,53 @@ pub struct Keyword  { namespace: Option<Arc<str>>, name: Arc<str> }
 
 Both support `simple(name)`, `qualified(ns, name)`, `parse(str)`, and
 `full_name() -> String`.
+
+### Phase B3 — Shared static arena
+
+#### Intern tables (`intern` module)
+
+```rust
+pub fn intern_keyword(namespace: Option<&str>, name: &str)
+    -> StaticGcPtr<Keyword>;
+pub fn intern_symbol(namespace: Option<&str>, name: &str, version: Option<&str>)
+    -> StaticGcPtr<Symbol>;
+```
+
+Global `OnceLock<Mutex<HashMap<…>>>` tables.  First call allocates the
+`Keyword`/`Symbol` into program-lifetime memory via `static_alloc`; subsequent
+calls return a clone of the same `StaticGcPtr` (pointer-stable identity across
+all isolates).
+
+#### `SharedValue` and `SharedAtom` (`shared` module)
+
+```rust
+pub enum SharedValue {
+    Nil, Bool(bool), Long(i64), Double(f64), Char(char), Uuid(u128),
+    Str(Arc<str>),
+    Keyword(StaticGcPtr<Keyword>),
+    Symbol(StaticGcPtr<Symbol>),
+    ByteBlob(Arc<[u8]>),              // BEAM off-heap-binary trick
+}
+
+pub struct SharedAtom {
+    pub cell: Arc<ArcSwap<SharedValue>>,
+    pub meta: Mutex<Option<SharedValue>>,
+}
+
+impl SharedAtom {
+    pub fn new(val: SharedValue) -> Self
+    pub fn deref_val(&self) -> Arc<SharedValue>     // atomic load
+    pub fn reset(&self, val: SharedValue) -> Arc<SharedValue>
+    pub fn swap<F>(&self, f: F) -> Arc<SharedValue> // CAS-retry
+}
+
+pub fn promote(value: &Value)   -> Result<SharedValue, PromoteError>;
+pub fn demote (sv:    &SharedValue) -> Value;
+```
+
+`promote` converts an isolate-local `Value` to `SharedValue` (fails for
+closures, resources, atoms, …).  `demote` converts back into a fresh
+isolate-local `Value`.
 
 ### `ClojureHash`
 

--- a/crates/cljrs-value/src/clone.rs
+++ b/crates/cljrs-value/src/clone.rs
@@ -41,6 +41,7 @@ use num_bigint::BigInt;
 
 use crate::collections::{PersistentHashSet, PersistentVector, SortedMap, SortedSet};
 use crate::error::ValueError;
+use crate::shared::SharedAtom;
 use crate::types::DelayState;
 use crate::{Keyword, MapValue, PersistentList, PersistentQueue, SetValue, Symbol, Value};
 use cljrs_gc::GcPtr;
@@ -151,6 +152,13 @@ pub enum SerializedValue {
         meta: Box<SerializedValue>,
     },
     Reduced(Box<SerializedValue>),
+
+    // Phase B3: cross-isolate shared references (Arc cloned, not deep-copied).
+    /// `SharedAtom` is inherently cross-isolate; the `Arc` is simply cloned so
+    /// both isolates share the same underlying `ArcSwap` cell.
+    SharedAtom(Arc<SharedAtom>),
+    /// `ByteBlob` is an immutable refcounted buffer; clone the `Arc`.
+    ByteBlob(Arc<[u8]>),
 }
 
 // Compile-time Send + Sync assertions.
@@ -334,6 +342,10 @@ pub fn serialize(v: &Value) -> Result<SerializedValue, CloneError> {
         Value::TransientMap(_) => Err(not_shareable("transient-map")),
         Value::TransientSet(_) => Err(not_shareable("transient-set")),
         Value::TransientVector(_) => Err(not_shareable("transient-vector")),
+
+        // ── Phase B3: cross-isolate shared references (pass Arc through) ──
+        Value::SharedAtom(a) => Ok(SerializedValue::SharedAtom(a.clone())),
+        Value::ByteBlob(b) => Ok(SerializedValue::ByteBlob(b.clone())),
     }
 }
 
@@ -544,6 +556,10 @@ pub fn deserialize(sv: SerializedValue) -> Value {
                 items.into_iter().map(deserialize).collect(),
             )))
         }
+
+        // Phase B3: cross-isolate shared references — clone the Arc.
+        SerializedValue::SharedAtom(a) => Value::SharedAtom(a),
+        SerializedValue::ByteBlob(b) => Value::ByteBlob(b),
     }
 }
 

--- a/crates/cljrs-value/src/intern.rs
+++ b/crates/cljrs-value/src/intern.rs
@@ -1,0 +1,149 @@
+//! Global keyword and symbol intern tables (Phase B3).
+//!
+//! Interned keywords and symbols are allocated once into program-lifetime
+//! memory and reused for every subsequent request with the same identity.
+//! This gives each unique (namespace, name) pair a stable address that is
+//! consistent across all isolates — required for correct hash-map key lookups
+//! when maps move between isolates via the structured-clone boundary.
+//!
+//! ## Design
+//!
+//! Each table is a `OnceLock<Mutex<HashMap<…, StaticGcPtr<T>>>>`.  On the
+//! first call for a given key the value is allocated via [`cljrs_gc::static_alloc`]
+//! (arena in `no-gc` builds, `Box::leak` in GC builds) and the pointer is
+//! inserted.  Subsequent calls return a clone of the stored pointer (O(1),
+//! just copies a `NonNull`).
+//!
+//! ## Contention
+//!
+//! The global `Mutex` is only held during the brief table lookup + optional
+//! insert.  Keywords are created at read/compile time, not in hot evaluation
+//! loops, so contention is not a concern for now.  A sharded or lock-free
+//! table can replace this if profiling ever shows otherwise.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use cljrs_gc::{StaticGcPtr, static_alloc};
+
+use crate::keyword::Keyword;
+use crate::symbol::Symbol;
+
+// ── Keyword intern table ──────────────────────────────────────────────────────
+
+type KwKey = (Option<Arc<str>>, Arc<str>);
+static KEYWORD_TABLE: OnceLock<Mutex<HashMap<KwKey, StaticGcPtr<Keyword>>>> = OnceLock::new();
+
+fn kw_table() -> &'static Mutex<HashMap<KwKey, StaticGcPtr<Keyword>>> {
+    KEYWORD_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Intern a keyword into program-lifetime memory.
+///
+/// The first call for a given `(namespace, name)` pair allocates the
+/// `Keyword` and stores it; subsequent calls return the same `StaticGcPtr`.
+/// The returned pointer is `Send + Sync` and valid for the lifetime of the
+/// process.
+pub fn intern_keyword(namespace: Option<&str>, name: &str) -> StaticGcPtr<Keyword> {
+    let ns_arc: Option<Arc<str>> = namespace.map(Arc::from);
+    let name_arc: Arc<str> = Arc::from(name);
+    let key = (ns_arc.clone(), name_arc.clone());
+
+    let mut table = kw_table().lock().unwrap();
+    if let Some(existing) = table.get(&key) {
+        return existing.clone();
+    }
+    let kw = Keyword {
+        namespace: ns_arc,
+        name: name_arc,
+    };
+    let ptr = static_alloc(kw);
+    table.insert(key, ptr.clone());
+    ptr
+}
+
+// ── Symbol intern table ───────────────────────────────────────────────────────
+
+type SymKey = (Option<Arc<str>>, Arc<str>, Option<Arc<str>>);
+static SYMBOL_TABLE: OnceLock<Mutex<HashMap<SymKey, StaticGcPtr<Symbol>>>> = OnceLock::new();
+
+fn sym_table() -> &'static Mutex<HashMap<SymKey, StaticGcPtr<Symbol>>> {
+    SYMBOL_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Intern a symbol into program-lifetime memory.
+///
+/// The first call for a given `(namespace, name, version)` triple allocates
+/// the `Symbol`; subsequent calls return the same `StaticGcPtr`.
+pub fn intern_symbol(
+    namespace: Option<&str>,
+    name: &str,
+    version: Option<&str>,
+) -> StaticGcPtr<Symbol> {
+    let ns_arc: Option<Arc<str>> = namespace.map(Arc::from);
+    let name_arc: Arc<str> = Arc::from(name);
+    let ver_arc: Option<Arc<str>> = version.map(Arc::from);
+    let key = (ns_arc.clone(), name_arc.clone(), ver_arc.clone());
+
+    let mut table = sym_table().lock().unwrap();
+    if let Some(existing) = table.get(&key) {
+        return existing.clone();
+    }
+    let sym = Symbol {
+        namespace: ns_arc,
+        name: name_arc,
+        version: ver_arc,
+    };
+    let ptr = static_alloc(sym);
+    table.insert(key, ptr.clone());
+    ptr
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cljrs_gc::StaticGcPtr;
+
+    #[test]
+    fn keyword_intern_returns_same_ptr_for_same_name() {
+        let a = intern_keyword(None, "foo");
+        let b = intern_keyword(None, "foo");
+        assert!(
+            StaticGcPtr::ptr_eq(&a, &b),
+            "same name must return same pointer"
+        );
+    }
+
+    #[test]
+    fn keyword_intern_qualified() {
+        let a = intern_keyword(Some("clojure.core"), "map");
+        let b = intern_keyword(Some("clojure.core"), "map");
+        assert!(StaticGcPtr::ptr_eq(&a, &b));
+        assert_eq!(a.get().namespace.as_deref(), Some("clojure.core"));
+        assert_eq!(a.get().name.as_ref(), "map");
+    }
+
+    #[test]
+    fn keyword_intern_different_names_differ() {
+        let a = intern_keyword(None, "foo");
+        let b = intern_keyword(None, "bar");
+        assert!(!StaticGcPtr::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn symbol_intern_returns_same_ptr() {
+        let a = intern_symbol(None, "foo", None);
+        let b = intern_symbol(None, "foo", None);
+        assert!(StaticGcPtr::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn symbol_intern_versioned() {
+        let a = intern_symbol(Some("my.ns"), "myfn", Some("abc1234"));
+        let b = intern_symbol(Some("my.ns"), "myfn", Some("abc1234"));
+        assert!(StaticGcPtr::ptr_eq(&a, &b));
+        assert_eq!(a.get().version.as_deref(), Some("abc1234"));
+    }
+}

--- a/crates/cljrs-value/src/lib.rs
+++ b/crates/cljrs-value/src/lib.rs
@@ -3,10 +3,12 @@ pub mod clone;
 pub mod collections;
 pub mod error;
 pub mod hash;
+pub mod intern;
 pub mod keyword;
 pub mod native_object;
 pub mod regex;
 pub mod resource;
+pub mod shared;
 pub mod symbol;
 pub mod types;
 pub mod value;
@@ -17,9 +19,11 @@ pub use collections::{
 };
 pub use error::{ExceptionInfo, ValueError, ValueResult};
 pub use hash::ClojureHash;
+pub use intern::{intern_keyword, intern_symbol};
 pub use keyword::Keyword;
 pub use native_object::{NativeObject, NativeObjectBox, gc_native_object};
 pub use resource::{Resource, ResourceHandle};
+pub use shared::{PromoteError, SharedAtom, SharedValue, demote, promote};
 pub use symbol::Symbol;
 pub use types::{
     Agent, Arity, Atom, BoundFn, CljxCons, CljxFn, CljxFnArity, CljxFuture, CljxPromise, Delay,

--- a/crates/cljrs-value/src/shared.rs
+++ b/crates/cljrs-value/src/shared.rs
@@ -1,0 +1,340 @@
+//! Cross-isolate shared mutable state: `SharedValue`, `SharedAtom` (Phase B3).
+//!
+//! The isolate model is share-nothing for GC-heap data.  But some state
+//! genuinely needs to be visible across isolates — global configuration, shared
+//! counters, published results.  Phase B3 adds an *explicit*, *honest* escape
+//! hatch: `shared-atom`.
+//!
+//! ## Two-tier mutable references (per the ADR)
+//!
+//! | Primitive | Backing | `Send`? | Use case |
+//! |-----------|---------|---------|----------|
+//! | `atom`      | `GcPtr<Atom>` (`Mutex<Value>`) | `!Send` | isolate-local, fast |
+//! | `shared-atom` | `Arc<SharedAtom>` (`ArcSwap<SharedValue>`) | ✓ | cross-isolate, lock-free CAS |
+//!
+//! A value stored in a `shared-atom` must be **promotable** — it must be
+//! representable as a `SharedValue`.  The promotion cost is paid once on
+//! publish; reads (`deref`) are an atomic load.
+//!
+//! ## `SharedValue`
+//!
+//! Covers only the "plain data" subset of `Value`:
+//! - Scalars (stored inline, no allocation)
+//! - Strings (`Arc<str>`, immutable, refcounted)
+//! - Keywords / symbols (`StaticGcPtr<T>`, interned, program-lifetime)
+//! - Large byte buffers (`Arc<[u8]>`, the BEAM off-heap-binary trick)
+//!
+//! Closures, native resources, and isolate-bound GC objects are not
+//! promotable.  This restriction is enforced at publish time via `promote`.
+
+use std::sync::{Arc, Mutex};
+
+use arc_swap::ArcSwap;
+use cljrs_gc::{GcPtr, StaticGcPtr};
+
+use crate::intern::{intern_keyword, intern_symbol};
+use crate::keyword::Keyword;
+use crate::symbol::Symbol;
+use crate::value::Value;
+
+// ── PromoteError ─────────────────────────────────────────────────────────────
+
+/// Returned when a `Value` cannot be promoted to [`SharedValue`].
+#[derive(Debug, Clone)]
+pub struct PromoteError {
+    pub type_name: &'static str,
+}
+
+impl PromoteError {
+    pub fn not_promotable(type_name: &'static str) -> Self {
+        Self { type_name }
+    }
+}
+
+impl std::fmt::Display for PromoteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "value of type '{}' cannot be promoted to a shared-atom: \
+             only scalars, strings, keywords, symbols, and byte-blobs are supported",
+            self.type_name
+        )
+    }
+}
+
+impl std::error::Error for PromoteError {}
+
+// ── SharedValue ───────────────────────────────────────────────────────────────
+
+/// A `Send + Sync` value representation for cross-isolate sharing.
+///
+/// Covers a carefully chosen subset of `Value`: scalars (stored inline),
+/// immutable strings and byte buffers (refcounted via `Arc`), and interned
+/// keywords/symbols (program-lifetime `StaticGcPtr`).  Anything that holds
+/// isolate-local `GcPtr`s is excluded.
+///
+/// Cycles are impossible — `SharedValue` contains no `SharedValue` references
+/// — so plain `Arc` refcounting is sufficient and cycle-free.
+#[derive(Debug, Clone)]
+pub enum SharedValue {
+    Nil,
+    Bool(bool),
+    Long(i64),
+    Double(f64),
+    Char(char),
+    Uuid(u128),
+    /// Immutable interned string slice.
+    Str(Arc<str>),
+    /// Keyword interned into the global static arena.
+    Keyword(StaticGcPtr<Keyword>),
+    /// Symbol interned into the global static arena.
+    Symbol(StaticGcPtr<Symbol>),
+    /// Large refcounted byte buffer (the BEAM off-heap-binary trick).
+    /// Shared without copy across the isolate boundary; freed when the last
+    /// reference is dropped.
+    ByteBlob(Arc<[u8]>),
+}
+
+// SAFETY: all variants are either value types or `Arc`/`StaticGcPtr` wrappers
+// that are themselves `Send + Sync`.
+unsafe impl Send for SharedValue {}
+unsafe impl Sync for SharedValue {}
+
+impl SharedValue {
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            SharedValue::Nil => "nil",
+            SharedValue::Bool(_) => "boolean",
+            SharedValue::Long(_) => "long",
+            SharedValue::Double(_) => "double",
+            SharedValue::Char(_) => "char",
+            SharedValue::Uuid(_) => "uuid",
+            SharedValue::Str(_) => "string",
+            SharedValue::Keyword(_) => "keyword",
+            SharedValue::Symbol(_) => "symbol",
+            SharedValue::ByteBlob(_) => "byte-blob",
+        }
+    }
+}
+
+// ── promote / demote ──────────────────────────────────────────────────────────
+
+/// Promote a `Value` to a [`SharedValue`] for cross-isolate publishing.
+///
+/// The promotion cost is paid once (at `reset!`/`swap!` time); reads of the
+/// resulting `SharedAtom` are lock-free atomic loads.
+///
+/// Returns [`PromoteError`] for values that hold isolate-local state.
+pub fn promote(value: &Value) -> Result<SharedValue, PromoteError> {
+    match value {
+        Value::Nil => Ok(SharedValue::Nil),
+        Value::Bool(b) => Ok(SharedValue::Bool(*b)),
+        Value::Long(n) => Ok(SharedValue::Long(*n)),
+        Value::Double(d) => Ok(SharedValue::Double(*d)),
+        Value::Char(c) => Ok(SharedValue::Char(*c)),
+        Value::Uuid(u) => Ok(SharedValue::Uuid(*u)),
+        Value::Str(s) => Ok(SharedValue::Str(Arc::from(s.get().as_str()))),
+        Value::Keyword(kw) => {
+            let kw = kw.get();
+            let ptr = intern_keyword(kw.namespace.as_deref(), &kw.name);
+            Ok(SharedValue::Keyword(ptr))
+        }
+        Value::Symbol(sym) => {
+            let sym = sym.get();
+            let ptr = intern_symbol(sym.namespace.as_deref(), &sym.name, sym.version.as_deref());
+            Ok(SharedValue::Symbol(ptr))
+        }
+        Value::ByteArray(arr) => {
+            let bytes = arr.get().lock().unwrap();
+            let blob: Arc<[u8]> = bytes.iter().map(|&b| b as u8).collect::<Vec<_>>().into();
+            Ok(SharedValue::ByteBlob(blob))
+        }
+        Value::ByteBlob(blob) => Ok(SharedValue::ByteBlob(blob.clone())),
+        other => Err(PromoteError::not_promotable(other.type_name())),
+    }
+}
+
+/// Demote a [`SharedValue`] back into an isolate-local `Value`.
+///
+/// Always succeeds.  Keywords and symbols are cloned from their interned
+/// static-arena allocation into a fresh `GcPtr` on the calling isolate's heap.
+/// Map lookups compare by namespace/name content (not pointer identity) so
+/// equality is preserved across the round-trip.
+pub fn demote(sv: &SharedValue) -> Value {
+    match sv {
+        SharedValue::Nil => Value::Nil,
+        SharedValue::Bool(b) => Value::Bool(*b),
+        SharedValue::Long(n) => Value::Long(*n),
+        SharedValue::Double(d) => Value::Double(*d),
+        SharedValue::Char(c) => Value::Char(*c),
+        SharedValue::Uuid(u) => Value::Uuid(*u),
+        SharedValue::Str(s) => Value::Str(GcPtr::new(s.as_ref().to_owned())),
+        SharedValue::Keyword(kw) => Value::Keyword(GcPtr::new(kw.get().clone())),
+        SharedValue::Symbol(sym) => Value::Symbol(GcPtr::new(sym.get().clone())),
+        SharedValue::ByteBlob(blob) => Value::ByteBlob(blob.clone()),
+    }
+}
+
+// ── SharedAtom ────────────────────────────────────────────────────────────────
+
+/// A cross-isolate mutable reference backed by a lock-free `ArcSwap`.
+///
+/// `reset!` and `swap!` promote the new value and perform an atomic pointer
+/// swap — no locking, O(1) for simple resets, O(retries) for CAS-retry
+/// `swap!` under write contention.  `deref` is a single atomic load plus an
+/// `Arc` reference-count bump.
+///
+/// Wrapped in `Value::SharedAtom(Arc<SharedAtom>)`.  The `Arc` gives the atom
+/// identity (pointer equality) and allows any number of isolates to hold a
+/// reference.
+#[derive(Debug)]
+pub struct SharedAtom {
+    pub cell: Arc<ArcSwap<SharedValue>>,
+    pub meta: Mutex<Option<SharedValue>>,
+}
+
+impl SharedAtom {
+    pub fn new(val: SharedValue) -> Self {
+        Self {
+            cell: Arc::new(ArcSwap::new(Arc::new(val))),
+            meta: Mutex::new(None),
+        }
+    }
+
+    /// Load the current value.  Lock-free atomic load + refcount bump.
+    pub fn deref_val(&self) -> Arc<SharedValue> {
+        self.cell.load_full()
+    }
+
+    /// Atomically replace the value and return the new `Arc`.
+    pub fn reset(&self, val: SharedValue) -> Arc<SharedValue> {
+        let arc = Arc::new(val);
+        self.cell.store(arc.clone());
+        arc
+    }
+
+    /// CAS-retry swap: apply `f` to the current value and store the result.
+    /// Returns the new value.  Retries automatically if another writer races.
+    pub fn swap<F>(&self, mut f: F) -> Arc<SharedValue>
+    where
+        F: FnMut(&SharedValue) -> SharedValue,
+    {
+        self.cell.rcu(|old| Arc::new(f(old)))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::keyword::Keyword;
+    use crate::value::Value;
+    use cljrs_gc::GcPtr;
+
+    use super::*;
+
+    fn kw(name: &str) -> Value {
+        Value::Keyword(GcPtr::new(Keyword::simple(name)))
+    }
+
+    #[test]
+    fn promote_scalars() {
+        assert!(matches!(promote(&Value::Nil), Ok(SharedValue::Nil)));
+        assert!(matches!(
+            promote(&Value::Bool(true)),
+            Ok(SharedValue::Bool(true))
+        ));
+        assert!(matches!(
+            promote(&Value::Long(42)),
+            Ok(SharedValue::Long(42))
+        ));
+    }
+
+    #[test]
+    fn promote_keyword_interns() {
+        let v = kw("foo");
+        let sv = promote(&v).unwrap();
+        let sv2 = promote(&kw("foo")).unwrap();
+        if let (SharedValue::Keyword(a), SharedValue::Keyword(b)) = (sv, sv2) {
+            assert!(
+                cljrs_gc::StaticGcPtr::ptr_eq(&a, &b),
+                "same keyword should intern to same StaticGcPtr"
+            );
+        } else {
+            panic!("expected SharedValue::Keyword");
+        }
+    }
+
+    #[test]
+    fn demote_roundtrip_long() {
+        let sv = SharedValue::Long(99);
+        assert!(matches!(demote(&sv), Value::Long(99)));
+    }
+
+    #[test]
+    fn demote_roundtrip_keyword() {
+        let sv = promote(&kw("test")).unwrap();
+        let v = demote(&sv);
+        if let Value::Keyword(kw_ptr) = v {
+            assert_eq!(kw_ptr.get().name.as_ref(), "test");
+        } else {
+            panic!("expected Value::Keyword");
+        }
+    }
+
+    #[test]
+    fn promote_non_promotable_returns_err() {
+        let atom = Value::Atom(GcPtr::new(crate::types::Atom::new(Value::Nil)));
+        assert!(promote(&atom).is_err());
+    }
+
+    #[test]
+    fn promote_byte_blob() {
+        let arr: Vec<i8> = vec![1, 2, 3];
+        let v = Value::ByteArray(GcPtr::new(std::sync::Mutex::new(arr)));
+        let sv = promote(&v).unwrap();
+        assert!(matches!(sv, SharedValue::ByteBlob(_)));
+    }
+
+    #[test]
+    fn shared_atom_reset_and_deref() {
+        let atom = SharedAtom::new(SharedValue::Long(0));
+        atom.reset(SharedValue::Long(42));
+        let val = atom.deref_val();
+        assert!(matches!(val.as_ref(), SharedValue::Long(42)));
+    }
+
+    #[test]
+    fn shared_atom_swap() {
+        let atom = SharedAtom::new(SharedValue::Long(1));
+        atom.swap(|old| {
+            if let SharedValue::Long(n) = old {
+                SharedValue::Long(n + 1)
+            } else {
+                SharedValue::Long(0)
+            }
+        });
+        let val = atom.deref_val();
+        assert!(matches!(val.as_ref(), SharedValue::Long(2)));
+    }
+
+    #[test]
+    fn shared_atom_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SharedAtom>();
+        assert_send_sync::<Arc<SharedAtom>>();
+    }
+
+    #[test]
+    fn byte_blob_shared_across_clone() {
+        let blob: Arc<[u8]> = vec![10u8, 20, 30].into();
+        let v1 = Value::ByteBlob(blob.clone());
+        let v2 = Value::ByteBlob(blob.clone());
+        // Same underlying buffer
+        if let (Value::ByteBlob(a), Value::ByteBlob(b)) = (&v1, &v2) {
+            assert!(Arc::ptr_eq(a, b));
+        }
+    }
+}

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -37,8 +37,8 @@ pub(crate) fn value_gcptr_is_static(value: &Value) -> bool {
         | Value::Double(_)
         | Value::Char(_)
         | Value::Uuid(_) => true,
-        // Arc-managed — not GcPtr.
-        Value::Resource(_) => true,
+        // Arc-managed — not GcPtr; always considered static.
+        Value::Resource(_) | Value::SharedAtom(_) | Value::ByteBlob(_) => true,
         // GcPtr variants.
         Value::BigInt(p) => p.is_static_alloc(),
         Value::BigDecimal(p) => p.is_static_alloc(),

--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -13,6 +13,7 @@ use crate::hash::{
 use crate::keyword::Keyword;
 use crate::regex::Matcher;
 use crate::resource::ResourceHandle;
+use crate::shared::SharedAtom;
 use crate::symbol::Symbol;
 use crate::types::{
     Agent, Atom, BoundFn, CljxCons, CljxFn, CljxFuture, CljxPromise, Delay, LazySeq, MultiFn,
@@ -107,6 +108,14 @@ pub enum Value {
     // ── Mutable state ─────────────────────────────────────────────────────────
     Var(GcPtr<Var>),
     Atom(GcPtr<Atom>),
+    /// Cross-isolate mutable reference backed by `Arc<ArcSwap<SharedValue>>`.
+    /// Unlike `Atom`, a `SharedAtom` can cross the isolate boundary (the `Arc`
+    /// is cloned, not deep-copied) and its contents are lock-free CAS-swapped.
+    SharedAtom(std::sync::Arc<SharedAtom>),
+    /// Immutable refcounted byte buffer (the BEAM off-heap-binary trick).
+    /// Shared without copy across the isolate boundary; refcount drops to zero
+    /// only when every isolate releases its reference.
+    ByteBlob(std::sync::Arc<[u8]>),
 
     // ── Reduced (early termination sentinel for reduce/transduce) ───────────
     Reduced(Box<Value>),
@@ -484,6 +493,10 @@ impl PartialEq for Value {
             (Value::Error(a), Value::Error(b)) => {
                 std::ptr::eq(a.get() as *const _, b.get() as *const _)
             }
+            // SharedAtom: pointer identity (same Arc → same atom).
+            (Value::SharedAtom(a), Value::SharedAtom(b)) => Arc::ptr_eq(a, b),
+            // ByteBlob: pointer identity (same Arc → same underlying buffer).
+            (Value::ByteBlob(a), Value::ByteBlob(b)) => Arc::ptr_eq(a, b),
             _ => false,
         }
     }
@@ -723,6 +736,15 @@ impl ClojureHash for Value {
                 let mut h: u32 = 0;
                 for item in a.get().0.lock().unwrap().iter() {
                     h = hash_combine_ordered(h, item.clojure_hash())
+                }
+                h
+            }
+
+            Value::SharedAtom(a) => Arc::as_ptr(a) as u32,
+            Value::ByteBlob(b) => {
+                let mut h: u32 = 0;
+                for byte in b.iter() {
+                    h = hash_combine_ordered(h, hash_i64(*byte as i64));
                 }
                 h
             }
@@ -1034,6 +1056,10 @@ pub fn pr_str(v: &Value, f: &mut fmt::Formatter<'_>, readably: bool) -> fmt::Res
         },
         Value::Var(v) => write!(f, "#'{}/{}", v.get().namespace, v.get().name),
         Value::Atom(a) => write!(f, "#<Atom {}>", a.get().deref()),
+        Value::SharedAtom(a) => {
+            write!(f, "#<SharedAtom {}>", a.deref_val().type_name())
+        }
+        Value::ByteBlob(b) => write!(f, "#<ByteBlob {} bytes>", b.len()),
         Value::Namespace(n) => write!(f, "#<Namespace {}>", n.get().name),
         Value::Protocol(p) => write!(f, "#<Protocol {}>", p.get().name),
         Value::ProtocolFn(pf) => {
@@ -1149,6 +1175,8 @@ impl Value {
             | Value::MultiFn(_) => "fn",
             Value::Var(_) => "var",
             Value::Atom(_) => "atom",
+            Value::SharedAtom(_) => "shared-atom",
+            Value::ByteBlob(_) => "byte-blob",
             Value::Namespace(_) => "namespace",
             Value::LazySeq(_) => "lazyseq",
             Value::Cons(_) => "cons",
@@ -1274,8 +1302,9 @@ impl cljrs_gc::Trace for Value {
             | Value::DoubleArray(_)
             | Value::CharArray(_) => {}
             Value::NativeObject(p) => visitor.visit(p),
-            // Resource is Arc-ref-counted, not GcPtr — nothing to trace.
-            Value::Resource(_) => {}
+            // Resource, SharedAtom, and ByteBlob are Arc-ref-counted outside the
+            // GC heap — nothing to trace through the GC visitor.
+            Value::Resource(_) | Value::SharedAtom(_) | Value::ByteBlob(_) => {}
             Value::TransientMap(m) => visitor.visit(m),
             Value::TransientVector(p) => visitor.visit(p),
             Value::TransientSet(m) => visitor.visit(m),
@@ -1687,6 +1716,8 @@ fn type_discriminant(v: &Value) -> u8 {
         Value::Macro(_) => 16,
         Value::Var(_) => 17,
         Value::Atom(_) => 18,
+        Value::SharedAtom(_) => 46,
+        Value::ByteBlob(_) => 47,
         Value::Namespace(_) => 19,
         Value::Protocol(_) => 20,
         Value::ProtocolFn(_) => 21,


### PR DESCRIPTION
- cljrs-gc: add StaticGcPtr<T> (Send+Sync raw pointer to program-lifetime
  data) and static_alloc<T>() (arena bump-alloc in no-gc, Box::leak in GC
  mode); StaticArena gains alloc_val<T>() for header-free T allocation.

- cljrs-value/intern: global keyword/symbol intern tables backed by
  OnceLock<Mutex<HashMap<…, StaticGcPtr<T>>>>; intern_keyword /
  intern_symbol guarantee pointer-stable identity across all isolates,
  which is required for correct hash-map key lookups after a B2 clone.

- cljrs-value/shared: SharedValue (Send+Sync subset of Value — scalars,
  Arc<str>, StaticGcPtr<Keyword/Symbol>, Arc<[u8]> blobs); SharedAtom
  (Arc<ArcSwap<SharedValue>>, lock-free CAS swap); promote/demote
  conversions between isolate-local Value and SharedValue.

- cljrs-value/value: add Value::SharedAtom(Arc<SharedAtom>) and
  Value::ByteBlob(Arc<[u8]>) variants; wire into PartialEq, ClojureHash,
  Trace, Display, type_name, type_discriminant.

- cljrs-value/clone: SharedAtom and ByteBlob cross the isolate boundary
  via Arc clone (no deep copy); SerializedValue gains matching variants.

- 12 new tests: keyword/symbol intern identity; promote/demote roundtrips;
  SharedAtom reset+swap; ByteBlob Arc sharing.

https://claude.ai/code/session_01W7h3mV22kPqkytYbzy9aDG