### PR TITLE
Add cljrs-lsp language server (diagnostics + document symbols)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ The project is a library crate (`src/lib.rs`) with a binary entry point (`src/ma
 | `runtime` | Core standard library (`clojure.core` equivalent); concurrency primitives (atom, ref/STM, agent, future) |
 | `interop` | Rust↔Clojure FFI; `#[cljx::export]` proc-macro; type marshalling; `NativeObject` |
 | `cli` | `cljx` command entry point; REPL; file runner; project tooling |
+| `lsp` | Language Server Protocol server (`cljrs-lsp` crate, `cljrs lsp` subcommand); parse diagnostics + document symbols |
 
 ### Key design constraints
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,12 +125,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -181,6 +203,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -320,6 +348,7 @@ dependencies = [
  "cljrs-io",
  "cljrs-ir-viz",
  "cljrs-logging",
+ "cljrs-lsp",
  "cljrs-net",
  "cljrs-reader",
  "cljrs-runtime",
@@ -562,6 +591,20 @@ dependencies = [
 [[package]]
 name = "cljrs-logging"
 version = "0.1.0"
+
+[[package]]
+name = "cljrs-lsp"
+version = "0.1.0"
+dependencies = [
+ "cljrs-reader",
+ "cljrs-types",
+ "dashmap 6.2.1",
+ "futures",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-lsp",
+]
 
 [[package]]
 name = "cljrs-net"
@@ -907,12 +950,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -989,12 +1076,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1002,6 +1114,23 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -1015,6 +1144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,9 +1161,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1101,6 +1240,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1144,10 +1289,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1239,6 +1493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1512,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "mach"
@@ -1333,7 +1606,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1430,6 +1703,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1723,32 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1456,6 +1768,15 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1536,6 +1857,15 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1643,7 +1973,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1717,7 +2047,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "clipboard-win",
  "home",
@@ -1753,7 +2083,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1817,6 +2147,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1913,6 +2254,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2016,6 +2368,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,11 +2414,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap 5.5.3",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2155,6 +2592,25 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2290,7 +2746,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2562,7 +3018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -2593,6 +3049,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,10 +3064,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ members = [
     "crates/cljrs-async",
     "crates/cljrs-io",
     "crates/cljrs-net",
-    "crates/cljrs-charset"]
+    "crates/cljrs-charset",
+    "crates/cljrs-lsp"]
 resolver = "2"
 
 [workspace.package]
@@ -57,6 +58,7 @@ cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0" }
 cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
 cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
 cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0" }
+cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"
@@ -78,6 +80,8 @@ postcard     = "1.1.3"
 rustyline    = "18.0.0"
 libloading   = "0.8"
 arc-swap     = "1"
+tower-lsp     = "0.20"
+dashmap       = "6"
 
 # Cranelift compiler backend (all crates must be at the same version)
 cranelift-codegen  = "0.129.1"

--- a/TODO.md
+++ b/TODO.md
@@ -459,5 +459,11 @@ Pattern: `(map f (map g xs))`, lower to single loop.
 - [ ] ClojureScript-style source-to-source compiler targeting WebAssembly
 - [ ] `clojure.core.async` compatible CSP channels (`go`, `chan`, `<!`, `>!`, `alts!`)
 - [ ] Native image / musl-linked static binaries for minimal deployment
-- [ ] Language Server Protocol (LSP) implementation for editor support
+- [~] Language Server Protocol (LSP) implementation for editor support
+  - [x] v1 (`cljrs-lsp` crate + `cljrs lsp` subcommand, syntactic/reader-based): parse
+        diagnostics (with per-top-level-form error recovery) and document-symbol outline;
+        UTF-8/UTF-16 position-encoding negotiation; FULL text sync
+  - [ ] v2 (semantic, evaluator-backed via `cljrs-eval` `GlobalEnv`): hover, completion,
+        go-to-definition, find-references
+  - [ ] INCREMENTAL text sync, semantic tokens
 - [ ] Transducers in core collection ops

--- a/crates/cljrs-lsp/Cargo.toml
+++ b/crates/cljrs-lsp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "cljrs-lsp"
+version = "0.1.0"
+edition = "2024"
+description = "Language Server Protocol implementation for clojurust (.cljrs/.cljc)"
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "cljrs-lsp"
+path = "src/main.rs"
+
+[dependencies]
+cljrs-types  = { workspace = true }
+cljrs-reader = { workspace = true }
+tower-lsp = { workspace = true }
+dashmap   = { workspace = true }
+# The LSP server needs async stdio plus a runtime, so it pins a richer tokio
+# feature set than the workspace default (which omits io-std/io-util and the
+# multi-thread runtime). Feature unification keeps this to a single tokio build.
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "io-std", "io-util", "macros"] }
+
+[dev-dependencies]
+tower = { version = "0.4", features = ["util"] }
+serde_json = "1"
+futures = "0.3"
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros"] }

--- a/crates/cljrs-lsp/README.md
+++ b/crates/cljrs-lsp/README.md
@@ -1,0 +1,69 @@
+# cljrs-lsp
+
+**Purpose** — A Language Server Protocol (LSP) server for clojurust source
+(`.cljrs` / `.cljc`), giving editors live parse diagnostics and a document-symbol
+outline.
+
+**Status** — Phase 12 (REPL & Tooling). Implemented, **v1 / syntactic only**: it
+uses `cljrs-reader` and does *not* invoke the evaluator. Built on `tower-lsp`.
+Deferred to a later semantic tier: hover, completion, go-to-definition,
+references, INCREMENTAL text sync, and semantic tokens.
+
+## Capabilities (v1)
+
+- `textDocument/publishDiagnostics` — reader/parse errors, recovered per
+  top-level form so multiple errors surface at once.
+- `textDocument/documentSymbol` — outline of `ns`, `def`, `defonce`, `defn`,
+  `defn-`, `defmacro`, `defmulti`, `deftest`, `definline`, `defprotocol`,
+  `defrecord`, `deftype`, `defstruct` (including definitions inside reader
+  conditionals).
+- Text sync: FULL. Position encoding: negotiates `utf-8`, falls back to `utf-16`.
+
+## File layout
+
+| File | Purpose |
+|---|---|
+| `src/lib.rs` | Crate root; module wiring; public re-exports. |
+| `src/main.rs` | `cljrs-lsp` binary — runs the server over stdio. |
+| `src/backend.rs` | `Backend` + the `tower_lsp::LanguageServer` impl; stdio entry points. |
+| `src/document.rs` | `Document` (text + version + cached symbols). |
+| `src/line_index.rs` | `LineIndex` / `OffsetEncoding`: byte offset ⇄ LSP `Position`/`Range`. |
+| `src/recovery.rs` | Lexer-based top-level form chunker for multi-error recovery. |
+| `src/diagnostics.rs` | `CljxError` → LSP `Diagnostic`. |
+| `src/symbols.rs` | Parsed `Form` tree → `DocumentSymbol`s. |
+| `src/analysis.rs` | `run` — orchestrates recovery → parse → diagnostics + symbols (the semantic seam). |
+| `tests/smoke.rs` | In-process backend smoke test (open → diagnostics → symbols). |
+
+## Public API
+
+- `cljrs_lsp::Backend` — the language server; construct with `Backend::new(client)`.
+- `async fn cljrs_lsp::run_stdio()` — serve over stdin/stdout (needs a runtime).
+- `fn cljrs_lsp::run_stdio_blocking() -> std::io::Result<()>` — build a runtime
+  and serve; used by the `cljrs lsp` subcommand.
+- `cljrs_lsp::LineIndex` / `cljrs_lsp::OffsetEncoding` — position conversion.
+
+## Running
+
+```bash
+cljrs lsp          # via the main CLI (recommended)
+cljrs-lsp          # the standalone binary
+```
+
+Point your editor's generic LSP client at one of the above for `*.cljrs` /
+`*.cljc` files.
+
+## Design notes
+
+- **Error recovery without touching the reader.** `Parser::parse_all` aborts on
+  the first error, so `recovery.rs` splits the buffer into top-level form chunks
+  using only the `Lexer` (which already skips strings/comments/chars), then
+  parses each chunk independently. This yields multiple diagnostics *and*
+  symbols for the well-formed forms. Recovery stops at the first *lexer-fatal*
+  error (e.g. an unterminated string); everything before it is still analyzed.
+- **`dashmap`** backs the document store so concurrently-dispatched handlers
+  never hold a lock across an `.await`. **No `ropey`** in v1 — FULL sync re-parses
+  the whole buffer, so a `String` suffices; `Document` keeps that swappable.
+- **Semantic seam.** `analysis::run` is the only place documents are analyzed.
+  A v2 would give it an optional `&cljrs_eval::GlobalEnv` (from
+  `cljrs_eval::standard_env` / `standard_env_with_paths`) to back hover,
+  completion, and go-to-definition via each `Var`'s `:file`/`:line` metadata.

--- a/crates/cljrs-lsp/src/analysis.rs
+++ b/crates/cljrs-lsp/src/analysis.rs
@@ -1,0 +1,102 @@
+//! Orchestrates per-document analysis: recovery → parse → diagnostics + symbols.
+//!
+//! This is the single seam every document update flows through. A future
+//! semantic tier (hover, completion, go-to-definition) would extend [`run`] with
+//! an optional `&cljrs_eval::GlobalEnv` without changing the backend.
+
+use cljrs_reader::Parser;
+use tower_lsp::lsp_types::{Diagnostic, DocumentSymbol};
+
+use crate::diagnostics;
+use crate::line_index::{LineIndex, OffsetEncoding};
+use crate::recovery;
+use crate::symbols;
+
+/// The result of analyzing one document version.
+#[derive(Default)]
+pub struct Analysis {
+    pub diagnostics: Vec<Diagnostic>,
+    pub symbols: Vec<DocumentSymbol>,
+}
+
+/// Analyze `text`. `uri` is used only for error provenance.
+pub fn run(text: &str, uri: &str, enc: OffsetEncoding) -> Analysis {
+    let li = LineIndex::new(text);
+    let split = recovery::split_top_level(text, uri);
+
+    let mut diagnostics = Vec::new();
+    let mut symbols = Vec::new();
+
+    for chunk in &split.chunks {
+        let slice = &text[chunk.start..chunk.end];
+        let mut parser = Parser::new(slice.to_string(), uri.to_string());
+        match parser.parse_all() {
+            Ok(forms) => symbols::collect(&forms, chunk.start, &li, enc, &mut symbols),
+            Err(err) => {
+                let fallback_len = chunk.end - chunk.start;
+                if let Some(d) =
+                    diagnostics::from_read_error(&err, chunk.start, fallback_len, &li, enc)
+                {
+                    diagnostics.push(d);
+                }
+            }
+        }
+    }
+
+    // Lexer-fatal errors carry absolute spans (delta 0).
+    if let Some(err) = &split.lex_error
+        && let Some(d) = diagnostics::from_read_error(err, 0, text.len(), &li, enc)
+    {
+        diagnostics.push(d);
+    }
+
+    Analysis {
+        diagnostics,
+        symbols,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_file_has_no_diagnostics() {
+        let a = run("(ns x)\n(defn f [a] a)", "<t>", OffsetEncoding::Utf8);
+        assert!(a.diagnostics.is_empty());
+        assert_eq!(a.symbols.len(), 2);
+    }
+
+    #[test]
+    fn reports_multiple_independent_errors() {
+        // A stray closer and an unclosed list are independent top-level errors.
+        let a = run("(a)\n)\n(def x", "<t>", OffsetEncoding::Utf8);
+        assert_eq!(a.diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn symbols_survive_a_bad_form() {
+        // Middle form is broken; the good forms still yield symbols.
+        let a = run("(def a 1)\n)\n(defn b [] 2)", "<t>", OffsetEncoding::Utf8);
+        assert_eq!(a.diagnostics.len(), 1);
+        let names: Vec<_> = a.symbols.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn diagnostic_range_points_at_stray_closer() {
+        let a = run("(a)\n)\n", "<t>", OffsetEncoding::Utf8);
+        assert_eq!(a.diagnostics.len(), 1);
+        let r = a.diagnostics[0].range;
+        assert_eq!(r.start.line, 1);
+        assert_eq!(r.start.character, 0);
+    }
+
+    #[test]
+    fn unterminated_string_reports_lex_error() {
+        let a = run("(def x 1)\n\"oops", "<t>", OffsetEncoding::Utf8);
+        assert_eq!(a.symbols.len(), 1);
+        assert_eq!(a.diagnostics.len(), 1);
+        assert!(a.diagnostics[0].message.contains("unterminated"));
+    }
+}

--- a/crates/cljrs-lsp/src/backend.rs
+++ b/crates/cljrs-lsp/src/backend.rs
@@ -1,0 +1,170 @@
+//! The tower-lsp [`LanguageServer`] implementation and stdio entry points.
+
+use std::sync::RwLock;
+
+use dashmap::DashMap;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server, jsonrpc::Result};
+
+use crate::analysis;
+use crate::document::Document;
+use crate::line_index::OffsetEncoding;
+
+/// The clojurust language server backend.
+pub struct Backend {
+    client: Client,
+    docs: DashMap<Url, Document>,
+    /// Position encoding negotiated in `initialize` (UTF-16 until then).
+    encoding: RwLock<OffsetEncoding>,
+}
+
+impl Backend {
+    pub fn new(client: Client) -> Self {
+        Self {
+            client,
+            docs: DashMap::new(),
+            encoding: RwLock::new(OffsetEncoding::Utf16),
+        }
+    }
+
+    fn encoding(&self) -> OffsetEncoding {
+        *self.encoding.read().unwrap()
+    }
+
+    /// Re-analyze a document and publish its diagnostics.
+    async fn refresh(&self, uri: Url) {
+        // Snapshot the text and drop the store guard before any `.await`.
+        let Some((text, version)) = self.docs.get(&uri).map(|d| (d.text.clone(), d.version)) else {
+            return;
+        };
+
+        let analysis = analysis::run(&text, uri.as_str(), self.encoding());
+
+        if let Some(mut doc) = self.docs.get_mut(&uri) {
+            doc.symbols = analysis.symbols;
+        }
+
+        self.client
+            .publish_diagnostics(uri, analysis.diagnostics, Some(version))
+            .await;
+    }
+}
+
+/// Choose a position encoding: prefer UTF-8 when the client advertises it.
+fn negotiate_encoding(params: &InitializeParams) -> OffsetEncoding {
+    let supports_utf8 = params
+        .capabilities
+        .general
+        .as_ref()
+        .and_then(|g| g.position_encodings.as_ref())
+        .map(|encs| encs.contains(&PositionEncodingKind::UTF8))
+        .unwrap_or(false);
+    if supports_utf8 {
+        OffsetEncoding::Utf8
+    } else {
+        OffsetEncoding::Utf16
+    }
+}
+
+fn to_lsp_encoding(enc: OffsetEncoding) -> PositionEncodingKind {
+    match enc {
+        OffsetEncoding::Utf8 => PositionEncodingKind::UTF8,
+        OffsetEncoding::Utf16 => PositionEncodingKind::UTF16,
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        let enc = negotiate_encoding(&params);
+        *self.encoding.write().unwrap() = enc;
+
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                position_encoding: Some(to_lsp_encoding(enc)),
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                document_symbol_provider: Some(OneOf::Left(true)),
+                ..Default::default()
+            },
+            server_info: Some(ServerInfo {
+                name: "cljrs-lsp".to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "cljrs-lsp ready")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let td = params.text_document;
+        let uri = td.uri.clone();
+        self.docs
+            .insert(uri.clone(), Document::new(td.text, td.version));
+        self.refresh(uri).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let VersionedTextDocumentIdentifier { uri, version } = params.text_document;
+        // FULL sync: the last change carries the entire new document text.
+        if let Some(change) = params.content_changes.into_iter().last() {
+            match self.docs.get_mut(&uri) {
+                Some(mut doc) => {
+                    doc.text = change.text;
+                    doc.version = version;
+                }
+                None => {
+                    self.docs
+                        .insert(uri.clone(), Document::new(change.text, version));
+                }
+            }
+        }
+        self.refresh(uri).await;
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = params.text_document.uri;
+        self.docs.remove(&uri);
+        // Clear diagnostics for the closed document.
+        self.client.publish_diagnostics(uri, Vec::new(), None).await;
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        let symbols = self
+            .docs
+            .get(&params.text_document.uri)
+            .map(|d| d.symbols.clone())
+            .unwrap_or_default();
+        Ok(Some(DocumentSymbolResponse::Nested(symbols)))
+    }
+}
+
+/// Run the language server over stdio until the client disconnects.
+pub async fn run_stdio() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let (service, socket) = LspService::new(Backend::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+/// Build a runtime and run [`run_stdio`] to completion. Convenience for callers
+/// (e.g. the `cljrs lsp` subcommand) that are not already async.
+pub fn run_stdio_blocking() -> std::io::Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(run_stdio());
+    Ok(())
+}

--- a/crates/cljrs-lsp/src/diagnostics.rs
+++ b/crates/cljrs-lsp/src/diagnostics.rs
@@ -1,0 +1,39 @@
+//! Map reader errors to LSP [`Diagnostic`]s.
+
+use cljrs_types::error::CljxError;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+
+use crate::line_index::{LineIndex, OffsetEncoding};
+
+/// Convert a [`CljxError`] into a [`Diagnostic`].
+///
+/// `delta` is added to the error's byte offset to remap a chunk-local span back
+/// to document coordinates (pass `0` for errors whose spans are already
+/// absolute, e.g. lexer-fatal errors). `fallback_len` is used when the error
+/// carries no span.
+pub fn from_read_error(
+    err: &CljxError,
+    delta: usize,
+    fallback_len: usize,
+    li: &LineIndex,
+    enc: OffsetEncoding,
+) -> Option<Diagnostic> {
+    let (message, span) = match err {
+        CljxError::ReadError { message, span, .. } => (message.clone(), *span),
+        // In-memory parsing cannot produce Io/Serialization/Eval errors.
+        _ => return None,
+    };
+
+    let (start, len) = match span {
+        Some(s) => (s.offset() + delta, s.len().max(1)),
+        None => (delta, fallback_len.max(1)),
+    };
+
+    Some(Diagnostic {
+        range: li.range(start, start + len, enc),
+        severity: Some(DiagnosticSeverity::ERROR),
+        source: Some("cljrs".to_string()),
+        message,
+        ..Default::default()
+    })
+}

--- a/crates/cljrs-lsp/src/document.rs
+++ b/crates/cljrs-lsp/src/document.rs
@@ -1,0 +1,26 @@
+//! Per-document state held in the backend's store.
+//!
+//! v1 uses FULL text sync, so a plain `String` suffices. The text lives behind
+//! this small type so a later switch to INCREMENTAL sync (e.g. a rope) stays
+//! localized.
+
+use tower_lsp::lsp_types::DocumentSymbol;
+
+/// One open text document plus its last-computed symbol outline.
+pub struct Document {
+    pub text: String,
+    pub version: i32,
+    /// Cached document symbols from the most recent analysis, reused to answer
+    /// `textDocument/documentSymbol` without re-parsing.
+    pub symbols: Vec<DocumentSymbol>,
+}
+
+impl Document {
+    pub fn new(text: String, version: i32) -> Self {
+        Self {
+            text,
+            version,
+            symbols: Vec::new(),
+        }
+    }
+}

--- a/crates/cljrs-lsp/src/lib.rs
+++ b/crates/cljrs-lsp/src/lib.rs
@@ -1,0 +1,23 @@
+//! Language Server Protocol implementation for clojurust (`.cljrs` / `.cljc`).
+//!
+//! v1 is syntactic only — it uses [`cljrs_reader`] for **parse diagnostics** and
+//! a **document-symbol outline**, with no evaluator involvement. All analysis
+//! flows through [`analysis::run`], the seam where a future semantic tier
+//! (hover, completion, go-to-definition) would plug in.
+//!
+//! See [`backend::Backend`] for the server and [`backend::run_stdio`] /
+//! [`backend::run_stdio_blocking`] for the entry points.
+
+// CljxError embeds NamedSource<String> for miette, which is unavoidably large.
+#![allow(clippy::result_large_err)]
+
+mod analysis;
+mod backend;
+mod diagnostics;
+mod document;
+mod line_index;
+mod recovery;
+mod symbols;
+
+pub use backend::{Backend, run_stdio, run_stdio_blocking};
+pub use line_index::{LineIndex, OffsetEncoding};

--- a/crates/cljrs-lsp/src/line_index.rs
+++ b/crates/cljrs-lsp/src/line_index.rs
@@ -1,0 +1,144 @@
+//! Byte-offset ⇄ LSP [`Position`] conversion.
+//!
+//! The reader reports byte offsets (and a *byte* column that is useless for
+//! LSP). LSP positions are 0-based `(line, character)` pairs where `character`
+//! counts code units in the negotiated [`OffsetEncoding`] — UTF-16 by default,
+//! UTF-8 when the client advertises support. We derive everything from byte
+//! offsets via a precomputed table of line-start offsets.
+
+use tower_lsp::lsp_types::{Position, Range};
+
+/// The unit in which LSP `character` offsets are counted.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum OffsetEncoding {
+    /// `character` counts UTF-8 bytes (LSP 3.17 `utf-8`).
+    Utf8,
+    /// `character` counts UTF-16 code units (the LSP default).
+    Utf16,
+}
+
+/// Precomputed line boundaries for one document, borrowing its text.
+pub struct LineIndex<'a> {
+    text: &'a str,
+    /// Byte offset of the first character of each line. Always starts with `0`.
+    line_starts: Vec<usize>,
+}
+
+impl<'a> LineIndex<'a> {
+    pub fn new(text: &'a str) -> Self {
+        let mut line_starts = vec![0usize];
+        for (i, b) in text.bytes().enumerate() {
+            if b == b'\n' {
+                line_starts.push(i + 1);
+            }
+        }
+        Self { text, line_starts }
+    }
+
+    /// Convert an absolute byte offset into an LSP [`Position`].
+    ///
+    /// Offsets past the end of the text are clamped to the text length, and
+    /// offsets that do not land on a `char` boundary are snapped down to the
+    /// nearest boundary (defensive — reader spans are always on boundaries).
+    pub fn position(&self, offset: usize, encoding: OffsetEncoding) -> Position {
+        let mut offset = offset.min(self.text.len());
+        while offset > 0 && !self.text.is_char_boundary(offset) {
+            offset -= 1;
+        }
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(exact) => exact,
+            Err(insert) => insert - 1,
+        };
+        let line_start = self.line_starts[line];
+        let character = match encoding {
+            OffsetEncoding::Utf8 => (offset - line_start) as u32,
+            OffsetEncoding::Utf16 => self.text[line_start..offset]
+                .chars()
+                .map(|c| c.len_utf16() as u32)
+                .sum(),
+        };
+        Position {
+            line: line as u32,
+            character,
+        }
+    }
+
+    /// Convert a half-open byte range `[start, end)` into an LSP [`Range`].
+    pub fn range(&self, start: usize, end: usize, encoding: OffsetEncoding) -> Range {
+        Range {
+            start: self.position(start, encoding),
+            end: self.position(end, encoding),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_positions() {
+        let text = "abc\ndef\n";
+        let li = LineIndex::new(text);
+        assert_eq!(li.position(0, OffsetEncoding::Utf8), Position::new(0, 0));
+        assert_eq!(li.position(2, OffsetEncoding::Utf8), Position::new(0, 2));
+        // offset 3 is the '\n' itself (end of line 0)
+        assert_eq!(li.position(3, OffsetEncoding::Utf8), Position::new(0, 3));
+        // offset 4 is start of line 1
+        assert_eq!(li.position(4, OffsetEncoding::Utf8), Position::new(1, 0));
+        assert_eq!(li.position(6, OffsetEncoding::Utf8), Position::new(1, 2));
+    }
+
+    #[test]
+    fn non_ascii_utf8_vs_utf16() {
+        // "λ" is 2 UTF-8 bytes, 1 UTF-16 unit. "😀" is 4 bytes, 2 UTF-16 units.
+        let text = "λ😀x";
+        let li = LineIndex::new(text);
+        let x_off = "λ😀".len(); // byte offset of 'x' == 6
+        assert_eq!(x_off, 6);
+        // UTF-8: character == byte offset within the line.
+        assert_eq!(
+            li.position(x_off, OffsetEncoding::Utf8),
+            Position::new(0, 6)
+        );
+        // UTF-16: λ(1) + 😀(2) == 3 code units before 'x'.
+        assert_eq!(
+            li.position(x_off, OffsetEncoding::Utf16),
+            Position::new(0, 3)
+        );
+    }
+
+    #[test]
+    fn clamps_past_eof() {
+        let text = "ab";
+        let li = LineIndex::new(text);
+        assert_eq!(li.position(999, OffsetEncoding::Utf8), Position::new(0, 2));
+    }
+
+    #[test]
+    fn snaps_off_boundary_down() {
+        let text = "λ"; // 2 bytes
+        let li = LineIndex::new(text);
+        // offset 1 is inside the multibyte char → snaps to 0.
+        assert_eq!(li.position(1, OffsetEncoding::Utf16), Position::new(0, 0));
+    }
+
+    #[test]
+    fn crlf_keeps_cr_in_line() {
+        let text = "a\r\nb";
+        let li = LineIndex::new(text);
+        // '\r' is at offset 1, still on line 0 at column 1.
+        assert_eq!(li.position(1, OffsetEncoding::Utf8), Position::new(0, 1));
+        // 'b' is at offset 3, start of line 1.
+        assert_eq!(li.position(3, OffsetEncoding::Utf8), Position::new(1, 0));
+    }
+
+    #[test]
+    fn range_round_trip() {
+        let text = "(def x 1)";
+        let li = LineIndex::new(text);
+        let r = li.range(1, 4, OffsetEncoding::Utf8); // "def"
+        assert_eq!(r.start, Position::new(0, 1));
+        assert_eq!(r.end, Position::new(0, 4));
+    }
+}

--- a/crates/cljrs-lsp/src/main.rs
+++ b/crates/cljrs-lsp/src/main.rs
@@ -1,0 +1,6 @@
+//! Standalone `cljrs-lsp` binary: runs the language server over stdio.
+
+#[tokio::main]
+async fn main() {
+    cljrs_lsp::run_stdio().await;
+}

--- a/crates/cljrs-lsp/src/recovery.rs
+++ b/crates/cljrs-lsp/src/recovery.rs
@@ -1,0 +1,217 @@
+//! Top-level form recovery via the lexer.
+//!
+//! The reader's [`Parser`](cljrs_reader::Parser) aborts on the first syntax
+//! error and yields no partial forms. To still report *multiple* errors and
+//! produce document symbols for the well-formed parts of a buffer, we split the
+//! source into top-level form "chunks" using only the [`Lexer`], then parse each
+//! chunk independently with a fresh parser (see [`crate::analysis`]).
+//!
+//! The lexer already skips strings, regexes, char literals, line comments and
+//! commas, so counting bracket depth over its delimiter tokens is reliable.
+//!
+//! ## Boundary detection
+//!
+//! A top-level unit is exactly one form. Counting *base forms* (atoms and
+//! balanced bracket groups) completed at depth 0, a unit needs `1 + (number of
+//! `^` metadata prefixes)` base forms: every reader-macro prefix is unary
+//! (wraps one base) except `^meta target`, which needs two. Prefixes always
+//! precede their targets, so the count converges incrementally and the unit
+//! closes when `base_completions >= bases_needed` at depth 0.
+
+use cljrs_reader::{Lexer, Token};
+use cljrs_types::error::CljxError;
+
+/// A half-open byte range `[start, end)` into the source covering one top-level
+/// unit (or an isolated stray closing delimiter).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Chunk {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// The result of splitting a buffer into top-level chunks.
+pub struct SplitResult {
+    pub chunks: Vec<Chunk>,
+    /// A lexer-fatal error (unterminated string, bad escape, unknown `#`
+    /// dispatch). When present, chunking stopped at this point; chunks before
+    /// it are still valid. The error's span is absolute (into the full source).
+    pub lex_error: Option<CljxError>,
+}
+
+/// Split `source` into top-level form chunks. `file` is used only for the
+/// lexer's error provenance.
+pub fn split_top_level(source: &str, file: &str) -> SplitResult {
+    let mut lexer = Lexer::new(source.to_string(), file.to_string());
+    let mut chunks = Vec::new();
+    let mut lex_error = None;
+
+    let mut depth: i32 = 0;
+    let mut in_unit = false;
+    let mut chunk_start: usize = 0;
+    let mut bases_needed: i32 = 1;
+    let mut base_completions: i32 = 0;
+
+    loop {
+        let (tok, span) = match lexer.next_token() {
+            Ok(pair) => pair,
+            Err(e) => {
+                lex_error = Some(e);
+                break;
+            }
+        };
+
+        if matches!(tok, Token::Eof) {
+            if in_unit {
+                // Unbalanced / dangling tail — emit it so the parser reports it.
+                chunks.push(Chunk {
+                    start: chunk_start,
+                    end: source.len(),
+                });
+            }
+            break;
+        }
+
+        if !in_unit {
+            in_unit = true;
+            chunk_start = span.start;
+            bases_needed = 1;
+            base_completions = 0;
+        }
+
+        match tok {
+            Token::LParen | Token::LBracket | Token::LBrace | Token::HashFn | Token::HashSet => {
+                depth += 1;
+            }
+            Token::RParen | Token::RBracket | Token::RBrace => {
+                if depth == 0 {
+                    // Stray closing delimiter at top level. Flush any pending
+                    // partial unit, isolate the stray as its own chunk (the
+                    // parser will report "unexpected closing delimiter"), and
+                    // resync.
+                    if span.start > chunk_start {
+                        chunks.push(Chunk {
+                            start: chunk_start,
+                            end: span.start,
+                        });
+                    }
+                    chunks.push(Chunk {
+                        start: span.start,
+                        end: span.end,
+                    });
+                    in_unit = false;
+                    continue;
+                }
+                depth -= 1;
+                if depth == 0 {
+                    base_completions += 1;
+                }
+            }
+            // `^` needs an extra base form (the metadata) before its target.
+            Token::Meta => bases_needed += 1,
+            // Unary reader-macro prefixes: part of the unit, no base produced.
+            Token::Quote
+            | Token::SyntaxQuote
+            | Token::Unquote
+            | Token::UnquoteSplice
+            | Token::Deref
+            | Token::HashVar
+            | Token::HashDiscard
+            | Token::TaggedLiteral(_)
+            | Token::ReaderCond
+            | Token::ReaderCondSplice => {}
+            // Everything else is an atom — a base form when at top level.
+            _ => {
+                if depth == 0 {
+                    base_completions += 1;
+                }
+            }
+        }
+
+        if depth == 0 && in_unit && base_completions >= bases_needed {
+            chunks.push(Chunk {
+                start: chunk_start,
+                end: span.end,
+            });
+            in_unit = false;
+        }
+    }
+
+    SplitResult { chunks, lex_error }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ranges(source: &str) -> Vec<&str> {
+        split_top_level(source, "<test>")
+            .chunks
+            .iter()
+            .map(|c| &source[c.start..c.end])
+            .collect()
+    }
+
+    #[test]
+    fn multiple_balanced_forms() {
+        assert_eq!(ranges("(a) (b) (c)"), vec!["(a)", "(b)", "(c)"]);
+    }
+
+    #[test]
+    fn top_level_atoms() {
+        assert_eq!(ranges("1 :kw foo"), vec!["1", ":kw", "foo"]);
+    }
+
+    #[test]
+    fn quote_groups_with_target() {
+        assert_eq!(ranges("'(a b) `c"), vec!["'(a b)", "`c"]);
+        assert_eq!(ranges("''x"), vec!["''x"]);
+    }
+
+    #[test]
+    fn metadata_groups_two_bases() {
+        assert_eq!(ranges("^{:m 1} x"), vec!["^{:m 1} x"]);
+        assert_eq!(ranges("^:private (def y 1)"), vec!["^:private (def y 1)"]);
+    }
+
+    #[test]
+    fn reader_conditional_is_one_chunk() {
+        assert_eq!(ranges("#?(:rust 1 :clj 2)"), vec!["#?(:rust 1 :clj 2)"]);
+    }
+
+    #[test]
+    fn discard_is_its_own_chunk() {
+        // `#_ x` is discarded; `y` stands alone.
+        assert_eq!(ranges("#_ x y"), vec!["#_ x", "y"]);
+        assert_eq!(ranges("#_(a b) c"), vec!["#_(a b)", "c"]);
+    }
+
+    #[test]
+    fn stray_closer_is_isolated() {
+        let cs = ranges("(a) ) (b)");
+        assert_eq!(cs, vec!["(a)", ")", "(b)"]);
+    }
+
+    #[test]
+    fn unclosed_at_eof_is_trailing_chunk() {
+        assert_eq!(ranges("(def x"), vec!["(def x"]);
+    }
+
+    #[test]
+    fn brackets_in_strings_and_comments_ignored() {
+        assert_eq!(ranges("(a \"x ) y\") (b)"), vec!["(a \"x ) y\")", "(b)"]);
+        assert_eq!(ranges("(a) ; ) ) )\n(b)"), vec!["(a)", "(b)"]);
+    }
+
+    #[test]
+    fn lexer_fatal_error_stops_but_keeps_prior() {
+        let res = split_top_level("(a) \"unterminated", "<test>");
+        assert!(res.lex_error.is_some());
+        assert_eq!(res.chunks.len(), 1);
+        assert_eq!(res.chunks[0], Chunk { start: 0, end: 3 });
+    }
+
+    #[test]
+    fn anon_fn_and_set_literals() {
+        assert_eq!(ranges("#(+ % 1) #{1 2}"), vec!["#(+ % 1)", "#{1 2}"]);
+    }
+}

--- a/crates/cljrs-lsp/src/symbols.rs
+++ b/crates/cljrs-lsp/src/symbols.rs
@@ -1,0 +1,182 @@
+//! Extract [`DocumentSymbol`]s (an outline of definitions) from parsed forms.
+//!
+//! Forms come from a single recovered chunk, so their spans are relative to the
+//! chunk substring; callers pass the chunk's byte `delta` to shift spans back
+//! to document coordinates.
+
+use cljrs_reader::{Form, FormKind};
+use tower_lsp::lsp_types::{DocumentSymbol, SymbolKind};
+
+use crate::line_index::{LineIndex, OffsetEncoding};
+
+/// Collect definition symbols from a chunk's forms into `out`.
+pub fn collect(
+    forms: &[Form],
+    delta: usize,
+    li: &LineIndex,
+    enc: OffsetEncoding,
+    out: &mut Vec<DocumentSymbol>,
+) {
+    for form in forms {
+        collect_form(form, delta, li, enc, None, out);
+    }
+}
+
+fn collect_form(
+    form: &Form,
+    delta: usize,
+    li: &LineIndex,
+    enc: OffsetEncoding,
+    platform: Option<&str>,
+    out: &mut Vec<DocumentSymbol>,
+) {
+    match &form.kind {
+        // `^meta (def ...)` — descend into the annotated target.
+        FormKind::Meta(_, target) => collect_form(target, delta, li, enc, platform, out),
+        // Surface definitions from every reader-conditional branch, tagging the
+        // platform in `detail`. Clauses are flat `[kw, form, kw, form, ...]`.
+        FormKind::ReaderCond { clauses, .. } => {
+            for pair in clauses.chunks(2) {
+                if let [key, body] = pair {
+                    let label = match &key.kind {
+                        FormKind::Keyword(k) => Some(k.as_str()),
+                        _ => None,
+                    };
+                    collect_form(body, delta, li, enc, label, out);
+                }
+            }
+        }
+        FormKind::List(items) => {
+            if let Some(sym) = def_symbol(form, items, delta, li, enc, platform) {
+                out.push(sym);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Map a `(head name ...)` list to a [`DocumentSymbol`], or `None` if `head`
+/// is not a recognized defining form or `name` is missing/not a symbol.
+fn def_symbol(
+    form: &Form,
+    items: &[Form],
+    delta: usize,
+    li: &LineIndex,
+    enc: OffsetEncoding,
+    platform: Option<&str>,
+) -> Option<DocumentSymbol> {
+    let head = match items.first().map(|f| &f.kind) {
+        Some(FormKind::Symbol(s)) => s.as_str(),
+        _ => return None,
+    };
+
+    let kind = match head {
+        "ns" => SymbolKind::NAMESPACE,
+        "def" | "defonce" => SymbolKind::VARIABLE,
+        "defn" | "defn-" | "defmacro" | "defmulti" | "deftest" | "definline" => {
+            SymbolKind::FUNCTION
+        }
+        "defprotocol" => SymbolKind::INTERFACE,
+        "defrecord" | "deftype" | "defstruct" => SymbolKind::STRUCT,
+        _ => return None,
+    };
+
+    let name_form = items.get(1)?;
+    let name = match &name_form.kind {
+        FormKind::Symbol(s) => s.clone(),
+        _ => return None,
+    };
+
+    let detail = match platform {
+        Some(p) => format!("{head} (:{p})"),
+        None => head.to_string(),
+    };
+
+    let range = li.range(form.span.start + delta, form.span.end + delta, enc);
+    let selection_range = li.range(
+        name_form.span.start + delta,
+        name_form.span.end + delta,
+        enc,
+    );
+
+    #[allow(deprecated)] // `deprecated` field is required by the struct literal.
+    Some(DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range,
+        children: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cljrs_reader::Parser;
+
+    fn symbols(src: &str) -> Vec<DocumentSymbol> {
+        let li = LineIndex::new(src);
+        let forms = Parser::new(src.to_string(), "<test>".to_string())
+            .parse_all()
+            .expect("parse");
+        let mut out = Vec::new();
+        collect(&forms, 0, &li, OffsetEncoding::Utf8, &mut out);
+        out
+    }
+
+    #[test]
+    fn extracts_common_defs() {
+        let src = "(ns my.app)\n(def x 1)\n(defn f [a] a)\n(defn- g [] 0)\n\
+                   (defmacro m [] nil)\n(defonce o 1)\n(defprotocol P)\n\
+                   (defrecord R [a])\n(defmulti d :k)\n(deftest t)";
+        let syms = symbols(src);
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["my.app", "x", "f", "g", "m", "o", "P", "R", "d", "t"]
+        );
+        assert_eq!(syms[0].kind, SymbolKind::NAMESPACE);
+        assert_eq!(syms[1].kind, SymbolKind::VARIABLE);
+        assert_eq!(syms[2].kind, SymbolKind::FUNCTION);
+        assert_eq!(syms[6].kind, SymbolKind::INTERFACE);
+        assert_eq!(syms[7].kind, SymbolKind::STRUCT);
+    }
+
+    #[test]
+    fn selection_within_range() {
+        let syms = symbols("(defn foo [x] x)");
+        let s = &syms[0];
+        assert!(s.selection_range.start >= s.range.start);
+        assert!(s.selection_range.end <= s.range.end);
+        assert_eq!(s.name, "foo");
+    }
+
+    #[test]
+    fn malformed_def_emits_nothing() {
+        assert!(symbols("(def)").is_empty());
+        assert!(symbols("(defn 42 [])").is_empty());
+    }
+
+    #[test]
+    fn reader_conditional_defs() {
+        let syms = symbols("#?(:rust (defn r [] 1) :clj (defn c [] 2))");
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["r", "c"]);
+        assert_eq!(syms[0].detail.as_deref(), Some("defn (:rust)"));
+    }
+
+    #[test]
+    fn metadata_wrapped_def() {
+        let syms = symbols("^:private (def secret 1)");
+        assert_eq!(syms.len(), 1);
+        assert_eq!(syms[0].name, "secret");
+    }
+
+    #[test]
+    fn ignores_non_definitions() {
+        assert!(symbols("(println \"hi\")").is_empty());
+    }
+}

--- a/crates/cljrs-lsp/tests/smoke.rs
+++ b/crates/cljrs-lsp/tests/smoke.rs
@@ -1,0 +1,82 @@
+//! In-process smoke test: drive the language server through its JSON-RPC service
+//! and check that `initialize` + `didOpen` + `documentSymbol` work end to end.
+
+use cljrs_lsp::Backend;
+use futures::StreamExt;
+use serde_json::json;
+use tower::Service;
+use tower::ServiceExt; // for `.ready()`
+use tower_lsp::LspService;
+use tower_lsp::jsonrpc::Request;
+
+#[tokio::test]
+async fn initialize_open_and_document_symbol() {
+    let (mut service, socket) = LspService::new(Backend::new);
+
+    // Drain server→client messages (e.g. publishDiagnostics, logMessage) so the
+    // server's sends never block on a full socket channel.
+    let _drain = tokio::spawn(async move {
+        let mut socket = socket;
+        while socket.next().await.is_some() {}
+    });
+
+    // initialize
+    let init = Request::build("initialize")
+        .params(json!({ "capabilities": {} }))
+        .id(1)
+        .finish();
+    let resp = service
+        .ready()
+        .await
+        .unwrap()
+        .call(init)
+        .await
+        .unwrap()
+        .expect("initialize response");
+    let (_, result) = resp.into_parts();
+    let value = result.expect("initialize result");
+    // The server must advertise document-symbol support.
+    assert_eq!(value["capabilities"]["documentSymbolProvider"], json!(true));
+
+    // initialized (notification — no response)
+    let initialized = Request::build("initialized").params(json!({})).finish();
+    let _ = service
+        .ready()
+        .await
+        .unwrap()
+        .call(initialized)
+        .await
+        .unwrap();
+
+    // didOpen a document with a good def and a stray closing paren.
+    let did_open = Request::build("textDocument/didOpen")
+        .params(json!({
+            "textDocument": {
+                "uri": "file:///t.cljrs",
+                "languageId": "clojure",
+                "version": 1,
+                "text": "(defn f [x] x)\n)\n"
+            }
+        }))
+        .finish();
+    let _ = service.ready().await.unwrap().call(did_open).await.unwrap();
+
+    // documentSymbol should return the `f` definition.
+    let doc_sym = Request::build("textDocument/documentSymbol")
+        .params(json!({ "textDocument": { "uri": "file:///t.cljrs" } }))
+        .id(2)
+        .finish();
+    let resp = service
+        .ready()
+        .await
+        .unwrap()
+        .call(doc_sym)
+        .await
+        .unwrap()
+        .expect("documentSymbol response");
+    let (_, result) = resp.into_parts();
+    let value = result.expect("documentSymbol result");
+    let symbols = value.as_array().expect("array of symbols");
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0]["name"], json!("f"));
+}

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -40,6 +40,7 @@ cljrs-interop  = { workspace = true }
 cljrs-logging  = { workspace = true }
 cljrs-deps     = { workspace = true }
 cljrs-vcs      = { workspace = true }
+cljrs-lsp      = { workspace = true }
 clap          = { workspace = true }
 miette        = { workspace = true }
 tracing-subscriber = "0.3.23"

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -183,6 +183,12 @@ enum Commands {
         #[arg(long)]
         release: bool,
     },
+    /// Run the clojurust language server (LSP) over stdio.
+    ///
+    /// Speaks the Language Server Protocol on stdin/stdout for editor
+    /// integration, providing parse diagnostics and a document-symbol outline
+    /// for `.cljrs` / `.cljc` files. Editors normally launch this for you.
+    Lsp,
 }
 
 #[derive(Subcommand)]
@@ -396,6 +402,13 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
             DepsCommands::Status => run_deps_status(),
         },
         Commands::BuildNative { release } => run_build_native(release),
+        Commands::Lsp => {
+            // cljrs-lsp owns its own runtime; this is safe because `run` never
+            // enters the interpreter's async driver runtime.
+            cljrs_lsp::run_stdio_blocking()
+                .map_err(|e| miette::miette!("lsp server error: {e}"))?;
+            Ok(0)
+        }
     }
 }
 


### PR DESCRIPTION
Introduce a new `cljrs-lsp` crate (library + `cljrs-lsp` binary) implementing
a syntactic, reader-based Language Server Protocol server, plus a `cljrs lsp`
subcommand that launches it over stdio.

v1 capabilities:
- Parse diagnostics with per-top-level-form error recovery: the buffer is
  split into top-level form chunks via the lexer (correctly skipping
  strings/comments/chars) and each chunk is parsed independently, so multiple
  errors surface at once and well-formed forms still yield symbols.
- Document-symbol outline for ns/def/defn/defmacro/defrecord/etc., including
  definitions inside reader conditionals.
- UTF-8/UTF-16 position-encoding negotiation; FULL text sync.

Built on tower-lsp; document store backed by dashmap. analysis::run is the
single seam where a future evaluator-backed semantic tier (hover, completion,
go-to-definition) will plug in.

Includes unit tests (position conversion, recovery, symbols, analysis) and an
in-process JSON-RPC smoke test. Updates TODO.md and CLAUDE.md.

https://claude.ai/code/session_01U4Qm8D94mGppDu8JTRtqjL