### PR TITLE
AOT: fix silent nil from compiled closures with >8 args

### DIFF
--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -1620,10 +1620,161 @@ unsafe fn rt_call_compiled(
                 args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
             )
         }
+        9 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8])
+        }
+        10 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9])
+        }
+        11 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10])
+        }
+        12 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11])
+        }
+        13 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12])
+        }
+        14 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13])
+        }
+        15 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13], args[14])
+        }
+        16 => {
+            let f: extern "C" fn(
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+                *const Value,
+            ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
+            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13], args[14], args[15])
+        }
         _ => {
-            // For functions with more than 8 params, fall back to rt_call style.
-            // This shouldn't happen in practice for most Clojure code.
-            eprintln!("[rt] warning: compiled function with {nargs} args, falling back");
+            // The compiled-function trampoline supports up to a fixed maximum
+            // arity (captures + params).  Exceeding it is rare but must never
+            // silently corrupt results (the previous behaviour returned nil,
+            // which produced wrong answers, e.g. a reduce over a let-bound
+            // collection whose closure over-captures enclosing locals).  Log
+            // loudly and surface a thrown error.  `total_params = ncaptures +
+            // param_count`, so this only triggers for closures that capture an
+            // unusually large number of enclosing locals.
+            eprintln!(
+                "[rt] error: compiled function arity {nargs} exceeds trampoline maximum (16)"
+            );
+            stash_pending_exception(Value::Str(GcPtr::new(format!(
+                "compiled function arity {nargs} exceeds trampoline maximum (16)"
+            ))));
             rt_const_nil()
         }
     }

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -1632,7 +1632,9 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+            )
         }
         10 => {
             let f: extern "C" fn(
@@ -1647,7 +1649,10 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+                args[9],
+            )
         }
         11 => {
             let f: extern "C" fn(
@@ -1663,7 +1668,10 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+                args[9], args[10],
+            )
         }
         12 => {
             let f: extern "C" fn(
@@ -1680,7 +1688,10 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+                args[9], args[10], args[11],
+            )
         }
         13 => {
             let f: extern "C" fn(
@@ -1698,7 +1709,10 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+                args[9], args[10], args[11], args[12],
+            )
         }
         14 => {
             let f: extern "C" fn(
@@ -1717,7 +1731,10 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+                args[9], args[10], args[11], args[12], args[13],
+            )
         }
         15 => {
             let f: extern "C" fn(
@@ -1737,7 +1754,10 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13], args[14])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+                args[9], args[10], args[11], args[12], args[13], args[14],
+            )
         }
         16 => {
             let f: extern "C" fn(
@@ -1758,7 +1778,10 @@ unsafe fn rt_call_compiled(
                 *const Value,
                 *const Value,
             ) -> *const Value = unsafe { std::mem::transmute(fn_addr) };
-            f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13], args[14], args[15])
+            f(
+                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
+                args[9], args[10], args[11], args[12], args[13], args[14], args[15],
+            )
         }
         _ => {
             // The compiled-function trampoline supports up to a fixed maximum

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -1294,6 +1294,28 @@ fn test_into_basic() {
 
 #[test]
 #[cfg(feature = "aot_full_test")]
+fn test_high_arity_closure_call() {
+    // Regression: a closure passed to a HOF (reduce) inside a loop over a
+    // let-bound collection over-captures enclosing locals, so its compiled
+    // arity (captures + params) exceeded the call trampoline's old 8-arg
+    // ceiling, which silently returned nil.  All of these must compute the
+    // real result, not nil.
+    assert_output(
+        "high_arity_closure_call",
+        r#"
+(let [v [10 20 30]]
+  (println (loop [i 0 r 0]
+             (if (= i 2) r (recur (inc i) (reduce (fn [a x] x) 0 v))))))
+(let [v (vec (range 100))]
+  (println (loop [i 0 r 0]
+             (if (= i 3) r (recur (inc i) (reduce (fn [a x] (+ a x)) 0 v))))))
+"#,
+        "30\n4950",
+    );
+}
+
+#[test]
+#[cfg(feature = "aot_full_test")]
 fn test_into_set() {
     // Exercises the hash-set target fast path in `rt_into`.
     assert_output(


### PR DESCRIPTION
rt_call_compiled, the trampoline that dispatches a compiled function by
argument count, only handled 0..=8 args; the catch-all arm logged a
warning and returned nil. A compiled closure's real arity is
ncaptures + param_count (see rt_make_fn), so any closure that captures
enough enclosing locals silently evaluated to nil.

This surfaced as wrong results for a closure passed to a HOF inside a
loop over a let-bound collection, e.g.

  (let [v (vec (range 100))]
    (loop [i 0 r 0]
      (if (= i n) r (recur (inc i) (reduce (fn [a x] x) 0 v)))))

returned nil under AOT (the interpreter returns 99). The (fn [a x] x)
over-captures the enclosing let/loop locals, pushing its compiled arity
to 9 and tripping the catch-all.

Extend the trampoline to 16 args (covers ncaptures + params for
realistic closures) and make the remaining overflow arm loud + throwing
instead of silently returning nil. Add an AOT regression test.

Note: the over-capture itself (an unused (fn [a x] x) capturing 7
enclosing locals) is a separate ANF-lowering inefficiency worth a
follow-up; this commit removes the silent-corruption hazard it exposed.

https://claude.ai/code/session_01PsLSGXtx1rKzBNBFLETuLR