### PR TITLE
JIT phase 10.4: OSR-entry IR transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ name = "cljrs-jit"
 version = "0.1.0"
 dependencies = [
  "cljrs-compiler",
+ "cljrs-env",
  "cljrs-eval",
  "cljrs-gc",
  "cljrs-ir",

--- a/TODO.md
+++ b/TODO.md
@@ -411,8 +411,8 @@ Foundations already in place:
 
 ### Phase 10.4 — OSR (on-stack replacement)
 
-- [ ] Loop back-edge counters at loop headers
-- [ ] OSR-entry compilation (entry block = loop header; live-ins as params) and mid-loop transfer of the interpreter register file into the native frame — promotes single-call hot loops typical of scripts/REPL
+- [x] Loop back-edge counters at loop headers — `interpret_ir_with_osr` counts `RecurJump`s per header within one execution (lazily allocated; straight-line code pays nothing); crossing `osr_threshold()` (override → `CLJRS_OSR_THRESHOLD` → JIT threshold) issues an idempotent `jit_state::osr_request` to the background worker. Per-execution counting is deliberate: hot-within-one-call is exactly the case invocation tiering misses; loops spread over many short calls are already covered by the invocation counter
+- [x] OSR-entry compilation (entry block = loop header; live-ins as params) and mid-loop transfer of the interpreter register file into the native frame — `cljrs_ir::osr::build_osr_function` keeps the blocks reachable from the header, rewires header φs to take an extra edge from a fresh entry block (loop variables arrive as fresh params), passes other pre-loop values as params bound to their original `VarId`s, and drops `RegionEnd`s whose `RegionStart` ran in the interpreter (the interpreter frame closes those regions after the transfer). The worker compiles the variant through the ordinary backend, registers it under its own reclamation epoch (rebind staling covers OSR epochs via `take_osr_epochs`), and publishes `(fn_ptr, epoch, live_ins)`; the interpreter polls at loop-header entry (after φ resolution) and, on `Ready`, snapshots the live-in registers and calls native code with the same rooting + frame-epoch protocol as ordinary JIT-native calls. *Milestone holds:* a single-call 2M-iteration `loop`/`recur` script promotes to native mid-run (`crates/cljrs/tests/osr_promotion.rs`); any transform/compile failure marks the slot failed and the loop finishes at Tier 1
 
 ### Phase 10.5 — Context-driven bump allocation
 

--- a/crates/cljrs-eval/README.md
+++ b/crates/cljrs-eval/README.md
@@ -28,12 +28,14 @@ src/
   lib.rs          — module declarations, re-exports, standard_env_minimal/standard_env/standard_env_with_paths,
                     register_compiler_sources, ensure_compiler_loaded
   apply.rs        — IR-aware function dispatch: tries IR cache, falls back to cljrs_interp::apply
-  ir_interp.rs    — tier-1 IR interpreter: executes IrFunction over a VarId→Value register file
+  ir_interp.rs    — tier-1 IR interpreter: executes IrFunction over a VarId→Value register file;
+                    counts loop back-edges and transfers into compiled OSR entries (Phase 10.4)
   ir_cache.rs     — thread-safe cache of lowered IR keyed by arity ID (NotAttempted/Cached/Unsupported)
   ir_convert.rs   — converts Clojure Value data structures (maps/vectors/keywords) → Rust IR types
   lower.rs        — bridges the Clojure compiler front-end (cljrs.compiler.anf/lower-fn-body) to produce IrFunction
   jit_state.rs    — JIT invocation counters, native-fn-pointer dispatch table (keyed by ir_arity_id),
-                    per-arity epoch, and active-frame tracking for code unloading (Phase 10.2)
+                    per-arity epoch, active-frame tracking for code unloading (Phase 10.2), and the
+                    OSR slot table keyed by (arity_id, loop header) (Phase 10.4)
 ```
 
 ---
@@ -133,6 +135,44 @@ pub unsafe fn dispatch_jit_call(fn_ptr, args) -> *const Value;
 Each native call brackets itself with `push_jit_frame(epoch)` so the JIT code
 cache can free a superseded module only once no frame is executing it
 (`live_epochs` scanned at the stop-the-world GC safepoint).
+
+## OSR — on-stack replacement (Phase 10.4)
+
+A single hot call containing a `loop*`/`recur` never returns to re-dispatch, so
+the invocation counter cannot promote it.  Instead:
+
+1. `interpret_ir_with_osr` (the dispatch path used by `apply::execute_ir`,
+   which passes the arity ID) counts back-edges per `RecurJump` target.  The
+   counters are local to one execution on purpose: hot-within-one-call is
+   exactly the case invocation tiering misses.
+2. Crossing `osr_threshold()` calls `jit_state::osr_request`, which enqueues
+   `(arity_id, header_block, IrFunction)` to the JIT worker exactly once.
+3. The worker builds the OSR-entry variant (`cljrs_ir::osr::build_osr_function`),
+   compiles it, and publishes `(fn_ptr, epoch, live_ins)` via `store_osr_fn`.
+4. At each subsequent loop-header entry (after φ resolution, so the loop
+   variables are current), the interpreter polls `osr_poll`; on `Ready` it
+   snapshots the live-in registers and calls the native entry
+   (`try_osr_enter`) — the native frame finishes the loop *and* the rest of
+   the function, and its return value becomes the call's result.
+
+OSR `jit_state` surface:
+
+```rust
+pub fn set_osr_threshold(t: u32);                  // back-edges before compile
+pub fn osr_threshold() -> u32;                     // override → CLJRS_OSR_THRESHOLD → jit_threshold()
+pub fn set_osr_enqueue_hook(f);                    // installed by cljrs_jit::init
+pub fn osr_request(arity_id, header, ir_func);     // idempotent compile request
+pub fn osr_poll(arity_id, header) -> OsrPoll;      // NotRequested | Pending | Ready(OsrSlot) | Failed
+pub fn store_osr_fn(arity_id, header, ptr, epoch, live_ins);  // worker publishes
+pub fn mark_osr_failed(arity_id, header);          // worker declines; interpreters stop polling
+pub fn take_osr_epochs(arity_id) -> Vec<u64>;      // on redefinition: drop entries, return epochs
+```
+
+`OsrSlot { fn_ptr, epoch, live_ins }` carries the interpreter registers to pass
+(in parameter order); the transfer uses the same rooting + `push_jit_frame`
+protocol as ordinary JIT-native calls.  Scratch regions opened before the loop
+stay open across the transfer (the OSR variant drops their `RegionEnd`s) and
+unwind with the interpreter frame.
 
 ## Special-form coverage in the IR interpreter
 

--- a/crates/cljrs-eval/src/apply.rs
+++ b/crates/cljrs-eval/src/apply.rs
@@ -130,12 +130,16 @@ fn execute_ir(
         args.to_vec()
     };
 
-    let result = crate::ir_interp::interpret_ir(
+    // OSR (Phase 10.4) is enabled here — this path has a stable arity
+    // identity, so a hot loop inside a single call can promote to native
+    // code mid-run.
+    let result = crate::ir_interp::interpret_ir_with_osr(
         ir_func,
         ir_args,
         &caller_env.globals,
         &f.defining_ns,
         &mut env,
+        Some(arity.ir_arity_id),
     );
 
     cljrs_env::callback::pop_eval_context();

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -78,6 +78,119 @@ impl Drop for RegionEntry {
     }
 }
 
+// ── OSR (on-stack replacement) bookkeeping ──────────────────────────────────
+
+/// Per-execution OSR state — Phase 10.4.
+///
+/// Allocated lazily on the first loop back-edge of an OSR-eligible execution
+/// (a top-level arity dispatched through `execute_ir`), so straight-line
+/// functions pay nothing.  Back-edge counts are local to one execution on
+/// purpose: a loop that is hot *within a single call* is exactly the case
+/// invocation-count tiering cannot promote; loops spread over many short
+/// calls are already covered by the invocation counter.
+struct OsrLocal {
+    arity_id: u64,
+    threshold: u32,
+    /// Back-edge count per loop header (`BlockId.0`).
+    counts: std::collections::HashMap<u32, u32>,
+    /// Header we are waiting on: compilation requested (or already published),
+    /// checked at each loop-header entry.
+    polling: Option<BlockId>,
+    /// Headers that must not be polled or re-requested in this execution
+    /// (compilation failed, or a transfer was declined).
+    dead: std::collections::HashSet<u32>,
+}
+
+/// Record one loop back-edge to `target`.  Crossing the threshold requests OSR
+/// compilation (idempotent across executions via the global table).
+fn record_back_edge(
+    osr: &mut Option<Box<OsrLocal>>,
+    arity_id: u64,
+    target: BlockId,
+    ir_func: &IrFunction,
+) {
+    let ol = osr.get_or_insert_with(|| {
+        Box::new(OsrLocal {
+            arity_id,
+            threshold: crate::jit_state::osr_threshold().max(1),
+            counts: std::collections::HashMap::new(),
+            polling: None,
+            dead: std::collections::HashSet::new(),
+        })
+    });
+    if ol.polling == Some(target) || ol.dead.contains(&target.0) {
+        return;
+    }
+    let count = {
+        let c = ol.counts.entry(target.0).or_insert(0);
+        *c += 1;
+        *c
+    };
+    if count == 1 {
+        // A previous execution may already have requested (or finished)
+        // compilation of this loop — start polling right away.
+        match crate::jit_state::osr_poll(arity_id, target.0) {
+            crate::jit_state::OsrPoll::Ready(_) | crate::jit_state::OsrPoll::Pending => {
+                ol.polling = Some(target);
+                return;
+            }
+            crate::jit_state::OsrPoll::Failed => {
+                ol.dead.insert(target.0);
+                return;
+            }
+            crate::jit_state::OsrPoll::NotRequested => {}
+        }
+    }
+    if count >= ol.threshold {
+        crate::jit_state::osr_request(arity_id, target.0, ir_func);
+        ol.polling = Some(target);
+    }
+}
+
+/// Transfer this execution into compiled OSR-entry code: snapshot the live-in
+/// registers, call the native entry, and hand back its result as the result of
+/// the whole call.
+///
+/// Returns `None` (caller keeps interpreting) if any live-in register is not
+/// yet initialized — a conservatively declined transfer, not an error.
+fn try_osr_enter(
+    slot: &crate::jit_state::OsrSlot,
+    regs: &Registers,
+    env: &mut Env,
+) -> Option<EvalResult> {
+    let mut call_args: Vec<Value> = Vec::with_capacity(slot.live_ins.len());
+    for var in slot.live_ins.iter() {
+        match regs.values.get(var.0 as usize).and_then(|v| v.as_ref()) {
+            Some(v) => call_args.push(v.clone()),
+            None => return None,
+        }
+    }
+    cljrs_logging::feat_debug!(
+        "jit",
+        "osr entering native code ({} live-ins, epoch={})",
+        call_args.len(),
+        slot.epoch
+    );
+
+    // Same protocol as `call_jit_native` (apply.rs): keep the backing module
+    // alive for the duration of the frame, root the caller env and the
+    // snapshot, and track allocations made inside the native frame.
+    let _jit_frame = crate::jit_state::push_jit_frame(slot.epoch);
+    let _caller_root = cljrs_env::gc_roots::push_env_root(env);
+    let _arg_roots = cljrs_env::gc_roots::root_values(&call_args);
+    let _alloc_frame = cljrs_gc::push_alloc_frame();
+
+    let arg_ptrs: Vec<*const Value> = call_args.iter().map(|v| v as *const Value).collect();
+    // SAFETY: fn_ptr was produced by Cranelift JIT with the C ABI and exactly
+    // `live_ins.len()` `*const Value` params (`build_osr_function` caps this at
+    // the dispatch limit); all arg pointers are live for the call.
+    let result_ptr = unsafe { crate::jit_state::dispatch_jit_call(slot.fn_ptr, &arg_ptrs) };
+    // SAFETY: result_ptr points to a live Value in ALLOC_ROOTS; clone it
+    // before the alloc frame drops.
+    let result = unsafe { (*result_ptr).clone() };
+    Some(Ok(result))
+}
+
 // ── Public entry point ──────────────────────────────────────────────────────
 
 /// Execute an IR function with the given arguments.
@@ -97,6 +210,23 @@ pub fn interpret_ir(
     globals: &Arc<GlobalEnv>,
     ns: &Arc<str>,
     env: &mut Env,
+) -> EvalResult {
+    interpret_ir_with_osr(ir_func, args, globals, ns, env, None)
+}
+
+/// Like [`interpret_ir`], with OSR enabled when `osr_arity_id` is given.
+///
+/// `osr_arity_id` is the `ir_arity_id` under which loop back-edges are counted
+/// and OSR-compiled entries are published.  Pass `None` (or use
+/// [`interpret_ir`]) for executions that have no stable arity identity, e.g.
+/// IR closures and region-parameterised subfunction calls.
+pub fn interpret_ir_with_osr(
+    ir_func: &IrFunction,
+    args: Vec<Value>,
+    globals: &Arc<GlobalEnv>,
+    ns: &Arc<str>,
+    env: &mut Env,
+    osr_arity_id: Option<u64>,
 ) -> EvalResult {
     // GC safepoint at function entry.
     cljrs_env::gc_roots::gc_safepoint(env);
@@ -134,6 +264,10 @@ pub fn interpret_ir(
     let mut current_block_idx: usize = 0;
     let mut prev_block_id = BlockId(u32::MAX); // sentinel
 
+    // Lazily allocated OSR back-edge state (only for OSR-eligible executions
+    // that actually take a loop back-edge).
+    let mut osr: Option<Box<OsrLocal>> = None;
+
     loop {
         let block = &ir_func.blocks[current_block_idx];
 
@@ -146,6 +280,32 @@ pub fn interpret_ir(
                         break;
                     }
                 }
+            }
+        }
+
+        // OSR transfer: once a hot loop header's compilation has been
+        // requested, check for published native code each time we re-enter the
+        // header (i.e. after its phis — the loop variables — are resolved).
+        if let Some(ol) = osr.as_deref_mut()
+            && ol.polling == Some(block.id)
+        {
+            match crate::jit_state::osr_poll(ol.arity_id, block.id.0) {
+                crate::jit_state::OsrPoll::Ready(slot) => {
+                    // Regions opened before the loop stay open across the
+                    // transfer (the OSR variant drops their RegionEnds) and
+                    // are closed as usual when `region_stack` unwinds after
+                    // the native call returns.
+                    if let Some(result) = try_osr_enter(&slot, &regs, env) {
+                        return result;
+                    }
+                    ol.polling = None;
+                    ol.dead.insert(block.id.0);
+                }
+                crate::jit_state::OsrPoll::Failed => {
+                    ol.polling = None;
+                    ol.dead.insert(block.id.0);
+                }
+                _ => {}
             }
         }
 
@@ -185,6 +345,12 @@ pub fn interpret_ir(
             Terminator::RecurJump { target, args: _ } => {
                 // GC safepoint at loop back-edge.
                 cljrs_env::gc_roots::gc_safepoint(env);
+
+                // Loop back-edge counter: a hot header triggers background OSR
+                // compilation; the transfer happens at the header entry above.
+                if let Some(arity_id) = osr_arity_id {
+                    record_back_edge(&mut osr, arity_id, *target, ir_func);
+                }
 
                 // Jump to the target (loop header) block.
                 // Phi nodes at the target block entry will resolve the new

--- a/crates/cljrs-eval/src/jit_state.rs
+++ b/crates/cljrs-eval/src/jit_state.rs
@@ -183,6 +183,176 @@ pub fn record_call(arity_id: u64, ir_func: Arc<IrFunction>) {
     }
 }
 
+// ── OSR (on-stack replacement) state — Phase 10.4 ────────────────────────────
+//
+// A single hot call containing a `loop*`/`recur` never returns to re-dispatch,
+// so the invocation counter above can never promote it.  The IR interpreter
+// instead counts loop back-edges per execution; when a header crosses
+// [`osr_threshold`] it requests compilation of an OSR-entry variant (built by
+// `cljrs_ir::osr::build_osr_function` on the JIT worker).  Once the worker
+// publishes the compiled entry here, the interpreter transfers its register
+// file into the native frame at the next loop-header entry.
+
+/// A published, compiled OSR entry for one `(arity_id, loop header)` pair.
+#[derive(Clone)]
+pub struct OsrSlot {
+    /// Native OSR-entry code: C ABI, `live_ins.len()` `*const Value` params,
+    /// one `*const Value` return.
+    pub fn_ptr: *const (),
+    /// Reclamation epoch of the backing module (see [`push_jit_frame`]).
+    pub epoch: u64,
+    /// Interpreter registers to pass, in parameter order
+    /// (`cljrs_ir::osr::OsrFunction::live_ins`).
+    pub live_ins: Arc<[cljrs_ir::VarId]>,
+}
+
+// SAFETY: `fn_ptr` is executable code owned by the JIT code cache; it carries
+// no thread affinity.  All other fields are plain data.
+unsafe impl Send for OsrSlot {}
+unsafe impl Sync for OsrSlot {}
+
+enum OsrState {
+    /// Compilation requested, worker has not finished yet.
+    Queued,
+    /// Native entry published.
+    Ready(OsrSlot),
+    /// Compilation declined or failed — stop polling, stay at Tier 1.
+    Failed,
+}
+
+/// Result of polling for a compiled OSR entry.
+pub enum OsrPoll {
+    NotRequested,
+    Pending,
+    Ready(OsrSlot),
+    Failed,
+}
+
+static OSR_TABLE: RwLock<Option<HashMap<(u64, u32), OsrState>>> = RwLock::new(None);
+
+type OsrEnqueueFn = Box<dyn Fn(u64, u32, Arc<IrFunction>) + Send + Sync + 'static>;
+static OSR_ENQUEUE_HOOK: OnceLock<OsrEnqueueFn> = OnceLock::new();
+
+/// Install the OSR compilation enqueue hook (installed once by
+/// `cljrs_jit::init`).  Receives `(arity_id, header_block, function)`; must be
+/// non-blocking.
+pub fn set_osr_enqueue_hook(f: impl Fn(u64, u32, Arc<IrFunction>) + Send + Sync + 'static) {
+    let _ = OSR_ENQUEUE_HOOK.set(Box::new(f));
+}
+
+/// Per-process override; 0 means "env var or default".
+static OSR_THRESHOLD_OVERRIDE: AtomicU32 = AtomicU32::new(0);
+
+pub fn set_osr_threshold(t: u32) {
+    OSR_THRESHOLD_OVERRIDE.store(t, Ordering::Relaxed);
+}
+
+/// Back-edge count at which a loop header is considered hot.  Defaults to the
+/// invocation threshold ([`jit_threshold`]); override with
+/// `CLJRS_OSR_THRESHOLD` or [`set_osr_threshold`].
+pub fn osr_threshold() -> u32 {
+    let v = OSR_THRESHOLD_OVERRIDE.load(Ordering::Relaxed);
+    if v != 0 {
+        return v;
+    }
+    std::env::var("CLJRS_OSR_THRESHOLD")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or_else(jit_threshold)
+}
+
+/// Poll for a compiled OSR entry for the loop at `header` in `arity_id`.
+pub fn osr_poll(arity_id: u64, header: u32) -> OsrPoll {
+    let guard = OSR_TABLE.read().unwrap();
+    match guard.as_ref().and_then(|m| m.get(&(arity_id, header))) {
+        None => OsrPoll::NotRequested,
+        Some(OsrState::Queued) => OsrPoll::Pending,
+        Some(OsrState::Ready(slot)) => OsrPoll::Ready(slot.clone()),
+        Some(OsrState::Failed) => OsrPoll::Failed,
+    }
+}
+
+/// Request OSR compilation for the loop at `header` in `arity_id`.  Idempotent:
+/// only the first request per `(arity_id, header)` enqueues (and pays for one
+/// `IrFunction` clone); with no JIT installed the entry is marked failed so
+/// callers stop polling.
+pub fn osr_request(arity_id: u64, header: u32, ir_func: &IrFunction) {
+    let hook = OSR_ENQUEUE_HOOK.get();
+    {
+        let mut guard = OSR_TABLE.write().unwrap();
+        let map = guard.get_or_insert_with(HashMap::new);
+        match map.entry((arity_id, header)) {
+            std::collections::hash_map::Entry::Occupied(_) => return,
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(if hook.is_some() {
+                    OsrState::Queued
+                } else {
+                    OsrState::Failed
+                });
+            }
+        }
+    }
+    if let Some(hook) = hook {
+        cljrs_logging::feat_debug!(
+            "jit",
+            "osr enqueue arity_id={} header=bb{}",
+            arity_id,
+            header
+        );
+        hook(arity_id, header, Arc::new(ir_func.clone()));
+    }
+}
+
+/// Publish a compiled OSR entry.  Called by the JIT worker thread.
+pub fn store_osr_fn(
+    arity_id: u64,
+    header: u32,
+    ptr: *const (),
+    epoch: u64,
+    live_ins: Vec<cljrs_ir::VarId>,
+) {
+    let mut guard = OSR_TABLE.write().unwrap();
+    let map = guard.get_or_insert_with(HashMap::new);
+    map.insert(
+        (arity_id, header),
+        OsrState::Ready(OsrSlot {
+            fn_ptr: ptr,
+            epoch,
+            live_ins: live_ins.into(),
+        }),
+    );
+}
+
+/// Record that OSR compilation for `(arity_id, header)` declined or failed, so
+/// interpreters stop polling and the loop stays at Tier 1.
+pub fn mark_osr_failed(arity_id: u64, header: u32) {
+    let mut guard = OSR_TABLE.write().unwrap();
+    let map = guard.get_or_insert_with(HashMap::new);
+    map.insert((arity_id, header), OsrState::Failed);
+}
+
+/// Drop all OSR entries for `arity_id` (the owning var was rebound), returning
+/// the epochs of published code so the caller can hand them to the code cache
+/// for reclamation once no frame executes them.
+pub fn take_osr_epochs(arity_id: u64) -> Vec<u64> {
+    let mut guard = OSR_TABLE.write().unwrap();
+    let Some(map) = guard.as_mut() else {
+        return Vec::new();
+    };
+    let keys: Vec<(u64, u32)> = map
+        .keys()
+        .filter(|(a, _)| *a == arity_id)
+        .copied()
+        .collect();
+    let mut epochs = Vec::new();
+    for key in keys {
+        if let Some(OsrState::Ready(slot)) = map.remove(&key) {
+            epochs.push(slot.epoch);
+        }
+    }
+    epochs
+}
+
 // ── Active JIT frame tracking (for code unloading) ──────────────────────────────
 //
 // Code unloading (Phase 10.2) frees a superseded `JITModule` only once no frame
@@ -391,6 +561,47 @@ mod tests {
         assert!(live_epochs().contains(&e));
         drop(guard);
         assert!(!live_epochs().contains(&e));
+    }
+
+    #[test]
+    fn osr_slot_round_trips_and_rebind_takes_epochs() {
+        use cljrs_ir::VarId;
+        let id = 0xF200_0001;
+        // Unpublished header polls as NotRequested.
+        assert!(matches!(osr_poll(id, 1), OsrPoll::NotRequested));
+
+        let ptr = 0x5678usize as *const ();
+        store_osr_fn(id, 1, ptr, 901, vec![VarId(3), VarId(4)]);
+        match osr_poll(id, 1) {
+            OsrPoll::Ready(slot) => {
+                assert_eq!(slot.fn_ptr, ptr);
+                assert_eq!(slot.epoch, 901);
+                assert_eq!(&*slot.live_ins, &[VarId(3), VarId(4)]);
+            }
+            _ => panic!("expected Ready"),
+        }
+
+        // A second loop in the same arity that failed to compile.
+        mark_osr_failed(id, 7);
+        assert!(matches!(osr_poll(id, 7), OsrPoll::Failed));
+
+        // Rebinding the var takes only the published epochs and clears all
+        // entries for the arity.
+        let epochs = take_osr_epochs(id);
+        assert_eq!(epochs, vec![901]);
+        assert!(matches!(osr_poll(id, 1), OsrPoll::NotRequested));
+        assert!(matches!(osr_poll(id, 7), OsrPoll::NotRequested));
+    }
+
+    #[test]
+    fn osr_request_without_hook_marks_failed() {
+        // The test binary never installs the OSR enqueue hook (that's
+        // cljrs_jit::init's job), so a request must immediately fail closed
+        // rather than leave interpreters polling forever.
+        let id = 0xF200_0002;
+        let ir = IrFunction::new(None, None);
+        osr_request(id, 2, &ir);
+        assert!(matches!(osr_poll(id, 2), OsrPoll::Failed));
     }
 
     #[test]

--- a/crates/cljrs-eval/src/lib.rs
+++ b/crates/cljrs-eval/src/lib.rs
@@ -33,7 +33,7 @@ pub use cljrs_env::loader::load_ns;
 pub use cljrs_interp::eval::eval;
 
 pub use apply::force_eager_lowering;
-pub use jit_state::{set_enqueue_hook, set_jit_threshold, store_native_fn};
+pub use jit_state::{set_enqueue_hook, set_jit_threshold, set_osr_threshold, store_native_fn};
 
 use crate::ir_interp::eager_lower_fn;
 use std::sync::Arc;

--- a/crates/cljrs-eval/tests/osr_transfer.rs
+++ b/crates/cljrs-eval/tests/osr_transfer.rs
@@ -1,0 +1,151 @@
+//! Phase 10.4 (OSR) — semantic equivalence of the OSR-entry transform.
+//!
+//! `cljrs_ir::osr::build_osr_function` produces a variant of a function whose
+//! entry block jumps straight to a loop header, with the loop variables and
+//! every pre-loop value the loop reads passed as parameters.  The runtime
+//! transfer hands the interpreter's registers to that variant, so the variant
+//! must compute *exactly* what the original call would have computed from that
+//! point on — including everything after the loop exits.
+//!
+//! These tests check that contract using the Tier-1 interpreter on both sides
+//! (no Cranelift involved): running the OSR variant from a mid-loop state must
+//! equal the remainder of the original computation.
+
+use std::sync::Arc;
+
+use cljrs_eval::{Env, ir_interp::interpret_ir};
+use cljrs_interp::standard_env_minimal;
+use cljrs_ir::osr::build_osr_function;
+use cljrs_ir::{Block, BlockId, Const, Inst, IrFunction, KnownFn, Terminator, VarId};
+use cljrs_value::Value;
+
+/// `(fn [n] (loop [i 0 acc 0] (if (< i n) (recur (+ i 1) (+ acc i)) acc)))`,
+/// hand-lowered.  See `cljrs-ir/src/osr.rs` tests for the block layout.
+fn sum_loop_fn() -> IrFunction {
+    let mut f = IrFunction::new(Some(Arc::from("sum-to")), None);
+    let v = |n: u32| VarId(n);
+    f.params = vec![(Arc::from("n"), v(0))];
+    f.next_var = 9;
+    f.next_block = 4;
+    f.blocks = vec![
+        Block {
+            id: BlockId(0),
+            phis: vec![],
+            insts: vec![
+                Inst::Const(v(1), Const::Long(0)),
+                Inst::Const(v(2), Const::Long(0)),
+            ],
+            terminator: Terminator::Jump(BlockId(1)),
+        },
+        Block {
+            id: BlockId(1),
+            phis: vec![
+                Inst::Phi(v(3), vec![(BlockId(0), v(1)), (BlockId(2), v(6))]),
+                Inst::Phi(v(4), vec![(BlockId(0), v(2)), (BlockId(2), v(7))]),
+            ],
+            insts: vec![Inst::CallKnown(v(5), KnownFn::Lt, vec![v(3), v(0)])],
+            terminator: Terminator::Branch {
+                cond: v(5),
+                then_block: BlockId(2),
+                else_block: BlockId(3),
+            },
+        },
+        Block {
+            id: BlockId(2),
+            phis: vec![],
+            insts: vec![
+                Inst::Const(v(8), Const::Long(1)),
+                Inst::CallKnown(v(6), KnownFn::Add, vec![v(3), v(8)]),
+                Inst::CallKnown(v(7), KnownFn::Add, vec![v(4), v(3)]),
+            ],
+            terminator: Terminator::RecurJump {
+                target: BlockId(1),
+                args: vec![v(6), v(7)],
+            },
+        },
+        Block {
+            id: BlockId(3),
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::Return(v(4)),
+        },
+    ];
+    f
+}
+
+fn run(ir: &IrFunction, args: Vec<Value>) -> Value {
+    let _mutator = cljrs_gc::register_mutator();
+    let globals = standard_env_minimal(None, None, None);
+    let mut env = Env::new(globals.clone(), "user");
+    let ns: Arc<str> = Arc::from("user");
+    cljrs_env::callback::push_eval_context(&env);
+    let result = interpret_ir(ir, args, &globals, &ns, &mut env);
+    cljrs_env::callback::pop_eval_context();
+    result.expect("interpret")
+}
+
+#[test]
+fn osr_variant_resumes_mid_loop_state() {
+    let orig = sum_loop_fn();
+    // Whole-call baseline: sum 0..10 = 45.
+    assert_eq!(run(&orig, vec![Value::Long(10)]), Value::Long(45));
+
+    let osr = build_osr_function(&orig, BlockId(1)).expect("transform");
+    // live-ins: [i (v3), acc (v4), n (v0)] — see the transform's ordering
+    // contract (header φ destinations first, then outer values by VarId).
+    assert_eq!(osr.live_ins, vec![VarId(3), VarId(4), VarId(0)]);
+
+    // Resume from i=5, acc=10 (the state after 5 interpreted iterations):
+    // remaining iterations add 5+6+7+8+9 → 45.
+    let resumed = run(
+        &osr.func,
+        vec![Value::Long(5), Value::Long(10), Value::Long(10)],
+    );
+    assert_eq!(resumed, Value::Long(45));
+}
+
+#[test]
+fn osr_variant_matches_original_for_every_entry_point() {
+    let orig = sum_loop_fn();
+    let osr = build_osr_function(&orig, BlockId(1)).expect("transform");
+    let n = 12i64;
+    let expected = run(&orig, vec![Value::Long(n)]);
+
+    // Entering the OSR variant at any iteration boundary k must finish with
+    // the same answer the original produces.
+    for k in 0..=n {
+        let acc: i64 = (0..k).sum();
+        let resumed = run(
+            &osr.func,
+            vec![Value::Long(k), Value::Long(acc), Value::Long(n)],
+        );
+        assert_eq!(resumed, expected, "diverged when resuming at i={k}");
+    }
+}
+
+#[test]
+fn osr_variant_runs_post_loop_code() {
+    // Wrap the loop exit in extra post-loop work — `(+ acc n)` after the loop —
+    // to check the OSR variant carries the continuation, not just the loop.
+    let mut orig = sum_loop_fn();
+    let result_var = VarId(9);
+    orig.next_var = 10;
+    orig.blocks[3] = Block {
+        id: BlockId(3),
+        phis: vec![],
+        insts: vec![Inst::CallKnown(
+            result_var,
+            KnownFn::Add,
+            vec![VarId(4), VarId(0)],
+        )],
+        terminator: Terminator::Return(result_var),
+    };
+    assert_eq!(run(&orig, vec![Value::Long(10)]), Value::Long(55));
+
+    let osr = build_osr_function(&orig, BlockId(1)).expect("transform");
+    let resumed = run(
+        &osr.func,
+        vec![Value::Long(5), Value::Long(10), Value::Long(10)],
+    );
+    assert_eq!(resumed, Value::Long(55));
+}

--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -19,6 +19,9 @@ can depend on the same types without a circular dependency.
 src/
   lib.rs  — all IR types: IrFunction, Block, Inst, Terminator, VarId, BlockId,
              KnownFn, Effect, Const, ClosureTemplate, RegionAllocKind
+  osr.rs  — OSR-entry transform (Phase 10.4): build_osr_function rewrites a
+             function so its entry jumps straight to a hot loop header, with
+             live-in values (loop φs + pre-loop defs) arriving as parameters
   lower/
     mod.rs      — re-exports: lower_fn_body, lower_fn_body_destructured, analyze,
                   inline, optimize, EscapeContext …
@@ -227,6 +230,31 @@ pub struct AnalysisResult {
 These are the same types the optimizer uses internally; they are exposed
 publicly so downstream tooling (e.g. `cljrs-ir-viz`) can present
 escape-analysis results without re-implementing the use-chain walk.
+
+### OSR-entry construction (`osr` module, Phase 10.4)
+
+```rust
+/// Cap on OSR parameters (the JIT dispatch shim supports 8 native args).
+pub const MAX_OSR_PARAMS: usize = 8;
+
+pub struct OsrFunction {
+    /// Entry block jumps to the loop header; loop state arrives as params.
+    pub func: IrFunction,
+    /// For each param (in order), the original VarId whose current value the
+    /// interpreter must pass when transferring into the native frame.
+    pub live_ins: Vec<VarId>,
+}
+
+/// Build the OSR-entry variant of `orig` for the loop header `header`
+/// (a `RecurJump` target).  Keeps only blocks reachable from the header;
+/// header φs get a new incoming edge from the fresh entry block fed by fresh
+/// parameters (loop variables), other live-ins become parameters bound to
+/// their original VarIds.  `RegionEnd`s whose `RegionStart` executed before
+/// the loop (i.e. in the interpreter) are dropped — the interpreter frame
+/// closes those regions after the transfer returns.  Errs (caller stays at
+/// Tier 1) if the header is unknown or live-ins exceed MAX_OSR_PARAMS.
+pub fn build_osr_function(orig: &IrFunction, header: BlockId) -> Result<OsrFunction, String>;
+```
 
 ### Source mapping
 

--- a/crates/cljrs-ir/src/lib.rs
+++ b/crates/cljrs-ir/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::result_large_err)]
 
 pub mod lower;
+pub mod osr;
 
 use cljrs_types::error::CljxError::SerializationError;
 use cljrs_types::error::CljxResult;

--- a/crates/cljrs-ir/src/osr.rs
+++ b/crates/cljrs-ir/src/osr.rs
@@ -1,0 +1,459 @@
+//! On-stack replacement (OSR) entry construction — Phase 10.4.
+//!
+//! A script or REPL form is often a *single* call containing one very hot
+//! `loop*` / `recur`.  Such a function never returns to re-dispatch, so
+//! invocation-count tiering never promotes it.  OSR promotes it *mid-run*:
+//! the Tier-1 interpreter counts loop back-edges and, when a loop header gets
+//! hot, the JIT compiles an **OSR-entry variant** of the function built here —
+//! a copy of the function whose entry block jumps straight to the loop header
+//! and whose live-in values arrive as parameters.  The interpreter then
+//! transfers its register file into the native frame at the next loop-header
+//! entry and the rest of the call (the remaining iterations *and* everything
+//! after the loop) runs natively.
+//!
+//! ## The transform
+//!
+//! Given a function and a loop-header block `H` (the target of a `RecurJump`):
+//!
+//! 1. Compute `R`, the set of blocks reachable from `H`.  Only those blocks
+//!    are kept; everything before the loop has already executed in the
+//!    interpreter.
+//! 2. Compute the **live-ins**: values produced outside `R` but read inside
+//!    it, plus the loop variables themselves (the φ destinations at `H`).
+//! 3. Build a new entry block that jumps to `H`.  Each φ at `H` gets one new
+//!    incoming edge from that entry block, fed by a fresh parameter; φ edges
+//!    from blocks outside `R` (the original loop-entry path) are dropped.
+//!    Non-φ live-ins become parameters bound to their original `VarId`s.
+//!
+//! The result is a self-contained [`IrFunction`] compiled by the ordinary JIT
+//! backend.  [`OsrFunction::live_ins`] tells the interpreter which of *its*
+//! registers to pass, in parameter order.
+//!
+//! ## Scratch regions opened before the loop
+//!
+//! The optimizer wraps lowered function bodies in `RegionStart`/`RegionEnd`,
+//! so the loop's continuation usually contains a `RegionEnd` whose matching
+//! `RegionStart` already executed *in the interpreter*.  The interpreter owns
+//! that region (its frame closes it on unwind), so the OSR variant must not
+//! close it again: such unmatched `RegionEnd`s are dropped, and `RegionAlloc`s
+//! that name an interpreter-owned handle have the handle operand replaced with
+//! a local nil (the handle is a placeholder — region allocation targets the
+//! thread-local region stack).  This only *extends* the region's lifetime to
+//! the end of the interpreter frame, which is safe: escape analysis already
+//! guarantees nothing allocated under the region outlives its original
+//! `RegionEnd`.  Region pairs entirely inside the loop are kept as-is.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use crate::{Block, BlockId, Inst, IrFunction, Terminator, VarId};
+
+/// Hard cap on OSR-function parameters: the dispatch shim
+/// (`cljrs_eval::jit_state::dispatch_jit_call`) supports at most 8 native
+/// arguments.
+pub const MAX_OSR_PARAMS: usize = 8;
+
+/// An OSR-entry variant of a function, ready for JIT compilation.
+pub struct OsrFunction {
+    /// The transformed function: entry block jumps to the loop header, loop
+    /// state arrives via parameters.
+    pub func: IrFunction,
+    /// For each parameter of `func` (in order), the *original* `VarId` whose
+    /// current value the interpreter must pass when transferring into the
+    /// native frame.
+    pub live_ins: Vec<VarId>,
+}
+
+/// Successor block IDs of a terminator.
+fn successors(term: &Terminator) -> Vec<BlockId> {
+    match term {
+        Terminator::Jump(t) => vec![*t],
+        Terminator::Branch {
+            then_block,
+            else_block,
+            ..
+        } => vec![*then_block, *else_block],
+        Terminator::RecurJump { target, .. } => vec![*target],
+        Terminator::Return(_) | Terminator::Unreachable => vec![],
+    }
+}
+
+/// VarIds read by a terminator.
+fn terminator_uses(term: &Terminator) -> Vec<VarId> {
+    match term {
+        Terminator::Jump(_) | Terminator::Unreachable => vec![],
+        Terminator::Branch { cond, .. } => vec![*cond],
+        Terminator::Return(v) => vec![*v],
+        Terminator::RecurJump { args, .. } => args.clone(),
+    }
+}
+
+/// Build the OSR-entry variant of `orig` for the loop header `header`.
+///
+/// Returns an error (leaving the caller at Tier 1) when the loop cannot be
+/// soundly or practically OSR-compiled:
+/// - `header` is not a block of `orig`;
+/// - more than [`MAX_OSR_PARAMS`] live-in values would be required.
+pub fn build_osr_function(orig: &IrFunction, header: BlockId) -> Result<OsrFunction, String> {
+    let blocks_by_id: HashMap<BlockId, &Block> = orig.blocks.iter().map(|b| (b.id, b)).collect();
+    if !blocks_by_id.contains_key(&header) {
+        return Err(format!("OSR: header block {header} not found"));
+    }
+
+    // 1. Blocks reachable from the header.
+    let mut reach: HashSet<BlockId> = HashSet::new();
+    let mut queue: VecDeque<BlockId> = VecDeque::new();
+    reach.insert(header);
+    queue.push_back(header);
+    while let Some(bid) = queue.pop_front() {
+        let block = blocks_by_id[&bid];
+        for succ in successors(&block.terminator) {
+            if reach.insert(succ) {
+                queue.push_back(succ);
+            }
+        }
+    }
+
+    // Region handles created before the loop (RegionStart outside the
+    // reachable set).  References to them inside the loop are rewritten — see
+    // the module docs.
+    let outer_handles: HashSet<VarId> = orig
+        .blocks
+        .iter()
+        .filter(|b| !reach.contains(&b.id))
+        .flat_map(|b| &b.insts)
+        .filter_map(|inst| match inst {
+            Inst::RegionStart(dst) => Some(*dst),
+            _ => None,
+        })
+        .collect();
+
+    // 2. Defs and uses within the reachable region.  φ entries whose
+    //    predecessor lies outside the region are edges that can never be taken
+    //    in the OSR function, so their sources do not count as uses.
+    //    Interpreter-owned region handles never count as uses: the
+    //    instructions naming them are dropped or rewritten in step 4.
+    let mut defs: HashSet<VarId> = HashSet::new();
+    let mut uses: HashSet<VarId> = HashSet::new();
+    for block in orig.blocks.iter().filter(|b| reach.contains(&b.id)) {
+        for phi in &block.phis {
+            if let Inst::Phi(dst, entries) = phi {
+                defs.insert(*dst);
+                for (pred, src) in entries {
+                    if reach.contains(pred) {
+                        uses.insert(*src);
+                    }
+                }
+            }
+        }
+        for inst in &block.insts {
+            if let Some(d) = inst.dst() {
+                defs.insert(d);
+            }
+            for u in inst.uses() {
+                if !outer_handles.contains(&u) {
+                    uses.insert(u);
+                }
+            }
+        }
+        for u in terminator_uses(&block.terminator) {
+            uses.insert(u);
+        }
+    }
+
+    // 3. Parameters.  Loop variables (φ destinations at the header) come
+    //    first, fed through *fresh* VarIds wired into the φs; then every value
+    //    defined before the loop but read inside it, bound to its original
+    //    VarId directly.
+    let header_block = blocks_by_id[&header];
+    let phi_dsts: Vec<VarId> = header_block
+        .phis
+        .iter()
+        .filter_map(|p| match p {
+            Inst::Phi(dst, _) => Some(*dst),
+            _ => None,
+        })
+        .collect();
+
+    let mut outer_live: Vec<VarId> = uses.difference(&defs).copied().collect();
+    outer_live.sort_by_key(|v| v.0);
+
+    if phi_dsts.len() + outer_live.len() > MAX_OSR_PARAMS {
+        return Err(format!(
+            "OSR: {} live-in values exceed the {MAX_OSR_PARAMS}-parameter dispatch limit",
+            phi_dsts.len() + outer_live.len()
+        ));
+    }
+
+    let mut next_var = orig.next_var;
+    let mut params: Vec<(Arc<str>, VarId)> = Vec::new();
+    let mut live_ins: Vec<VarId> = Vec::new();
+    let mut phi_params: Vec<VarId> = Vec::new();
+    for (i, dst) in phi_dsts.iter().enumerate() {
+        let p = VarId(next_var);
+        next_var += 1;
+        params.push((Arc::from(format!("__osr_phi{i}")), p));
+        live_ins.push(*dst);
+        phi_params.push(p);
+    }
+    for v in &outer_live {
+        params.push((Arc::from(format!("__osr_v{}", v.0)), *v));
+        live_ins.push(*v);
+    }
+
+    // 4. Blocks: a fresh entry that jumps to the header, then the reachable
+    //    blocks in their original order with φ edges rewired and
+    //    interpreter-owned region references dropped/rewritten.
+    let needs_nil_handle = orig
+        .blocks
+        .iter()
+        .filter(|b| reach.contains(&b.id))
+        .flat_map(|b| &b.insts)
+        .any(|inst| matches!(inst, Inst::RegionAlloc(_, r, _, _) if outer_handles.contains(r)));
+    let nil_handle = VarId(next_var);
+    let mut entry_insts = Vec::new();
+    if needs_nil_handle {
+        next_var += 1;
+        entry_insts.push(Inst::Const(nil_handle, crate::Const::Nil));
+    }
+
+    let entry_id = BlockId(orig.next_block);
+    let mut blocks = Vec::with_capacity(reach.len() + 1);
+    blocks.push(Block {
+        id: entry_id,
+        phis: vec![],
+        insts: entry_insts,
+        terminator: Terminator::Jump(header),
+    });
+    for block in orig.blocks.iter().filter(|b| reach.contains(&b.id)) {
+        let mut b = block.clone();
+        for phi in &mut b.phis {
+            if let Inst::Phi(_, entries) = phi {
+                entries.retain(|(pred, _)| reach.contains(pred));
+            }
+        }
+        if b.id == header {
+            for (phi, param) in b.phis.iter_mut().zip(&phi_params) {
+                if let Inst::Phi(_, entries) = phi {
+                    entries.push((entry_id, *param));
+                }
+            }
+        }
+        // The interpreter owns regions opened before the loop and closes them
+        // when its frame unwinds after the transfer returns; the OSR variant
+        // must not close them again.
+        b.insts
+            .retain(|inst| !matches!(inst, Inst::RegionEnd(r) if outer_handles.contains(r)));
+        // Region handles are placeholders (allocation targets the thread-local
+        // region stack); rebind interpreter-owned ones to a local nil.
+        for inst in &mut b.insts {
+            if let Inst::RegionAlloc(_, r, _, _) = inst
+                && outer_handles.contains(r)
+            {
+                *r = nil_handle;
+            }
+        }
+        blocks.push(b);
+    }
+
+    let name = format!(
+        "{}__osr_bb{}",
+        orig.name.as_deref().unwrap_or("<anon>"),
+        header.0
+    );
+    Ok(OsrFunction {
+        func: IrFunction {
+            name: Some(Arc::from(name)),
+            params,
+            blocks,
+            next_var,
+            next_block: orig.next_block + 1,
+            span: orig.span.clone(),
+            subfunctions: orig.subfunctions.clone(),
+            is_async: orig.is_async,
+        },
+        live_ins,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Const, KnownFn};
+
+    /// Build the canonical counting loop:
+    ///
+    /// ```clojure
+    /// (fn [n] (loop [i 0 acc 0] (if (< i n) (recur (+ i 1) (+ acc i)) acc)))
+    /// ```
+    ///
+    /// bb0: v1=0; v2=0; jump bb1
+    /// bb1: v3=φ[(bb0,v1),(bb2,v6)]; v4=φ[(bb0,v2),(bb2,v7)]
+    ///      v5=(< v3 v0); branch v5 bb2 bb3
+    /// bb2: v8=1; v6=(+ v3 v8); v7=(+ v4 v3); recur_jump bb1 [v6,v7]
+    /// bb3: return v4
+    fn sum_loop_fn() -> IrFunction {
+        let mut f = IrFunction::new(Some(Arc::from("sum-to")), None);
+        let v = |n: u32| VarId(n);
+        f.params = vec![(Arc::from("n"), v(0))];
+        f.next_var = 9;
+        f.next_block = 4;
+        f.blocks = vec![
+            Block {
+                id: BlockId(0),
+                phis: vec![],
+                insts: vec![
+                    Inst::Const(v(1), Const::Long(0)),
+                    Inst::Const(v(2), Const::Long(0)),
+                ],
+                terminator: Terminator::Jump(BlockId(1)),
+            },
+            Block {
+                id: BlockId(1),
+                phis: vec![
+                    Inst::Phi(v(3), vec![(BlockId(0), v(1)), (BlockId(2), v(6))]),
+                    Inst::Phi(v(4), vec![(BlockId(0), v(2)), (BlockId(2), v(7))]),
+                ],
+                insts: vec![Inst::CallKnown(v(5), KnownFn::Lt, vec![v(3), v(0)])],
+                terminator: Terminator::Branch {
+                    cond: v(5),
+                    then_block: BlockId(2),
+                    else_block: BlockId(3),
+                },
+            },
+            Block {
+                id: BlockId(2),
+                phis: vec![],
+                insts: vec![
+                    Inst::Const(v(8), Const::Long(1)),
+                    Inst::CallKnown(v(6), KnownFn::Add, vec![v(3), v(8)]),
+                    Inst::CallKnown(v(7), KnownFn::Add, vec![v(4), v(3)]),
+                ],
+                terminator: Terminator::RecurJump {
+                    target: BlockId(1),
+                    args: vec![v(6), v(7)],
+                },
+            },
+            Block {
+                id: BlockId(3),
+                phis: vec![],
+                insts: vec![],
+                terminator: Terminator::Return(v(4)),
+            },
+        ];
+        f
+    }
+
+    #[test]
+    fn live_ins_are_loop_vars_then_outer_values() {
+        let orig = sum_loop_fn();
+        let osr = build_osr_function(&orig, BlockId(1)).unwrap();
+        // φ destinations (i, acc) first, then the outer param n.
+        assert_eq!(osr.live_ins, vec![VarId(3), VarId(4), VarId(0)]);
+        assert_eq!(osr.func.params.len(), 3);
+        // The init constants v1/v2 are pre-loop only and must not be live-ins.
+        assert!(!osr.live_ins.contains(&VarId(1)));
+        assert!(!osr.live_ins.contains(&VarId(2)));
+    }
+
+    #[test]
+    fn entry_block_jumps_to_header_and_phis_are_rewired() {
+        let orig = sum_loop_fn();
+        let osr = build_osr_function(&orig, BlockId(1)).unwrap();
+        // blocks[0] is the fresh OSR entry.
+        let entry = &osr.func.blocks[0];
+        assert_eq!(entry.id, BlockId(4));
+        assert!(entry.phis.is_empty() && entry.insts.is_empty());
+        assert!(matches!(entry.terminator, Terminator::Jump(BlockId(1))));
+        // The pre-loop block bb0 is dropped.
+        assert!(osr.func.blocks.iter().all(|b| b.id != BlockId(0)));
+
+        // Header φs: the bb0 edge is gone, the back-edge stays, and a new edge
+        // from the OSR entry feeds each loop variable from its fresh param.
+        let header = osr.func.blocks.iter().find(|b| b.id == BlockId(1)).unwrap();
+        let phi_i = match &header.phis[0] {
+            Inst::Phi(dst, entries) => {
+                assert_eq!(*dst, VarId(3));
+                entries.clone()
+            }
+            other => panic!("expected phi, got {other}"),
+        };
+        assert!(!phi_i.iter().any(|(pred, _)| *pred == BlockId(0)));
+        assert!(phi_i.contains(&(BlockId(2), VarId(6))));
+        let osr_edge = phi_i
+            .iter()
+            .find(|(pred, _)| *pred == BlockId(4))
+            .expect("OSR entry edge");
+        // The φ param VarId is fresh and matches params[0].
+        assert_eq!(osr_edge.1, osr.func.params[0].1);
+        assert!(osr_edge.1.0 >= 9);
+    }
+
+    #[test]
+    fn header_must_exist() {
+        let orig = sum_loop_fn();
+        assert!(build_osr_function(&orig, BlockId(99)).is_err());
+    }
+
+    #[test]
+    fn interpreter_owned_region_end_is_dropped() {
+        // Mirror the optimizer's function-level region wrap: RegionStart in
+        // the pre-loop entry, RegionEnd in the post-loop exit.
+        let mut orig = sum_loop_fn();
+        let handle = VarId(20);
+        orig.next_var = 21;
+        orig.blocks[0].insts.insert(0, Inst::RegionStart(handle));
+        orig.blocks[3].insts.push(Inst::RegionEnd(handle));
+
+        let osr = build_osr_function(&orig, BlockId(1)).unwrap();
+        // The handle must not leak into the live-ins (it would waste a param
+        // and the interpreter binds it to nil anyway)…
+        assert!(!osr.live_ins.contains(&handle));
+        // …and the unmatched RegionEnd is gone: the interpreter closes the
+        // region when its frame unwinds after the transfer returns.
+        let exit = osr.func.blocks.iter().find(|b| b.id == BlockId(3)).unwrap();
+        assert!(
+            !exit.insts.iter().any(|i| matches!(i, Inst::RegionEnd(_))),
+            "unmatched RegionEnd must be dropped from the OSR variant"
+        );
+    }
+
+    #[test]
+    fn loop_local_region_pairs_are_kept() {
+        // A region opened and closed entirely inside the loop body must keep
+        // both ends — native code manages it like any other instruction.
+        let mut orig = sum_loop_fn();
+        let handle = VarId(20);
+        orig.next_var = 21;
+        orig.blocks[2].insts.insert(0, Inst::RegionStart(handle));
+        orig.blocks[2].insts.push(Inst::RegionEnd(handle));
+
+        let osr = build_osr_function(&orig, BlockId(1)).unwrap();
+        let body = osr.func.blocks.iter().find(|b| b.id == BlockId(2)).unwrap();
+        assert!(body.insts.iter().any(|i| matches!(i, Inst::RegionStart(_))));
+        assert!(body.insts.iter().any(|i| matches!(i, Inst::RegionEnd(_))));
+    }
+
+    #[test]
+    fn too_many_live_ins_decline() {
+        // A self-looping header with 9 φs blows the 8-arg dispatch limit.
+        let mut f = IrFunction::new(Some(Arc::from("wide")), None);
+        let phis = (0..9u32)
+            .map(|i| Inst::Phi(VarId(i), vec![(BlockId(0), VarId(i + 16))]))
+            .collect();
+        f.next_var = 32;
+        f.next_block = 1;
+        f.blocks = vec![Block {
+            id: BlockId(0),
+            phis,
+            insts: (0..9u32)
+                .map(|i| Inst::Const(VarId(i + 16), Const::Long(0)))
+                .collect(),
+            terminator: Terminator::RecurJump {
+                target: BlockId(0),
+                args: (16..25).map(VarId).collect(),
+            },
+        }];
+        assert!(build_osr_function(&f, BlockId(0)).is_err());
+    }
+}

--- a/crates/cljrs-jit/Cargo.toml
+++ b/crates/cljrs-jit/Cargo.toml
@@ -31,3 +31,4 @@ cranelift-native   = { workspace = true }
 [dev-dependencies]
 cljrs-stdlib = { workspace = true }
 cljrs-reader = { workspace = true }
+cljrs-env    = { workspace = true }

--- a/crates/cljrs-jit/README.md
+++ b/crates/cljrs-jit/README.md
@@ -4,20 +4,22 @@
 native code via Cranelift, making `cljrs run` and the REPL approach AOT-class
 throughput with no explicit compile step.
 
-**Status:** Phase 10.2 — functional for non-capturing, non-variadic,
-non-destructuring top-level `defn`s (the same set that Tier-1 handles), with
-epoch-tagged **code unloading**: redefined functions' native code is reclaimed
-at stop-the-world GC safepoints, keeping executable memory bounded across a long
-REPL session.
+**Status:** Phase 10.4 — functional for non-capturing top-level `defn`s (the
+same set that Tier-1 handles), with epoch-tagged **code unloading** (redefined
+functions' native code is reclaimed at stop-the-world GC safepoints, keeping
+executable memory bounded across a long REPL session) and **OSR** (on-stack
+replacement): a single-call hot `loop*`/`recur` is promoted to native code
+mid-run via loop back-edge counters and an OSR-entry compile.
 
 ## File layout
 
 | File | Description |
 |------|-------------|
-| `src/lib.rs` | Public API: `init()` — installs the enqueue, var-rebind, and STW-reclaim hooks and spawns the worker; `on_var_rebind`/`arity_ids` drive staling on redefinition |
-| `src/jit_compiler.rs` | `compile_jit(arity_id, ir_func)` — builds `JITModule`, registers rt_abi symbols, calls shared codegen; returns `CompiledFn { fn_ptr, module, code_size }` |
-| `src/jit_worker.rs` | Background worker thread: receives `CompileRequest`s, registers each module in `code_cache`, publishes the function pointer + epoch to `cljrs_eval::jit_state`. Each compile is wrapped in `catch_unwind` so a codegen panic on one function cannot kill the worker (the function just stays at Tier 1) |
+| `src/lib.rs` | Public API: `init()` — installs the enqueue (function + OSR), var-rebind, and STW-reclaim hooks and spawns the worker; `on_var_rebind`/`arity_ids` drive staling on redefinition (whole-function and OSR epochs) |
+| `src/jit_compiler.rs` | `compile_jit(func_name, ir_func)` — builds `JITModule`, registers rt_abi symbols, calls shared codegen; returns `CompiledFn { fn_ptr, module, code_size }` |
+| `src/jit_worker.rs` | Background worker thread: receives `CompileRequest::Function` and `CompileRequest::Osr` requests, registers each module in `code_cache`, publishes the function pointer + epoch (whole-function: `jit_state::store_native_fn`; OSR: `jit_state::store_osr_fn` with the live-in list). Each compile is wrapped in `catch_unwind` so a codegen panic on one function cannot kill the worker (the function just stays at Tier 1; failed OSR compiles are recorded via `mark_osr_failed`) |
 | `src/code_cache.rs` | Epoch-tagged registry of compiled modules; `mark_stale` on redefinition, `reclaim_at_stw` frees stale modules with no live frame via `JITModule::free_memory` |
+| `src/osr_integration.rs` | (test-only) end-to-end OSR test: lowers a real `loop*` from source, builds + compiles the OSR entry, and calls the native code with a mid-loop register snapshot |
 
 ## Public API
 
@@ -48,6 +50,7 @@ call_cljrs_fn
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `CLJRS_JIT_THRESHOLD` | `1000` | Calls before a function is JIT-compiled |
+| `CLJRS_OSR_THRESHOLD` | = JIT threshold | Loop back-edges (within one call) before an OSR entry is compiled |
 | `CLJRS_NO_JIT` | unset | Set to any value to disable JIT init |
 | `CLJRS_NO_IR` | unset | Disables IR lowering (also disables JIT) |
 
@@ -77,3 +80,33 @@ lifecycle of a compiled arity's native code:
    With all mutators parked, it scans active frames across all threads
    (`jit_state::live_epochs`) and frees every stale module whose epoch has **no**
    live frame — resolving the unload-vs-execute race without a separate protocol.
+
+## OSR — on-stack replacement (Phase 10.4)
+
+A script or REPL form is often a *single* call containing one very hot
+`loop*`/`recur`; it never returns to re-dispatch, so the invocation counter
+above can never promote it.  OSR promotes it mid-run:
+
+1. **Back-edge counters.** `interpret_ir_with_osr` (Tier 1, `cljrs-eval`)
+   counts `RecurJump`s per loop header within one execution.  Crossing
+   `osr_threshold()` calls `jit_state::osr_request`, whose hook (installed by
+   `init()`) enqueues `CompileRequest::Osr { arity_id, header, ir_func }`.
+2. **OSR-entry compile.** The worker calls
+   `cljrs_ir::osr::build_osr_function`, which keeps only the blocks reachable
+   from the loop header and turns the loop's live-in values (the header φs +
+   pre-loop defs the loop reads) into parameters.  The variant is compiled by
+   the ordinary backend and registered in the `code_cache` under its own
+   epoch; `jit_state::store_osr_fn` publishes `(fn_ptr, epoch, live_ins)`.
+3. **Mid-loop transfer.** At its next loop-header entry (after φ resolution,
+   so the loop variables are current), the interpreter snapshots the live-in
+   registers and calls the native entry; the native frame runs the remaining
+   iterations *and* everything after the loop, and its return value becomes
+   the call's result.  The transfer uses the same rooting + frame-epoch
+   protocol as ordinary JIT-native calls, so GC and code unloading see OSR
+   frames like any other native frame.
+4. **Unloading.** On var rebind, `jit_state::take_osr_epochs` drops the
+   arity's OSR entries and their epochs are staled alongside the
+   whole-function epoch.
+
+Failures anywhere (transform declined, codegen error, panic) mark the
+`(arity_id, header)` slot failed; the loop simply finishes at Tier 1.

--- a/crates/cljrs-jit/src/code_cache.rs
+++ b/crates/cljrs-jit/src/code_cache.rs
@@ -260,7 +260,8 @@ mod reclaim_integration {
         let arity_id = 0xC0DE_0001u64;
 
         // Emulate the worker: compile, register (→ epoch), publish ptr + epoch.
-        let compiled = crate::jit_compiler::compile_jit(arity_id, &ir).unwrap();
+        let compiled =
+            crate::jit_compiler::compile_jit(&format!("__cljrs_jit_{arity_id}"), &ir).unwrap();
         let fn_ptr = compiled.fn_ptr;
         let epoch = crate::code_cache::register(arity_id, compiled);
         cljrs_eval::jit_state::store_native_fn(arity_id, fn_ptr, epoch);

--- a/crates/cljrs-jit/src/jit_compiler.rs
+++ b/crates/cljrs-jit/src/jit_compiler.rs
@@ -27,8 +27,9 @@ pub(crate) struct CompiledFn {
 unsafe impl Send for CompiledFn {}
 
 /// Compile `ir_func` to native code, returning the function pointer and the
-/// owning module.
-pub(crate) fn compile_jit(arity_id: u64, ir_func: &IrFunction) -> Result<CompiledFn, String> {
+/// owning module.  `func_name` only names the symbol inside this module
+/// (each compilation gets its own `JITModule`).
+pub(crate) fn compile_jit(func_name: &str, ir_func: &IrFunction) -> Result<CompiledFn, String> {
     let mut builder = JITBuilder::new(cranelift_module::default_libcall_names())
         .map_err(|e| format!("JITBuilder::new: {e}"))?;
 
@@ -43,11 +44,10 @@ pub(crate) fn compile_jit(arity_id: u64, ir_func: &IrFunction) -> Result<Compile
     let mut compiler = new_compiler_from_module(jit_module, ptr_type)
         .map_err(|e| format!("new_compiler_from_module: {e:?}"))?;
 
-    let func_name = format!("__cljrs_jit_{arity_id}");
     let param_count = ir_func.params.len();
 
     let func_id: FuncId = compiler
-        .declare_function(&func_name, param_count)
+        .declare_function(func_name, param_count)
         .map_err(|e| format!("declare_function: {e:?}"))?;
 
     compiler

--- a/crates/cljrs-jit/src/jit_worker.rs
+++ b/crates/cljrs-jit/src/jit_worker.rs
@@ -3,7 +3,15 @@
 //! Receives compilation requests on a channel, compiles each `IrFunction` via
 //! Cranelift, hands the module to the epoch-tagged [`code_cache`](crate::code_cache),
 //! and atomically publishes the resulting function pointer + epoch via
-//! `cljrs_eval::jit_state::store_native_fn`.
+//! `cljrs_eval::jit_state`.
+//!
+//! Two request kinds arrive on the same channel:
+//! - whole-function compiles (invocation counter crossed the threshold), and
+//! - OSR-entry compiles (a loop back-edge counter crossed the threshold —
+//!   Phase 10.4).  The worker builds the OSR-entry variant with
+//!   [`cljrs_ir::osr::build_osr_function`], compiles it, and publishes
+//!   `(fn_ptr, epoch, live-ins)` via `jit_state::store_osr_fn`; failures are
+//!   recorded via `jit_state::mark_osr_failed` so interpreters stop polling.
 //!
 //! Ownership of every compiled `JITModule` lives in the `code_cache`, which
 //! reclaims superseded modules at stop-the-world safepoints (Phase 10.2).
@@ -11,14 +19,23 @@
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 
-use cljrs_ir::IrFunction;
+use cljrs_ir::{BlockId, IrFunction};
 
 use crate::code_cache;
 use crate::jit_compiler::compile_jit;
 
-pub(crate) struct CompileRequest {
-    pub(crate) arity_id: u64,
-    pub(crate) ir_func: Arc<IrFunction>,
+pub(crate) enum CompileRequest {
+    /// Whole-function compile for a hot arity.
+    Function {
+        arity_id: u64,
+        ir_func: Arc<IrFunction>,
+    },
+    /// OSR-entry compile for a hot loop header inside `arity_id`.
+    Osr {
+        arity_id: u64,
+        header: u32,
+        ir_func: Arc<IrFunction>,
+    },
 }
 
 /// Spawn the background JIT worker thread.
@@ -31,48 +48,115 @@ pub(crate) fn start_worker(rx: Receiver<CompileRequest>) {
 
 fn worker_loop(rx: Receiver<CompileRequest>) {
     for req in &rx {
-        cljrs_logging::feat_debug!("jit", "compiling arity_id={}", req.arity_id);
+        match req {
+            CompileRequest::Function { arity_id, ir_func } => {
+                compile_function_request(arity_id, &ir_func)
+            }
+            CompileRequest::Osr {
+                arity_id,
+                header,
+                ir_func,
+            } => compile_osr_request(arity_id, header, &ir_func),
+        }
+    }
+}
 
-        // Isolate each compilation: a panic in codegen (e.g. an unsupported IR
-        // shape that trips a Cranelift assertion) must not kill the worker
-        // thread and silently disable the JIT for the rest of the session.  On
-        // panic the function simply stays at Tier 1, exactly like a clean
-        // compile error.
-        let compiled = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            compile_jit(req.arity_id, &req.ir_func)
-        })) {
-            Ok(result) => result,
-            Err(_) => {
-                cljrs_logging::feat_debug!(
-                    "jit",
-                    "compile panicked arity_id={}; staying at Tier 1",
-                    req.arity_id
-                );
-                continue;
-            }
-        };
+fn compile_function_request(arity_id: u64, ir_func: &IrFunction) {
+    cljrs_logging::feat_debug!("jit", "compiling arity_id={}", arity_id);
 
-        match compiled {
-            Ok(compiled) => {
-                let fn_ptr = compiled.fn_ptr;
-                // Hand ownership of the module to the code cache; it returns the
-                // epoch that identifies this code for later reclamation.
-                let epoch = code_cache::register(req.arity_id, compiled);
-                cljrs_logging::feat_debug!(
-                    "jit",
-                    "compiled  arity_id={} epoch={} fn_ptr={:p}",
-                    req.arity_id,
-                    epoch,
-                    fn_ptr,
-                );
-                // Atomically publish the function pointer + epoch so future
-                // calls on mutator threads skip the interpreter.
-                cljrs_eval::jit_state::store_native_fn(req.arity_id, fn_ptr, epoch);
-            }
-            Err(e) => {
-                cljrs_logging::feat_debug!("jit", "compile error arity_id={}: {}", req.arity_id, e,);
-                // Don't retry; the function stays at Tier 1.
-            }
+    // Isolate each compilation: a panic in codegen (e.g. an unsupported IR
+    // shape that trips a Cranelift assertion) must not kill the worker
+    // thread and silently disable the JIT for the rest of the session.  On
+    // panic the function simply stays at Tier 1, exactly like a clean
+    // compile error.
+    let compiled = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        compile_jit(&format!("__cljrs_jit_{arity_id}"), ir_func)
+    })) {
+        Ok(result) => result,
+        Err(_) => {
+            cljrs_logging::feat_debug!(
+                "jit",
+                "compile panicked arity_id={}; staying at Tier 1",
+                arity_id
+            );
+            return;
+        }
+    };
+
+    match compiled {
+        Ok(compiled) => {
+            let fn_ptr = compiled.fn_ptr;
+            // Hand ownership of the module to the code cache; it returns the
+            // epoch that identifies this code for later reclamation.
+            let epoch = code_cache::register(arity_id, compiled);
+            cljrs_logging::feat_debug!(
+                "jit",
+                "compiled  arity_id={} epoch={} fn_ptr={:p}",
+                arity_id,
+                epoch,
+                fn_ptr,
+            );
+            // Atomically publish the function pointer + epoch so future
+            // calls on mutator threads skip the interpreter.
+            cljrs_eval::jit_state::store_native_fn(arity_id, fn_ptr, epoch);
+        }
+        Err(e) => {
+            cljrs_logging::feat_debug!("jit", "compile error arity_id={}: {}", arity_id, e,);
+            // Don't retry; the function stays at Tier 1.
+        }
+    }
+}
+
+fn compile_osr_request(arity_id: u64, header: u32, ir_func: &IrFunction) {
+    cljrs_logging::feat_debug!(
+        "jit",
+        "osr compiling arity_id={} header=bb{}",
+        arity_id,
+        header
+    );
+
+    // Same panic isolation as whole-function compiles: on any failure the
+    // loop simply keeps running at Tier 1.
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let osr = cljrs_ir::osr::build_osr_function(ir_func, BlockId(header))?;
+        let name = format!("__cljrs_jit_{arity_id}_osr{header}");
+        let compiled = compile_jit(&name, &osr.func)?;
+        Ok::<_, String>((compiled, osr.live_ins))
+    }));
+
+    match outcome {
+        Ok(Ok((compiled, live_ins))) => {
+            let fn_ptr = compiled.fn_ptr;
+            let epoch = code_cache::register(arity_id, compiled);
+            cljrs_logging::feat_debug!(
+                "jit",
+                "osr compiled arity_id={} header=bb{} epoch={} fn_ptr={:p} live_ins={}",
+                arity_id,
+                header,
+                epoch,
+                fn_ptr,
+                live_ins.len(),
+            );
+            cljrs_eval::jit_state::store_osr_fn(arity_id, header, fn_ptr, epoch, live_ins);
+        }
+        Ok(Err(e)) => {
+            cljrs_logging::feat_debug!(
+                "jit",
+                "osr declined arity_id={} header=bb{}: {}",
+                arity_id,
+                header,
+                e,
+            );
+            cljrs_eval::jit_state::mark_osr_failed(arity_id, header);
+        }
+        Err(_) => {
+            cljrs_logging::feat_debug!(
+                "jit",
+                "osr compile panicked arity_id={} header=bb{}; staying at Tier 1",
+                arity_id,
+                header
+            );
+            cljrs_eval::jit_state::mark_osr_failed(arity_id, header);
         }
     }
 }

--- a/crates/cljrs-jit/src/lib.rs
+++ b/crates/cljrs-jit/src/lib.rs
@@ -36,6 +36,8 @@ use cljrs_value::Value;
 pub mod code_cache;
 mod jit_compiler;
 mod jit_worker;
+#[cfg(all(test, not(feature = "no-gc")))]
+mod osr_integration;
 
 static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
@@ -58,11 +60,24 @@ pub fn init() {
 
     // Register the enqueue hook so the IR dispatch path can hand us hot
     // functions.
+    let fn_tx = tx.clone();
     cljrs_eval::set_enqueue_hook(move |arity_id, ir_func: Arc<IrFunction>| {
         // Non-blocking: if the queue is full, skip this compile request.
         // The function will keep running at Tier 1 until the queue drains.
-        let _ = tx.try_send(jit_worker::CompileRequest { arity_id, ir_func });
+        let _ = fn_tx.try_send(jit_worker::CompileRequest::Function { arity_id, ir_func });
     });
+
+    // Register the OSR enqueue hook (Phase 10.4) so a hot loop back-edge can
+    // request compilation of an OSR-entry variant mid-call.
+    cljrs_eval::jit_state::set_osr_enqueue_hook(
+        move |arity_id, header, ir_func: Arc<IrFunction>| {
+            let _ = tx.try_send(jit_worker::CompileRequest::Osr {
+                arity_id,
+                header,
+                ir_func,
+            });
+        },
+    );
 
     // Code unloading (Phase 10.2):
     //
@@ -99,6 +114,11 @@ fn on_var_rebind(old: &Value, new: &Value) {
             continue;
         }
         if let Some(epoch) = cljrs_eval::jit_state::take_native_epoch(id) {
+            code_cache::mark_stale(epoch);
+        }
+        // OSR-entry code for loops inside the old definition is superseded by
+        // the rebind just like its whole-function code.
+        for epoch in cljrs_eval::jit_state::take_osr_epochs(id) {
             code_cache::mark_stale(epoch);
         }
     }

--- a/crates/cljrs-jit/src/osr_integration.rs
+++ b/crates/cljrs-jit/src/osr_integration.rs
@@ -1,0 +1,92 @@
+//! Phase 10.4 — end-to-end OSR: lower a real `loop*`/`recur` from source,
+//! build the OSR-entry variant, compile it with Cranelift, and *call* the
+//! native code with a mid-loop interpreter state, mimicking exactly what
+//! `interpret_ir_with_osr`'s transfer does.
+//!
+//! Gated to the default GC build like the reclaim integration test: under
+//! `no-gc`, `lower_via_rust` runs the escape-blacklist check which can reject
+//! otherwise-fine functions.
+
+use std::sync::Arc;
+
+use cljrs_ir::{BlockId, IrFunction, Terminator};
+use cljrs_value::Value;
+
+/// Lower a function body to IR on a generously sized stack (Clojure eval is
+/// deeply recursive), mirroring the code_cache test helper.
+fn build_ir(name: &str, params: &[Arc<str>], body_src: &str) -> IrFunction {
+    let name = name.to_string();
+    let params = params.to_vec();
+    let body_src = body_src.to_string();
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            let mut parser = cljrs_reader::Parser::new(body_src, "<osr-test>".to_string());
+            let mut forms = Vec::new();
+            while let Ok(Some(f)) = parser.parse_one() {
+                forms.push(f);
+            }
+            let globals = cljrs_stdlib::standard_env();
+            let mut env = cljrs_eval::Env::new(globals, "user");
+            cljrs_compiler::aot::lower_via_rust(Some(&name), "user", &params, &forms, &mut env)
+                .expect("lowering should succeed")
+        })
+        .unwrap()
+        .join()
+        .unwrap()
+}
+
+/// The loop header of the (single) `RecurJump` in the function.
+fn find_loop_header(ir: &IrFunction) -> BlockId {
+    ir.blocks
+        .iter()
+        .find_map(|b| match &b.terminator {
+            Terminator::RecurJump { target, .. } => Some(*target),
+            _ => None,
+        })
+        .expect("function should contain a RecurJump back-edge")
+}
+
+#[test]
+fn osr_entry_compiles_and_resumes_natively_mid_loop() {
+    let _mutator = cljrs_gc::register_mutator();
+
+    // (fn sum-below [n] (loop [i 0 acc 0] (if (< i n) (recur (+ i 1) (+ acc i)) acc)))
+    let ir = build_ir(
+        "sum-below",
+        &[Arc::from("n")],
+        "(loop [i 0 acc 0] (if (< i n) (recur (+ i 1) (+ acc i)) acc))",
+    );
+
+    let header = find_loop_header(&ir);
+    let osr = cljrs_ir::osr::build_osr_function(&ir, header).expect("transform");
+    assert!(
+        (1..=8).contains(&osr.live_ins.len()),
+        "expected a dispatchable live-in count, got {}",
+        osr.live_ins.len()
+    );
+
+    let compiled =
+        crate::jit_compiler::compile_jit("__cljrs_jit_osr_test", &osr.func).expect("compile");
+    let fn_ptr = compiled.fn_ptr;
+    let epoch = crate::code_cache::register(0xC0DE_0540, compiled);
+
+    // Mid-loop interpreter state for n=10, paused at i=5: acc = 0+1+2+3+4 = 10.
+    // The transform orders live-ins as [header φ dsts (i, acc), then outer (n)].
+    let call_args = vec![Value::Long(5), Value::Long(10), Value::Long(10)];
+
+    // Same transfer protocol as ir_interp::try_osr_enter.
+    let result = {
+        let _jit_frame = cljrs_eval::jit_state::push_jit_frame(epoch);
+        let _arg_roots = cljrs_env::gc_roots::root_values(&call_args);
+        let _alloc_frame = cljrs_gc::push_alloc_frame();
+        let arg_ptrs: Vec<*const Value> = call_args.iter().map(|v| v as *const Value).collect();
+        // SAFETY: the OSR entry was compiled with `live_ins.len()` `*const
+        // Value` params; all arg pointers are rooted and live for the call.
+        let result_ptr = unsafe { cljrs_eval::jit_state::dispatch_jit_call(fn_ptr, &arg_ptrs) };
+        unsafe { (*result_ptr).clone() }
+    };
+
+    // Remaining iterations add 5+6+7+8+9 → 45 = sum 0..10.
+    assert_eq!(result, Value::Long(45));
+}

--- a/crates/cljrs/tests/osr_promotion.rs
+++ b/crates/cljrs/tests/osr_promotion.rs
@@ -1,0 +1,97 @@
+//! Phase 10.4 milestone — a *single-call* hot `loop`/`recur` promotes to
+//! native code mid-run via OSR (on-stack replacement).
+//!
+//! Invocation-count tiering can never promote this shape: the function is
+//! called exactly once and never returns to re-dispatch.  The loop back-edge
+//! counter must trip instead, the JIT worker compiles an OSR-entry variant in
+//! the background, and the Tier-1 interpreter transfers its register file into
+//! the native frame at a loop-header entry — all observable through
+//! `-X debug:jit` and, above all, through a correct final result.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct Run {
+    stdout: String,
+    stderr: String,
+}
+
+fn run_jit(src: &str) -> Run {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "cljrs_osr_promotion_{}_{nanos}_{seq}.cljrs",
+        std::process::id()
+    ));
+    std::fs::write(&path, src).expect("write script");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .args(["--jit-threshold", "100", "-X", "debug:jit", "run"])
+        .arg(&path)
+        .env("CLJRS_EAGER_LOWER", "1")
+        .output()
+        .expect("spawn cljrs");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "cljrs exited with {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Run {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+#[test]
+fn single_call_hot_loop_promotes_mid_run() {
+    // One call, two million back-edges.  The OSR threshold follows
+    // --jit-threshold (100), so the loop gets hot almost immediately and has
+    // ample iterations left for the background compile to land mid-run.
+    let src = r#"
+        (defn sum-below [n]
+          (loop [i 0 acc 0]
+            (if (< i n)
+              (recur (+ i 1) (+ acc i))
+              acc)))
+        (println "sum=" (sum-below 2000000))
+    "#;
+
+    let run = run_jit(src);
+
+    // Correctness first: 0+1+…+1999999 = 1999999000000, whichever tier
+    // finished the loop.
+    assert!(
+        run.stdout.contains("sum= 1999999000000"),
+        "wrong loop result; stdout:\n{}\nstderr:\n{}",
+        run.stdout,
+        run.stderr
+    );
+
+    // The back-edge counter must have requested OSR compilation…
+    assert!(
+        run.stderr.contains("osr enqueue"),
+        "loop never tripped the back-edge counter; stderr:\n{}",
+        run.stderr
+    );
+    // …the worker must have compiled and published the OSR entry…
+    assert!(
+        run.stderr.contains("osr compiled"),
+        "OSR entry was not compiled; stderr:\n{}",
+        run.stderr
+    );
+    // …and the interpreter must have transferred into native code mid-run.
+    assert!(
+        run.stderr.contains("osr entering native code"),
+        "interpreter never transferred into the OSR frame; stderr:\n{}",
+        run.stderr
+    );
+}


### PR DESCRIPTION
build_osr_function rewrites a function for on-stack replacement at a hot
loop header: only blocks reachable from the header are kept, the header
phis gain an incoming edge from a fresh entry block fed by fresh
parameters (the loop variables), and every pre-loop value the loop reads
becomes a parameter bound to its original VarId. live_ins tells the
interpreter which registers to pass, in parameter order.

RegionEnds whose RegionStart executed before the loop (the optimizer's
function-level region wrap runs in the interpreter before the transfer)
are dropped: the interpreter frame closes those regions after the
transfer returns, which only extends region lifetime — escape analysis
already guarantees nothing allocated under a region outlives its
original RegionEnd. Region pairs entirely inside the loop are kept.

Declines (caller stays at Tier 1) when live-ins exceed the 8-parameter
native dispatch limit.

https://claude.ai/code/session_01WBjhENNaboHRgA366aJPTA