### PR TITLE
docs: add Memory Management section on the bump allocator

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,13 @@ name: Publish
 on:
   push:
     branches: [main]
+    # Skip publishing when a push only touches documentation or the website.
+    # GitHub skips the workflow only when *every* changed file matches one of
+    # these globs, so a push that also touches code still publishes. Manual
+    # workflow_dispatch runs always publish, ignoring these filters.
+    paths-ignore:
+      - 'docs/**'
+      - 'www/**'
   workflow_dispatch:
 
 env:

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -38,3 +38,8 @@
 - [The `#[export]` macro](rust-interop/export-macro.md)
 - [Interpreter mode](rust-interop/interpreter.md)
 - [AOT mode](rust-interop/aot.md)
+
+# Memory Management
+
+- [Overview](memory/index.md)
+- [The bump allocator](memory/bump-allocator.md)

--- a/docs/book/src/memory/bump-allocator.md
+++ b/docs/book/src/memory/bump-allocator.md
@@ -1,0 +1,158 @@
+# The Bump Allocator
+
+The bump allocator — called a **region** in the code — is the fastest way
+clojurust can hand out memory. Instead of allocating each object individually
+on the GC heap and later tracing it, a region carves objects out of a
+contiguous block by advancing ("bumping") a single pointer, and frees them all
+at once when the region's scope ends.
+
+It is roughly **2.6× faster** than a GC-heap allocation: there is no mutex, no
+per-object `Box::new`, and no collection pause.
+
+> **The bump allocator only works in AOT mode right now.** It is enabled only
+> in binaries produced by [`cljrs compile`](../rust-interop/aot.md). When you
+> run code through the interpreter — `cljrs run`, `cljrs repl`, or
+> `cljrs eval` — every allocation goes to the GC heap. The [Why AOT
+> only?](#why-aot-only) section explains the reason.
+
+## How it works
+
+A region owns one or more **chunks** of raw memory (the default chunk is
+4 KiB). It tracks a single bump pointer into the active chunk:
+
+```text
+chunk:  [ obj A ][ obj B ][ obj C ][ free ............ ]
+                                    ^
+                                    bump pointer
+```
+
+Allocating an object is:
+
+1. Align the bump pointer up to the object's alignment.
+2. If the object fits in the current chunk, write it there and advance the
+   pointer past it. This is the common, near-instant path.
+3. If it doesn't fit, allocate a fresh chunk (sized `max(4 KiB, 2 × object
+   size)`), chain it on, and allocate from it.
+
+There is no per-object bookkeeping for *freeing* — a region does not free
+objects one at a time. When the region's scope ends, it:
+
+1. Runs any registered destructors in **reverse (LIFO)** order, so objects that
+   may reference earlier ones are torn down first.
+2. Releases its chunks back to the system allocator (keeping the first chunk to
+   reuse) and rewinds the bump pointer.
+
+That bulk reset is what makes the allocator cheap: the cost of freeing a
+thousand short-lived objects is one chunk free, not a thousand.
+
+### Scopes and the region stack
+
+Regions live on a thread-local **region stack**. AOT-compiled code brackets a
+region-eligible scope with two runtime calls:
+
+- `rt_region_start` pushes a fresh region onto the stack at scope entry.
+- `rt_region_end` pops it at scope exit, running destructors and freeing chunks.
+
+Only the **top** region receives allocations. While a region is active, the
+runtime's allocation helpers route region-eligible collections into it and fall
+back to the GC heap when no region is active:
+
+```rust
+fn box_coll_val(v: Value) -> *const Value {
+    if region_is_active() {
+        // bump-allocate into the active region
+        try_alloc_in_region(v).unwrap().get() as *const Value
+    } else {
+        box_val(v) // fall back to the GC heap
+    }
+}
+```
+
+This fallback is why region promotion is always safe: if escape analysis is
+conservative, or no region happens to be active, the object simply lands on the
+GC heap with identical semantics — just a little slower.
+
+## How the compiler decides what to bump-allocate
+
+You never mark an allocation as region-eligible yourself. During AOT
+compilation, an **escape analysis** pass classifies every allocation on a
+four-level lattice:
+
+| State | Meaning | Allocator |
+|---|---|---|
+| `NoEscape` | never leaves the function | **region** |
+| `ArgEscape` | stored into an argument that escapes | GC heap |
+| `Returns` | returned to the caller | region *if the caller doesn't let it escape* |
+| `Escapes` | stored in the heap, captured by a closure, returned to the world | GC heap |
+
+An allocation is promoted to a region only when it provably **does not escape**
+the scope that created it — it is not returned, not stored in a longer-lived
+container, not captured by a closure, and not passed to a call that could
+retain it. The analysis understands many built-ins precisely (for example
+`(first coll)` and `(count coll)` don't cause their argument to escape, while
+`(conj coll x)` lets `coll` escape but not `x`), and it follows `recur` into
+loop headers so loop-local intermediates can be region-allocated too.
+
+Escape analysis also reaches across function boundaries: small non-capturing
+callees are inlined so their allocations become local again, and larger callees
+can be specialized to inherit the caller's region, so a helper that builds and
+returns a short-lived vector can still be bump-allocated at a call site that
+immediately discards it.
+
+## Why AOT only?
+
+The bump allocator depends on **compile-time** escape analysis, and that pass
+runs only in the AOT compilation pipeline. The decision of *what* may be
+region-allocated, and *where* the `rt_region_start` / `rt_region_end` brackets
+go, is baked statically into the generated machine code.
+
+The interpreter takes a different path: Clojure source is read, macro-expanded,
+and lowered to IR, but the escape-optimization pass is **not** run, so the IR
+the tree-walking evaluator executes contains no region instructions. With no
+escape information available, the interpreter cannot safely decide at runtime
+which objects outlive their scope, so it allocates everything on the GC heap —
+the always-correct default. (The IR interpreter *can* execute region
+instructions if they are already present in the IR, but the interpreter's own
+front end never emits them.)
+
+In short:
+
+- **`cljrs compile` (AOT):** escape analysis runs, regions are used, GC handles
+  the rest.
+- **`cljrs run` / `repl` / `eval` (interpreter):** no escape analysis,
+  everything on the GC heap, no bump allocation.
+
+## Relationship to the GC
+
+In the default build the two allocators run side by side, and the bump
+allocator never hides memory from the collector:
+
+- Region-allocated pointers carry a low-bit tag. The GC's mark phase checks the
+  tag **without dereferencing** the pointer and skips region objects — their
+  chunk memory may already have been freed and reused once the region's scope
+  ended, so following them would be unsafe.
+- Instead, every live region on the thread's region stack is treated as a **GC
+  root**. The collector walks the objects inside active regions, so any GC-heap
+  object reachable *only* through a region stays alive during collection.
+
+So the bump allocator is a fast path for provably short-lived objects, and the
+tracing GC remains the backstop for everything with a longer or unknown
+lifetime.
+
+## The `no-gc` build
+
+clojurust can also be built with the `no-gc` Cargo feature, which removes the
+tracing GC entirely and makes regions the *only* allocator. In that mode every
+function call and every `loop` iteration pushes a scratch region that is freed
+when the scope exits, return values are evaluated in the caller's region, and
+program-lifetime values (from `def`, `defn`, `atom`, and friends) live in a
+global static arena. This trades the GC's generality for zero collection pauses
+and is documented separately; the default distribution ships with the GC
+enabled.
+
+## See also
+
+- [Memory management overview](index.md) — how the GC and bump allocator fit
+  together, and the `CLJRS_GC_STATS` counters.
+- [AOT mode](../rust-interop/aot.md) — how `cljrs compile` builds the native
+  binary the bump allocator runs in.

--- a/docs/book/src/memory/index.md
+++ b/docs/book/src/memory/index.md
@@ -1,0 +1,63 @@
+# Memory Management
+
+Every Clojure value in clojurust lives behind a `GcPtr<T>` — a raw pointer
+into managed memory. clojurust uses **two** allocators that cooperate behind
+that pointer:
+
+| Allocator | When it runs | Reclaims memory |
+|---|---|---|
+| **Tracing GC** (mark-and-sweep) | always, in the default build | during `collect` (stop-the-world) |
+| **Bump allocator** (regions) | AOT-compiled code only | in bulk, when a region's scope ends |
+
+The garbage collector is the backstop: it manages the full object graph and is
+the only allocator the interpreter uses. The bump allocator is a **compile-time
+optimization** layered on top — when the AOT compiler can prove that an object
+does not outlive the function (or loop) that created it, it allocates that
+object in a region that is freed all at once, with no tracing and no GC pause.
+
+You don't manage either allocator by hand. You write ordinary Clojure; the
+compiler decides what is region-eligible and the GC handles everything else.
+
+## Tracing GC
+
+The default collector is a **non-moving, stop-the-world mark-and-sweep** GC.
+Key properties:
+
+- `GcPtr<T>` stores a stable address — objects never move, so a pointer stays
+  valid for the lifetime of the object.
+- `clone` is an O(1) pointer copy; `drop` is a no-op. Reference **cycles are
+  collected**, because liveness is determined by reachability from roots, not
+  reference counts.
+- Collection is triggered by a memory threshold. The default hard limit is
+  1/4 of system RAM (a fixed **64 MB** soft limit on `wasm32`, which cannot
+  query system memory).
+- Each OS thread (isolate) owns an independent heap and collects on its own,
+  with no cross-thread coordination.
+
+## Bump allocator (regions)
+
+The [bump allocator](bump-allocator.md) is a region-based fast path for
+short-lived, non-escaping allocations. It is selected automatically by the
+AOT compiler's **escape analysis** and is described in detail in the next
+chapter.
+
+> **AOT only.** The bump allocator currently runs only in AOT-compiled
+> binaries (`cljrs compile`). The interpreter (`cljrs run`, `cljrs repl`,
+> `cljrs eval`) allocates everything on the GC heap. See
+> [The bump allocator](bump-allocator.md) for why.
+
+## Inspecting allocation behaviour
+
+Both allocators feed a single set of process-global counters. Set the
+`CLJRS_GC_STATS` environment variable to dump them at program exit:
+
+```bash
+CLJRS_GC_STATS=- ./myapp        # write a summary to stdout
+CLJRS_GC_STATS=stats.txt ./myapp # write the summary to a file
+```
+
+The summary reports GC allocations and bytes, **region (bump) allocations and
+bytes**, GC collection count, total pause time, and objects/bytes freed — so
+you can see how much work the bump allocator is taking off the GC. The
+interpreter exposes the same counters through the `cljrs --gc-stats [FILE]`
+flag.

--- a/docs/book/src/rust-interop/aot.md
+++ b/docs/book/src/rust-interop/aot.md
@@ -97,3 +97,12 @@ The AOT harness uses `cargo build --release --offline` by default. All
 dependencies (the clojurust crates and the user crate) must be resolvable
 without network access. Point to local paths in `Cargo.toml` as shown in
 [Project setup](project-setup.md).
+
+## Memory management
+
+AOT-compiled binaries get an extra allocation fast path that the interpreter
+does not: the **bump allocator**. The AOT compiler's escape analysis promotes
+short-lived, non-escaping objects into bump-allocated regions, leaving the
+tracing GC to handle everything else. See
+[Memory Management](../memory/index.md) and
+[The bump allocator](../memory/bump-allocator.md) for details.


### PR DESCRIPTION
Add a new Memory Management part to the book after the AOT chapter:

- memory/index.md: overview of the two cooperating allocators (tracing GC
  and the region-based bump allocator), plus the CLJRS_GC_STATS counters.
- memory/bump-allocator.md: how the bump allocator works (chunks, bump
  pointer, bulk reset, region stack), how escape analysis decides what gets
  region-allocated, its relationship to the GC, and the no-gc build.

Emphasize that the bump allocator currently only runs in AOT-compiled
binaries (cljrs compile); the interpreter allocates everything on the GC
heap because escape analysis runs only in the AOT pipeline.

Wire both pages into SUMMARY.md and add a cross-link from the AOT chapter.