### PR TITLE
Remove -main call from graph.cljrs

### DIFF
--- a/samples/graph.cljrs
+++ b/samples/graph.cljrs
@@ -64,6 +64,3 @@
           end (nanotime)]
       (println "Result:" result)
       (println "Time (ms):" (/ (- end start) 1e6)))))
-
-; cljrs doesn't recognize -main yet, just fire the main here
-(-main)

--- a/samples/life.cljrs
+++ b/samples/life.cljrs
@@ -68,6 +68,3 @@
           end    (nanotime)]
       (println "Final population:" result)
       (println "Time (ms):" (/ (- end start) 1e6)))))
-
-; cljrs doesn't recognise -main yet, fire it directly
-(-main)


### PR DESCRIPTION
-main should be run now automatically. As is this will run it twice 