### PR TITLE
samples/http_get.cljrs: add HTTPS request via TLS

### DIFF
--- a/samples/http_get.cljrs
+++ b/samples/http_get.cljrs
@@ -1,43 +1,47 @@
-;; http-get.cljrs — basic HTTP GET using cljrs-net and cljrs-charset.
+;; http-get.cljrs — HTTP GET (plain TCP) and HTTPS GET (TLS) using cljrs-net and cljrs-charset.
 ;;
-;; Opens a plain TCP connection to clj.rs:80, encodes an HTTP/1.0 request
-;; as UTF-8 bytes with cljrs-charset, sends it, drains all response byte
-;; chunks, decodes each chunk back to a string, and prints the first line.
+;; Makes two requests to clj.rs and prints the first response line of each:
+;;   1. Plain HTTP on port 80 over TCP.
+;;   2. HTTPS on port 443 over TLS — passes :transport :tls to net/connect, which
+;;      performs a TLS handshake verified against webpki root certificates before
+;;      the HTTP exchange; the connection map shape is identical to plain TCP.
 ;;
 ;; The request encoding and response decoding are done explicitly through
-;; cljrs-charset to show the encode/decode cycle; cljrs-net's :out channel
-;; would also accept a raw string, but charset makes the byte conversion visible.
+;; cljrs-charset to show the encode/decode cycle.
 
 (ns http-get-sample)
 
 (require '[clojure.rust.net     :as net])
 (require '[clojure.rust.charset :as charset])
-(require '[clojure.core.async   :refer [take! put! close!]])
+(require '[clojure.core.async   :refer [take! put!]])
 (require '[clojure.string       :as str])
 
 (def ^:private host "clj.rs")
-(def ^:private port 80)
 
-(defn ^:async -main [& _args]
-  (let [conn (await (take! (net/connect {:host host :port port})))]
-
-    ;; Build the HTTP request, encode it to UTF-8 bytes, and send it.
-    ;; Do not close :out — let the server close the connection after responding
-    ;; (Connection: close in the request header instructs it to do so).
-    ;; Closing :out prematurely causes pool_writer to send TCP FIN before the
-    ;; server has a chance to respond, which often triggers an RST instead of
-    ;; the expected HTTP response.
+(defn ^:async fetch-first-line
+  "Open `conn-chan`, send an HTTP/1.0 GET /, drain the response, and return
+  the first response line.  Closes the connection before returning."
+  [conn-chan]
+  (let [conn (await (take! conn-chan))]
+    ;; Encode the request to UTF-8 bytes and send it.  Do not close :out before
+    ;; draining :in — closing :out prematurely sends TCP FIN and can trigger RST
+    ;; from the server before the response arrives.
     (await (put! (:out conn)
                  (charset/encode (str "GET / HTTP/1.0\r\n"
-                                      "Host: " host "\r\n"
-                                      "Connection: close\r\n"
-                                      "\r\n"))))
-
-    ;; Drain all response byte chunks from :in, decode each one to a string,
-    ;; concatenate, and print only the first line.
+                                       "Host: " host "\r\n"
+                                       "Connection: close\r\n"
+                                       "\r\n"))))
     (let [{:keys [values]} (await (net/drain-to (:in conn)))
           response         (reduce str "" (map charset/decode values))
           first-line       (first (str/split-lines response))]
-      (println first-line))
+      (net/close conn)
+      first-line)))
 
-    (net/close conn)))
+(defn ^:async -main [& _args]
+  ;; Plain HTTP over TCP
+  (let [line (await (fetch-first-line (net/connect {:host host :port 80})))]
+    (println "HTTP :" line))
+
+  ;; HTTPS over TLS — webpki root certificates are used for server verification
+  (let [line (await (fetch-first-line (net/connect {:host host :port 443 :transport :tls})))]
+    (println "HTTPS:" line)))


### PR DESCRIPTION
Extracts the send/receive pattern into fetch-first-line so it can be
reused for both transports, then calls it twice — once over plain TCP
on port 80 and once over TLS on port 443 using net/connect's
:transport :tls option (webpki roots, no extra config needed).

https://claude.ai/code/session_01P1U5dBD8Xzd792tuTkatdY