### PR TITLE
Phase 10.0: make codegen generic over cranelift_module::Module

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -384,7 +384,7 @@ Foundations already in place:
 
 ### Phase 10.0 — Backend refactor
 
-- [ ] Make `codegen.rs` generic over `cranelift_module::Module` (drives both `ObjectModule` for AOT and `JITModule` for JIT); AOT behavior unchanged
+- [x] Make `codegen.rs` generic over `cranelift_module::Module` (drives both `ObjectModule` for AOT and `JITModule` for JIT); AOT behavior unchanged
 
 ### Phase 10.1 — Minimal JIT tier (first working JIT)
 

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -21,7 +21,7 @@ src/
   ir.rs         — re-exports all types from cljrs-ir crate
   ir_convert.rs — Value → IrFunction conversion (Clojure data → Rust IR types)
   rt_abi.rs     — C-ABI runtime bridge: ~40 extern "C" functions called by compiled code
-  codegen.rs    — Cranelift code generator: IrFunction → native object code
+  codegen.rs    — Cranelift code generator: IrFunction → native code, generic over cranelift_module::Module (AOT ObjectModule / future JIT JITModule)
   aot.rs        — AOT driver: source → parse → expand → lower → codegen → cargo build → binary
   escape.rs     — (no-gc only) blacklist analysis: 4 checks that reject no-gc–unsafe IR patterns
   cljrs/compiler/
@@ -113,13 +113,28 @@ walk directly, preserving full semantics.
 
 ### Cranelift codegen (`codegen.rs`)
 
+`Compiler<M>` is **generic over `cranelift_module::Module`** (defaulting to
+`ObjectModule`) so the same CLIF-emitting core drives both the AOT backend
+(`ObjectModule`) and a future JIT backend (`JITModule`); the lowering logic and
+`rt_abi` signatures are shared verbatim. Backend-agnostic methods live in
+`impl<M: Module> Compiler<M>`; only construction and finalization are
+backend-specific.
+
 ```rust
-pub struct Compiler { ... }
-impl Compiler {
-    pub fn new() -> CodegenResult<Self>;
+pub struct Compiler<M: Module = ObjectModule> { ... }
+
+// Backend-agnostic (shared by AOT and JIT):
+impl<M: Module> Compiler<M> {
+    pub fn from_module(module: M) -> CodegenResult<Self>;       // declares rt_abi bridge
+    pub fn module_mut(&mut self) -> &mut M;
     pub fn declare_function(&mut self, name: &str, param_count: usize) -> CodegenResult<FuncId>;
     pub fn compile_function(&mut self, ir_func: &IrFunction, func_id: FuncId) -> CodegenResult<()>;
-    pub fn finish(self) -> Vec<u8>;
+}
+
+// AOT-specific (ObjectModule):
+impl Compiler<ObjectModule> {
+    pub fn new() -> CodegenResult<Self>;   // host-targeted ObjectModule
+    pub fn finish(self) -> Vec<u8>;        // emit relocatable object code
 }
 ```
 

--- a/crates/cljrs-compiler/src/codegen.rs
+++ b/crates/cljrs-compiler/src/codegen.rs
@@ -175,9 +175,16 @@ struct RuntimeFuncs {
 
 // ── Compiler context ────────────────────────────────────────────────────────
 
-/// AOT compiler: translates IR functions to native object code via Cranelift.
-pub struct Compiler {
-    module: ObjectModule,
+/// Cranelift compiler: translates IR functions to native code via a
+/// [`cranelift_module::Module`].
+///
+/// The struct is generic over the backing module so that the same
+/// CLIF-emitting core drives both the AOT backend (`ObjectModule`, the default)
+/// and the JIT backend (`JITModule`).  The lowering logic and `rt_abi`
+/// signatures are shared verbatim between the two; only module construction and
+/// the `finish`/finalize step differ per backend.
+pub struct Compiler<M: Module = ObjectModule> {
+    module: M,
     ctx: cranelift_codegen::Context,
     fb_ctx: FunctionBuilderContext,
     rt: RuntimeFuncs,
@@ -186,30 +193,16 @@ pub struct Compiler {
     user_funcs: HashMap<Arc<str>, FuncId>,
 }
 
-impl Compiler {
-    /// Create a new compiler targeting the host architecture.
-    pub fn new() -> CodegenResult<Self> {
-        let mut flag_builder = settings::builder();
-        flag_builder.set("opt_level", "speed").unwrap();
-        flag_builder.set("is_pic", "true").unwrap();
-
-        let isa_builder = cranelift_native::builder()
-            .map_err(|e| CodegenError::Codegen(format!("failed to create ISA builder: {e}")))?;
-        let isa = isa_builder
-            .finish(settings::Flags::new(flag_builder))
-            .map_err(|e| CodegenError::Codegen(format!("failed to build ISA: {e}")))?;
-
-        let ptr_type = isa.pointer_type();
-
-        let obj_builder = ObjectBuilder::new(
-            isa,
-            "clojurust_aot",
-            cranelift_module::default_libcall_names(),
-        )?;
-        let mut module = ObjectModule::new(obj_builder);
-
+impl<M: Module> Compiler<M> {
+    /// Build a compiler over an already-constructed module.
+    ///
+    /// Declares the `rt_abi` runtime bridge functions so emitted code can call
+    /// into them.  Shared by both the AOT (`ObjectModule`) and JIT
+    /// (`JITModule`) backends; each constructs its own module then hands it
+    /// here.
+    pub fn from_module(mut module: M) -> CodegenResult<Self> {
+        let ptr_type = module.isa().pointer_type();
         let rt = declare_runtime_funcs(&mut module, ptr_type)?;
-
         Ok(Self {
             ctx: module.make_context(),
             fb_ctx: FunctionBuilderContext::new(),
@@ -218,6 +211,12 @@ impl Compiler {
             ptr_type,
             user_funcs: HashMap::new(),
         })
+    }
+
+    /// Mutable access to the underlying module (e.g. for a JIT backend to
+    /// finalize definitions and obtain code pointers after compilation).
+    pub fn module_mut(&mut self) -> &mut M {
+        &mut self.module
     }
 
     /// Declare a user function (makes it available for calls before definition).
@@ -263,6 +262,31 @@ impl Compiler {
         self.ctx.clear();
         Ok(())
     }
+}
+
+impl Compiler<ObjectModule> {
+    /// Create a new AOT compiler targeting the host architecture, backed by an
+    /// `ObjectModule` that emits a relocatable object file.
+    pub fn new() -> CodegenResult<Self> {
+        let mut flag_builder = settings::builder();
+        flag_builder.set("opt_level", "speed").unwrap();
+        flag_builder.set("is_pic", "true").unwrap();
+
+        let isa_builder = cranelift_native::builder()
+            .map_err(|e| CodegenError::Codegen(format!("failed to create ISA builder: {e}")))?;
+        let isa = isa_builder
+            .finish(settings::Flags::new(flag_builder))
+            .map_err(|e| CodegenError::Codegen(format!("failed to build ISA: {e}")))?;
+
+        let obj_builder = ObjectBuilder::new(
+            isa,
+            "clojurust_aot",
+            cranelift_module::default_libcall_names(),
+        )?;
+        let module = ObjectModule::new(obj_builder);
+
+        Self::from_module(module)
+    }
 
     /// Finish compilation and return the object code bytes.
     pub fn finish(self) -> Vec<u8> {
@@ -275,9 +299,9 @@ impl Compiler {
 
 /// Translates a single [`IrFunction`] into Cranelift IR using a
 /// [`FunctionBuilder`].
-struct FunctionTranslator<'a, 'b> {
+struct FunctionTranslator<'a, 'b, M: Module> {
     builder: &'b mut FunctionBuilder<'a>,
-    module: &'b mut ObjectModule,
+    module: &'b mut M,
     rt: &'b RuntimeFuncs,
     ptr_type: types::Type,
     /// Maps IR VarId → Cranelift Variable.
@@ -288,7 +312,7 @@ struct FunctionTranslator<'a, 'b> {
     block_map: HashMap<BlockId, cranelift_codegen::ir::Block>,
 }
 
-impl<'a, 'b> FunctionTranslator<'a, 'b> {
+impl<'a, 'b, M: Module> FunctionTranslator<'a, 'b, M> {
     fn translate(&mut self, ir_func: &IrFunction) -> CodegenResult<()> {
         // Create all CLIF blocks upfront.
         for block in &ir_func.blocks {
@@ -1436,8 +1460,8 @@ impl<'a, 'b> FunctionTranslator<'a, 'b> {
 // ── Runtime function declaration ────────────────────────────────────────────
 
 /// Helper to declare a single runtime function.
-fn declare_rt(
-    module: &mut ObjectModule,
+fn declare_rt<M: Module>(
+    module: &mut M,
     name: &str,
     params: &[types::Type],
     ret: types::Type,
@@ -1452,8 +1476,8 @@ fn declare_rt(
 }
 
 /// Declare all runtime bridge functions and return cached FuncIds.
-fn declare_runtime_funcs(
-    module: &mut ObjectModule,
+fn declare_runtime_funcs<M: Module>(
+    module: &mut M,
     ptr: types::Type,
 ) -> CodegenResult<RuntimeFuncs> {
     // Declare rt_safepoint: void -> void.  We declare it as returning ptr


### PR DESCRIPTION
Refactor the Cranelift code generator so the CLIF-emitting core is driven
by any `cranelift_module::Module`, sharing lowering logic and rt_abi
signatures verbatim between the AOT backend (`ObjectModule`) and a future
JIT backend (`JITModule`).

- `Compiler<M: Module = ObjectModule>`: backend-agnostic methods
  (`from_module`, `module_mut`, `declare_function`, `compile_function`)
  live in `impl<M: Module>`; backend-specific construction (`new`) and
  finalization (`finish`) stay in `impl Compiler<ObjectModule>`.
- `FunctionTranslator`, `declare_rt`, and `declare_runtime_funcs` made
  generic over `M: Module`.
- AOT path unchanged: `Compiler` defaults to `ObjectModule`, so `aot.rs`
  needs no changes.
- Update crate README to document the generic Compiler API.

Verified: cargo build, clippy, full cargo test, and the aot_full_test
end-to-end suite all pass; AOT behavior unchanged.