### PR TITLE
Add cljrs-charset crate: streaming charset encoding/decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
 name = "cljrs-charset"
 version = "0.1.0"
 dependencies = [
+ "cljrs-async",
  "cljrs-env",
  "cljrs-gc",
  "cljrs-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cljrs-charset"
+version = "0.1.0"
+dependencies = [
+ "cljrs-env",
+ "cljrs-gc",
+ "cljrs-value",
+ "encoding_rs",
+]
+
+[[package]]
 name = "cljrs-compiler"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ members = [
     "crates/cljrs-wasm",
     "crates/cljrs-async",
     "crates/cljrs-io",
-    "crates/cljrs-net"]
+    "crates/cljrs-net",
+    "crates/cljrs-charset"]
 resolver = "2"
 
 [workspace.package]
@@ -55,6 +56,7 @@ cljrs-vcs          = { path = "crates/cljrs-vcs",          version = "0.1.0" }
 cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0" }
 cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
 cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
+cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/crates/cljrs-charset/Cargo.toml
+++ b/crates/cljrs-charset/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cljrs-charset"
+version = "0.1.0"
+edition = "2024"
+description = "Charset encoding and decoding with stream support — clojure.rust.charset"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cljrs-gc    = { workspace = true }
+cljrs-value = { workspace = true }
+cljrs-env   = { workspace = true }
+encoding_rs = { workspace = true }

--- a/crates/cljrs-charset/Cargo.toml
+++ b/crates/cljrs-charset/Cargo.toml
@@ -10,4 +10,5 @@ repository.workspace = true
 cljrs-gc    = { workspace = true }
 cljrs-value = { workspace = true }
 cljrs-env   = { workspace = true }
+cljrs-async = { workspace = true }
 encoding_rs = { workspace = true }

--- a/crates/cljrs-charset/README.md
+++ b/crates/cljrs-charset/README.md
@@ -1,0 +1,61 @@
+# cljrs-charset
+
+**Purpose**: Charset encoding and decoding with stream support for clojurust — exposes the `clojure.rust.charset` namespace, backed by [`encoding_rs`](https://github.com/nicowillis/encoding_rs) (the WHATWG encoding standard implementation).
+
+**Status**: Phase 1 — implemented and tested.
+
+## File layout
+
+| File | Description |
+|---|---|
+| `src/lib.rs` | Crate entry point; `NS` constant; `init()` registers the namespace; unit tests |
+| `src/codec.rs` | `CljDecoder` and `CljEncoder` — `NativeObject` wrappers around `encoding_rs::Decoder`/`Encoder` with `Mutex`-based interior mutability |
+| `src/fns.rs` | Clojure-callable builtin function implementations and registration |
+
+## Public API
+
+### `init(globals: &Arc<GlobalEnv>)`
+
+Register the `clojure.rust.charset` namespace.  Idempotent: subsequent calls are no-ops.
+
+### `NS: &str`
+
+The namespace name: `"clojure.rust.charset"`.
+
+## Clojure namespace: `clojure.rust.charset`
+
+| Function | Arity | Description |
+|---|---|---|
+| `decoder` | 0–1 | `(decoder)` or `(decoder :shift-jis)` — create a streaming decoder. Optional charset keyword or string; defaults to UTF-8. |
+| `encoder` | 0–1 | `(encoder)` or `(encoder :windows-1252)` — create a streaming encoder. |
+| `update!` | 2 | Feed a chunk to a codec. `(update! dec bytes)` → string; `(update! enc string)` → byte-blob. Returns accumulated output for this chunk. |
+| `finish!` | 1 | Flush and close a codec. `(finish! dec)` → string; `(finish! enc)` → byte-blob. After `finish!`, further calls return an error. |
+| `decode` | 1–2 | One-shot decode: `(decode bytes)` or `(decode bytes :iso-8859-1)` → string. |
+| `encode` | 1–2 | One-shot encode: `(encode string)` or `(encode string :shift-jis)` → byte-blob. |
+
+### Charset labels
+
+Any label recognised by `encoding_rs` is accepted as a keyword or string:
+`:utf-8`, `:utf-16le`, `:shift-jis`, `:windows-1252`, `:iso-8859-1`, etc.
+`nil` or omitted defaults to UTF-8.
+
+### Unmappable characters
+
+When encoding to a non-Unicode charset, characters that cannot be represented
+are replaced with HTML numeric character references (e.g. `&#128512;` for 😀).
+
+### Example
+
+```clojure
+(require '[clojure.rust.charset :as charset])
+
+;; Streaming decode (e.g. reading from a network stream in chunks)
+(let [dec (charset/decoder :shift-jis)]
+  (charset/update! dec chunk1)   ;; => "..."
+  (charset/update! dec chunk2)   ;; => "..."
+  (charset/finish! dec))         ;; => "tail"
+
+;; One-shot
+(charset/decode my-bytes :windows-1252)   ;; => "Hello World"
+(charset/encode "こんにちは" :shift-jis) ;; => #bytes[...]
+```

--- a/crates/cljrs-charset/README.md
+++ b/crates/cljrs-charset/README.md
@@ -1,6 +1,6 @@
 # cljrs-charset
 
-**Purpose**: Charset encoding and decoding with stream support for clojurust — exposes the `clojure.rust.charset` namespace, backed by [`encoding_rs`](https://github.com/nicowillis/encoding_rs) (the WHATWG encoding standard implementation).
+**Purpose**: Charset encoding and decoding with stream support for clojurust — exposes the `clojure.rust.charset` and `clojure.rust.charset.async` namespaces, backed by [`encoding_rs`](https://github.com/nicowillis/encoding_rs) (the WHATWG encoding standard implementation).
 
 **Status**: Phase 1 — implemented and tested.
 
@@ -8,19 +8,26 @@
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | Crate entry point; `NS` constant; `init()` registers the namespace; unit tests |
-| `src/codec.rs` | `CljDecoder` and `CljEncoder` — `NativeObject` wrappers around `encoding_rs::Decoder`/`Encoder` with `Mutex`-based interior mutability |
-| `src/fns.rs` | Clojure-callable builtin function implementations and registration |
+| `src/lib.rs` | Crate entry point; `NS`/`NS_ASYNC` constants; `init()` and `init_async()`; unit tests |
+| `src/codec.rs` | `CljDecoder` and `CljEncoder` — `NativeObject` wrappers around `encoding_rs::Decoder`/`Encoder` with `Mutex`-based interior mutability; shared decode/encode helpers |
+| `src/fns.rs` | Clojure-callable builtin function implementations and registration for the sync namespace |
+| `src/codec_chan.rs` | Async channel-to-channel transformers: `decode-chan` and `encode-chan` with their registration |
 
 ## Public API
 
 ### `init(globals: &Arc<GlobalEnv>)`
 
-Register the `clojure.rust.charset` namespace.  Idempotent: subsequent calls are no-ops.
+Register the `clojure.rust.charset` namespace.  Idempotent.
 
-### `NS: &str`
+### `init_async(globals: &Arc<GlobalEnv>)`
 
-The namespace name: `"clojure.rust.charset"`.
+Register the `clojure.rust.charset.async` namespace.  Idempotent.  Requires
+`cljrs_async::init` and a running Tokio `LocalSet` before channel functions
+are called.
+
+### `NS: &str` / `NS_ASYNC: &str`
+
+The namespace names: `"clojure.rust.charset"` and `"clojure.rust.charset.async"`.
 
 ## Clojure namespace: `clojure.rust.charset`
 
@@ -28,10 +35,24 @@ The namespace name: `"clojure.rust.charset"`.
 |---|---|---|
 | `decoder` | 0–1 | `(decoder)` or `(decoder :shift-jis)` — create a streaming decoder. Optional charset keyword or string; defaults to UTF-8. |
 | `encoder` | 0–1 | `(encoder)` or `(encoder :windows-1252)` — create a streaming encoder. |
-| `update!` | 2 | Feed a chunk to a codec. `(update! dec bytes)` → string; `(update! enc string)` → byte-blob. Returns accumulated output for this chunk. |
+| `update!` | 2 | Feed a chunk to a codec. `(update! dec bytes)` → string; `(update! enc string)` → byte-blob. |
 | `finish!` | 1 | Flush and close a codec. `(finish! dec)` → string; `(finish! enc)` → byte-blob. After `finish!`, further calls return an error. |
 | `decode` | 1–2 | One-shot decode: `(decode bytes)` or `(decode bytes :iso-8859-1)` → string. |
 | `encode` | 1–2 | One-shot encode: `(encode string)` or `(encode string :shift-jis)` → byte-blob. |
+
+## Clojure namespace: `clojure.rust.charset.async`
+
+| Function | Arity | Description |
+|---|---|---|
+| `decode-chan` | 1–3 | `(decode-chan bytes-chan)` / `(decode-chan bytes-chan :shift-jis)` / `(decode-chan bytes-chan :shift-jis 16)` — reads `ByteBlob` values from the input channel, decodes them, and delivers strings onto a new output channel. Closed when the input closes. |
+| `encode-chan` | 1–3 | `(encode-chan strings-chan)` / `(encode-chan strings-chan :windows-1252)` / `(encode-chan strings-chan :windows-1252 16)` — reads strings from the input channel, encodes them, and delivers `ByteBlob` values onto a new output channel. |
+
+### Async conventions
+
+- Both functions **return the output channel immediately**; a producer task drives the transform in the background.
+- The default output buffer is 8 items; the producer yields whenever the consumer hasn't drained it (natural backpressure).
+- `Value::Nil` on the input channel signals closure; the producer flushes any partial codec state (e.g. a split multi-byte sequence) and closes the output.
+- Non-blob / non-string values — including `Value::Error` — are forwarded to the output channel unchanged so consumers can detect upstream errors.
 
 ### Charset labels
 
@@ -41,21 +62,38 @@ Any label recognised by `encoding_rs` is accepted as a keyword or string:
 
 ### Unmappable characters
 
-When encoding to a non-Unicode charset, characters that cannot be represented
-are replaced with HTML numeric character references (e.g. `&#128512;` for 😀).
+When encoding to a non-Unicode charset, unmappable characters are replaced with
+HTML numeric character references (e.g. `&#128512;` for 😀).
 
 ### Example
 
 ```clojure
 (require '[clojure.rust.charset :as charset])
+(require '[clojure.rust.charset.async :as ca])
+(require '[clojure.core.async :as async])
 
-;; Streaming decode (e.g. reading from a network stream in chunks)
+;; Synchronous streaming decode
 (let [dec (charset/decoder :shift-jis)]
   (charset/update! dec chunk1)   ;; => "..."
   (charset/update! dec chunk2)   ;; => "..."
   (charset/finish! dec))         ;; => "tail"
 
 ;; One-shot
-(charset/decode my-bytes :windows-1252)   ;; => "Hello World"
+(charset/decode my-bytes :windows-1252)  ;; => "Hello World"
 (charset/encode "こんにちは" :shift-jis) ;; => #bytes[...]
+
+;; Async pipeline: byte-chan from network → decode → process strings
+(let [bytes-ch  (network/read-chan conn)
+      strings-ch (ca/decode-chan bytes-ch :utf-8)]
+  (async/go-loop []
+    (when-let [s (async/<! strings-ch)]
+      (process! s)
+      (recur))))
+
+;; Async encode pipeline
+(let [in-ch  (async/chan 8)
+      out-ch (ca/encode-chan in-ch :shift-jis)]
+  (async/onto-chan! in-ch ["Hello" " " "世界"])
+  ;; out-ch delivers ByteBlob values
+  )
 ```

--- a/crates/cljrs-charset/src/codec.rs
+++ b/crates/cljrs-charset/src/codec.rs
@@ -1,0 +1,208 @@
+//! Streaming codec wrappers around `encoding_rs::Decoder` and `encoding_rs::Encoder`.
+//!
+//! Both types implement [`NativeObject`] so they can be stored as
+//! `Value::NativeObject` and passed to Clojure-level functions.
+//! Interior mutability is provided by `Mutex` so that the codec can be updated
+//! through a shared `&GcPtr<NativeObjectBox>` reference.
+
+use std::{any::Any, fmt, sync::Mutex};
+
+use cljrs_gc::{MarkVisitor, Trace};
+use cljrs_value::{NativeObject, ValueError, ValueResult};
+use encoding_rs::Encoding;
+
+// ── Decoder ───────────────────────────────────────────────────────────────────
+
+/// A streaming byte-to-string decoder backed by `encoding_rs`.
+///
+/// Feed byte chunks via [`CljDecoder::update`]; flush trailing state via
+/// [`CljDecoder::finish`], which consumes the inner decoder so the object
+/// cannot be used afterwards.
+pub struct CljDecoder {
+    // Option is None after finish!; held inside Mutex for interior mutability.
+    inner: Mutex<Option<encoding_rs::Decoder>>,
+    encoding_name: &'static str,
+}
+
+// SAFETY: `encoding_rs::Decoder` contains only `&'static Encoding` (a static
+// lookup table) plus plain value-type state.  Moving it across threads is safe;
+// the Mutex ensures exclusive access to the mutable state.
+unsafe impl Send for CljDecoder {}
+unsafe impl Sync for CljDecoder {}
+
+impl CljDecoder {
+    pub fn new(encoding: &'static Encoding) -> Self {
+        Self {
+            inner: Mutex::new(Some(encoding.new_decoder())),
+            encoding_name: encoding.name(),
+        }
+    }
+
+    /// Decode a non-final byte chunk, returning the decoded text produced.
+    ///
+    /// Returns an error if the decoder was already finished.
+    pub fn update(&self, src: &[u8]) -> ValueResult<String> {
+        let mut guard = self.inner.lock().unwrap();
+        let dec = guard
+            .as_mut()
+            .ok_or_else(|| ValueError::Other("decoder is already finished".into()))?;
+        Ok(decode_bytes(dec, src, false))
+    }
+
+    /// Flush any buffered trailing bytes and mark the decoder as finished.
+    ///
+    /// Returns the remaining decoded text (may be empty).  Calling again
+    /// after finish returns an error.
+    pub fn finish(&self) -> ValueResult<String> {
+        let mut guard = self.inner.lock().unwrap();
+        let mut dec = guard
+            .take()
+            .ok_or_else(|| ValueError::Other("decoder is already finished".into()))?;
+        Ok(decode_bytes(&mut dec, &[], true))
+    }
+}
+
+/// Decode `src` into a new `String`.
+///
+/// `max_utf8_buffer_length` pre-sizes the buffer so that `decode_to_string`
+/// completes in a single call without reallocation.
+fn decode_bytes(dec: &mut encoding_rs::Decoder, src: &[u8], last: bool) -> String {
+    let cap = dec
+        .max_utf8_buffer_length(src.len())
+        .unwrap_or_else(|| src.len().saturating_mul(4).max(4));
+    let mut out = String::with_capacity(cap);
+    let _ = dec.decode_to_string(src, &mut out, last);
+    out
+}
+
+impl fmt::Debug for CljDecoder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Decoder({})", self.encoding_name)
+    }
+}
+
+impl Trace for CljDecoder {
+    fn trace(&self, _: &mut MarkVisitor) {}
+}
+
+impl NativeObject for CljDecoder {
+    fn type_tag(&self) -> &str {
+        "Decoder"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Encoder ───────────────────────────────────────────────────────────────────
+
+/// A streaming string-to-bytes encoder backed by `encoding_rs`.
+///
+/// Feed string chunks via [`CljEncoder::update`]; flush via
+/// [`CljEncoder::finish`].  Unmappable characters are replaced with HTML
+/// numeric character references (`&#NNNN;`).
+pub struct CljEncoder {
+    inner: Mutex<Option<encoding_rs::Encoder>>,
+    encoding_name: &'static str,
+}
+
+// SAFETY: Same reasoning as CljDecoder — the Encoder contains only a static
+// pointer plus value-type state; the Mutex guards mutable access.
+unsafe impl Send for CljEncoder {}
+unsafe impl Sync for CljEncoder {}
+
+impl CljEncoder {
+    pub fn new(encoding: &'static Encoding) -> Self {
+        Self {
+            inner: Mutex::new(Some(encoding.new_encoder())),
+            encoding_name: encoding.name(),
+        }
+    }
+
+    /// Encode a non-final string chunk, returning the encoded bytes produced.
+    ///
+    /// Returns an error if the encoder was already finished.
+    pub fn update(&self, src: &str) -> ValueResult<Vec<u8>> {
+        let mut guard = self.inner.lock().unwrap();
+        let enc = guard
+            .as_mut()
+            .ok_or_else(|| ValueError::Other("encoder is already finished".into()))?;
+        Ok(encode_str(enc, src, false))
+    }
+
+    /// Flush any pending state and mark the encoder as finished.
+    ///
+    /// Returns any trailing encoded bytes (may be empty).
+    pub fn finish(&self) -> ValueResult<Vec<u8>> {
+        let mut guard = self.inner.lock().unwrap();
+        let mut enc = guard
+            .take()
+            .ok_or_else(|| ValueError::Other("encoder is already finished".into()))?;
+        Ok(encode_str(&mut enc, "", true))
+    }
+}
+
+/// Encode `src` into a `Vec<u8>`.
+///
+/// Unmappable characters are substituted with HTML numeric character
+/// references (e.g. `&#12354;` for あ when encoding as Latin-1).  The loop
+/// handles `OutputFull` by extending the output buffer.
+fn encode_str(enc: &mut encoding_rs::Encoder, src: &str, last: bool) -> Vec<u8> {
+    use encoding_rs::EncoderResult;
+
+    let mut out = Vec::new();
+    let mut remaining = src;
+
+    loop {
+        let space = enc
+            .max_buffer_length_from_utf8_without_replacement(remaining.len().max(1))
+            .unwrap_or_else(|| remaining.len().saturating_mul(4).max(8));
+        let old_len = out.len();
+        out.resize(old_len + space, 0u8);
+
+        let is_last = last && remaining.is_empty();
+        let (result, read, written) =
+            enc.encode_from_utf8_without_replacement(remaining, &mut out[old_len..], is_last);
+        out.truncate(old_len + written);
+        remaining = &remaining[read..];
+
+        match result {
+            EncoderResult::InputEmpty => {
+                if last && !is_last {
+                    // All input consumed; now do the final flush call.
+                    continue;
+                }
+                break;
+            }
+            EncoderResult::OutputFull => {} // loop with more buffer
+            EncoderResult::Unmappable(ch) => {
+                // encoding_rs already counted the unmappable char's bytes in
+                // `read`, so `remaining` is already past it.  Just emit the
+                // HTML numeric character reference substitution.
+                let ncr = format!("&#{};", ch as u32);
+                out.extend_from_slice(ncr.as_bytes());
+            }
+        }
+    }
+
+    out
+}
+
+impl fmt::Debug for CljEncoder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Encoder({})", self.encoding_name)
+    }
+}
+
+impl Trace for CljEncoder {
+    fn trace(&self, _: &mut MarkVisitor) {}
+}
+
+impl NativeObject for CljEncoder {
+    fn type_tag(&self) -> &str {
+        "Encoder"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/cljrs-charset/src/codec.rs
+++ b/crates/cljrs-charset/src/codec.rs
@@ -66,7 +66,7 @@ impl CljDecoder {
 ///
 /// `max_utf8_buffer_length` pre-sizes the buffer so that `decode_to_string`
 /// completes in a single call without reallocation.
-fn decode_bytes(dec: &mut encoding_rs::Decoder, src: &[u8], last: bool) -> String {
+pub(crate) fn decode_bytes(dec: &mut encoding_rs::Decoder, src: &[u8], last: bool) -> String {
     let cap = dec
         .max_utf8_buffer_length(src.len())
         .unwrap_or_else(|| src.len().saturating_mul(4).max(4));
@@ -147,7 +147,7 @@ impl CljEncoder {
 /// Unmappable characters are substituted with HTML numeric character
 /// references (e.g. `&#12354;` for あ when encoding as Latin-1).  The loop
 /// handles `OutputFull` by extending the output buffer.
-fn encode_str(enc: &mut encoding_rs::Encoder, src: &str, last: bool) -> Vec<u8> {
+pub(crate) fn encode_str(enc: &mut encoding_rs::Encoder, src: &str, last: bool) -> Vec<u8> {
     use encoding_rs::EncoderResult;
 
     let mut out = Vec::new();

--- a/crates/cljrs-charset/src/codec.rs
+++ b/crates/cljrs-charset/src/codec.rs
@@ -87,7 +87,7 @@ impl Trace for CljDecoder {
 
 impl NativeObject for CljDecoder {
     fn type_tag(&self) -> &str {
-        "Decoder"
+        "cljrs-charset/Decoder"
     }
     fn as_any(&self) -> &dyn Any {
         self
@@ -200,7 +200,7 @@ impl Trace for CljEncoder {
 
 impl NativeObject for CljEncoder {
     fn type_tag(&self) -> &str {
-        "Encoder"
+        "cljrs-charset/Encoder"
     }
     fn as_any(&self) -> &dyn Any {
         self

--- a/crates/cljrs-charset/src/codec_chan.rs
+++ b/crates/cljrs-charset/src/codec_chan.rs
@@ -38,8 +38,16 @@ const DEFAULT_CAP: usize = 8;
 
 pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
     let entries: &[(&str, Arity, NativeFnPtr)] = &[
-        ("decode-chan", Arity::Variadic { min: 1 }, builtin_decode_chan),
-        ("encode-chan", Arity::Variadic { min: 1 }, builtin_encode_chan),
+        (
+            "decode-chan",
+            Arity::Variadic { min: 1 },
+            builtin_decode_chan,
+        ),
+        (
+            "encode-chan",
+            Arity::Variadic { min: 1 },
+            builtin_encode_chan,
+        ),
     ];
     for (name, arity, func) in entries {
         let nf = NativeFn::new(*name, arity.clone(), *func);

--- a/crates/cljrs-charset/src/codec_chan.rs
+++ b/crates/cljrs-charset/src/codec_chan.rs
@@ -1,0 +1,206 @@
+//! Async channel-to-channel charset transformers — `clojure.rust.charset.async`.
+//!
+//! `decode-chan` and `encode-chan` each accept an input channel and return a
+//! new output channel immediately.  A producer task spawned via
+//! `cljrs_async::spawn_future` drives values from input to output,
+//! applying incremental charset decode/encode along the way.
+//!
+//! The same backpressure and error-passthrough conventions used by
+//! `cljrs-io` apply here:
+//! - A small output buffer (default 8) bounds memory; the producer yields
+//!   whenever the consumer hasn't drained the buffer.
+//! - `Value::Nil` from the input channel signals "input is closed".  The
+//!   producer flushes any partial codec state, puts the tail (if non-empty),
+//!   and closes the output.
+//! - Non-ByteBlob / non-Str values (including `Value::Error`) are forwarded
+//!   to the output channel unchanged.
+
+use std::sync::Arc;
+
+use cljrs_async::{
+    channel::{chan_put as put, chan_ref, chan_take, make_chan},
+    spawn_future,
+};
+use cljrs_env::env::GlobalEnv;
+use cljrs_gc::GcPtr;
+use cljrs_value::{Arity, NativeFn, NativeFnPtr, NativeObjectBox, Value, ValueError, ValueResult};
+
+use crate::{
+    codec::{decode_bytes, encode_str},
+    fns::resolve_encoding,
+};
+
+/// Default output-channel buffer: the producer may stay this many items
+/// ahead of the consumer before it blocks.
+const DEFAULT_CAP: usize = 8;
+
+// ── Registration ─────────────────────────────────────────────────────────────
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let entries: &[(&str, Arity, NativeFnPtr)] = &[
+        ("decode-chan", Arity::Variadic { min: 1 }, builtin_decode_chan),
+        ("encode-chan", Arity::Variadic { min: 1 }, builtin_encode_chan),
+    ];
+    for (name, arity, func) in entries {
+        let nf = NativeFn::new(*name, arity.clone(), *func);
+        globals.intern(ns, Arc::from(*name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── Argument helpers ──────────────────────────────────────────────────────────
+
+/// Extract a channel `GcPtr` from the argument list, validating the type.
+fn channel_arg(args: &[Value], idx: usize) -> ValueResult<GcPtr<NativeObjectBox>> {
+    match &args[idx] {
+        Value::NativeObject(ch) if ch.get().type_tag() == "Channel" => Ok(ch.clone()),
+        Value::NativeObject(ch) => Err(ValueError::WrongType {
+            expected: "channel",
+            got: ch.get().type_tag().to_string(),
+        }),
+        other => Err(ValueError::WrongType {
+            expected: "channel",
+            got: other.type_name().to_string(),
+        }),
+    }
+}
+
+fn cap_arg_or(args: &[Value], idx: usize, default: usize) -> ValueResult<usize> {
+    match args.get(idx) {
+        None | Some(Value::Nil) => Ok(default),
+        Some(Value::Long(n)) if *n >= 0 => Ok(*n as usize),
+        Some(Value::Long(n)) => Err(ValueError::Other(format!(
+            "channel capacity must be non-negative, got {n}"
+        ))),
+        Some(other) => Err(ValueError::WrongType {
+            expected: "integer capacity",
+            got: other.type_name().to_string(),
+        }),
+    }
+}
+
+// ── decode-chan ───────────────────────────────────────────────────────────────
+
+/// `(decode-chan bytes-chan)` /
+/// `(decode-chan bytes-chan :shift-jis)` /
+/// `(decode-chan bytes-chan :shift-jis 16)`
+///
+/// Reads `ByteBlob` values from `bytes-chan`, decodes them with the given
+/// charset (default UTF-8), and delivers decoded strings onto a new output
+/// channel.  The output channel is closed when the input closes.
+///
+/// Non-ByteBlob values (e.g. `Value::Error`) are forwarded to the output
+/// channel without modification so callers can detect upstream errors with
+/// the standard `error?` check.
+///
+/// Requires the `cljrs-async` runtime (`cljrs_async::init`) and a running
+/// Tokio `LocalSet`.
+fn builtin_decode_chan(args: &[Value]) -> ValueResult<Value> {
+    let in_ch = channel_arg(args, 0)?;
+    let encoding = resolve_encoding(args.get(1))?;
+    let cap = cap_arg_or(args, 2, DEFAULT_CAP)?;
+
+    let out_ch = make_chan(cap);
+    let out_val = Value::NativeObject(out_ch.clone());
+
+    spawn_future(async move {
+        let mut dec = encoding.new_decoder();
+
+        'pump: loop {
+            match chan_take(&in_ch).await {
+                Value::Nil => {
+                    // Input closed — flush any bytes buffered inside the decoder
+                    // (e.g. a trailing partial multi-byte sequence → U+FFFD).
+                    let tail = decode_bytes(&mut dec, &[], true);
+                    if !tail.is_empty() {
+                        put(&out_ch, str_val(tail)).await;
+                    }
+                    break;
+                }
+                Value::ByteBlob(blob) => {
+                    let s = decode_bytes(&mut dec, blob.as_ref(), false);
+                    // Skip empty strings: they happen when the decoder is
+                    // buffering an incomplete multi-byte sequence.
+                    if !s.is_empty() && !put(&out_ch, str_val(s)).await {
+                        break 'pump; // output closed by consumer
+                    }
+                }
+                other => {
+                    // Forward errors and any other values unchanged.
+                    if !put(&out_ch, other).await {
+                        break 'pump;
+                    }
+                }
+            }
+        }
+
+        chan_ref(out_ch.get()).close();
+        Ok(Value::Nil)
+    });
+
+    Ok(out_val)
+}
+
+// ── encode-chan ───────────────────────────────────────────────────────────────
+
+/// `(encode-chan strings-chan)` /
+/// `(encode-chan strings-chan :windows-1252)` /
+/// `(encode-chan strings-chan :windows-1252 16)`
+///
+/// Reads `String` values from `strings-chan`, encodes them with the given
+/// charset (default UTF-8), and delivers `ByteBlob` values onto a new output
+/// channel.  Unmappable characters are replaced with HTML numeric character
+/// references.  The output channel is closed when the input closes.
+///
+/// Requires the `cljrs-async` runtime (`cljrs_async::init`) and a running
+/// Tokio `LocalSet`.
+fn builtin_encode_chan(args: &[Value]) -> ValueResult<Value> {
+    let in_ch = channel_arg(args, 0)?;
+    let encoding = resolve_encoding(args.get(1))?;
+    let cap = cap_arg_or(args, 2, DEFAULT_CAP)?;
+
+    let out_ch = make_chan(cap);
+    let out_val = Value::NativeObject(out_ch.clone());
+
+    spawn_future(async move {
+        let mut enc = encoding.new_encoder();
+
+        'pump: loop {
+            match chan_take(&in_ch).await {
+                Value::Nil => {
+                    // Input closed — flush any pending encoder state.
+                    let tail = encode_str(&mut enc, "", true);
+                    if !tail.is_empty() {
+                        put(&out_ch, blob_val(tail)).await;
+                    }
+                    break;
+                }
+                Value::Str(s) => {
+                    let bytes = encode_str(&mut enc, s.get().as_str(), false);
+                    if !bytes.is_empty() && !put(&out_ch, blob_val(bytes)).await {
+                        break 'pump; // output closed by consumer
+                    }
+                }
+                other => {
+                    if !put(&out_ch, other).await {
+                        break 'pump;
+                    }
+                }
+            }
+        }
+
+        chan_ref(out_ch.get()).close();
+        Ok(Value::Nil)
+    });
+
+    Ok(out_val)
+}
+
+// ── Value constructors ────────────────────────────────────────────────────────
+
+fn str_val(s: String) -> Value {
+    Value::Str(GcPtr::new(s))
+}
+
+fn blob_val(bytes: Vec<u8>) -> Value {
+    Value::ByteBlob(Arc::from(bytes.as_slice()))
+}

--- a/crates/cljrs-charset/src/codec_chan.rs
+++ b/crates/cljrs-charset/src/codec_chan.rs
@@ -15,7 +15,7 @@
 //! - Non-ByteBlob / non-Str values (including `Value::Error`) are forwarded
 //!   to the output channel unchanged.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use cljrs_async::{
     channel::{chan_put as put, chan_ref, chan_take, make_chan},
@@ -116,6 +116,13 @@ fn builtin_decode_chan(args: &[Value]) -> ValueResult<Value> {
                     }
                     break;
                 }
+                Value::ByteArray(a) => {
+                    let raw: Vec<u8> = a.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+                    let s = decode_bytes(&mut dec, &raw, false);
+                    if !s.is_empty() && !put(&out_ch, str_val(s)).await {
+                        break 'pump;
+                    }
+                }
                 Value::ByteBlob(blob) => {
                     let s = decode_bytes(&mut dec, blob.as_ref(), false);
                     // Skip empty strings: they happen when the decoder is
@@ -202,5 +209,6 @@ fn str_val(s: String) -> Value {
 }
 
 fn blob_val(bytes: Vec<u8>) -> Value {
-    Value::ByteBlob(Arc::from(bytes.as_slice()))
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
 }

--- a/crates/cljrs-charset/src/fns.rs
+++ b/crates/cljrs-charset/src/fns.rs
@@ -1,6 +1,7 @@
 //! Native function implementations for `clojure.rust.charset`.
 
-use std::sync::Arc;
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
 
 use cljrs_env::env::GlobalEnv;
 use cljrs_gc::GcPtr;
@@ -48,11 +49,15 @@ pub(crate) fn resolve_encoding(arg: Option<&Value>) -> ValueResult<&'static Enco
         .ok_or_else(|| ValueError::Other(format!("unknown charset: {label}")))
 }
 
-fn bytes_from_value(v: &Value) -> ValueResult<&[u8]> {
+fn bytes_from_value(v: &Value) -> ValueResult<Cow<'_, [u8]>> {
     match v {
-        Value::ByteBlob(b) => Ok(b.as_ref()),
+        Value::ByteBlob(b) => Ok(Cow::Borrowed(b.as_ref())),
+        Value::ByteArray(a) => {
+            let bytes: Vec<u8> = a.get().lock().unwrap().iter().map(|&b| b as u8).collect();
+            Ok(Cow::Owned(bytes))
+        }
         other => Err(ValueError::WrongType {
-            expected: "byte-blob",
+            expected: "byte-array or byte-blob",
             got: other.type_name().to_string(),
         }),
     }
@@ -79,7 +84,8 @@ fn as_native<'a>(v: &'a Value, expected: &'static str) -> ValueResult<&'a Native
 }
 
 fn bytes_to_value(bytes: Vec<u8>) -> Value {
-    Value::ByteBlob(Arc::from(bytes.as_slice()))
+    let signed: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+    Value::ByteArray(GcPtr::new(Mutex::new(signed)))
 }
 
 // ── Streaming constructors ────────────────────────────────────────────────────
@@ -103,7 +109,7 @@ fn builtin_encoder(args: &[Value]) -> ValueResult<Value> {
 // ── Streaming operations ──────────────────────────────────────────────────────
 
 /// `(update! decoder bytes)` → string
-/// `(update! encoder string)` → byte-blob
+/// `(update! encoder string)` → byte-array
 ///
 /// Feed an incremental chunk to a codec.  The codec remains open for further
 /// calls; use `finish!` to flush trailing state.
@@ -111,7 +117,7 @@ fn builtin_update(args: &[Value]) -> ValueResult<Value> {
     let obj = as_native(&args[0], "Decoder or Encoder")?;
     if let Some(dec) = obj.downcast_ref::<CljDecoder>() {
         let bytes = bytes_from_value(&args[1])?;
-        let s = dec.update(bytes)?;
+        let s = dec.update(&bytes)?;
         Ok(Value::Str(GcPtr::new(s)))
     } else if let Some(enc) = obj.downcast_ref::<CljEncoder>() {
         let s = str_from_value(&args[1])?;
@@ -126,7 +132,7 @@ fn builtin_update(args: &[Value]) -> ValueResult<Value> {
 }
 
 /// `(finish! decoder)` → string
-/// `(finish! encoder)` → byte-blob
+/// `(finish! encoder)` → byte-array
 ///
 /// Flush any buffered state and close the codec.  Further calls to `update!`
 /// or `finish!` on the same object will return an error.
@@ -155,7 +161,7 @@ fn builtin_finish(args: &[Value]) -> ValueResult<Value> {
 fn builtin_decode(args: &[Value]) -> ValueResult<Value> {
     let bytes = bytes_from_value(&args[0])?;
     let enc = resolve_encoding(args.get(1))?;
-    let (cow, _, _) = enc.decode(bytes);
+    let (cow, _, _) = enc.decode(&bytes);
     Ok(Value::Str(GcPtr::new(cow.into_owned())))
 }
 
@@ -167,5 +173,6 @@ fn builtin_encode(args: &[Value]) -> ValueResult<Value> {
     let s = str_from_value(&args[0])?;
     let enc = resolve_encoding(args.get(1))?;
     let (cow, _, _) = enc.encode(s);
-    Ok(Value::ByteBlob(Arc::from(cow.as_ref())))
+    let signed: Vec<i8> = cow.iter().map(|&b| b as i8).collect();
+    Ok(Value::ByteArray(GcPtr::new(Mutex::new(signed))))
 }

--- a/crates/cljrs-charset/src/fns.rs
+++ b/crates/cljrs-charset/src/fns.rs
@@ -32,7 +32,7 @@ pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
 ///
 /// Accepts a keyword (`:utf-8`) or string (`"utf-8"`); `None`/`nil` defaults
 /// to UTF-8.  Unrecognised labels return an error.
-fn resolve_encoding(arg: Option<&Value>) -> ValueResult<&'static Encoding> {
+pub(crate) fn resolve_encoding(arg: Option<&Value>) -> ValueResult<&'static Encoding> {
     let label: String = match arg {
         None | Some(Value::Nil) => return Ok(encoding_rs::UTF_8),
         Some(Value::Keyword(k)) => k.get().name.as_ref().to_string(),

--- a/crates/cljrs-charset/src/fns.rs
+++ b/crates/cljrs-charset/src/fns.rs
@@ -1,0 +1,171 @@
+//! Native function implementations for `clojure.rust.charset`.
+
+use std::sync::Arc;
+
+use cljrs_env::env::GlobalEnv;
+use cljrs_gc::GcPtr;
+use cljrs_value::{Arity, NativeFn, NativeFnPtr, NativeObjectBox, Value, ValueError, ValueResult};
+use encoding_rs::Encoding;
+
+use crate::codec::{CljDecoder, CljEncoder};
+
+// ── Registration ─────────────────────────────────────────────────────────────
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let entries: &[(&str, Arity, NativeFnPtr)] = &[
+        ("decoder", Arity::Variadic { min: 0 }, builtin_decoder),
+        ("encoder", Arity::Variadic { min: 0 }, builtin_encoder),
+        ("update!", Arity::Fixed(2), builtin_update),
+        ("finish!", Arity::Fixed(1), builtin_finish),
+        ("decode", Arity::Variadic { min: 1 }, builtin_decode),
+        ("encode", Arity::Variadic { min: 1 }, builtin_encode),
+    ];
+    for (name, arity, func) in entries {
+        let nf = NativeFn::new(*name, arity.clone(), *func);
+        globals.intern(ns, Arc::from(*name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Resolve an optional charset argument to an `encoding_rs::Encoding`.
+///
+/// Accepts a keyword (`:utf-8`) or string (`"utf-8"`); `None`/`nil` defaults
+/// to UTF-8.  Unrecognised labels return an error.
+fn resolve_encoding(arg: Option<&Value>) -> ValueResult<&'static Encoding> {
+    let label: String = match arg {
+        None | Some(Value::Nil) => return Ok(encoding_rs::UTF_8),
+        Some(Value::Keyword(k)) => k.get().name.as_ref().to_string(),
+        Some(Value::Str(s)) => s.get().clone(),
+        Some(other) => {
+            return Err(ValueError::WrongType {
+                expected: "charset keyword or string",
+                got: other.type_name().to_string(),
+            });
+        }
+    };
+    Encoding::for_label(label.as_bytes())
+        .ok_or_else(|| ValueError::Other(format!("unknown charset: {label}")))
+}
+
+fn bytes_from_value(v: &Value) -> ValueResult<&[u8]> {
+    match v {
+        Value::ByteBlob(b) => Ok(b.as_ref()),
+        other => Err(ValueError::WrongType {
+            expected: "byte-blob",
+            got: other.type_name().to_string(),
+        }),
+    }
+}
+
+fn str_from_value(v: &Value) -> ValueResult<&str> {
+    match v {
+        Value::Str(s) => Ok(s.get().as_str()),
+        other => Err(ValueError::WrongType {
+            expected: "string",
+            got: other.type_name().to_string(),
+        }),
+    }
+}
+
+fn as_native<'a>(v: &'a Value, expected: &'static str) -> ValueResult<&'a NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => Ok(obj.get()),
+        other => Err(ValueError::WrongType {
+            expected,
+            got: other.type_name().to_string(),
+        }),
+    }
+}
+
+fn bytes_to_value(bytes: Vec<u8>) -> Value {
+    Value::ByteBlob(Arc::from(bytes.as_slice()))
+}
+
+// ── Streaming constructors ────────────────────────────────────────────────────
+
+/// `(decoder)` or `(decoder :shift-jis)` — return a streaming decoder.
+fn builtin_decoder(args: &[Value]) -> ValueResult<Value> {
+    let enc = resolve_encoding(args.first())?;
+    Ok(Value::NativeObject(cljrs_value::gc_native_object(
+        CljDecoder::new(enc),
+    )))
+}
+
+/// `(encoder)` or `(encoder :windows-1252)` — return a streaming encoder.
+fn builtin_encoder(args: &[Value]) -> ValueResult<Value> {
+    let enc = resolve_encoding(args.first())?;
+    Ok(Value::NativeObject(cljrs_value::gc_native_object(
+        CljEncoder::new(enc),
+    )))
+}
+
+// ── Streaming operations ──────────────────────────────────────────────────────
+
+/// `(update! decoder bytes)` → string
+/// `(update! encoder string)` → byte-blob
+///
+/// Feed an incremental chunk to a codec.  The codec remains open for further
+/// calls; use `finish!` to flush trailing state.
+fn builtin_update(args: &[Value]) -> ValueResult<Value> {
+    let obj = as_native(&args[0], "Decoder or Encoder")?;
+    if let Some(dec) = obj.downcast_ref::<CljDecoder>() {
+        let bytes = bytes_from_value(&args[1])?;
+        let s = dec.update(bytes)?;
+        Ok(Value::Str(GcPtr::new(s)))
+    } else if let Some(enc) = obj.downcast_ref::<CljEncoder>() {
+        let s = str_from_value(&args[1])?;
+        let bytes = enc.update(s)?;
+        Ok(bytes_to_value(bytes))
+    } else {
+        Err(ValueError::WrongType {
+            expected: "Decoder or Encoder",
+            got: obj.type_tag().to_string(),
+        })
+    }
+}
+
+/// `(finish! decoder)` → string
+/// `(finish! encoder)` → byte-blob
+///
+/// Flush any buffered state and close the codec.  Further calls to `update!`
+/// or `finish!` on the same object will return an error.
+fn builtin_finish(args: &[Value]) -> ValueResult<Value> {
+    let obj = as_native(&args[0], "Decoder or Encoder")?;
+    if let Some(dec) = obj.downcast_ref::<CljDecoder>() {
+        let s = dec.finish()?;
+        Ok(Value::Str(GcPtr::new(s)))
+    } else if let Some(enc) = obj.downcast_ref::<CljEncoder>() {
+        let bytes = enc.finish()?;
+        Ok(bytes_to_value(bytes))
+    } else {
+        Err(ValueError::WrongType {
+            expected: "Decoder or Encoder",
+            got: obj.type_tag().to_string(),
+        })
+    }
+}
+
+// ── One-shot helpers ──────────────────────────────────────────────────────────
+
+/// `(decode bytes)` or `(decode bytes :shift-jis)` — decode bytes to a string.
+///
+/// Uses `encoding_rs`'s one-shot path which avoids creating a persistent
+/// codec object.  Malformed sequences are replaced with U+FFFD.
+fn builtin_decode(args: &[Value]) -> ValueResult<Value> {
+    let bytes = bytes_from_value(&args[0])?;
+    let enc = resolve_encoding(args.get(1))?;
+    let (cow, _, _) = enc.decode(bytes);
+    Ok(Value::Str(GcPtr::new(cow.into_owned())))
+}
+
+/// `(encode string)` or `(encode string :windows-1252)` — encode a string to bytes.
+///
+/// Uses `encoding_rs`'s one-shot path.  Unmappable characters are replaced
+/// with HTML numeric character references.
+fn builtin_encode(args: &[Value]) -> ValueResult<Value> {
+    let s = str_from_value(&args[0])?;
+    let enc = resolve_encoding(args.get(1))?;
+    let (cow, _, _) = enc.encode(s);
+    Ok(Value::ByteBlob(Arc::from(cow.as_ref())))
+}

--- a/crates/cljrs-charset/src/lib.rs
+++ b/crates/cljrs-charset/src/lib.rs
@@ -1,0 +1,113 @@
+//! Charset encoding and decoding with stream support — `clojure.rust.charset`.
+//!
+//! Provides the `clojure.rust.charset` namespace backed by [`encoding_rs`],
+//! which supports the WHATWG encoding standard (UTF-8, UTF-16, Shift-JIS,
+//! windows-1252, ISO-8859-*, and many more).
+//!
+//! # Clojure API
+//!
+//! ```clojure
+//! ;; Streaming decode
+//! (let [dec (charset/decoder :shift-jis)]
+//!   (charset/update! dec some-bytes)   ;; => "partial string"
+//!   (charset/finish! dec))             ;; => "tail string"
+//!
+//! ;; Streaming encode
+//! (let [enc (charset/encoder :windows-1252)]
+//!   (charset/update! enc "Hello")      ;; => #bytes[...]
+//!   (charset/finish! enc))             ;; => #bytes[]
+//!
+//! ;; One-shot helpers
+//! (charset/decode blob)                ;; UTF-8 decode
+//! (charset/decode blob :iso-8859-1)   ;; with explicit charset
+//! (charset/encode "こんにちは" :shift-jis)
+//! ```
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! let globals = cljrs_stdlib::standard_env();
+//! cljrs_charset::init(&globals);
+//! ```
+
+use std::sync::Arc;
+
+use cljrs_env::env::GlobalEnv;
+
+mod codec;
+mod fns;
+
+/// The Clojure namespace populated by this crate.
+pub const NS: &str = "clojure.rust.charset";
+
+/// Register the `clojure.rust.charset` namespace into `globals`.
+///
+/// Idempotent: the namespace is built only on the first call.
+pub fn init(globals: &Arc<GlobalEnv>) {
+    if globals.is_loaded(NS) {
+        return;
+    }
+    globals.get_or_create_ns(NS);
+    globals.refer_all(NS, "clojure.core");
+    fns::register(globals, NS);
+    globals.mark_loaded(NS);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::codec::{CljDecoder, CljEncoder};
+
+    #[test]
+    fn utf8_roundtrip_streaming() {
+        let input = "Hello, 世界! こんにちは";
+
+        let enc = CljEncoder::new(encoding_rs::UTF_8);
+        let mut encoded = enc.update(input).unwrap();
+        encoded.extend_from_slice(&enc.finish().unwrap());
+
+        let dec = CljDecoder::new(encoding_rs::UTF_8);
+        let mut decoded = dec.update(&encoded).unwrap();
+        decoded.push_str(&dec.finish().unwrap());
+
+        assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn utf8_chunked_decode() {
+        let bytes = "abcdef".as_bytes();
+        let dec = CljDecoder::new(encoding_rs::UTF_8);
+        let mut out = dec.update(&bytes[..3]).unwrap();
+        out.push_str(&dec.update(&bytes[3..]).unwrap());
+        out.push_str(&dec.finish().unwrap());
+        assert_eq!(out, "abcdef");
+    }
+
+    #[test]
+    fn finish_after_finish_returns_error() {
+        let dec = CljDecoder::new(encoding_rs::UTF_8);
+        dec.finish().unwrap();
+        assert!(dec.finish().is_err());
+    }
+
+    #[test]
+    fn update_after_finish_returns_error() {
+        let enc = CljEncoder::new(encoding_rs::UTF_8);
+        enc.finish().unwrap();
+        assert!(enc.update("more").is_err());
+    }
+
+    #[test]
+    fn latin1_encode_unmappable_uses_ncr() {
+        // "café" — 'é' (U+00E9) is mappable in latin-1; emoji is not.
+        let enc = CljEncoder::new(encoding_rs::WINDOWS_1252);
+        let bytes = enc.update("A\u{1F600}B").unwrap();
+        enc.finish().unwrap();
+        // Byte for 'A', then NCR bytes, then byte for 'B'.
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(s.starts_with('A'));
+        assert!(s.contains("&#128512;")); // U+1F600 = 128512
+        assert!(s.ends_with('B'));
+    }
+}

--- a/crates/cljrs-charset/src/lib.rs
+++ b/crates/cljrs-charset/src/lib.rs
@@ -1,44 +1,53 @@
 //! Charset encoding and decoding with stream support — `clojure.rust.charset`.
 //!
-//! Provides the `clojure.rust.charset` namespace backed by [`encoding_rs`],
-//! which supports the WHATWG encoding standard (UTF-8, UTF-16, Shift-JIS,
-//! windows-1252, ISO-8859-*, and many more).
+//! Provides two namespaces:
 //!
-//! # Clojure API
+//! - **`clojure.rust.charset`** — synchronous streaming codecs
+//!   ([`decoder`]/[`encoder`] + [`update!`]/[`finish!`]) and one-shot helpers
+//!   ([`decode`]/[`encode`]).
+//! - **`clojure.rust.charset.async`** — async channel-to-channel transformers:
+//!   [`decode-chan`] reads `ByteBlob` values from a `core.async` channel and
+//!   delivers decoded strings onto a new channel; [`encode-chan`] does the
+//!   reverse.
 //!
-//! ```clojure
-//! ;; Streaming decode
-//! (let [dec (charset/decoder :shift-jis)]
-//!   (charset/update! dec some-bytes)   ;; => "partial string"
-//!   (charset/finish! dec))             ;; => "tail string"
-//!
-//! ;; Streaming encode
-//! (let [enc (charset/encoder :windows-1252)]
-//!   (charset/update! enc "Hello")      ;; => #bytes[...]
-//!   (charset/finish! enc))             ;; => #bytes[]
-//!
-//! ;; One-shot helpers
-//! (charset/decode blob)                ;; UTF-8 decode
-//! (charset/decode blob :iso-8859-1)   ;; with explicit charset
-//! (charset/encode "こんにちは" :shift-jis)
-//! ```
+//! Both namespaces are backed by [`encoding_rs`], which implements the WHATWG
+//! encoding standard (UTF-8, UTF-16, Shift-JIS, windows-1252, ISO-8859-*, …).
 //!
 //! # Usage
 //!
 //! ```rust,ignore
 //! let globals = cljrs_stdlib::standard_env();
+//!
+//! // Synchronous codecs
 //! cljrs_charset::init(&globals);
+//!
+//! // Async channel transforms (also requires cljrs_async::init)
+//! cljrs_async::init(&globals);
+//! cljrs_charset::init_async(&globals);
 //! ```
+//!
+//! [`decoder`]: crate::NS
+//! [`encoder`]: crate::NS
+//! [`update!`]: crate::NS
+//! [`finish!`]: crate::NS
+//! [`decode`]: crate::NS
+//! [`encode`]: crate::NS
+//! [`decode-chan`]: crate::NS_ASYNC
+//! [`encode-chan`]: crate::NS_ASYNC
 
 use std::sync::Arc;
 
 use cljrs_env::env::GlobalEnv;
 
 mod codec;
+mod codec_chan;
 mod fns;
 
-/// The Clojure namespace populated by this crate.
+/// The synchronous codec namespace.
 pub const NS: &str = "clojure.rust.charset";
+
+/// The async channel-transform namespace.
+pub const NS_ASYNC: &str = "clojure.rust.charset.async";
 
 /// Register the `clojure.rust.charset` namespace into `globals`.
 ///
@@ -51,6 +60,21 @@ pub fn init(globals: &Arc<GlobalEnv>) {
     globals.refer_all(NS, "clojure.core");
     fns::register(globals, NS);
     globals.mark_loaded(NS);
+}
+
+/// Register the `clojure.rust.charset.async` namespace into `globals`.
+///
+/// Idempotent.  Requires the `cljrs-async` runtime ([`cljrs_async::init`])
+/// and a running Tokio `LocalSet` — call both before spawning tasks that use
+/// the namespace.
+pub fn init_async(globals: &Arc<GlobalEnv>) {
+    if globals.is_loaded(NS_ASYNC) {
+        return;
+    }
+    globals.get_or_create_ns(NS_ASYNC);
+    globals.refer_all(NS_ASYNC, "clojure.core");
+    codec_chan::register(globals, NS_ASYNC);
+    globals.mark_loaded(NS_ASYNC);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/cljrs-charset/src/lib.rs
+++ b/crates/cljrs-charset/src/lib.rs
@@ -85,6 +85,47 @@ mod tests {
     }
 
     #[test]
+    fn utf8_multibyte_split_across_chunks() {
+        // 'あ' = U+3042 encodes as 3 bytes: E3 81 82.
+        // Split every possible way across two update! calls and verify the
+        // decoder buffers the incomplete sequence internally and completes it
+        // on the next call — the defining behaviour of a streaming decoder.
+        let input = "あいう"; // 9 bytes total: [E3 81 82] [E3 81 84] [E3 81 86]
+        let bytes = input.as_bytes();
+        assert_eq!(bytes.len(), 9);
+
+        for split in 1..bytes.len() {
+            let dec = CljDecoder::new(encoding_rs::UTF_8);
+            // First chunk may end mid-character; decoder must buffer the partial bytes.
+            let part1 = dec.update(&bytes[..split]).unwrap();
+            // Second chunk supplies the remaining bytes; decoder completes the char.
+            let part2 = dec.update(&bytes[split..]).unwrap();
+            let tail = dec.finish().unwrap();
+            let decoded = part1 + &part2 + &tail;
+            assert_eq!(
+                decoded, input,
+                "split at byte {split} produced wrong output"
+            );
+        }
+    }
+
+    #[test]
+    fn utf8_split_finish_replaces_incomplete_sequence() {
+        // If the stream ends with an incomplete multi-byte sequence, finish!
+        // should replace the dangling bytes with U+FFFD (replacement character).
+        let dec = CljDecoder::new(encoding_rs::UTF_8);
+        // First two bytes of 'あ' (E3 81), no third byte — stream ends here.
+        let partial = dec.update(&[0xE3, 0x81]).unwrap();
+        assert_eq!(partial, ""); // nothing output yet; bytes are buffered
+        let tail = dec.finish().unwrap();
+        assert_eq!(
+            partial + &tail,
+            "\u{FFFD}",
+            "incomplete trailing sequence must produce U+FFFD"
+        );
+    }
+
+    #[test]
     fn finish_after_finish_returns_error() {
         let dec = CljDecoder::new(encoding_rs::UTF_8);
         dec.finish().unwrap();


### PR DESCRIPTION
Introduces the clojure.rust.charset namespace backed by encoding_rs.

- CljDecoder / CljEncoder: NativeObject wrappers around encoding_rs
  Decoder/Encoder with Mutex interior mutability and Send+Sync safety
- update! feeds incremental byte/string chunks to the codec
- finish! flushes trailing state and closes the codec
- decode / encode: one-shot helpers for the common no-streaming case
- Unmappable characters substituted with HTML numeric character refs
- 5 unit tests covering roundtrip, chunking, double-finish errors,
  and NCR substitution

https://claude.ai/code/session_01T98WEx2UzqpJKH4UjQwpZx