### PR TITLE
Phase 10.2: JIT code unloading (epoch-tagged STW reclamation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,8 @@ dependencies = [
  "cljrs-gc",
  "cljrs-ir",
  "cljrs-logging",
+ "cljrs-reader",
+ "cljrs-stdlib",
  "cljrs-value",
  "cranelift-codegen",
  "cranelift-frontend",

--- a/TODO.md
+++ b/TODO.md
@@ -397,8 +397,8 @@ Foundations already in place:
 
 ### Phase 10.2 — Code unloading
 
-- [ ] Per-version code tagged with `ir_arity_id` + epoch; mark prior arity stale on redefinition
-- [ ] Reclaim stale epochs at the existing STW safepoint, freeing only epochs with no live JIT frame (resolves the unload-vs-execute race)
+- [x] Per-version code tagged with `ir_arity_id` + epoch; mark prior arity stale on redefinition (var-rebind hook in `cljrs-value` `Var::bind` → `cljrs-jit` `on_var_rebind` → `code_cache::mark_stale`; dispatch pointer nulled so future calls fall back to the interpreter)
+- [x] Reclaim stale epochs at the existing STW safepoint, freeing only epochs with no live JIT frame (resolves the unload-vs-execute race) — per-thread active-frame tracking (`jit_state::push_jit_frame`/`live_epochs`) + `code_cache::reclaim_at_stw` (calls `JITModule::free_memory`), installed via `set_stw_reclaim_hook`
 
 ### Phase 10.3 — Shrink the interpreter seam (ROI order)
 

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -123,6 +123,8 @@ pub struct Compiler<M: Module = ObjectModule> { ... }
 impl<M: Module> Compiler<M> {
     pub fn declare_function(&mut self, name: &str, param_count: usize) -> CodegenResult<FuncId>;
     pub fn compile_function(&mut self, ir_func: &IrFunction, func_id: FuncId) -> CodegenResult<()>;
+    pub fn into_inner_module(self) -> M;        // JIT: reclaim the module after compiling
+    pub fn last_code_size(&self) -> u32;        // machine-code bytes of the last compiled fn (JIT memory accounting)
 }
 
 // AOT-specific (ObjectModule only):

--- a/crates/cljrs-compiler/src/codegen.rs
+++ b/crates/cljrs-compiler/src/codegen.rs
@@ -189,6 +189,10 @@ pub struct Compiler<M: Module = ObjectModule> {
     ptr_type: types::Type,
     /// Maps user-defined function names to their FuncIds.
     user_funcs: HashMap<Arc<str>, FuncId>,
+    /// Total machine-code size (bytes) of the most recently compiled function,
+    /// captured before `ctx` is cleared.  Used by the JIT to account for the
+    /// executable memory backing each compiled arity.
+    last_code_size: u32,
 }
 
 // ── Generic methods (work with any Module backend) ──────────────────────────
@@ -213,6 +217,12 @@ impl<M: Module> Compiler<M> {
     /// `get_finalized_function()` on it.
     pub fn into_inner_module(self) -> M {
         self.module
+    }
+
+    /// Machine-code size in bytes of the function compiled by the most recent
+    /// [`compile_function`](Self::compile_function) call (0 if none).
+    pub fn last_code_size(&self) -> u32 {
+        self.last_code_size
     }
 
     /// Compile an IR function and define it in the module.
@@ -243,6 +253,12 @@ impl<M: Module> Compiler<M> {
         }
 
         self.module.define_function(func_id, &mut self.ctx)?;
+        // Capture the emitted code size before clearing the context.
+        self.last_code_size = self
+            .ctx
+            .compiled_code()
+            .map(|c| c.code_info().total_size)
+            .unwrap_or(0);
         self.ctx.clear();
         Ok(())
     }
@@ -281,6 +297,7 @@ impl Compiler<ObjectModule> {
             rt,
             ptr_type,
             user_funcs: HashMap::new(),
+            last_code_size: 0,
         })
     }
 
@@ -307,6 +324,7 @@ pub fn new_compiler_from_module<M: Module>(
         rt,
         ptr_type,
         user_funcs: HashMap::new(),
+        last_code_size: 0,
     })
 }
 

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -13,3 +13,4 @@ The `gc_roots` module manages GC root registration for the interpreter's Rust ca
 - `gc_safepoint(env: &Env)` — interpreter-level safepoint: parks if collection in progress, or initiates collection on memory pressure
 - `force_collect(env: &Env)` — immediately initiates a GC collection bypassing memory-pressure threshold
 - `async_gc_collect()` — services a pending GC request from a Tokio `LocalSet` task at a cooperative yield point; safe to call when no other tasks are polling, so thread-local root stacks are stable and fully describe all suspended-task `GcPtr`s
+- `set_stw_reclaim_hook(f)` — (Phase 10.2) installs a stop-the-world reclaim hook the JIT uses to free superseded native code; runs inside the STW guard at the tail of every collection (`force_collect`, `gc_safepoint`, `async_gc_collect`), when all mutator threads are parked

--- a/crates/cljrs-env/src/gc_roots.rs
+++ b/crates/cljrs-env/src/gc_roots.rs
@@ -4,6 +4,34 @@ use crate::env::Env;
 #[cfg(not(feature = "no-gc"))]
 use crate::env::GlobalEnv;
 use std::cell::RefCell;
+use std::sync::OnceLock;
+
+// ── Stop-the-world reclaim hook (JIT code unloading) ────────────────────────
+//
+// The JIT tier (`cljrs-jit`) reclaims superseded native code only at a
+// stop-the-world safepoint, when every mutator thread is parked and active JIT
+// frames can be scanned safely.  GC collection is the existing STW point, so
+// the JIT installs a hook here that runs at the tail of every collection while
+// the STW guard is still held.
+
+type StwReclaimHook = Box<dyn Fn() + Send + Sync + 'static>;
+static STW_RECLAIM_HOOK: OnceLock<StwReclaimHook> = OnceLock::new();
+
+/// Install the stop-the-world reclaim hook (called once by `cljrs_jit::init`).
+///
+/// The hook runs inside the STW guard after each collection, so it may assume
+/// all other mutator threads are parked.
+pub fn set_stw_reclaim_hook(f: impl Fn() + Send + Sync + 'static) {
+    let _ = STW_RECLAIM_HOOK.set(Box::new(f));
+}
+
+/// Run the STW reclaim hook if one is installed.  Caller must hold the STW guard.
+#[cfg(not(feature = "no-gc"))]
+fn run_stw_reclaim() {
+    if let Some(hook) = STW_RECLAIM_HOOK.get() {
+        hook();
+    }
+}
 
 // ── Thread-local Env root registry ──────────────────────────────────────────
 //
@@ -146,6 +174,8 @@ pub fn force_collect(env: &Env) {
         crate::taps::trace_roots(visitor);
         cljrs_gc::trace_thread_alloc_roots(visitor);
     });
+    // Reclaim superseded JIT code while the world is still stopped.
+    run_stw_reclaim();
 }
 
 /// Interpreter-level GC safepoint.
@@ -202,6 +232,8 @@ pub fn gc_safepoint(env: &Env) {
         // Trace in-flight allocations from this thread's alloc root frames
         cljrs_gc::trace_thread_alloc_roots(visitor);
     });
+    // Reclaim superseded JIT code while the world is still stopped.
+    run_stw_reclaim();
     // _stw_guard drop clears in_progress, waking parked threads.
 }
 
@@ -322,4 +354,6 @@ pub fn async_gc_collect() {
         crate::taps::trace_roots(visitor);
         cljrs_gc::trace_thread_alloc_roots(visitor);
     });
+    // Reclaim superseded JIT code while the world is still stopped.
+    run_stw_reclaim();
 }

--- a/crates/cljrs-eval/README.md
+++ b/crates/cljrs-eval/README.md
@@ -32,6 +32,8 @@ src/
   ir_cache.rs     — thread-safe cache of lowered IR keyed by arity ID (NotAttempted/Cached/Unsupported)
   ir_convert.rs   — converts Clojure Value data structures (maps/vectors/keywords) → Rust IR types
   lower.rs        — bridges the Clojure compiler front-end (cljrs.compiler.anf/lower-fn-body) to produce IrFunction
+  jit_state.rs    — JIT invocation counters, native-fn-pointer dispatch table (keyed by ir_arity_id),
+                    per-arity epoch, and active-frame tracking for code unloading (Phase 10.2)
 ```
 
 ---
@@ -97,6 +99,30 @@ pub mod lower {
 6. `eval_call` in `cljrs_interp` routes `Value::Fn` calls through `globals.call_cljrs_fn`
    (the registered hook) rather than calling the tree-walker directly, so IR-cached
    arities are used on direct call paths too
+7. JIT tier: before the IR cache, `call_cljrs_fn` checks `jit_state::get_native_fn(arity_id)`
+   for compiled native code and, if present, dispatches to it (rooting args + pushing a
+   frame epoch for code unloading first)
+
+## JIT state & code unloading (`jit_state`)
+
+`jit_state` is the seam between the Tier-1 interpreter and the background JIT
+(`cljrs-jit`). Public surface:
+
+```rust
+pub fn set_jit_threshold(t: u32);                 // calls before compile (default 1000)
+pub fn record_call(arity_id, ir_func);            // bump counter; enqueue when hot
+pub fn set_enqueue_hook(f);                        // installed by cljrs_jit::init
+pub fn store_native_fn(arity_id, ptr, epoch);      // worker publishes compiled code
+pub fn get_native_fn(arity_id) -> Option<(*const (), u64)>;   // (fn_ptr, epoch)
+pub fn take_native_epoch(arity_id) -> Option<u64>; // on redefinition: null ptr, drop entry, return epoch
+pub fn push_jit_frame(epoch) -> JitFrameGuard;     // mark a native frame live for its call
+pub fn live_epochs() -> HashSet<u64>;              // epochs with a live frame (call at STW only)
+pub unsafe fn dispatch_jit_call(fn_ptr, args) -> *const Value;
+```
+
+Each native call brackets itself with `push_jit_frame(epoch)` so the JIT code
+cache can free a superseded module only once no frame is executing it
+(`live_epochs` scanned at the stop-the-world GC safepoint).
 
 ## Special-form coverage in the IR interpreter
 

--- a/crates/cljrs-eval/src/apply.rs
+++ b/crates/cljrs-eval/src/apply.rs
@@ -38,8 +38,8 @@ pub fn call_cljrs_fn(f: &CljxFn, args: &[Value], caller_env: &mut Env) -> EvalRe
         let arity_id = arity.ir_arity_id;
 
         // 1. JIT-native: fastest path — skip interpreter entirely.
-        if let Some(fn_ptr) = crate::jit_state::get_native_fn(arity_id) {
-            return call_jit_native(fn_ptr, args, caller_env);
+        if let Some((fn_ptr, epoch)) = crate::jit_state::get_native_fn(arity_id) {
+            return call_jit_native(fn_ptr, epoch, args, caller_env);
         }
 
         // 2. IR interpreter (also bumps invocation counter).
@@ -147,7 +147,16 @@ fn execute_ir(
 ///
 /// Roots the caller env and the argument slice on the GC shadow stack before
 /// entering native code, so GC safepoints inside the JIT frame can find them.
-fn call_jit_native(fn_ptr: *const (), args: &[Value], caller_env: &mut Env) -> EvalResult {
+fn call_jit_native(
+    fn_ptr: *const (),
+    epoch: u64,
+    args: &[Value],
+    caller_env: &mut Env,
+) -> EvalResult {
+    // Register this native frame's code epoch so code unloading cannot free the
+    // backing module while it executes.  Pushed *before* entering native code
+    // and *before* any safepoint can occur, and popped on return/unwind.
+    let _jit_frame = crate::jit_state::push_jit_frame(epoch);
     // Register the caller env so its GcPtrs survive any GC triggered inside
     // the JIT frame (at rt_safepoint calls).
     let _caller_root = cljrs_env::gc_roots::push_env_root(caller_env);

--- a/crates/cljrs-eval/src/jit_state.rs
+++ b/crates/cljrs-eval/src/jit_state.rs
@@ -11,9 +11,9 @@
 //! 4. `dispatch_jit_call` transmutes the raw pointer to the correct arity
 //!    and invokes the native code.
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, Ordering};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 
 use cljrs_ir::IrFunction;
 use cljrs_value::Value;
@@ -49,6 +49,11 @@ pub struct JitEntry {
     /// Finalized native function pointer, or null if not yet compiled.
     /// Calling convention: SystemV/C ABI, N ptr-sized params, one ptr-sized return.
     pub native_fn_ptr: AtomicPtr<()>,
+    /// Reclamation epoch of the published native code (0 = none).  Assigned by
+    /// the JIT worker when it registers the compiled module; used by code
+    /// unloading to identify which `JITModule` backs this pointer and to track
+    /// whether a frame executing this code is live at a safepoint.
+    pub epoch: AtomicU64,
 }
 
 impl JitEntry {
@@ -57,6 +62,7 @@ impl JitEntry {
             invocation_count: AtomicU32::new(0),
             compile_queued: AtomicBool::new(false),
             native_fn_ptr: AtomicPtr::new(std::ptr::null_mut()),
+            epoch: AtomicU64::new(0),
         }
     }
 }
@@ -84,8 +90,13 @@ fn get_or_create_entry(arity_id: u64) -> Arc<JitEntry> {
         .clone()
 }
 
-/// Return the compiled native function pointer for `arity_id`, if available.
-pub fn get_native_fn(arity_id: u64) -> Option<*const ()> {
+/// Return the compiled native function pointer and its reclamation epoch for
+/// `arity_id`, if native code is currently published.
+///
+/// The caller **must** keep the returned `epoch` live (via [`push_jit_frame`])
+/// for the entire native call, so code unloading at a stop-the-world safepoint
+/// does not free the backing module while it executes.
+pub fn get_native_fn(arity_id: u64) -> Option<(*const (), u64)> {
     let guard = JIT_TABLE.read().unwrap();
     let cache = guard.as_ref()?;
     let entry = cache.get(&arity_id)?;
@@ -93,15 +104,43 @@ pub fn get_native_fn(arity_id: u64) -> Option<*const ()> {
     if ptr.is_null() {
         None
     } else {
-        Some(ptr as *const ())
+        let epoch = entry.epoch.load(Ordering::Acquire);
+        Some((ptr as *const (), epoch))
     }
 }
 
-/// Publish a compiled native function pointer for `arity_id`.
-/// Called by the JIT worker thread after successful compilation.
-pub fn store_native_fn(arity_id: u64, ptr: *const ()) {
+/// Publish a compiled native function pointer and its reclamation epoch for
+/// `arity_id`.  Called by the JIT worker thread after successful compilation.
+///
+/// Stores the epoch before the pointer (release ordering) so that any reader
+/// that observes a non-null pointer also observes the matching epoch.
+pub fn store_native_fn(arity_id: u64, ptr: *const (), epoch: u64) {
     let entry = get_or_create_entry(arity_id);
+    entry.epoch.store(epoch, Ordering::Release);
     entry.native_fn_ptr.store(ptr as *mut (), Ordering::Release);
+}
+
+/// Clear the published native pointer for `arity_id` and return the epoch that
+/// was backing it, if any.
+///
+/// Called when a var holding this function is redefined: future dispatches fall
+/// back to the interpreter immediately (the pointer is nulled), and the
+/// returned epoch is handed to the code cache so the now-superseded module is
+/// reclaimed at the next safepoint once no frame is executing it.  Also drops
+/// the per-arity table entry, keeping `JIT_TABLE` bounded across a long REPL
+/// session of redefinitions.
+pub fn take_native_epoch(arity_id: u64) -> Option<u64> {
+    let mut guard = JIT_TABLE.write().unwrap();
+    let cache = guard.as_mut()?;
+    let entry = cache.remove(&arity_id)?;
+    let ptr = entry
+        .native_fn_ptr
+        .swap(std::ptr::null_mut(), Ordering::AcqRel);
+    if ptr.is_null() {
+        None
+    } else {
+        Some(entry.epoch.load(Ordering::Acquire))
+    }
 }
 
 // ── Enqueue hook ──────────────────────────────────────────────────────────────
@@ -142,6 +181,88 @@ pub fn record_call(arity_id: u64, ir_func: Arc<IrFunction>) {
         cljrs_logging::feat_debug!("jit", "enqueue arity_id={} (count={})", arity_id, count);
         hook(arity_id, ir_func);
     }
+}
+
+// ── Active JIT frame tracking (for code unloading) ──────────────────────────────
+//
+// Code unloading (Phase 10.2) frees a superseded `JITModule` only once no frame
+// is executing its code.  We track that precisely: each in-flight native call
+// pushes its code epoch onto a per-thread stack for the duration of the call.
+//
+// At a stop-the-world safepoint every mutator thread is parked, so the reclaimer
+// can read all threads' stacks to compute the set of epochs that must not be
+// freed.  Cross-thread reads are sound because:
+//   - Each thread mutates only its own stack, and only while running (never
+//     while parked: push/pop bracket the native call and release before any
+//     safepoint poll inside it).
+//   - At STW all other threads are frozen, so their stacks are stable.
+//
+// The per-thread stack lives behind a `Mutex` that is essentially uncontended
+// on the hot path (only the owning thread locks it, briefly); the reclaimer
+// contends for it only at the rare STW safepoint.
+
+struct ThreadFrames {
+    stack: Mutex<Vec<u64>>,
+}
+
+static FRAME_REGISTRY: RwLock<Vec<Weak<ThreadFrames>>> = RwLock::new(Vec::new());
+
+thread_local! {
+    static MY_FRAMES: Arc<ThreadFrames> = {
+        let frames = Arc::new(ThreadFrames { stack: Mutex::new(Vec::new()) });
+        let mut reg = FRAME_REGISTRY.write().unwrap();
+        // Opportunistically drop registrations for threads that have exited.
+        reg.retain(|w| w.strong_count() > 0);
+        reg.push(Arc::downgrade(&frames));
+        frames
+    };
+}
+
+/// RAII guard that pops one active-frame epoch on drop (including on unwind,
+/// e.g. when native code throws back through the dispatch boundary).
+pub struct JitFrameGuard {
+    epoch: u64,
+}
+
+impl Drop for JitFrameGuard {
+    fn drop(&mut self) {
+        MY_FRAMES.with(|f| {
+            let mut stack = f.stack.lock().unwrap();
+            // Pop the matching epoch.  Frames are strictly LIFO, so the epoch
+            // is almost always the top; search defensively in case of nesting.
+            if let Some(pos) = stack.iter().rposition(|&e| e == self.epoch) {
+                stack.remove(pos);
+            }
+        });
+    }
+}
+
+/// Register that this thread is about to enter native code backed by `epoch`.
+///
+/// Returns a guard that unregisters the frame on drop.  Must wrap the native
+/// call so code unloading never frees a module that is executing.
+pub fn push_jit_frame(epoch: u64) -> JitFrameGuard {
+    MY_FRAMES.with(|f| f.stack.lock().unwrap().push(epoch));
+    JitFrameGuard { epoch }
+}
+
+/// Collect the set of epochs with at least one active native frame across all
+/// mutator threads.
+///
+/// **Must be called at a stop-the-world safepoint** (all other mutator threads
+/// parked), so each thread's frame stack is stable while it is read.  Used by
+/// the JIT code cache to decide which stale modules are safe to free.
+pub fn live_epochs() -> HashSet<u64> {
+    let mut live = HashSet::new();
+    let reg = FRAME_REGISTRY.read().unwrap();
+    for weak in reg.iter() {
+        if let Some(frames) = weak.upgrade() {
+            for &epoch in frames.stack.lock().unwrap().iter() {
+                live.insert(epoch);
+            }
+        }
+    }
+    live
 }
 
 // ── JIT function dispatch ─────────────────────────────────────────────────────
@@ -242,5 +363,48 @@ pub unsafe fn dispatch_jit_call(fn_ptr: *const (), args: &[*const Value]) -> *co
             }
             n => panic!("JIT dispatch: unsupported arity {n} (max 8 in Phase 10.1)"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_round_trips_through_store_get_take() {
+        // Use sentinel ids/ptrs unlikely to collide with concurrent tests.
+        let id = 0xF100_0001;
+        let ptr = 0x1234usize as *const ();
+        store_native_fn(id, ptr, 777);
+        assert_eq!(get_native_fn(id), Some((ptr, 777)));
+        // take returns the epoch and removes the entry.
+        assert_eq!(take_native_epoch(id), Some(777));
+        assert_eq!(get_native_fn(id), None);
+        assert_eq!(take_native_epoch(id), None);
+    }
+
+    #[test]
+    fn frame_guard_marks_epoch_live_then_clears() {
+        let e = 0xBEEF_0001;
+        assert!(!live_epochs().contains(&e));
+        let guard = push_jit_frame(e);
+        assert!(live_epochs().contains(&e));
+        drop(guard);
+        assert!(!live_epochs().contains(&e));
+    }
+
+    #[test]
+    fn nested_frames_pop_in_lifo_order() {
+        let a = 0xBEEF_1001;
+        let b = 0xBEEF_1002;
+        let ga = push_jit_frame(a);
+        let gb = push_jit_frame(b);
+        let live = live_epochs();
+        assert!(live.contains(&a) && live.contains(&b));
+        drop(gb);
+        assert!(live_epochs().contains(&a));
+        assert!(!live_epochs().contains(&b));
+        drop(ga);
+        assert!(!live_epochs().contains(&a));
     }
 }

--- a/crates/cljrs-eval/src/lib.rs
+++ b/crates/cljrs-eval/src/lib.rs
@@ -28,7 +28,7 @@ pub mod lower;
 pub use cljrs_env::callback::invoke;
 pub use cljrs_env::env::{Env, GlobalEnv};
 pub use cljrs_env::error::{EvalError, EvalResult};
-pub use cljrs_env::gc_roots::force_collect;
+pub use cljrs_env::gc_roots::{force_collect, set_stw_reclaim_hook};
 pub use cljrs_env::loader::load_ns;
 pub use cljrs_interp::eval::eval;
 

--- a/crates/cljrs-jit/Cargo.toml
+++ b/crates/cljrs-jit/Cargo.toml
@@ -27,3 +27,7 @@ cranelift-frontend = { workspace = true }
 cranelift-module   = { workspace = true }
 cranelift-jit      = { workspace = true }
 cranelift-native   = { workspace = true }
+
+[dev-dependencies]
+cljrs-stdlib = { workspace = true }
+cljrs-reader = { workspace = true }

--- a/crates/cljrs-jit/README.md
+++ b/crates/cljrs-jit/README.md
@@ -1,19 +1,23 @@
 # cljrs-jit
 
-**Purpose:** In-process JIT compiler (Phase 10.1) that compiles hot clojurust
-functions to native code via Cranelift, making `cljrs run` and the REPL
-approach AOT-class throughput with no explicit compile step.
+**Purpose:** In-process JIT compiler that compiles hot clojurust functions to
+native code via Cranelift, making `cljrs run` and the REPL approach AOT-class
+throughput with no explicit compile step.
 
-**Status:** Phase 10.1 — functional for non-capturing, non-variadic,
-non-destructuring top-level `defn`s (the same set that Tier-1 handles).
+**Status:** Phase 10.2 — functional for non-capturing, non-variadic,
+non-destructuring top-level `defn`s (the same set that Tier-1 handles), with
+epoch-tagged **code unloading**: redefined functions' native code is reclaimed
+at stop-the-world GC safepoints, keeping executable memory bounded across a long
+REPL session.
 
 ## File layout
 
 | File | Description |
 |------|-------------|
-| `src/lib.rs` | Public API: `init()` — installs the enqueue hook and spawns the worker |
-| `src/jit_compiler.rs` | `compile_jit(arity_id, ir_func)` — builds `JITModule`, registers rt_abi symbols, calls shared codegen |
-| `src/jit_worker.rs` | Background worker thread: receives `CompileRequest`s, publishes results to `cljrs_eval::jit_state` |
+| `src/lib.rs` | Public API: `init()` — installs the enqueue, var-rebind, and STW-reclaim hooks and spawns the worker; `on_var_rebind`/`arity_ids` drive staling on redefinition |
+| `src/jit_compiler.rs` | `compile_jit(arity_id, ir_func)` — builds `JITModule`, registers rt_abi symbols, calls shared codegen; returns `CompiledFn { fn_ptr, module, code_size }` |
+| `src/jit_worker.rs` | Background worker thread: receives `CompileRequest`s, registers each module in `code_cache`, publishes the function pointer + epoch to `cljrs_eval::jit_state` |
+| `src/code_cache.rs` | Epoch-tagged registry of compiled modules; `mark_stale` on redefinition, `reclaim_at_stw` frees stale modules with no live frame via `JITModule::free_memory` |
 
 ## Public API
 
@@ -21,6 +25,13 @@ non-destructuring top-level `defn`s (the same set that Tier-1 handles).
 /// Initialise the JIT tier. Call once at process startup.
 /// Idempotent; safe to call multiple times.
 pub fn init();
+
+/// code_cache — code unloading (Phase 10.2)
+pub fn reclaim_at_stw() -> usize;   // free stale modules with no live frame (STW only)
+pub fn live_count() -> usize;       // live (in-use) modules
+pub fn stale_count() -> usize;      // modules awaiting reclamation
+pub fn reclaimed_count() -> u64;    // cumulative modules freed
+pub fn reclaimed_bytes() -> u64;    // cumulative machine-code bytes freed
 ```
 
 ## Execution tiers (after `init()`)
@@ -45,5 +56,24 @@ call_cljrs_fn
 - JIT-compiled code calls `rt_safepoint()` at function entry and loop back-edges.
 - The Tier-1 dispatch path roots argument slices via `cljrs_env::gc_roots::root_values`
   before entering native code, so GC STW scans find all live `Value`s.
-- Code unloading (Phase 10.2): `JITModule`s are kept alive in the worker thread
-  for the process lifetime; epoch-tagged reclamation at STW safepoints is deferred.
+
+## Code unloading (Phase 10.2)
+
+Emitted code holds no GC pointers (constants are materialized via `rt_abi`
+runtime calls), so a module can be freed without disturbing the heap. The
+lifecycle of a compiled arity's native code:
+
+1. **Compile & publish.** The worker compiles the module, `code_cache::register`
+   assigns it a monotonic **epoch** and takes ownership, and the worker publishes
+   `(fn_ptr, epoch)` into the `cljrs_eval::jit_state` dispatch table.
+2. **Track frames.** Each native call pushes its epoch onto a per-thread stack
+   (`jit_state::push_jit_frame`) for the duration of the call.
+3. **Stale on redefinition.** When a var holding the function is rebound, the
+   value layer's rebind hook (`cljrs_value::set_var_rebind_hook` →
+   `on_var_rebind`) nulls the dispatch pointer (future calls fall back to the
+   interpreter) and calls `code_cache::mark_stale(epoch)`.
+4. **Reclaim at STW.** `code_cache::reclaim_at_stw` runs at the existing
+   stop-the-world GC safepoint (installed via `cljrs_eval::set_stw_reclaim_hook`).
+   With all mutators parked, it scans active frames across all threads
+   (`jit_state::live_epochs`) and frees every stale module whose epoch has **no**
+   live frame — resolving the unload-vs-execute race without a separate protocol.

--- a/crates/cljrs-jit/src/code_cache.rs
+++ b/crates/cljrs-jit/src/code_cache.rs
@@ -1,0 +1,307 @@
+//! Epoch-tagged registry of compiled JIT code, with stop-the-world reclamation
+//! (Phase 10.2 — code unloading).
+//!
+//! ## Why this exists
+//!
+//! The REPL re-runs `defn` constantly; each redefinition produces a fresh
+//! `CljxFn` arity (new `ir_arity_id`) and orphans the previous one's native
+//! code.  Without reclamation, executable memory grows unbounded across a long
+//! session.  `cranelift-jit` never frees a module's code on drop — the memory
+//! must be released explicitly via [`JITModule::free_memory`], which is only
+//! sound once no `fn` pointer into that module will be called again.
+//!
+//! ## How reclamation stays safe
+//!
+//! Every compiled module is tagged with a monotonically increasing **epoch**
+//! and stored here.  Two events drive its lifecycle:
+//!
+//! - **Redefinition** ([`mark_stale`]): when a var holding a function is
+//!   rebound, the value layer's rebind hook nulls the dispatch pointer (so no
+//!   *new* call reaches the old code) and moves the old epoch to the stale set.
+//! - **Safepoint reclaim** ([`reclaim_at_stw`]): at the existing stop-the-world
+//!   GC safepoint — when every mutator thread is parked — we scan all active JIT
+//!   frames ([`cljrs_eval::jit_state::live_epochs`]).  A stale epoch with **no**
+//!   live frame can have no in-flight and no future caller, so its module memory
+//!   is freed.  This piggybacks on the GC's quiescent point and sidesteps the
+//!   unload-vs-execute race without a separate protocol.
+//!
+//! Because emitted code embeds no GC pointers (constants are materialized via
+//! `rt_abi` runtime calls), freeing a module never disturbs the heap.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use crate::jit_compiler::CompiledFn;
+
+/// Monotonic epoch source.  Never reused, so an epoch uniquely identifies one
+/// compiled module for the life of the process.
+static NEXT_EPOCH: AtomicU64 = AtomicU64::new(1);
+
+/// One entry in the registry: the owning module plus accounting metadata.
+struct CodeRecord {
+    /// The arity this code was compiled for (diagnostics only).
+    arity_id: u64,
+    compiled: CompiledFn,
+}
+
+#[derive(Default)]
+struct CacheState {
+    /// Current, in-use compiled code, keyed by epoch.
+    live: HashMap<u64, CodeRecord>,
+    /// Superseded code awaiting reclamation, keyed by epoch.
+    stale: HashMap<u64, CodeRecord>,
+    /// Cumulative count of modules whose memory has been freed.
+    reclaimed_count: u64,
+    /// Cumulative bytes of machine code freed.
+    reclaimed_bytes: u64,
+}
+
+fn cache() -> &'static Mutex<CacheState> {
+    static CACHE: OnceLock<Mutex<CacheState>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(CacheState::default()))
+}
+
+/// Register a freshly compiled module, returning its reclamation epoch.
+///
+/// The epoch is published into the dispatch table alongside the function
+/// pointer (see the worker), so a later [`mark_stale`] can find this module.
+pub(crate) fn register(arity_id: u64, compiled: CompiledFn) -> u64 {
+    let epoch = NEXT_EPOCH.fetch_add(1, Ordering::Relaxed);
+    let mut state = cache().lock().unwrap();
+    state.live.insert(epoch, CodeRecord { arity_id, compiled });
+    epoch
+}
+
+/// Move the module for `epoch` from the live set to the stale set, scheduling it
+/// for reclamation at the next safepoint.  No-op if the epoch is unknown or
+/// already stale.
+pub(crate) fn mark_stale(epoch: u64) {
+    let mut state = cache().lock().unwrap();
+    if let Some(record) = state.live.remove(&epoch) {
+        cljrs_logging::feat_debug!(
+            "jit",
+            "mark stale epoch={} arity_id={} ({} bytes)",
+            epoch,
+            record.arity_id,
+            record.compiled.code_size,
+        );
+        state.stale.insert(epoch, record);
+    }
+}
+
+/// Decide which stale epochs are safe to free: those with no active frame.
+///
+/// Factored out as a pure function over epoch sets so the safety rule is
+/// directly unit-testable without constructing real modules.
+fn select_reclaimable(stale_epochs: &HashSet<u64>, live_frames: &HashSet<u64>) -> Vec<u64> {
+    stale_epochs
+        .iter()
+        .copied()
+        .filter(|e| !live_frames.contains(e))
+        .collect()
+}
+
+/// Reclaim stale modules with no live frame.  **Must be called at a
+/// stop-the-world safepoint** (all mutator threads parked) so the active-frame
+/// scan is stable and no freed pointer can be entered afterward.
+///
+/// Returns the number of modules freed this pass.
+pub fn reclaim_at_stw() -> usize {
+    let live_frames = cljrs_eval::jit_state::live_epochs();
+    let mut state = cache().lock().unwrap();
+
+    let stale_epochs: HashSet<u64> = state.stale.keys().copied().collect();
+    let to_free = select_reclaimable(&stale_epochs, &live_frames);
+
+    let mut freed = 0usize;
+    for epoch in to_free {
+        if let Some(record) = state.stale.remove(&epoch) {
+            let bytes = record.compiled.code_size as u64;
+            // SAFETY: the module is stale (its dispatch pointer was nulled in
+            // `mark_stale`, so no new call can reach it) and no frame is
+            // executing its code (epoch ∉ live_frames, computed at STW with all
+            // mutators parked).  Therefore no `fn` pointer into this module is
+            // in use or will be used again.
+            unsafe {
+                record.compiled.module.free_memory();
+            }
+            state.reclaimed_count += 1;
+            state.reclaimed_bytes += bytes;
+            freed += 1;
+            cljrs_logging::feat_debug!(
+                "jit",
+                "reclaimed epoch={} arity_id={} ({} bytes)",
+                epoch,
+                record.arity_id,
+                bytes,
+            );
+        }
+    }
+    if freed > 0 {
+        cljrs_logging::feat_debug!(
+            "jit",
+            "reclaim pass freed {} module(s); {} live, {} still-stale",
+            freed,
+            state.live.len(),
+            state.stale.len(),
+        );
+    }
+    freed
+}
+
+// ── Diagnostics / test accessors ────────────────────────────────────────────
+
+/// Number of live (in-use) compiled modules.
+pub fn live_count() -> usize {
+    cache().lock().unwrap().live.len()
+}
+
+/// Number of stale modules awaiting reclamation.
+pub fn stale_count() -> usize {
+    cache().lock().unwrap().stale.len()
+}
+
+/// Cumulative number of modules whose memory has been freed.
+pub fn reclaimed_count() -> u64 {
+    cache().lock().unwrap().reclaimed_count
+}
+
+/// Cumulative bytes of machine code freed.
+pub fn reclaimed_bytes() -> u64 {
+    cache().lock().unwrap().reclaimed_bytes
+}
+
+// ── Test-only inspection helpers ────────────────────────────────────────────
+
+/// True if `epoch` is currently in the stale (awaiting-reclamation) set.
+#[cfg(test)]
+pub(crate) fn is_stale(epoch: u64) -> bool {
+    cache().lock().unwrap().stale.contains_key(&epoch)
+}
+
+/// True if `epoch` is currently in the live set.
+#[cfg(test)]
+pub(crate) fn is_live(epoch: u64) -> bool {
+    cache().lock().unwrap().live.contains_key(&epoch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reclaimable_excludes_live_frames() {
+        let stale: HashSet<u64> = [1, 2, 3, 4].into_iter().collect();
+        let live: HashSet<u64> = [2, 4].into_iter().collect();
+        let mut got = select_reclaimable(&stale, &live);
+        got.sort_unstable();
+        assert_eq!(
+            got,
+            vec![1, 3],
+            "only stale epochs without a live frame free"
+        );
+    }
+
+    #[test]
+    fn reclaimable_empty_when_all_live() {
+        let stale: HashSet<u64> = [5, 6].into_iter().collect();
+        let live: HashSet<u64> = [5, 6, 7].into_iter().collect();
+        assert!(select_reclaimable(&stale, &live).is_empty());
+    }
+
+    #[test]
+    fn reclaimable_all_when_none_live() {
+        let stale: HashSet<u64> = [8, 9].into_iter().collect();
+        let live: HashSet<u64> = HashSet::new();
+        let mut got = select_reclaimable(&stale, &live);
+        got.sort_unstable();
+        assert_eq!(got, vec![8, 9]);
+    }
+}
+
+/// End-to-end reclamation test over *real* compiled modules: a redefinition
+/// stales native code, an executing frame defers its release, and the next
+/// safepoint frees it (calling `JITModule::free_memory`).
+///
+/// Gated to the default GC build: under `no-gc`, `lower_via_rust` runs the
+/// escape-blacklist check which can reject otherwise-fine functions.
+#[cfg(all(test, not(feature = "no-gc")))]
+mod reclaim_integration {
+    use std::sync::Arc;
+
+    /// Lower a tiny function to IR on a generously sized stack (Clojure eval is
+    /// deeply recursive), mirroring the codegen-crate test helper.
+    fn build_ir(name: &str, params: &[Arc<str>], body_src: &str) -> cljrs_ir::IrFunction {
+        let name = name.to_string();
+        let params = params.to_vec();
+        let body_src = body_src.to_string();
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || {
+                let mut parser = cljrs_reader::Parser::new(body_src, "<jit-test>".to_string());
+                let mut forms = Vec::new();
+                while let Ok(Some(f)) = parser.parse_one() {
+                    forms.push(f);
+                }
+                let globals = cljrs_stdlib::standard_env();
+                let mut env = cljrs_eval::Env::new(globals, "user");
+                cljrs_compiler::aot::lower_via_rust(Some(&name), "user", &params, &forms, &mut env)
+                    .expect("lowering should succeed")
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+    }
+
+    #[test]
+    fn redefinition_reclaims_native_code_only_when_no_frame_is_live() {
+        let ir = build_ir("f", &[Arc::from("x")], "(+ x 1)");
+        let arity_id = 0xC0DE_0001u64;
+
+        // Emulate the worker: compile, register (→ epoch), publish ptr + epoch.
+        let compiled = crate::jit_compiler::compile_jit(arity_id, &ir).unwrap();
+        let fn_ptr = compiled.fn_ptr;
+        let epoch = crate::code_cache::register(arity_id, compiled);
+        cljrs_eval::jit_state::store_native_fn(arity_id, fn_ptr, epoch);
+        assert!(crate::code_cache::is_live(epoch));
+        assert_eq!(
+            cljrs_eval::jit_state::get_native_fn(arity_id),
+            Some((fn_ptr, epoch)),
+            "dispatch table should resolve to the compiled code + epoch",
+        );
+
+        // Emulate redefinition: the rebind hook nulls dispatch and stales the
+        // old epoch.
+        let taken = cljrs_eval::jit_state::take_native_epoch(arity_id).unwrap();
+        assert_eq!(taken, epoch);
+        assert_eq!(
+            cljrs_eval::jit_state::get_native_fn(arity_id),
+            None,
+            "future calls must no longer dispatch to stale code",
+        );
+        crate::code_cache::mark_stale(epoch);
+        assert!(crate::code_cache::is_stale(epoch));
+        assert!(!crate::code_cache::is_live(epoch));
+
+        // A frame executing this epoch defers reclamation.
+        {
+            let _frame = cljrs_eval::jit_state::push_jit_frame(epoch);
+            crate::code_cache::reclaim_at_stw();
+            assert!(
+                crate::code_cache::is_stale(epoch),
+                "must not free code while a frame is executing it",
+            );
+        }
+
+        // With no live frame, the next safepoint reclaim frees the module.
+        let before = crate::code_cache::reclaimed_count();
+        let freed = crate::code_cache::reclaim_at_stw();
+        assert!(
+            freed >= 1,
+            "stale module with no live frame should be freed"
+        );
+        assert!(!crate::code_cache::is_stale(epoch));
+        assert!(crate::code_cache::reclaimed_count() > before);
+    }
+}

--- a/crates/cljrs-jit/src/jit_compiler.rs
+++ b/crates/cljrs-jit/src/jit_compiler.rs
@@ -9,17 +9,21 @@ use cljrs_ir::IrFunction;
 
 /// A successfully compiled JIT function.
 ///
-/// The `JITModule` inside owns the executable memory; it must remain alive
-/// for as long as `fn_ptr` may be called.  Phase 10.2 implements unloading.
+/// The `JITModule` inside owns the executable memory; it must remain alive for
+/// as long as `fn_ptr` may be called.  The code cache (`code_cache.rs`) takes
+/// ownership and, once the code is stale and no frame executes it, reclaims the
+/// memory via [`JITModule::free_memory`] at a stop-the-world safepoint.
 pub(crate) struct CompiledFn {
     pub(crate) fn_ptr: *const (),
-    /// Keeps the executable memory alive.
-    pub(crate) _module: JITModule,
+    /// Owns the executable memory; reclaimed via `module.free_memory()`.
+    pub(crate) module: JITModule,
+    /// Machine-code size in bytes (for memory accounting / diagnostics).
+    pub(crate) code_size: u32,
 }
 
-// SAFETY: `fn_ptr` points into `JITModule`'s memory-mapped code section.
-// The JITModule is stored alongside the pointer and never freed here.
-// The function can be called from any thread that holds the pointer.
+// SAFETY: `fn_ptr` points into `JITModule`'s memory-mapped code section, which
+// the owned `JITModule` keeps alive.  The function can be called from any thread
+// that holds the pointer; the module is `Send`.
 unsafe impl Send for CompiledFn {}
 
 /// Compile `ir_func` to native code, returning the function pointer and the
@@ -50,6 +54,8 @@ pub(crate) fn compile_jit(arity_id: u64, ir_func: &IrFunction) -> Result<Compile
         .compile_function(ir_func, func_id)
         .map_err(|e| format!("compile_function: {e:?}"))?;
 
+    let code_size = compiler.last_code_size();
+
     let mut jit_module = compiler.into_inner_module();
 
     jit_module
@@ -60,7 +66,8 @@ pub(crate) fn compile_jit(arity_id: u64, ir_func: &IrFunction) -> Result<Compile
 
     Ok(CompiledFn {
         fn_ptr,
-        _module: jit_module,
+        module: jit_module,
+        code_size,
     })
 }
 

--- a/crates/cljrs-jit/src/jit_worker.rs
+++ b/crates/cljrs-jit/src/jit_worker.rs
@@ -1,19 +1,20 @@
 //! Background JIT compilation worker thread.
 //!
 //! Receives compilation requests on a channel, compiles each `IrFunction` via
-//! Cranelift, and atomically publishes the result via
+//! Cranelift, hands the module to the epoch-tagged [`code_cache`](crate::code_cache),
+//! and atomically publishes the resulting function pointer + epoch via
 //! `cljrs_eval::jit_state::store_native_fn`.
 //!
-//! The compiled `JITModule`s are kept in a local `Vec` on the worker thread
-//! for the lifetime of the process.  Phase 10.2 will add epoch-tagged
-//! unloading at STW safepoints.
+//! Ownership of every compiled `JITModule` lives in the `code_cache`, which
+//! reclaims superseded modules at stop-the-world safepoints (Phase 10.2).
 
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 
 use cljrs_ir::IrFunction;
 
-use crate::jit_compiler::{CompiledFn, compile_jit};
+use crate::code_cache;
+use crate::jit_compiler::compile_jit;
 
 pub(crate) struct CompileRequest {
     pub(crate) arity_id: u64,
@@ -29,26 +30,25 @@ pub(crate) fn start_worker(rx: Receiver<CompileRequest>) {
 }
 
 fn worker_loop(rx: Receiver<CompileRequest>) {
-    // Keep JITModules alive here so their executable memory is never freed.
-    // Function pointers stored in jit_state remain valid for the process lifetime.
-    // Phase 10.2 implements proper reclamation.
-    let mut live: Vec<CompiledFn> = Vec::new();
-
     for req in &rx {
         cljrs_logging::feat_debug!("jit", "compiling arity_id={}", req.arity_id);
 
         match compile_jit(req.arity_id, &req.ir_func) {
             Ok(compiled) => {
+                let fn_ptr = compiled.fn_ptr;
+                // Hand ownership of the module to the code cache; it returns the
+                // epoch that identifies this code for later reclamation.
+                let epoch = code_cache::register(req.arity_id, compiled);
                 cljrs_logging::feat_debug!(
                     "jit",
-                    "compiled  arity_id={} fn_ptr={:p}",
+                    "compiled  arity_id={} epoch={} fn_ptr={:p}",
                     req.arity_id,
-                    compiled.fn_ptr,
+                    epoch,
+                    fn_ptr,
                 );
-                // Atomically publish the function pointer so future calls
-                // on the main thread skip the interpreter.
-                cljrs_eval::jit_state::store_native_fn(req.arity_id, compiled.fn_ptr);
-                live.push(compiled);
+                // Atomically publish the function pointer + epoch so future
+                // calls on mutator threads skip the interpreter.
+                cljrs_eval::jit_state::store_native_fn(req.arity_id, fn_ptr, epoch);
             }
             Err(e) => {
                 cljrs_logging::feat_debug!("jit", "compile error arity_id={}: {}", req.arity_id, e,);
@@ -56,6 +56,4 @@ fn worker_loop(rx: Receiver<CompileRequest>) {
             }
         }
     }
-    // Channel closed (program exit) → drop JITModules.
-    drop(live);
 }

--- a/crates/cljrs-jit/src/lib.rs
+++ b/crates/cljrs-jit/src/lib.rs
@@ -26,11 +26,14 @@
 //! `CLJRS_JIT_THRESHOLD`, default 1000) are compiled in the background;
 //! subsequent calls dispatch directly to native code.
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
 
 use cljrs_ir::IrFunction;
+use cljrs_value::Value;
 
+pub mod code_cache;
 mod jit_compiler;
 mod jit_worker;
 
@@ -61,6 +64,51 @@ pub fn init() {
         let _ = tx.try_send(jit_worker::CompileRequest { arity_id, ir_func });
     });
 
+    // Code unloading (Phase 10.2):
+    //
+    // 1. When a var holding a function is redefined, mark the old definition's
+    //    compiled arities stale and stop dispatching to them.
+    cljrs_value::set_var_rebind_hook(on_var_rebind);
+    // 2. At each stop-the-world GC safepoint, reclaim stale modules that no
+    //    frame is executing.
+    cljrs_eval::set_stw_reclaim_hook(|| {
+        code_cache::reclaim_at_stw();
+    });
+
     // Spawn the background compilation thread.
     jit_worker::start_worker(rx);
+}
+
+/// Var-rebind hook: stale the native code of any arity that the *old* function
+/// value carried but the *new* value does not.
+///
+/// Nulling the dispatch pointer ([`jit_state::take_native_epoch`]) makes future
+/// calls fall back to the interpreter immediately; the returned epoch is handed
+/// to the code cache for reclamation once no frame is executing it.
+fn on_var_rebind(old: &Value, new: &Value) {
+    let old_fn = match old {
+        Value::Fn(f) => f,
+        _ => return,
+    };
+    // Arities still present in the new binding must not be staled (e.g. when a
+    // var is rebound to the same function object).
+    let new_ids: HashSet<u64> = arity_ids(new);
+    for arity in &old_fn.get().arities {
+        let id = arity.ir_arity_id;
+        if new_ids.contains(&id) {
+            continue;
+        }
+        if let Some(epoch) = cljrs_eval::jit_state::take_native_epoch(id) {
+            code_cache::mark_stale(epoch);
+        }
+    }
+}
+
+/// Collect the set of `ir_arity_id`s carried by a function value (empty for
+/// non-function values).
+fn arity_ids(value: &Value) -> HashSet<u64> {
+    match value {
+        Value::Fn(f) => f.get().arities.iter().map(|a| a.ir_arity_id).collect(),
+        _ => HashSet::new(),
+    }
 }

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -24,6 +24,7 @@ src/
   error.rs                       — ValueError enum, ValueResult<T> alias
   hash.rs                        — ClojureHash trait, Murmur3 helpers, JVM-compatible hash_string
   intern.rs                      — (Phase B3) global keyword/symbol intern tables backed by StaticGcPtr; intern_keyword, intern_symbol
+  jit_hooks.rs                   — (Phase 10.2) var-rebind hook the JIT installs to stale superseded native code; set_var_rebind_hook, notify_var_rebind (fired by Var::bind)
   keyword.rs                     — Keyword { namespace, name }
   shared.rs                      — (Phase B3) SharedValue enum, SharedAtom (Arc<ArcSwap<SharedValue>>), promote/demote; PromoteError
   symbol.rs                      — Symbol { namespace, name }
@@ -239,6 +240,18 @@ pub struct CljxFn {
 `is_async` is set by the interpreter when a `fn`/`defn` carries `^:async` (or an
 `{:async true}` attr-map). `CljxFn::new` defaults it to `false`; `cljrs-env`'s
 `dispatch_if_async` checks it at call time.
+
+### JIT rebind hook (`jit_hooks`, Phase 10.2)
+
+```rust
+/// Installed once by cljrs_jit::init. Called with (old_value, new_value).
+pub fn set_var_rebind_hook(f: impl Fn(&Value, &Value) + Send + Sync + 'static);
+```
+
+`Var::bind` invokes the hook (via `notify_var_rebind`) whenever it overwrites an
+existing binding, so the JIT can stale and reclaim native code compiled for a
+superseded function definition. When no JIT is active the cost is a single
+relaxed atomic load.
 
 ### `Namespace` (Phase 4)
 

--- a/crates/cljrs-value/src/clone.rs
+++ b/crates/cljrs-value/src/clone.rs
@@ -711,7 +711,7 @@ mod tests {
 
     #[test]
     fn fn_not_shareable() {
-        use crate::types::{Arity, CljxFn, NativeFn};
+        use crate::types::{Arity, NativeFn};
         let nf = Value::NativeFunction(GcPtr::new(NativeFn::new("test", Arity::Fixed(0), |_| {
             Ok(Value::Nil)
         })));

--- a/crates/cljrs-value/src/jit_hooks.rs
+++ b/crates/cljrs-value/src/jit_hooks.rs
@@ -1,0 +1,44 @@
+//! Cross-layer hooks the JIT installs into the value layer.
+//!
+//! The JIT tier (`cljrs-jit`) needs to learn when a var is rebound so it can
+//! mark the previous definition's compiled native code *stale* and reclaim it
+//! at the next stop-the-world safepoint (Phase 10.2 — code unloading).
+//!
+//! `cljrs-value` sits far below `cljrs-jit` in the dependency graph, so the
+//! coupling is inverted through a function-pointer hook: the JIT installs a
+//! callback via [`set_var_rebind_hook`], and [`Var::bind`](crate::types::Var::bind)
+//! invokes it (through [`notify_var_rebind`]) whenever it overwrites an existing
+//! binding.  When no JIT is active the hook is unset and the cost is a single
+//! relaxed atomic load.
+
+use std::sync::OnceLock;
+
+use crate::Value;
+
+/// Callback signature: `(old_value, new_value)`.
+///
+/// Called with the value being replaced and the value replacing it, so the
+/// implementation can stale only the definitions that are genuinely going away
+/// (an arity present in both `old` and `new` — e.g. rebinding a var to the same
+/// function object — must not be staled).
+type VarRebindHook = Box<dyn Fn(&Value, &Value) + Send + Sync + 'static>;
+
+static VAR_REBIND_HOOK: OnceLock<VarRebindHook> = OnceLock::new();
+
+/// Install the var-rebind hook.  Idempotent: only the first call wins.
+///
+/// Installed once by `cljrs_jit::init`.
+pub fn set_var_rebind_hook(f: impl Fn(&Value, &Value) + Send + Sync + 'static) {
+    let _ = VAR_REBIND_HOOK.set(Box::new(f));
+}
+
+/// Notify the JIT that a var holding `old` is being rebound to `new`.
+///
+/// No-op (one atomic load) when no hook is installed.  Called from
+/// `Var::bind` only when an existing value is being replaced.
+#[inline]
+pub(crate) fn notify_var_rebind(old: &Value, new: &Value) {
+    if let Some(hook) = VAR_REBIND_HOOK.get() {
+        hook(old, new);
+    }
+}

--- a/crates/cljrs-value/src/lib.rs
+++ b/crates/cljrs-value/src/lib.rs
@@ -4,6 +4,7 @@ pub mod collections;
 pub mod error;
 pub mod hash;
 pub mod intern;
+pub mod jit_hooks;
 pub mod keyword;
 pub mod native_object;
 pub mod regex;
@@ -20,6 +21,7 @@ pub use collections::{
 pub use error::{ExceptionInfo, ValueError, ValueResult};
 pub use hash::ClojureHash;
 pub use intern::{intern_keyword, intern_symbol};
+pub use jit_hooks::set_var_rebind_hook;
 pub use keyword::Keyword;
 pub use native_object::{NativeObject, NativeObjectBox, gc_native_object};
 pub use resource::{Resource, ResourceHandle};

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -251,7 +251,18 @@ impl Var {
             self.namespace,
             self.name
         );
-        *self.value.lock().unwrap() = Some(v);
+        // Replace the binding, holding the lock only across the swap.  The
+        // previous value (if any) is handed to the JIT rebind hook so it can
+        // reclaim native code compiled for a now-superseded definition
+        // (Phase 10.2 — code unloading).  `v.clone()` is O(1) for the only
+        // values that carry compiled code (`Value::Fn`, a `GcPtr` clone).
+        let prev = {
+            let mut slot = self.value.lock().unwrap();
+            slot.replace(v.clone())
+        };
+        if let Some(prev) = prev {
+            crate::jit_hooks::notify_var_rebind(&prev, &v);
+        }
     }
 
     pub fn get_meta(&self) -> Option<Value> {


### PR DESCRIPTION
Reclaims native code for redefined functions so executable memory stays
bounded across a long REPL/script session, instead of leaking every
superseded JITModule for the process lifetime.

Lifecycle of a compiled arity's code:
- Compile & publish: the worker hands the module to a new epoch-tagged
  code cache (cljrs-jit/code_cache.rs), which assigns a monotonic epoch
  and takes ownership; the worker publishes (fn_ptr, epoch) into the
  jit_state dispatch table.
- Track frames: each native call brackets itself with
  jit_state::push_jit_frame(epoch), recording the executing epoch on a
  per-thread stack.
- Stale on redefinition: Var::bind fires a var-rebind hook
  (cljrs-value/jit_hooks.rs); cljrs-jit's on_var_rebind nulls the
  dispatch pointer (future calls fall back to the interpreter) and marks
  the old epoch stale.
- Reclaim at STW: reclaim_at_stw runs inside the existing stop-the-world
  GC safepoint (via cljrs-env set_stw_reclaim_hook). With all mutators
  parked it scans active frames across threads (live_epochs) and frees
  every stale module with no live frame via JITModule::free_memory,
  resolving the unload-vs-execute race without a separate protocol.

Emitted code embeds no GC pointers, so freeing a module never disturbs
the heap. codegen now captures per-function machine-code size for memory
accounting.

Tests: pure reclaim-selection logic; frame tracking + epoch round-trip;
and a real compile -> stale -> deferred-while-frame-live -> free
integration test. Verified at runtime under -X debug:jit with frequent
GC: redefinitions compile, stale, and reclaim with bounded live/stale
sets and reused code addresses.

https://claude.ai/code/session_01FWJa36SLcpkoGyaZHZk3gy