### PR TITLE
Move versioned-symbol resolution into cljrs-env as a shared service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,7 @@ dependencies = [
  "cljrs-value",
  "cljrs-vcs",
  "regex",
+ "tempfile",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "cljrs-charset",
  "cljrs-compiler",
  "cljrs-deps",
+ "cljrs-dylib",
  "cljrs-eval",
  "cljrs-gc",
  "cljrs-interop",
@@ -475,6 +476,23 @@ dependencies = [
  "cljrs-reader",
  "cljrs-types",
  "thiserror",
+]
+
+[[package]]
+name = "cljrs-dylib"
+version = "0.1.0"
+dependencies = [
+ "cljrs-deps",
+ "cljrs-env",
+ "cljrs-gc",
+ "cljrs-interop",
+ "cljrs-interp",
+ "cljrs-logging",
+ "cljrs-reader",
+ "cljrs-value",
+ "cljrs-vcs",
+ "libloading",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "cljrs-reader",
  "cljrs-types",
  "cljrs-value",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-object",
  "target-lexicon",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "cranelift-jit",
  "cranelift-module",
  "cranelift-native",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ members = [
     "crates/cljrs-charset",
     "crates/cljrs-lsp",
     "crates/cljrs-base64",
-    "crates/cljrs-jit"]
+    "crates/cljrs-jit",
+    "crates/cljrs-dylib"]
 resolver = "2"
 
 [workspace.package]
@@ -62,6 +63,7 @@ cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
 cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0" }
 cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.0" }
 cljrs-jit          = { path = "crates/cljrs-jit",          version = "0.1.0" }
+cljrs-dylib        = { path = "crates/cljrs-dylib",        version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/TODO.md
+++ b/TODO.md
@@ -362,7 +362,7 @@ Pattern: `(map f (map g xs))`, lower to single loop.
 - [x] Calling Rust trait methods on `NativeObject` values via protocol dispatch
 - [ ] Safety restrictions: document which Rust APIs are safe to call from GC-managed code
 - [ ] `cljx.rust` namespace with intrinsics (`rust/cast`, `rust/ptr`, `rust/unsafe`, etc.)
-- [ ] Dynamic linking: load compiled Rust `.so`/`.dylib` at runtime
+- [x] Dynamic linking: load compiled Rust `.so`/`.dylib` at runtime — project-local lib via `cljrs build-native` + `load_native_lib`; **pinned native packages** (`:rust/load :dylib`) via `cljrs-dylib` (build the dep's crate at a pinned commit, ABI-fingerprint handshake, register into the `ns@<commit>` namespace). Deferred: statically linking pinned native crates into AOT harnesses (`#[export]` inventory collision between two versions of one crate), and a C-ABI vtable to replace the Rust-ABI `&mut Registry` boundary
 - [x] RAII resource management: `with-open` macro + `close` builtin for deterministic cleanup of `Resource` values
 - [ ] (Stretch) `#rust` typed sublanguage: functions annotated `#rust` receive Rust-typed arguments with lifetime bounds enforced at the interop boundary, bypassing `Value` boxing entirely for those call sites
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -60,12 +60,103 @@ When a function body is evaluated in a versioned context (commit `C`):
 | Symbol form                        | Resolved at          |
 |------------------------------------|----------------------|
 | Unqualified / same-namespace, no `@` | Commit `C` (inherited) |
+| Qualified self-reference (`my.ns/x` inside `my.ns@C`) | Commit `C` |
 | Explicitly versioned `foo@D`       | Commit `D`           |
 | External / cross-namespace, no `@` | HEAD (current)       |
 
 This means a versioned call is a logical "snapshot": internal helpers are also
 drawn from the same commit, but the standard library and cross-namespace
 dependencies use their current values unless explicitly pinned.
+
+### Whole-namespace snapshots
+
+Resolving `ns/name@commit` — by any execution tier — loads the **whole
+namespace** at that commit into an immutable namespace named `"ns@commit"`,
+then performs a plain lookup in it.  Consequences:
+
+- Historical definitions never intern into the live namespace (HEAD bindings
+  are never clobbered by a pinned lookup).
+- Top-level side effects of the pinned file run once, when the versioned
+  namespace is first loaded (per session, cached thereafter).
+- Same-namespace commit inheritance is structural: functions defined while
+  loading `ns@commit` carry `defining_ns = "ns@commit"`, so their internal
+  references resolve at the pinned commit on every tier without extra
+  bookkeeping.
+
+---
+
+## Execution tiers
+
+Versioned symbols work identically on all four execution paths; the shared
+resolver lives in `cljrs_env::versioned`:
+
+| Tier | Mechanism |
+|------|-----------|
+| Tree-walking interpreter | `eval_symbol` → `resolve_versioned_symbol` (thin shim) |
+| IR interpreter (Tier 2) | `LoadGlobal` carries the `@sha` in its name string; `load_global_value` detects it |
+| JIT-native (Tier 1) | codegen emits a **fill-once inline cache** per call site (`rt_load_global_versioned_ic`): versioned bindings are immutable, so the slot never needs invalidation; the cached value is permanently GC-rooted |
+| AOT binaries | same codegen; pinned sources are **embedded at compile time** (below) |
+
+### AOT: compile-time snapshot
+
+`cljrs compile` resolves every versioned require and bare versioned symbol
+during compilation (the `pin_versioned_references` pass), fetches each pinned
+source from git, and embeds it in the binary under the versioned namespace
+name.  The produced binary is **self-contained**:
+
+- no git repository, source files, or `~/.cljrs` cache needed at runtime;
+- the harness sets `versioned_offline`, so a versioned namespace that was not
+  embedded fails with a clear error instead of attempting a fetch;
+- a bad pin (missing commit, failed signature check) fails the *compile*;
+- `--verify-commit-signatures` runs `git verify-commit` at compile time — the
+  binary trusts its embedded sources.
+
+---
+
+## Native (Rust-backed) functions
+
+Native functions live in the running binary; there is no Clojure source to
+re-evaluate at a commit.  Two modes:
+
+### Default: verified HEAD binding
+
+A pinned lookup that falls back to a native function resolves to the current
+binary's implementation, **verified against the package's recorded
+provenance** (the commit it was built from, registered via
+`cljrs_interop::register_provenance!("ns", env!("CLJRS_PKG_COMMIT"))` or
+`Registry::set_provenance`):
+
+- provenance matches the pin (either may be abbreviated) → silent;
+- mismatch or no recorded provenance → warning, once per pin;
+- with `--enforce-native-versions` (or `:enforce-native-versions true` in
+  `cljrs.edn`) → hard error.
+
+### Opt-in: pinned native code (`:rust/load :dylib`) — experimental
+
+```clojure
+{:deps
+ {my.native.lib {:git/url   "https://github.com/user/my-native-lib"
+                 :git/sha   "abc1234ef"
+                 :rust/init "my_native_lib::cljrs_init"
+                 :rust/load :dylib}}}
+```
+
+When a pinned symbol resolves into such a dep's namespace, `cljrs-dylib`
+fetches the repository at the pinned commit, generates a wrapper cdylib crate
+(pinning the exact same `cljrs-interop` as the host), builds it with cargo
+(cached under `~/.cljrs/cache/dylibs/<crate>@<commit>/`), `dlopen`s it, and
+registers its exports into the immutable `"<ns>@<commit>"` namespace via a
+versioned `Registry` view.
+
+**ABI discipline:** the wrapper exports `cljrs_dylib_abi()` returning a
+fingerprint (cljrs version + `rustc -V`, baked at the wrapper's build time);
+the host refuses to call the Rust-ABI `cljrs_dylib_init(*mut Registry)`
+unless the fingerprint equals its own exactly.  Feature-flag skew between
+host and wrapper is *not* detected; a Rust toolchain is required at runtime.
+A full C-ABI vtable is the safer long-term design and is deliberately
+deferred, as is statically linking pinned native crates into AOT harnesses
+(open problem: two statically linked versions of one crate submit `#[export]`
+inventory entries under the same unversioned names).
 
 ---
 

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -33,3 +33,6 @@ cranelift-module   = { workspace = true }
 cranelift-object   = { workspace = true }
 cranelift-native   = { workspace = true }
 target-lexicon     = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -197,13 +197,27 @@ cross-type `Eq` always stay boxed.
 ### AOT driver (`aot.rs`)
 
 ```rust
-pub fn compile_file(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf]) -> AotResult<()>;
+pub fn compile_file(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf], rust_config: Option<&RustConfig>, verify_commit_signatures: bool) -> AotResult<()>;
 pub fn lower_via_clojure(name: Option<&str>, ns: &str, params: &[Arc<str>], forms: &[Form], env: &mut Env) -> AotResult<IrFunction>;
 
 pub enum AotError { Io, Parse, Codegen, Eval, Link, NoGcBlacklist(Vec<BlacklistViolation>) /* no-gc only */ }
 ```
 
-Pipeline: read source → parse → evaluate preamble → macro-expand → discover required namespaces → ANF lower (Clojure) → optimize (escape analysis + region alloc) → IR convert → **[no-gc] blacklist check** → Cranelift codegen → generate Cargo harness → `cargo build --release` → copy binary.
+Pipeline: read source → parse → evaluate preamble → macro-expand → pin versioned references → discover required namespaces → ANF lower (Clojure) → optimize (escape analysis + region alloc) → IR convert → **[no-gc] blacklist check** → Cranelift codegen → generate Cargo harness → `cargo build --release` → copy binary.
+
+**Versioned namespaces are snapshotted at compile time.** Versioned requires
+execute during expansion (fetching the pinned source from git); a discovery
+pass (`pin_versioned_references`) additionally walks the expanded program for
+bare versioned symbols (`mylib/foo@<sha>`) and force-loads each pin via
+`cljrs_env::versioned::pin_if_available`.  Every pinned source fetched this
+way is embedded in the binary under its versioned namespace name
+(`register_builtin_source("mylib@<sha>", …)`), so the produced binary is
+self-contained — the generated harness calls
+`globals.set_versioned_offline(true)`, and a versioned namespace that was not
+embedded fails with a clear error instead of attempting a git fetch.  A bad
+pin (missing commit, failed signature check) fails the *compile*.  When
+`verify_commit_signatures` is set, `git verify-commit` runs at compile time;
+the binary trusts its embedded sources.
 
 The generated harness `main()` calls `-main` (via `resolve`) after
 `__cljrs_main` returns, forwarding all command-line arguments (skipping the

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -129,6 +129,14 @@ walk directly, preserving full semantics.
   through to `rt_call` for non-protocol callees.  Cached values (interned keywords, impl fns)
   are kept alive by an IC root tracer registered per allocating thread; IC slots in compiled
   modules hold only indices/interned pointers, never GC roots.
+- **Versioned symbols:** `rt_load_global` detects a `name@<sha>` suffix and resolves it through
+  the shared `cljrs_env::versioned` resolver (lazily loading the immutable `ns@sha` namespace;
+  resolution failures surface as pending exceptions); lookups into a not-yet-loaded `ns@sha`
+  namespace trigger the same lazy load.  `rt_load_global_versioned_ic(ns, ns_len, name,
+  name_len, slot)` is the fast path emitted by codegen (`emit_load_global_versioned_ic`):
+  versioned bindings are immutable, so the per-call-site slot is filled once with a permanently
+  rooted boxed value (the `VERSIONED_IC` table, traced by the same IC root tracer) and never
+  invalidated.
   `jit_stats` module — relaxed diagnostic counters (`BOXED_ARITH_CALLS`, `GUARD_DEOPTS`,
   `KW_IC_FILLS`, `PROTO_IC_HITS`, `PROTO_IC_MISSES`) and `jit_stats::snapshot() -> String`
   (written by `cljrs --jit-stats`).

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -385,12 +385,16 @@ pub fn lower_file_to_ir(
 /// binary.  `src_dirs` are additional directories for `require` resolution
 /// during macro expansion.  `rust_config`, when present, causes the generated
 /// harness to depend on the user's Rust crate and call its `cljrs_init` hook
-/// before loading any Clojure code.
+/// before loading any Clojure code.  `verify_commit_signatures` enables
+/// `git verify-commit` on every versioned pin resolved during compilation
+/// (the produced binary trusts its embedded sources, so verification happens
+/// here, at compile time).
 pub fn compile_file(
     src_path: &Path,
     out_path: &Path,
     src_dirs: &[PathBuf],
     rust_config: Option<&cljrs_deps::RustConfig>,
+    verify_commit_signatures: bool,
 ) -> AotResult<()> {
     eprintln!("[aot] reading {}", src_path.display());
     let source = std::fs::read_to_string(src_path)?;
@@ -408,6 +412,11 @@ pub fn compile_file(
     } else {
         cljrs_stdlib::standard_env_with_paths(src_dirs.to_vec())
     };
+    if verify_commit_signatures {
+        globals
+            .verify_commit_signatures
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
     // Register clojure.core.async so that (require '[clojure.core.async ...])
     // and the `go`/`alt` macros resolve during macro-expansion. The GC
     // service is silently skipped when there is no LocalSet context.
@@ -442,8 +451,22 @@ pub fn compile_file(
     }
     eprintln!("[aot] macro-expanded {} form(s)", expanded.len());
 
-    // Discover user namespaces loaded during expansion (transitive deps).
-    let bundled_sources = discover_bundled_sources(&env.globals, &pre_loaded, src_dirs);
+    // ── 2a. Pin versioned references ──────────────────────────────────
+    // Versioned requires already executed (and were fetched) during
+    // expansion.  This pass additionally catches bare versioned symbols
+    // (`mylib/foo@<sha>`) anywhere in the program, force-loading each pin
+    // now so the binary is self-contained: every pinned source is recorded
+    // in `versioned_sources` for embedding, and a bad pin (missing commit,
+    // failed signature) fails the compile instead of the deployed binary.
+    pin_versioned_references(&expanded, &mut env)?;
+
+    // Discover user namespaces loaded during expansion (transitive deps),
+    // plus every pinned source fetched from git (embedded under the
+    // versioned namespace name, e.g. "mylib@abc1234").
+    let mut bundled_sources = discover_bundled_sources(&env.globals, &pre_loaded, src_dirs);
+    for (ns, src) in env.globals.versioned_sources_snapshot() {
+        bundled_sources.push((ns, src.to_string()));
+    }
     if !bundled_sources.is_empty() {
         eprintln!(
             "[aot] bundling {} required namespace(s): {}",
@@ -643,6 +666,94 @@ fn compile_subfunctions(ir_func: &IrFunction, compiler: &mut Compiler) -> AotRes
         compiler.compile_function(sub, func_id)?;
     }
     Ok(())
+}
+
+// ── Versioned pin discovery ──────────────────────────────────────────────────
+
+/// Walk the macro-expanded program for versioned symbols (`name@<sha>`,
+/// `ns/name@<sha>`) and force-load each pin at compile time.
+///
+/// Loading records the pinned source in `GlobalEnv::versioned_sources` for
+/// embedding.  Pins whose namespace has no locatable Clojure source are
+/// skipped (pure-Rust packages resolve through the native HEAD fallback at
+/// runtime; quoted symbols that merely look versioned stay inert).  Genuine
+/// load failures abort the compile.
+fn pin_versioned_references(
+    forms: &[cljrs_reader::Form],
+    env: &mut cljrs_eval::Env,
+) -> AotResult<()> {
+    let mut pins: Vec<(Option<String>, String)> = Vec::new();
+    for form in forms {
+        collect_versioned_syms(form, &mut pins);
+    }
+    pins.sort();
+    pins.dedup();
+
+    for (ns_part, commit) in pins {
+        let base: Arc<str> = match &ns_part {
+            Some(p) => {
+                let resolved = env
+                    .globals
+                    .resolve_alias(&env.current_ns, p)
+                    .unwrap_or_else(|| Arc::from(p.as_str()));
+                Arc::from(cljrs_env::versioned::base_ns_name(&resolved))
+            }
+            None => Arc::from(cljrs_env::versioned::base_ns_name(&env.current_ns)),
+        };
+        match cljrs_env::versioned::pin_if_available(&env.globals, &base, &commit) {
+            Ok(true) => eprintln!("[aot] pinned {base}@{commit}"),
+            Ok(false) => {}
+            Err(e) => {
+                return Err(AotError::Eval(format!(
+                    "failed to pin {base}@{commit}: {e:?}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Collect `(namespace-part, commit)` for every versioned symbol in the form
+/// tree (including quoted/metadata-wrapped positions).
+fn collect_versioned_syms(form: &cljrs_reader::Form, out: &mut Vec<(Option<String>, String)>) {
+    use cljrs_reader::form::FormKind;
+    match &form.kind {
+        FormKind::Symbol(s) => {
+            let sym = cljrs_value::Symbol::parse(s);
+            if let Some(v) = sym.version {
+                out.push((
+                    sym.namespace.as_deref().map(str::to_string),
+                    v.as_ref().to_string(),
+                ));
+            }
+        }
+        FormKind::List(items)
+        | FormKind::Vector(items)
+        | FormKind::Map(items)
+        | FormKind::Set(items)
+        | FormKind::AnonFn(items) => {
+            for item in items {
+                collect_versioned_syms(item, out);
+            }
+        }
+        FormKind::Quote(inner)
+        | FormKind::SyntaxQuote(inner)
+        | FormKind::Unquote(inner)
+        | FormKind::UnquoteSplice(inner)
+        | FormKind::Deref(inner)
+        | FormKind::Var(inner)
+        | FormKind::TaggedLiteral(_, inner) => collect_versioned_syms(inner, out),
+        FormKind::Meta(meta, inner) => {
+            collect_versioned_syms(meta, out);
+            collect_versioned_syms(inner, out);
+        }
+        FormKind::ReaderCond { clauses, .. } => {
+            for clause in clauses {
+                collect_versioned_syms(clause, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 // ── Bundled source discovery ─────────────────────────────────────────────────
@@ -899,6 +1010,10 @@ async fn run() {{
     // Initialize the standard environment so that rt_call and other
     // runtime bridge functions can look up builtins.
     let globals = cljrs_stdlib::standard_env();
+
+    // Versioned namespaces resolve only from sources embedded at compile
+    // time — an AOT binary never fetches from git at runtime.
+    globals.set_versioned_offline(true);
 
     // Register the async runtime (clojure.core.async, ^:async dispatch, await).
     cljrs_async::init(&globals);

--- a/crates/cljrs-compiler/src/codegen.rs
+++ b/crates/cljrs-compiler/src/codegen.rs
@@ -90,6 +90,7 @@ struct RuntimeFuncs {
     rt_identical: FuncId,
     rt_str: FuncId,
     rt_load_global: FuncId,
+    rt_load_global_versioned_ic: FuncId,
     rt_def_var: FuncId,
     rt_make_fn: FuncId,
     rt_make_fn_variadic: FuncId,
@@ -1277,6 +1278,13 @@ impl<'a, 'b, M: Module> FunctionTranslator<'a, 'b, M> {
         ns: &str,
         name: &str,
     ) -> CodegenResult<cranelift_codegen::ir::Value> {
+        // Versioned reference (`name@<sha>`): the binding is immutable for
+        // the lifetime of the process, so it goes through a fill-once
+        // per-call-site inline cache instead of a lookup on every execution.
+        if cljrs_value::symbol::split_version(name).1.is_some() {
+            return self.emit_load_global_versioned_ic(ns, name);
+        }
+
         // Create data objects for ns and name strings.
         let ns_data = self.module.declare_anonymous_data(false, false)?;
         let mut ns_desc = cranelift_module::DataDescription::new();
@@ -1304,6 +1312,79 @@ impl<'a, 'b, M: Module> FunctionTranslator<'a, 'b, M> {
             .ins()
             .call(func_ref, &[ns_ptr, ns_len, name_ptr, name_len]);
         Ok(self.builder.inst_results(call)[0])
+    }
+
+    /// Emit a versioned LoadGlobal (`ns/name@sha`) through a per-call-site
+    /// inline cache.
+    ///
+    /// Mirrors `emit_keyword_ic`: the site owns an 8-byte writable data slot.
+    /// Fast path: one load and a branch on the cached value pointer.  First
+    /// execution takes the miss edge into `rt_load_global_versioned_ic`,
+    /// which resolves the pinned symbol (lazily loading the `ns@sha`
+    /// namespace), permanently roots the boxed value, and stores it into the
+    /// slot.  Versioned bindings are immutable, so the slot never needs
+    /// invalidation.
+    fn emit_load_global_versioned_ic(
+        &mut self,
+        ns: &str,
+        name: &str,
+    ) -> CodegenResult<cranelift_codegen::ir::Value> {
+        // Writable zero-initialised slot for this call site.
+        let slot_data = self.module.declare_anonymous_data(true, false)?;
+        let mut slot_desc = cranelift_module::DataDescription::new();
+        slot_desc.define_zeroinit(8);
+        self.module.define_data(slot_data, &slot_desc)?;
+        let slot_gv = self
+            .module
+            .declare_data_in_func(slot_data, self.builder.func);
+        let slot_addr = self.builder.ins().global_value(self.ptr_type, slot_gv);
+
+        let flags = cranelift_codegen::ir::MemFlags::trusted();
+        let cached = self.builder.ins().load(self.ptr_type, flags, slot_addr, 0);
+
+        let miss_block = self.builder.create_block();
+        let merge_block = self.builder.create_block();
+        let merge_param = self.builder.append_block_param(merge_block, self.ptr_type);
+        self.builder.ins().brif(
+            cached,
+            merge_block,
+            &[BlockArg::Value(cached)],
+            miss_block,
+            &[],
+        );
+
+        // Miss: resolve + fill the slot.
+        self.builder.switch_to_block(miss_block);
+        let ns_data = self.module.declare_anonymous_data(false, false)?;
+        let mut ns_desc = cranelift_module::DataDescription::new();
+        ns_desc.define(ns.as_bytes().to_vec().into_boxed_slice());
+        self.module.define_data(ns_data, &ns_desc)?;
+        let ns_gv = self.module.declare_data_in_func(ns_data, self.builder.func);
+        let ns_ptr = self.builder.ins().global_value(self.ptr_type, ns_gv);
+        let ns_len = self.builder.ins().iconst(types::I64, ns.len() as i64);
+
+        let name_data = self.module.declare_anonymous_data(false, false)?;
+        let mut name_desc = cranelift_module::DataDescription::new();
+        name_desc.define(name.as_bytes().to_vec().into_boxed_slice());
+        self.module.define_data(name_data, &name_desc)?;
+        let name_gv = self
+            .module
+            .declare_data_in_func(name_data, self.builder.func);
+        let name_ptr = self.builder.ins().global_value(self.ptr_type, name_gv);
+        let name_len = self.builder.ins().iconst(types::I64, name.len() as i64);
+
+        let fill_ref = self.import_func(self.rt.rt_load_global_versioned_ic);
+        let call = self
+            .builder
+            .ins()
+            .call(fill_ref, &[ns_ptr, ns_len, name_ptr, name_len, slot_addr]);
+        let filled = self.builder.inst_results(call)[0];
+        self.builder
+            .ins()
+            .jump(merge_block, &[BlockArg::Value(filled)]);
+
+        self.builder.switch_to_block(merge_block);
+        Ok(merge_param)
     }
 
     /// Emit a LoadVar (ns/name lookup) — returns the Var object, not its value.
@@ -2018,6 +2099,12 @@ fn declare_runtime_funcs<M: Module>(
             module,
             "rt_load_global",
             &[ptr, types::I64, ptr, types::I64],
+            ptr,
+        )?,
+        rt_load_global_versioned_ic: declare_rt(
+            module,
+            "rt_load_global_versioned_ic",
+            &[ptr, types::I64, ptr, types::I64, ptr],
             ptr,
         )?,
         rt_def_var: declare_rt(

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -1930,6 +1930,13 @@ pub unsafe extern "C" fn rt_load_global(
         std::str::from_utf8_unchecked(std::slice::from_raw_parts(name_ptr, name_len as usize))
     };
 
+    // Versioned reference (`name@<sha>`): resolve through the shared
+    // versioned-namespace service.  (The IC bridge below is the fast path
+    // for these; this covers any non-IC caller.)
+    if let (base_name, Some(commit)) = cljrs_value::symbol::split_version(name) {
+        return resolve_versioned_boxed(ns, base_name, commit);
+    }
+
     // Look up in the global environment via the thread-local eval context.
     if let Some((globals, current_ns)) = cljrs_env::callback::capture_eval_context() {
         // Try the specified namespace first.
@@ -1948,8 +1955,48 @@ pub unsafe extern "C" fn rt_load_global(
         {
             return box_or_intern_val(val);
         }
+        // Reference into a versioned namespace (`lib@sha`/name) that has not
+        // been loaded this session: load it lazily and retry.
+        if let (base, Some(commit)) = cljrs_value::symbol::split_version(ns)
+            && !globals.is_loaded(ns)
+        {
+            match cljrs_env::versioned::ensure_versioned_ns_loaded(&globals, base, commit) {
+                Ok(_) => {
+                    if let Some(val) = globals.lookup_in_ns(ns, name) {
+                        return box_or_intern_val(val);
+                    }
+                }
+                Err(e) => {
+                    stash_pending_exception(Value::Str(GcPtr::new(format!("{e}"))));
+                    return rt_const_nil();
+                }
+            }
+        }
     }
     rt_const_nil()
+}
+
+/// Resolve `ns/name@commit` through the shared versioned resolver, boxing the
+/// result.  Resolution failures surface as a pending exception (versioned
+/// bindings are pinned by the programmer; silently yielding nil would mask
+/// typos and missing commits).
+fn resolve_versioned_boxed(ns_part: &str, name: &str, commit: &str) -> *const Value {
+    let Some((globals, current_ns)) = cljrs_env::callback::capture_eval_context() else {
+        return rt_const_nil();
+    };
+    match cljrs_env::versioned::resolve_versioned_value(
+        &globals,
+        &current_ns,
+        Some(ns_part),
+        name,
+        commit,
+    ) {
+        Ok(val) => box_or_intern_val(val),
+        Err(e) => {
+            stash_pending_exception(Value::Str(GcPtr::new(format!("{e}"))));
+            rt_const_nil()
+        }
+    }
 }
 
 /// Define (intern) a global var.  Returns a pointer to the Var value.
@@ -2032,7 +2079,13 @@ pub unsafe extern "C" fn rt_call(
 ) -> *const Value {
     let callee = unsafe { val_ref(callee) };
     let nargs = nargs as usize;
-    let arg_slice = unsafe { std::slice::from_raw_parts(args, nargs) };
+    // Zero-arg call sites pass a null args pointer (see emit_unknown_call);
+    // from_raw_parts requires non-null even for empty slices.
+    let arg_slice: &[*const Value] = if nargs == 0 || args.is_null() {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(args, nargs) }
+    };
 
     // Fast paths for map/set callables — avoid interpreter + GC heap allocation.
     match callee {
@@ -3673,6 +3726,7 @@ pub fn anchor_rt_symbols() {
     std::hint::black_box(rt_box_bool as *const () as usize);
     std::hint::black_box(rt_deopt as *const () as usize);
     std::hint::black_box(rt_kw_ic_fill as *const () as usize);
+    std::hint::black_box(rt_load_global_versioned_ic as *const () as usize);
     std::hint::black_box(rt_call_ic as *const () as usize);
 }
 
@@ -3839,9 +3893,18 @@ use std::sync::RwLock;
 
 static KW_INTERN: OnceLock<RwLock<std::collections::HashMap<String, SharedVal>>> = OnceLock::new();
 static PROTO_ICS: OnceLock<RwLock<Vec<Arc<ProtoIcCell>>>> = OnceLock::new();
+/// Resolved versioned values cached by compiled call sites, keyed by
+/// `"<ns>/<name@commit>"`.  Versioned bindings are immutable, so entries are
+/// never invalidated; the table permanently roots each boxed value.
+static VERSIONED_IC: OnceLock<RwLock<std::collections::HashMap<String, SharedVal>>> =
+    OnceLock::new();
 
 fn kw_intern_table() -> &'static RwLock<std::collections::HashMap<String, SharedVal>> {
     KW_INTERN.get_or_init(|| RwLock::new(std::collections::HashMap::new()))
+}
+
+fn versioned_ic_table() -> &'static RwLock<std::collections::HashMap<String, SharedVal>> {
+    VERSIONED_IC.get_or_init(|| RwLock::new(std::collections::HashMap::new()))
 }
 
 fn proto_ic_table() -> &'static RwLock<Vec<Arc<ProtoIcCell>>> {
@@ -3865,6 +3928,11 @@ fn ensure_ic_tracer_registered() {
         cljrs_gc::HEAP.register_root_tracer(|visitor| {
             use cljrs_gc::{GcVisitor as _, Trace as _};
             if let Some(table) = KW_INTERN.get() {
+                for v in table.read().unwrap().values() {
+                    visitor.visit(&v.0);
+                }
+            }
+            if let Some(table) = VERSIONED_IC.get() {
                 for v in table.read().unwrap().values() {
                     visitor.visit(&v.0);
                 }
@@ -3921,6 +3989,86 @@ pub unsafe extern "C" fn rt_kw_ic_fill(ptr: *const u8, len: u64, slot: *mut usiz
     // pointer, and aligned 8-byte stores cannot tear.
     unsafe { *slot = interned as usize };
     interned
+}
+
+/// Versioned-load inline-cache fill (slow path, once per call site).
+///
+/// Compiled code keeps an 8-byte writable slot per versioned `LoadGlobal`
+/// site (`ns/name@sha`).  Versioned bindings are immutable for the lifetime
+/// of the process, so the slot is filled once and never invalidated — no
+/// epoch or rebind machinery is needed.  On the first execution this bridge
+/// resolves the symbol through the shared versioned resolver (which may
+/// lazily load the `ns@sha` namespace from embedded source or git), interns
+/// the boxed value in a permanently rooted table, and stores the stable
+/// pointer into the slot.
+///
+/// Resolution failure leaves the slot empty (so a later execution retries)
+/// and surfaces a pending exception.
+///
+/// # Safety
+/// `ns_ptr`/`name_ptr` must describe valid UTF-8; `slot` must point to the
+/// call site's 8-byte data slot.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rt_load_global_versioned_ic(
+    ns_ptr: *const u8,
+    ns_len: u64,
+    name_ptr: *const u8,
+    name_len: u64,
+    slot: *mut usize,
+) -> *const Value {
+    let ns = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(ns_ptr, ns_len as usize))
+    };
+    let name = unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(name_ptr, name_len as usize))
+    };
+
+    let (base_name, version) = cljrs_value::symbol::split_version(name);
+    let Some(commit) = version else {
+        // Codegen only emits this bridge for versioned names; tolerate a
+        // stray unversioned call by deferring to the generic path (uncached).
+        return unsafe { rt_load_global(ns_ptr, ns_len, name_ptr, name_len) };
+    };
+
+    let key = format!("{ns}/{name}");
+    if let Some(v) = versioned_ic_table().read().unwrap().get(&key) {
+        let raw = v.0.get() as *const Value;
+        unsafe { *slot = raw as usize };
+        return raw;
+    }
+
+    let Some((globals, current_ns)) = cljrs_env::callback::capture_eval_context() else {
+        return rt_const_nil();
+    };
+    match cljrs_env::versioned::resolve_versioned_value(
+        &globals,
+        &current_ns,
+        Some(ns),
+        base_name,
+        commit,
+    ) {
+        Ok(val) => {
+            ensure_ic_tracer_registered();
+            let mut table = versioned_ic_table().write().unwrap();
+            // Re-check under the write lock so a racing resolution of the
+            // same symbol cannot replace (and un-root) a pointer already
+            // handed out.
+            if let Some(v) = table.get(&key) {
+                let raw = v.0.get() as *const Value;
+                unsafe { *slot = raw as usize };
+                return raw;
+            }
+            let ptr = GcPtr::new(val);
+            let raw = ptr.get() as *const Value;
+            table.insert(key, SharedVal(ptr));
+            unsafe { *slot = raw as usize };
+            raw
+        }
+        Err(e) => {
+            stash_pending_exception(Value::Str(GcPtr::new(format!("{e}"))));
+            rt_const_nil()
+        }
+    }
 }
 
 /// Invoke `callee` with already-cloned args, boxing the result and stashing a

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -37,7 +37,7 @@ fn compile_and_run(name: &str, source: &str) -> String {
         .spawn({
             let src = src_path.clone();
             let bin = bin_path.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[], None)
+            move || cljrs_compiler::aot::compile_file(&src, &bin, &[], None, false)
         })
         .unwrap()
         .join()
@@ -1038,7 +1038,7 @@ fn compile_and_run_multi(name: &str, main_source: &str, deps: &[(&str, &str)]) -
             let src = src_path.clone();
             let bin = bin_path.clone();
             let src_dir = src_dir.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None)
+            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None, false)
         })
         .unwrap()
         .join()
@@ -2138,5 +2138,179 @@ fn test_clojure_test_with_failure() {
     assert!(
         output.contains("FAIL in"),
         "expected FAIL message, got: {output}"
+    );
+}
+
+// ── Versioned namespaces (compile-time snapshot) ────────────────────────────
+
+/// Build a two-commit git fixture and return `(dir, src_dir, sha_v1)`.
+/// `src/mylib.cljrs` — v1: `the-answer` = 1; v2 (HEAD): `the-answer` = 2.
+#[cfg(feature = "aot_full_test")]
+fn make_versioned_lib_repo() -> (tempfile::TempDir, std::path::PathBuf, String) {
+    use std::path::Path;
+
+    fn git_ok(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .output()
+            .expect("git command failed to start");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let src_dir = root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    git_ok(&root, &["init", "-q", "-b", "main"]);
+    // Override any global commit.gpgsign so test commits don't invoke a
+    // signing server.
+    git_ok(&root, &["config", "commit.gpgsign", "false"]);
+
+    let lib_file = src_dir.join("mylib.cljrs");
+    std::fs::write(
+        &lib_file,
+        "(def the-answer 1)\n(defn describe [] (str \"v\" the-answer))\n",
+    )
+    .unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v1"]);
+    let sha_out = Command::new("git")
+        .arg("-C")
+        .arg(&root)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let sha_v1 = String::from_utf8(sha_out.stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+
+    std::fs::write(
+        &lib_file,
+        "(def the-answer 2)\n(defn describe [] (str \"v\" the-answer))\n",
+    )
+    .unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v2"]);
+
+    (dir, src_dir, sha_v1)
+}
+
+/// An AOT binary that pins a library namespace runs without the git repo,
+/// without source files, and without a cljrs cache (`HOME` redirected): the
+/// pinned source is fetched at compile time and embedded in the binary.
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn test_versioned_snapshot_is_self_contained() {
+    let _guard = AOT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let (repo_dir, src_dir, sha_v1) = make_versioned_lib_repo();
+
+    let out_dir = tempfile::tempdir().unwrap();
+    let src_path = out_dir.path().join("versioned_app.cljrs");
+    let bin_path = out_dir.path().join("versioned_app_bin");
+
+    // Both pin styles: a versioned require and a bare versioned symbol; plus
+    // the HEAD require to prove the live binding coexists untouched.
+    let app_source = format!(
+        r#"
+(require '[mylib@{sha} :as v1])
+(require '[mylib])
+(println (v1/describe))
+(println mylib/the-answer@{sha})
+(println mylib/the-answer)
+"#,
+        sha = sha_v1
+    );
+    std::fs::write(&src_path, app_source).unwrap();
+
+    let result = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn({
+            let src = src_path.clone();
+            let bin = bin_path.clone();
+            let src_dir = src_dir.clone();
+            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None, false)
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+    result.unwrap_or_else(|e| panic!("versioned AOT compilation failed: {e:?}"));
+
+    // Delete the library repo (source files AND git history) and run the
+    // binary from an empty cwd with HOME pointing at an empty dir (defeats
+    // ~/.cljrs caches).  The pinned values must come from embedded sources.
+    drop(repo_dir);
+    let empty_home = tempfile::tempdir().unwrap();
+    let empty_cwd = tempfile::tempdir().unwrap();
+
+    let output = Command::new(&bin_path)
+        .current_dir(empty_cwd.path())
+        .env("HOME", empty_home.path())
+        .output()
+        .expect("failed to run versioned binary");
+    assert!(
+        output.status.success(),
+        "versioned binary exited with {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(
+        stdout.trim(),
+        "v1\n1\n2",
+        "pinned values must be v1 and HEAD must stay v2; got:\n{stdout}"
+    );
+}
+
+/// A pin pointing at a commit that does not exist fails the *compile*, not
+/// the deployed binary.
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn test_versioned_bad_commit_fails_at_compile_time() {
+    let _guard = AOT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let (_repo_dir, src_dir, _sha_v1) = make_versioned_lib_repo();
+
+    let out_dir = tempfile::tempdir().unwrap();
+    let src_path = out_dir.path().join("bad_pin_app.cljrs");
+    let bin_path = out_dir.path().join("bad_pin_app_bin");
+
+    // Valid hash format, nonexistent commit.
+    std::fs::write(
+        &src_path,
+        "(println mylib/the-answer@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)\n",
+    )
+    .unwrap();
+
+    let result = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn({
+            let src = src_path.clone();
+            let bin = bin_path.clone();
+            let src_dir = src_dir.clone();
+            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None, false)
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+
+    let err = result.expect_err("compile must fail for a nonexistent pinned commit");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("aaaaaaa"),
+        "error should mention the bad commit: {msg}"
     );
 }

--- a/crates/cljrs-deps/README.md
+++ b/crates/cljrs-deps/README.md
@@ -54,7 +54,13 @@ pub enum Dependency {
     Local { root: PathBuf },
 }
 
-pub struct GitDep { pub url: Arc<str>, pub sha: Arc<str> }
+pub struct GitDep {
+    pub url: Arc<str>,
+    pub sha: Arc<str>,
+    pub rust_init:       Option<Arc<str>>,  // :rust/init  — native init fn path
+    pub rust_crate_dir:  Option<Arc<str>>,  // :rust/crate — Cargo.toml subdir
+    pub rust_load_dylib: bool,              // :rust/load :dylib — pinned native code
+}
 
 pub struct Alias {
     pub extra_paths: Vec<PathBuf>,
@@ -68,7 +74,12 @@ pub struct Alias {
 {:paths ["src"]
 
  :deps
- {my.lib {:git/url "https://github.com/user/my-lib" :git/sha "abc1234ef"}}
+ {my.lib {:git/url "https://github.com/user/my-lib" :git/sha "abc1234ef"}
+  ;; Native dep with opt-in pinned native code (cljrs-dylib):
+  my.native.lib {:git/url   "https://github.com/user/my-native-lib"
+                 :git/sha   "abc1234ef"
+                 :rust/init "my_native_lib::cljrs_init"
+                 :rust/load :dylib}}
 
  ;; Optional: embed a Rust crate in this project.
  ;; :crate is the path (relative to cljrs.edn) to the directory holding Cargo.toml.

--- a/crates/cljrs-deps/README.md
+++ b/crates/cljrs-deps/README.md
@@ -35,6 +35,8 @@ pub struct DepsConfig {
     pub deps:                     Vec<(Arc<str>, Dependency)>,
     pub aliases:                  Vec<(Arc<str>, Alias)>,
     pub verify_commit_signatures: bool,
+    pub enforce_native_versions:  bool,  // :enforce-native-versions — pinned-native
+                                         // provenance mismatches error instead of warning
     pub rust:                     Option<RustConfig>,
 }
 

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -42,6 +42,18 @@ pub type DepsResult<T> = Result<T, DepsError>;
 pub struct GitDep {
     pub url: Arc<str>,
     pub sha: Arc<str>,
+    /// `:rust/init` — fully-qualified path to the dep's native init function
+    /// (e.g. `"my_crate::cljrs_init"`), when the dep ships Rust code.
+    pub rust_init: Option<Arc<str>>,
+    /// `:rust/crate` — directory of the dep's Cargo.toml relative to its
+    /// repository root (defaults to the root).
+    pub rust_crate_dir: Option<Arc<str>>,
+    /// `:rust/load :dylib` — opt in to **pinned native code**: when a
+    /// versioned symbol resolves into this dep's namespace and falls back to
+    /// a native function, build the dep's crate at the pinned commit as a
+    /// cdylib and load it instead of using the current binary's
+    /// implementation.
+    pub rust_load_dylib: bool,
 }
 
 /// A dependency declared in `:deps` or `:extra-deps`.

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -111,6 +111,11 @@ pub struct DepsConfig {
     /// must pass `git verify-commit` before historical code is executed.
     /// Equivalent to the `--verify-commit-signatures` CLI flag.
     pub verify_commit_signatures: bool,
+    /// When true, a pinned lookup of a native (Rust-backed) function whose
+    /// recorded provenance does not match the requested commit is an error
+    /// instead of a warning.  Equivalent to the `--enforce-native-versions`
+    /// CLI flag.
+    pub enforce_native_versions: bool,
     /// Optional Rust-crate configuration for mixed Rust/Clojure projects.
     pub rust: Option<RustConfig>,
 }

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -104,6 +104,9 @@ fn extract_dependency(form: &Form, config_dir: &Path, name: &str) -> Result<Depe
     let mut git_url: Option<Arc<str>> = None;
     let mut git_sha: Option<Arc<str>> = None;
     let mut local_root: Option<PathBuf> = None;
+    let mut rust_init: Option<Arc<str>> = None;
+    let mut rust_crate_dir: Option<Arc<str>> = None;
+    let mut rust_load_dylib = false;
 
     let mut i = 0;
     while i + 1 < pairs.len() {
@@ -118,13 +121,29 @@ fn extract_dependency(form: &Form, config_dir: &Path, name: &str) -> Result<Depe
                 let rel = require_str(&pairs[i + 1], "local/root")?;
                 local_root = Some(config_dir.join(rel));
             }
+            Some("rust/init") => {
+                rust_init = Some(Arc::from(require_str(&pairs[i + 1], "rust/init")?));
+            }
+            Some("rust/crate") => {
+                rust_crate_dir = Some(Arc::from(require_str(&pairs[i + 1], "rust/crate")?));
+            }
+            Some("rust/load") => match keyword_name(&pairs[i + 1]) {
+                Some("dylib") => rust_load_dylib = true,
+                _ => return Err(format!("dep {name}: :rust/load must be :dylib")),
+            },
             _ => {}
         }
         i += 2;
     }
 
     match (git_url, git_sha, local_root) {
-        (Some(url), Some(sha), _) => Ok(Dependency::Git(GitDep { url, sha })),
+        (Some(url), Some(sha), _) => Ok(Dependency::Git(GitDep {
+            url,
+            sha,
+            rust_init,
+            rust_crate_dir,
+            rust_load_dylib,
+        })),
         (_, _, Some(root)) => Ok(Dependency::Local { root }),
         _ => Err(format!(
             "dep {name}: must specify either :git/url + :git/sha or :local/root"

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -56,6 +56,10 @@ fn extract_config(form: &Form, config_dir: &Path) -> Result<DepsConfig, String> 
                 FormKind::Bool(b) => config.verify_commit_signatures = *b,
                 _ => return Err(":verify-commit-signatures must be true or false".to_string()),
             },
+            Some("enforce-native-versions") => match &val.kind {
+                FormKind::Bool(b) => config.enforce_native_versions = *b,
+                _ => return Err(":enforce-native-versions must be true or false".to_string()),
+            },
             Some("rust") => {
                 config.rust = Some(extract_rust_config(val, config_dir)?);
             }

--- a/crates/cljrs-dylib/Cargo.toml
+++ b/crates/cljrs-dylib/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cljrs-dylib"
+version = "0.1.0"
+edition = "2024"
+description = "Pinned native packages for clojurust: build a dependency's Rust crate at a pinned commit as a cdylib and load it (:rust/load :dylib)"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cljrs-env     = { workspace = true }
+cljrs-vcs     = { workspace = true }
+cljrs-deps    = { workspace = true }
+cljrs-interop = { workspace = true }
+cljrs-logging = { workspace = true }
+libloading    = "0.8"
+
+[dev-dependencies]
+cljrs-interp = { workspace = true }
+cljrs-value  = { workspace = true }
+cljrs-gc     = { workspace = true }
+cljrs-reader = { workspace = true }
+tempfile     = "3"

--- a/crates/cljrs-dylib/README.md
+++ b/crates/cljrs-dylib/README.md
@@ -1,0 +1,68 @@
+# cljrs-dylib
+
+## Purpose
+
+Pinned native packages: build a dependency's Rust crate at a pinned git
+commit as a cdylib and load it, so versioned symbols (`my.lib/f@<sha>`) can
+resolve to **truly pinned** native code instead of the default verified HEAD
+binding (`:rust/load :dylib` in `cljrs.edn`).
+
+## Status
+
+Versioned-namespaces plan, Phase 5 (see `docs/versioned-namespaces-plan.md`).
+Implemented and tested end-to-end, but **experimental**: the init call
+crosses a Rust-ABI boundary guarded only by the fingerprint handshake
+(feature-flag skew between host and wrapper is not detected), and a Rust
+toolchain is required at runtime.  Statically linking pinned native crates
+into AOT harnesses is deferred (open problem: `#[export]` inventory
+collisions between two versions of one crate).
+
+## File layout
+
+```
+src/lib.rs  — install (loader hook), wrapper crate generation, cargo build +
+              cache, dlopen + ABI handshake, versioned Registry init
+build.rs    — captures `rustc -V` for the host side of the ABI fingerprint
+tests/
+  pinned_dylib_e2e.rs — gated end-to-end test (CLJRS_DYLIB_E2E=1): two-commit
+              native crate fixture; pinned resolution loads the v1 dylib while
+              HEAD stays untouched
+```
+
+## Public API
+
+```rust
+/// Install the pinned-native loader hook on the environment (idempotent).
+/// Called by the cljrs CLI during setup_globals.
+pub fn install(globals: &Arc<GlobalEnv>);
+
+/// The host's ABI fingerprint: "cljrs <version>; <rustc -V>; <debug|release>".
+/// A wrapper dylib is loaded only when its baked fingerprint equals this.
+pub fn abi_fingerprint() -> String;
+
+pub const ABI_SYMBOL: &[u8];   // b"cljrs_dylib_abi\0"
+pub const INIT_SYMBOL: &[u8];  // b"cljrs_dylib_init\0"
+```
+
+## How it works
+
+1. The versioned resolver (`cljrs_env::versioned`) calls the installed
+   `PinnedNativeLoader` when a pinned lookup is about to fall back to a
+   native function.
+2. The loader finds a `:rust/load :dylib` git dep covering the namespace
+   (exact or dotted-prefix match) with a `:rust/init` function.
+3. `cljrs_vcs::fetch_remote` + checkout at the pinned commit
+   (`~/.cljrs/cache/dylibs/checkouts/<crate>@<commit>`).
+4. A wrapper cdylib crate is generated
+   (`~/.cljrs/cache/dylibs/<crate>@<commit>/fp-<hash>/`), pinning the same
+   `cljrs-interop` as the host (local checkout path when found —
+   `CLJRS_WORKSPACE_ROOT` override honored — else the published `=version`),
+   and built with cargo **in the host's profile** (debug/release —
+   `cljrs-gc` object headers differ between profiles).
+5. dlopen → `cljrs_dylib_abi()` fingerprint must equal
+   `abi_fingerprint()` exactly, else refuse → `cljrs_dylib_init(*mut
+   Registry)` registers the package's exports through
+   `Registry::versioned(commit)`, landing every definition in the immutable
+   `"<ns>@<commit>"` namespace.
+6. The namespace is marked loaded; subsequent pinned lookups are plain
+   namespace hits.

--- a/crates/cljrs-dylib/build.rs
+++ b/crates/cljrs-dylib/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    // Capture the host rustc version for the ABI handshake: a pinned-package
+    // wrapper dylib is only loaded when it was built by the exact same
+    // compiler as this binary's runtime crates.
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    let version = std::process::Command::new(rustc)
+        .arg("-V")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=CLJRS_DYLIB_RUSTC={version}");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/crates/cljrs-dylib/src/lib.rs
+++ b/crates/cljrs-dylib/src/lib.rs
@@ -1,0 +1,422 @@
+//! Pinned native packages: build a dependency's Rust crate at a pinned git
+//! commit as a cdylib and load it (`:rust/load :dylib` in `cljrs.edn`).
+//!
+//! By default, a pinned symbol (`mylib/f@<sha>`) that resolves to a native
+//! (Rust-backed) function falls back to the **current binary's**
+//! implementation, with provenance verification (see
+//! `cljrs_env::versioned`).  This crate provides the opt-in alternative:
+//! true pinned native code.
+//!
+//! ## Flow
+//!
+//! 1. `install(globals)` registers a [`PinnedNativeLoader`] hook on the
+//!    environment.  The versioned resolver calls it whenever a pinned
+//!    lookup is about to fall back to a native function.
+//! 2. The hook checks `cljrs.edn` for a dep covering the namespace with
+//!    `:rust/load :dylib` and a `:rust/init` function.
+//! 3. The dep's repository is fetched (`cljrs_vcs::fetch_remote`), checked
+//!    out at the pinned commit, and wrapped in a generated cdylib crate
+//!    that pins the exact same `cljrs-interop` as the host.
+//! 4. `cargo build --release` (cached per `(crate, commit, rustc, cljrs
+//!    version)`), then `dlopen`.
+//! 5. **ABI handshake**: the wrapper exports `cljrs_dylib_abi()` returning
+//!    a fingerprint string (cljrs version + `rustc -V`, baked at the
+//!    wrapper's build time).  The host refuses to proceed unless it equals
+//!    the host's own fingerprint exactly.
+//! 6. The wrapper's `cljrs_dylib_init(*mut Registry)` registers the
+//!    package's exports through a [`Registry::versioned`] view, so the
+//!    pinned implementations land in the immutable `"<ns>@<commit>"`
+//!    namespace and never collide with the live ones.
+//!
+//! ## Safety model (experimental)
+//!
+//! `cljrs_dylib_init` crosses the boundary with a Rust-ABI `&mut Registry`.
+//! This is sound *only* because the handshake guarantees both sides were
+//! compiled by the identical compiler against the identical `cljrs-interop`
+//! version.  Feature-flag skew between host and wrapper builds is not
+//! detected; the whole mechanism is opt-in and documented as experimental.
+//! A full C-ABI vtable is the safer long-term design and is deliberately
+//! deferred.
+
+// EvalError is large by design across the workspace (same allow as cljrs-env).
+#![allow(clippy::result_large_err)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cljrs_deps::{Dependency, GitDep};
+use cljrs_env::env::GlobalEnv;
+use cljrs_env::error::{EvalError, EvalResult};
+
+/// Exported ABI-handshake symbol name.
+pub const ABI_SYMBOL: &[u8] = b"cljrs_dylib_abi\0";
+/// Exported init symbol name.
+pub const INIT_SYMBOL: &[u8] = b"cljrs_dylib_init\0";
+
+/// The host's ABI fingerprint: cljrs workspace version, the rustc that
+/// compiled this crate, and the build profile (debug/release — `cljrs-gc`'s
+/// object headers have `debug_assertions`-gated fields, so the profiles must
+/// match).  A wrapper dylib is only loaded when its baked fingerprint equals
+/// this string exactly.
+pub fn abi_fingerprint() -> String {
+    format!(
+        "cljrs {}; {}; {}",
+        env!("CARGO_PKG_VERSION"),
+        env!("CLJRS_DYLIB_RUSTC"),
+        host_profile(),
+    )
+}
+
+/// The host's build profile, which the wrapper build must match.
+fn host_profile() -> &'static str {
+    if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    }
+}
+
+/// Install the pinned-native package loader on `globals`.
+///
+/// Idempotent (first writer wins).  Called by the `cljrs` CLI during
+/// environment setup; embedders that want `:rust/load :dylib` support call
+/// it after constructing their `GlobalEnv`.
+pub fn install(globals: &Arc<GlobalEnv>) {
+    globals.set_pinned_native_loader(Arc::new(load_pinned));
+}
+
+/// The loader hook: returns `Ok(true)` when the package covering `base_ns`
+/// was built at `commit` and registered into `"<base_ns>@<commit>"`.
+fn load_pinned(globals: &Arc<GlobalEnv>, base_ns: &str, commit: &str) -> EvalResult<bool> {
+    let config = globals.deps_config.read().unwrap().clone();
+    let Some(config) = config else {
+        return Ok(false);
+    };
+    let Some(git) = find_dylib_dep(&config, base_ns) else {
+        return Ok(false);
+    };
+
+    let versioned_ns = format!("{base_ns}@{commit}");
+    if globals.is_loaded(&versioned_ns) {
+        return Ok(true);
+    }
+
+    let lib_path = build_pinned_wrapper(&git, commit)
+        .map_err(|e| EvalError::Runtime(format!("pinned native {versioned_ns}: {e}")))?;
+
+    load_library(globals, &lib_path, commit)
+        .map_err(|e| EvalError::Runtime(format!("pinned native {versioned_ns}: {e}")))?;
+
+    globals.mark_loaded(&versioned_ns);
+    eprintln!("[cljrs-dylib] loaded pinned native package {versioned_ns}");
+    Ok(true)
+}
+
+/// Find a `:rust/load :dylib` git dep whose name covers `base_ns` (exact
+/// match or dotted prefix: dep `my.lib` covers `my.lib.util`).
+fn find_dylib_dep(config: &cljrs_deps::DepsConfig, base_ns: &str) -> Option<GitDep> {
+    for (name, dep) in &config.deps {
+        if let Dependency::Git(git) = dep
+            && git.rust_load_dylib
+            && (name.as_ref() == base_ns
+                || base_ns
+                    .strip_prefix(name.as_ref())
+                    .is_some_and(|rest| rest.starts_with('.')))
+        {
+            return Some(git.clone());
+        }
+    }
+    None
+}
+
+// ── Wrapper build ─────────────────────────────────────────────────────────────
+
+/// Build (or reuse from cache) the wrapper cdylib for `git` at `commit`,
+/// returning the path to the built library.
+fn build_pinned_wrapper(git: &GitDep, commit: &str) -> Result<PathBuf, String> {
+    let init_fn = git
+        .rust_init
+        .as_deref()
+        .ok_or("dep has :rust/load :dylib but no :rust/init function")?;
+    let crate_name = init_fn.split("::").next().unwrap_or(init_fn);
+    // Cargo package names use '-', Rust paths use '_': accept either by
+    // depending on the package directory and renaming is unnecessary —
+    // we depend by path, and Cargo reads the real package name from the
+    // checkout's Cargo.toml.  The `extern crate` ident is the init path's
+    // first segment, which must match the package's lib name.
+    let pkg_ident = crate_name.replace('-', "_");
+
+    // 1. Fetch + checkout at the pinned commit.
+    let bare = cljrs_vcs::fetch_remote(&git.url, commit).map_err(|e| e.to_string())?;
+    let checkout = checkout_at(&bare, crate_name, commit)?;
+    let crate_dir = match git.rust_crate_dir.as_deref() {
+        Some(sub) => checkout.join(sub),
+        None => checkout.clone(),
+    };
+    if !crate_dir.join("Cargo.toml").exists() {
+        return Err(format!(
+            "no Cargo.toml at {} (set :rust/crate if the crate lives in a subdirectory)",
+            crate_dir.display()
+        ));
+    }
+
+    // 2. Cache key: same wrapper inputs → same artifact.
+    let fingerprint = abi_fingerprint();
+    let fp_hash = stable_hash(&format!("{fingerprint}|{}|{commit}", git.url));
+    let wrapper_dir = dylib_cache_root()
+        .join(format!("{pkg_ident}@{commit}"))
+        .join(format!("fp-{fp_hash}"));
+    let artifact = wrapper_artifact_path(&wrapper_dir);
+    if artifact.exists() {
+        return Ok(artifact);
+    }
+
+    // 3. Generate the wrapper crate.
+    write_wrapper_crate(&wrapper_dir, &crate_dir, crate_name, &pkg_ident, init_fn)?;
+
+    // 4. Build, matching the host's profile (see `abi_fingerprint`).
+    let offline = find_workspace_root().is_some();
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.arg("build").current_dir(&wrapper_dir);
+    if host_profile() == "release" {
+        cmd.arg("--release");
+    }
+    if offline {
+        cmd.arg("--offline");
+    }
+    eprintln!("[cljrs-dylib] building pinned native package {pkg_ident}@{commit}…");
+    let status = cmd.status().map_err(|e| format!("cargo: {e}"))?;
+    if !status.success() {
+        return Err(format!(
+            "cargo build of pinned wrapper failed (see output above; wrapper at {})",
+            wrapper_dir.display()
+        ));
+    }
+
+    if !artifact.exists() {
+        return Err(format!("built wrapper not found at {}", artifact.display()));
+    }
+    Ok(artifact)
+}
+
+/// Clone the bare cache repo into a working checkout at `commit`.
+fn checkout_at(bare: &Path, crate_name: &str, commit: &str) -> Result<PathBuf, String> {
+    let dest = dylib_cache_root()
+        .join("checkouts")
+        .join(format!("{crate_name}@{commit}"));
+    if dest.join(".git").exists() {
+        return Ok(dest);
+    }
+    std::fs::create_dir_all(dest.parent().unwrap()).map_err(|e| e.to_string())?;
+    let ok = std::process::Command::new("git")
+        .arg("clone")
+        .arg("--quiet")
+        .arg(bare)
+        .arg(&dest)
+        .status()
+        .map_err(|e| e.to_string())?
+        .success();
+    if !ok {
+        return Err(format!("git clone of {} failed", bare.display()));
+    }
+    let ok = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&dest)
+        .arg("checkout")
+        .arg("--quiet")
+        .arg(commit)
+        .status()
+        .map_err(|e| e.to_string())?
+        .success();
+    if !ok {
+        return Err(format!("git checkout {commit} failed"));
+    }
+    Ok(dest)
+}
+
+/// Write the generated wrapper crate (Cargo.toml, build.rs, src/lib.rs).
+fn write_wrapper_crate(
+    wrapper_dir: &Path,
+    crate_dir: &Path,
+    crate_name: &str,
+    pkg_ident: &str,
+    init_fn: &str,
+) -> Result<(), String> {
+    std::fs::create_dir_all(wrapper_dir.join("src")).map_err(|e| e.to_string())?;
+
+    // Pin cljrs-interop exactly like the AOT harness pins runtime crates:
+    // a local checkout when one is found (offline), the published version
+    // otherwise.  The handshake catches any residual mismatch.
+    let interop_dep = match find_workspace_root() {
+        Some(root) => format!(
+            "cljrs-interop = {{ path = \"{}\" }}",
+            root.join("crates/cljrs-interop").display()
+        ),
+        None => format!("cljrs-interop = \"={}\"", env!("CARGO_PKG_VERSION")),
+    };
+
+    let cargo_toml = format!(
+        r#"[package]
+name = "cljrs-pinned-wrapper"
+version = "{version}"
+edition = "2024"
+
+[workspace]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+{interop_dep}
+{crate_name} = {{ path = "{crate_dir}" }}
+
+[profile.release]
+panic = "unwind"
+"#,
+        version = env!("CARGO_PKG_VERSION"),
+        crate_dir = crate_dir.display(),
+    );
+    std::fs::write(wrapper_dir.join("Cargo.toml"), cargo_toml).map_err(|e| e.to_string())?;
+
+    let build_rs = r#"fn main() {
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    let version = std::process::Command::new(rustc)
+        .arg("-V")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=CLJRS_WRAPPER_RUSTC={version}");
+}
+"#;
+    std::fs::write(wrapper_dir.join("build.rs"), build_rs).map_err(|e| e.to_string())?;
+
+    let lib_rs = format!(
+        r#"//! Auto-generated pinned-package wrapper (cljrs-dylib).
+
+/// ABI fingerprint baked at build time; must equal the host's
+/// `cljrs_dylib::abi_fingerprint()` exactly (including the build profile —
+/// cljrs-gc object headers differ between debug and release).
+#[cfg(debug_assertions)]
+static ABI: &str = concat!(
+    "cljrs ",
+    env!("CARGO_PKG_VERSION"),
+    "; ",
+    env!("CLJRS_WRAPPER_RUSTC"),
+    "; debug\0"
+);
+#[cfg(not(debug_assertions))]
+static ABI: &str = concat!(
+    "cljrs ",
+    env!("CARGO_PKG_VERSION"),
+    "; ",
+    env!("CLJRS_WRAPPER_RUSTC"),
+    "; release\0"
+);
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cljrs_dylib_abi() -> *const std::os::raw::c_char {{
+    ABI.as_ptr() as *const std::os::raw::c_char
+}}
+
+/// Register the pinned package's exports into the host-provided registry.
+///
+/// # Safety
+/// `registry` must be a valid `*mut cljrs_interop::Registry` from a host
+/// whose ABI fingerprint matched `cljrs_dylib_abi()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cljrs_dylib_init(registry: *mut cljrs_interop::Registry) {{
+    let registry = unsafe {{ &mut *registry }};
+    // This dylib's own #[export] inventory (separate from the host's).
+    cljrs_interop::register_exports(registry);
+    {pkg_ident}::{init_tail}(registry);
+}}
+"#,
+        init_tail = init_fn
+            .split_once("::")
+            .map(|(_, rest)| rest)
+            .unwrap_or("cljrs_init"),
+    );
+    std::fs::write(wrapper_dir.join("src/lib.rs"), lib_rs).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// The built artifact path for a wrapper crate dir (host-profile build).
+fn wrapper_artifact_path(wrapper_dir: &Path) -> PathBuf {
+    let stem = "cljrs_pinned_wrapper";
+    #[cfg(target_os = "macos")]
+    let file = format!("lib{stem}.dylib");
+    #[cfg(target_os = "windows")]
+    let file = format!("{stem}.dll");
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let file = format!("lib{stem}.so");
+    wrapper_dir.join("target").join(host_profile()).join(file)
+}
+
+// ── Loading ───────────────────────────────────────────────────────────────────
+
+/// dlopen the wrapper, verify the ABI handshake, and run its init through a
+/// versioned `Registry` view.
+fn load_library(globals: &Arc<GlobalEnv>, path: &Path, commit: &str) -> Result<(), String> {
+    // SAFETY: the library is generated by `write_wrapper_crate` and built by
+    // us; the Rust-ABI init call is guarded by the fingerprint handshake.
+    unsafe {
+        let lib = libloading::Library::new(path).map_err(|e| e.to_string())?;
+
+        let abi: libloading::Symbol<unsafe extern "C" fn() -> *const std::os::raw::c_char> =
+            lib.get(ABI_SYMBOL).map_err(|e| e.to_string())?;
+        let got = std::ffi::CStr::from_ptr(abi())
+            .to_string_lossy()
+            .to_string();
+        let expected = abi_fingerprint();
+        if got != expected {
+            return Err(format!(
+                "ABI fingerprint mismatch: wrapper was built as `{got}` but this binary \
+                 expects `{expected}`; rebuild with the matching toolchain/cljrs version"
+            ));
+        }
+
+        let init: libloading::Symbol<unsafe extern "C" fn(*mut cljrs_interop::Registry)> =
+            lib.get(INIT_SYMBOL).map_err(|e| e.to_string())?;
+        let mut registry = cljrs_interop::Registry::versioned(globals.clone(), commit);
+        init(&mut registry as *mut _);
+
+        // The dylib's code must stay mapped as long as any registered
+        // NativeFn closure exists (same contract as the CLI's
+        // load_native_lib).
+        std::mem::forget(lib);
+    }
+    Ok(())
+}
+
+// ── Paths & misc ──────────────────────────────────────────────────────────────
+
+/// `~/.cljrs/cache/dylibs`.
+fn dylib_cache_root() -> PathBuf {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    home.join(".cljrs").join("cache").join("dylibs")
+}
+
+/// Locate a local clojurust checkout for path-pinned wrapper deps:
+/// `CLJRS_WORKSPACE_ROOT` override first, then this crate's compile-time
+/// manifest location (`<workspace>/crates/cljrs-dylib`).
+fn find_workspace_root() -> Option<PathBuf> {
+    let validate = |p: PathBuf| -> Option<PathBuf> {
+        (p.join("Cargo.toml").exists() && p.join("crates/cljrs-interop/Cargo.toml").exists())
+            .then_some(p)
+    };
+    if let Some(root) = std::env::var_os("CLJRS_WORKSPACE_ROOT") {
+        return validate(PathBuf::from(root));
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    validate(manifest_dir.parent()?.parent()?.to_path_buf())
+}
+
+/// Short stable hex hash for cache directory names.
+fn stable_hash(s: &str) -> String {
+    use std::hash::{DefaultHasher, Hash as _, Hasher as _};
+    let mut h = DefaultHasher::new();
+    s.hash(&mut h);
+    format!("{:016x}", h.finish())
+}

--- a/crates/cljrs-dylib/tests/pinned_dylib_e2e.rs
+++ b/crates/cljrs-dylib/tests/pinned_dylib_e2e.rs
@@ -1,0 +1,207 @@
+//! End-to-end test for pinned native packages (`:rust/load :dylib`).
+//!
+//! Heavyweight: builds a wrapper cdylib with cargo (compiling
+//! `cljrs-interop` and its dependency tree in release mode), so it only
+//! runs when `CLJRS_DYLIB_E2E=1` is set:
+//!
+//! ```sh
+//! CLJRS_DYLIB_E2E=1 cargo test -p cljrs-dylib --test pinned_dylib_e2e
+//! ```
+//!
+//! Fixture: a git repository holding a tiny native crate (`pinlib`) whose
+//! `cljrs_init` defines `pinlib/build-tag`.  Commit v1 returns 1; HEAD
+//! returns 2.  The host also registers its own (HEAD) implementation
+//! returning 99.  Resolving `pinlib/build-tag@<sha1>` must load the dylib
+//! built from commit v1 and return 1, leaving the host's binding untouched.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use cljrs_value::Value;
+
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .expect("git command failed to start");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_sha(dir: &Path, rev: &str) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", rev])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+/// Locate the clojurust workspace root (this crate is `<root>/crates/cljrs-dylib`).
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn pinlib_source(tag: i64) -> String {
+    format!(
+        r#"use cljrs_interop::{{Registry, wrap_fn0}};
+
+pub fn cljrs_init(registry: &mut Registry) {{
+    registry.define(
+        "pinlib/build-tag",
+        wrap_fn0("build-tag", || Ok::<i64, String>({tag})),
+    );
+}}
+"#
+    )
+}
+
+/// Build the two-commit native-crate fixture repo; returns `(dir, sha_v1)`.
+fn make_pinlib_repo(ws_root: &Path) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+
+    git_ok(root, &["init", "-q", "-b", "main"]);
+    // Override any global commit.gpgsign so test commits don't invoke a
+    // signing server.
+    git_ok(root, &["config", "commit.gpgsign", "false"]);
+
+    // The fixture pins cljrs-interop by absolute path into this workspace so
+    // the wrapper (which uses the same path) unifies on one crate instance.
+    let cargo_toml = format!(
+        r#"[package]
+name = "pinlib"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+
+[dependencies]
+cljrs-interop = {{ path = "{}" }}
+"#,
+        ws_root.join("crates/cljrs-interop").display()
+    );
+    std::fs::write(root.join("Cargo.toml"), cargo_toml).unwrap();
+
+    std::fs::write(root.join("src/lib.rs"), pinlib_source(1)).unwrap();
+    git_ok(root, &["add", "."]);
+    git_ok(root, &["commit", "-q", "-m", "v1"]);
+    let sha_v1 = git_sha(root, "HEAD");
+
+    std::fs::write(root.join("src/lib.rs"), pinlib_source(2)).unwrap();
+    git_ok(root, &["add", "."]);
+    git_ok(root, &["commit", "-q", "-m", "v2"]);
+
+    (dir, sha_v1)
+}
+
+#[test]
+fn pinned_native_dylib_end_to_end() {
+    if std::env::var("CLJRS_DYLIB_E2E").is_err() {
+        eprintln!("skipping pinned_native_dylib_end_to_end (set CLJRS_DYLIB_E2E=1 to run)");
+        return;
+    }
+
+    let ws_root = workspace_root();
+    let (repo, sha_v1) = make_pinlib_repo(&ws_root);
+
+    // Hermetic dylib/git caches + a pinned workspace for the wrapper deps.
+    let cache_home = tempfile::tempdir().unwrap();
+    // SAFETY: single gated test in this binary; no concurrent env readers.
+    unsafe {
+        std::env::set_var("HOME", cache_home.path());
+        std::env::set_var("CLJRS_WORKSPACE_ROOT", &ws_root);
+    }
+
+    let _mutator = cljrs_gc::register_mutator();
+    let globals = cljrs_interp::standard_env_minimal(None, None, None);
+
+    // Host's own (HEAD) implementation — must remain untouched.
+    let head_fn = cljrs_value::NativeFn {
+        name: Arc::from("build-tag"),
+        arity: cljrs_value::Arity::Fixed(0),
+        func: Arc::new(|_args| Ok(Value::Long(99))),
+    };
+    globals.get_or_create_ns("pinlib");
+    globals.intern(
+        "pinlib",
+        Arc::from("build-tag"),
+        Value::NativeFunction(cljrs_gc::GcPtr::new(head_fn)),
+    );
+
+    // cljrs.edn equivalent: pinlib is a git dep with :rust/load :dylib.
+    let config = cljrs_deps::DepsConfig {
+        deps: vec![(
+            Arc::from("pinlib"),
+            cljrs_deps::Dependency::Git(cljrs_deps::GitDep {
+                url: Arc::from(repo.path().to_string_lossy().as_ref()),
+                sha: Arc::from(sha_v1.as_str()),
+                rust_init: Some(Arc::from("pinlib::cljrs_init")),
+                rust_crate_dir: None,
+                rust_load_dylib: true,
+            }),
+        )],
+        ..Default::default()
+    };
+    *globals.deps_config.write().unwrap() = Some(Arc::new(config));
+
+    cljrs_dylib::install(&globals);
+
+    // Resolve the pinned symbol: must build + load the v1 dylib.
+    let resolved = cljrs_env::versioned::resolve_versioned_value(
+        &globals,
+        "user",
+        Some("pinlib"),
+        "build-tag",
+        &sha_v1,
+    )
+    .expect("pinned native resolution should succeed");
+    let Value::NativeFunction(nf) = &resolved else {
+        panic!("expected a native fn, got {resolved:?}");
+    };
+    let result = (nf.get().func)(&[]).expect("pinned fn call");
+    assert_eq!(result, Value::Long(1), "pinned dylib must be built from v1");
+
+    // The versioned namespace holds the pinned impl; HEAD is untouched.
+    let versioned_ns = format!("pinlib@{sha_v1}");
+    assert!(globals.is_loaded(&versioned_ns));
+    let head = globals.lookup_in_ns("pinlib", "build-tag").unwrap();
+    let Value::NativeFunction(head_nf) = &head else {
+        panic!("HEAD binding missing");
+    };
+    assert_eq!((head_nf.get().func)(&[]).unwrap(), Value::Long(99));
+
+    // Second resolution is served from the already-loaded namespace (no
+    // rebuild): same value.
+    let again = cljrs_env::versioned::resolve_versioned_value(
+        &globals,
+        "user",
+        Some("pinlib"),
+        "build-tag",
+        &sha_v1,
+    )
+    .expect("cached pinned resolution");
+    let Value::NativeFunction(nf2) = &again else {
+        panic!("expected a native fn");
+    };
+    assert_eq!((nf2.get().func)(&[]).unwrap(), Value::Long(1));
+}

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -2,6 +2,27 @@
 
 Environments for running programs in.
 
+## versioned module (non-WASM)
+
+Shared versioned-symbol/namespace resolution service used by **every**
+execution tier (tree-walker, IR interpreter, JIT/AOT `rt_load_global*`
+bridges). Resolving `ns/name@commit` ensures the immutable versioned
+namespace `"ns@commit"` is loaded — from an embedded builtin source first,
+falling back to fetching the file from git history — then performs a plain
+`lookup_in_ns("ns@commit", name)`. Native (Rust-backed) symbols with no
+Clojure source fall back to the HEAD implementation. Public API:
+
+- `resolve_versioned_value(globals, defining_ns, ns_part, name, commit) -> EvalResult<Value>`
+  — full resolution: alias handling, lazy namespace load, native HEAD fallback
+- `ensure_versioned_ns_loaded(globals, base_ns, commit) -> EvalResult<Arc<str>>`
+  — idempotent load of `"base_ns@commit"` (same cycle/cross-thread coordination
+  as the unversioned loader); returns the versioned namespace name
+- `base_ns_name(ns: &str) -> &str` — strip a trailing `@<commit>` suffix
+
+Sources fetched from git are recorded in `GlobalEnv::versioned_sources`
+(`record_versioned_source` / `versioned_sources_snapshot`) so the AOT
+compiler can embed them in produced binaries.
+
 ## gc_roots module
 
 The `gc_roots` module manages GC root registration for the interpreter's Rust call stack. Public API includes:
@@ -14,6 +35,11 @@ The `gc_roots` module manages GC root registration for the interpreter's Rust ca
 - `force_collect(env: &Env)` — immediately initiates a GC collection bypassing memory-pressure threshold
 - `async_gc_collect()` — services a pending GC request from a Tokio `LocalSet` task at a cooperative yield point; safe to call when no other tasks are polling, so thread-local root stacks are stable and fully describe all suspended-task `GcPtr`s
 - `set_stw_reclaim_hook(f)` — (Phase 10.2) installs a stop-the-world reclaim hook the JIT uses to free superseded native code; runs inside the STW guard at the tail of every collection (`force_collect`, `gc_safepoint`, `async_gc_collect`), when all mutator threads are parked
+
+Root tracing covers all namespaces (including immutable `ns@commit`
+namespaces) **and** the values in `GlobalEnv::version_cache`, so versioned
+values that exist only in the cache (native HEAD fallbacks) survive
+collection.
 
 ## apply module
 

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -29,6 +29,14 @@ binaries) restricts versioned loading to embedded sources — a missing
 embedding fails with a clear "was not embedded at compile time" error
 instead of fetching from git.
 
+Native (Rust-backed) packages get a **verified HEAD binding**: the fallback
+checks the pin against `GlobalEnv::native_provenance` (recorded via
+`set_native_provenance` / `Registry::set_provenance`; prefix-match in either
+direction for abbreviated hashes).  Mismatching or missing provenance warns
+once per pin (`provenance_warned`), or errors when
+`set_enforce_native_versions(true)` is set (`--enforce-native-versions`,
+cljrs.edn `:enforce-native-versions`).
+
 ## gc_roots module
 
 The `gc_roots` module manages GC root registration for the interpreter's Rust call stack. Public API includes:

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -22,6 +22,12 @@ Clojure source fall back to the HEAD implementation. Public API:
 Sources fetched from git are recorded in `GlobalEnv::versioned_sources`
 (`record_versioned_source` / `versioned_sources_snapshot`) so the AOT
 compiler can embed them in produced binaries.
+`pin_if_available(globals, base_ns, commit) -> EvalResult<bool>` is the AOT
+discovery hook: force-loads a pin when its source is locatable, skips
+otherwise.  `GlobalEnv::set_versioned_offline(true)` (called by AOT harness
+binaries) restricts versioned loading to embedded sources — a missing
+embedding fails with a clear "was not embedded at compile time" error
+instead of fetching from git.
 
 ## gc_roots module
 

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -37,6 +37,11 @@ once per pin (`provenance_warned`), or errors when
 `set_enforce_native_versions(true)` is set (`--enforce-native-versions`,
 cljrs.edn `:enforce-native-versions`).
 
+Opt-in pinned native code: `GlobalEnv::set_pinned_native_loader` installs a
+`PinnedNativeLoader` callback (provided by `cljrs-dylib`); the resolver
+consults it before the HEAD fallback, and a successful load redirects the
+lookup into the freshly registered `"<ns>@<commit>"` namespace.
+
 ## gc_roots module
 
 The `gc_roots` module manages GC root registration for the interpreter's Rust call stack. Public API includes:

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -120,6 +120,11 @@ pub struct GlobalEnv {
     /// `"<ns>@<commit>"`.  The AOT compiler embeds these in the produced
     /// binary so versioned namespaces resolve without git at runtime.
     pub versioned_sources: RwLock<HashMap<Arc<str>, Arc<str>>>,
+    /// When true (set by AOT harness main), versioned namespaces resolve
+    /// only from embedded builtin sources — never from git.  A versioned
+    /// namespace that was not embedded at compile time fails with a clear
+    /// error instead of attempting a fetch.
+    pub versioned_offline: AtomicBool,
 }
 
 impl std::fmt::Debug for GlobalEnv {
@@ -152,6 +157,7 @@ impl GlobalEnv {
             verify_commit_signatures: AtomicBool::new(false),
             sig_verify_cache: Mutex::new(HashSet::new()),
             versioned_sources: RwLock::new(HashMap::new()),
+            versioned_offline: AtomicBool::new(false),
         })
     }
 
@@ -425,6 +431,18 @@ impl GlobalEnv {
         let mut entries: Vec<_> = map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         entries.sort_by(|a, b| a.0.cmp(&b.0));
         entries
+    }
+
+    /// Restrict versioned-namespace resolution to embedded builtin sources
+    /// (no git).  Called by AOT harness binaries, which embed every pinned
+    /// source discovered at compile time.
+    pub fn set_versioned_offline(&self, offline: bool) {
+        self.versioned_offline.store(offline, Ordering::Relaxed);
+    }
+
+    /// True when versioned namespaces may only come from embedded sources.
+    pub fn versioned_offline(&self) -> bool {
+        self.versioned_offline.load(Ordering::Relaxed)
     }
 
     /// If `:verify-commit-signatures` is enabled, verify that `commit` inside

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -138,7 +138,19 @@ pub struct GlobalEnv {
     /// Pinned-native mismatches already warned about this session
     /// (key: `"<ns>@<commit>"`), so each pin warns at most once.
     pub provenance_warned: Mutex<HashSet<Arc<str>>>,
+    /// Optional loader for **pinned native packages** (`:rust/load :dylib`),
+    /// installed by `cljrs-dylib`.  Called by the versioned resolver with
+    /// `(globals, base_ns, commit)` before falling back to the HEAD native
+    /// binding; returns `Ok(true)` when it registered the package's pinned
+    /// implementations into the `"<base_ns>@<commit>"` namespace.
+    #[allow(clippy::type_complexity)]
+    pub pinned_native_loader: RwLock<Option<PinnedNativeLoader>>,
 }
+
+/// Loader callback for pinned native packages (see
+/// `GlobalEnv::pinned_native_loader`).
+pub type PinnedNativeLoader =
+    Arc<dyn Fn(&Arc<GlobalEnv>, &str, &str) -> EvalResult<bool> + Send + Sync>;
 
 impl std::fmt::Debug for GlobalEnv {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -174,6 +186,7 @@ impl GlobalEnv {
             native_provenance: RwLock::new(HashMap::new()),
             enforce_native_versions: AtomicBool::new(false),
             provenance_warned: Mutex::new(HashSet::new()),
+            pinned_native_loader: RwLock::new(None),
         })
     }
 
@@ -485,6 +498,15 @@ impl GlobalEnv {
     /// True when pinned-native provenance mismatches are errors.
     pub fn enforce_native_versions(&self) -> bool {
         self.enforce_native_versions.load(Ordering::Relaxed)
+    }
+
+    /// Install the pinned-native package loader (called once by
+    /// `cljrs_dylib::install`; first writer wins).
+    pub fn set_pinned_native_loader(&self, loader: PinnedNativeLoader) {
+        let mut guard = self.pinned_native_loader.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(loader);
+        }
     }
 
     /// If `:verify-commit-signatures` is enabled, verify that `commit` inside

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -116,6 +116,10 @@ pub struct GlobalEnv {
     /// Session-scoped cache of commits that have already passed signature
     /// verification this run, keyed by `(repo_root, commit_hash)`.
     pub sig_verify_cache: Mutex<HashSet<(Arc<str>, Arc<str>)>>,
+    /// Pinned source texts fetched from git this session, keyed by
+    /// `"<ns>@<commit>"`.  The AOT compiler embeds these in the produced
+    /// binary so versioned namespaces resolve without git at runtime.
+    pub versioned_sources: RwLock<HashMap<Arc<str>, Arc<str>>>,
 }
 
 impl std::fmt::Debug for GlobalEnv {
@@ -147,6 +151,7 @@ impl GlobalEnv {
             deps_config: RwLock::new(None),
             verify_commit_signatures: AtomicBool::new(false),
             sig_verify_cache: Mutex::new(HashSet::new()),
+            versioned_sources: RwLock::new(HashMap::new()),
         })
     }
 
@@ -403,6 +408,23 @@ impl GlobalEnv {
     pub fn cache_versioned_ns(&self, ns: &str, commit: &str) {
         let key: Arc<str> = Arc::from(format!("{ns}@{commit}"));
         self.version_cache.lock().unwrap().insert(key, Value::Nil);
+    }
+
+    /// Record the source text of a versioned namespace fetched from git.
+    /// Key: `"<ns>@<commit>"`.  Consumed by the AOT compiler for embedding.
+    pub fn record_versioned_source(&self, versioned_ns: &str, src: &str) {
+        self.versioned_sources
+            .write()
+            .unwrap()
+            .insert(Arc::from(versioned_ns), Arc::from(src));
+    }
+
+    /// Snapshot of all versioned sources fetched this session, sorted by key.
+    pub fn versioned_sources_snapshot(&self) -> Vec<(Arc<str>, Arc<str>)> {
+        let map = self.versioned_sources.read().unwrap();
+        let mut entries: Vec<_> = map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
     }
 
     /// If `:verify-commit-signatures` is enabled, verify that `commit` inside

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -125,6 +125,19 @@ pub struct GlobalEnv {
     /// namespace that was not embedded at compile time fails with a clear
     /// error instead of attempting a fetch.
     pub versioned_offline: AtomicBool,
+    /// Provenance of native (Rust-backed) packages recorded at registration:
+    /// namespace → the git commit the package was built from.  Consulted by
+    /// the versioned resolver's native HEAD fallback to detect pinned-commit
+    /// mismatches.
+    pub native_provenance: RwLock<HashMap<Arc<str>, Arc<str>>>,
+    /// When true, a pinned lookup of a native function whose recorded
+    /// provenance does not match the requested commit is an error instead of
+    /// a once-per-pin warning.  CLI: `--enforce-native-versions`; cljrs.edn:
+    /// `:enforce-native-versions true`.
+    pub enforce_native_versions: AtomicBool,
+    /// Pinned-native mismatches already warned about this session
+    /// (key: `"<ns>@<commit>"`), so each pin warns at most once.
+    pub provenance_warned: Mutex<HashSet<Arc<str>>>,
 }
 
 impl std::fmt::Debug for GlobalEnv {
@@ -158,6 +171,9 @@ impl GlobalEnv {
             sig_verify_cache: Mutex::new(HashSet::new()),
             versioned_sources: RwLock::new(HashMap::new()),
             versioned_offline: AtomicBool::new(false),
+            native_provenance: RwLock::new(HashMap::new()),
+            enforce_native_versions: AtomicBool::new(false),
+            provenance_warned: Mutex::new(HashSet::new()),
         })
     }
 
@@ -443,6 +459,32 @@ impl GlobalEnv {
     /// True when versioned namespaces may only come from embedded sources.
     pub fn versioned_offline(&self) -> bool {
         self.versioned_offline.load(Ordering::Relaxed)
+    }
+
+    /// Record the git commit a native (Rust-backed) package was built from.
+    /// Called at registration time (`Registry::set_provenance` or the
+    /// `register_provenance!` inventory entry in cljrs-interop).
+    pub fn set_native_provenance(&self, ns: &str, commit: &str) {
+        self.native_provenance
+            .write()
+            .unwrap()
+            .insert(Arc::from(ns), Arc::from(commit));
+    }
+
+    /// The recorded provenance commit for a native package's namespace.
+    pub fn native_provenance_for(&self, ns: &str) -> Option<Arc<str>> {
+        self.native_provenance.read().unwrap().get(ns).cloned()
+    }
+
+    /// Make pinned-native provenance mismatches hard errors.
+    pub fn set_enforce_native_versions(&self, enforce: bool) {
+        self.enforce_native_versions
+            .store(enforce, Ordering::Relaxed);
+    }
+
+    /// True when pinned-native provenance mismatches are errors.
+    pub fn enforce_native_versions(&self) -> bool {
+        self.enforce_native_versions.load(Ordering::Relaxed)
     }
 
     /// If `:verify-commit-signatures` is enabled, verify that `commit` inside

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -1,9 +1,7 @@
 //! Lexical environment: local frames, global namespace table, and current Env.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicBool;
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 
 use crate::async_hook::AsyncRuntime;

--- a/crates/cljrs-env/src/gc_roots.rs
+++ b/crates/cljrs-env/src/gc_roots.rs
@@ -310,10 +310,17 @@ fn trace_thread_env_roots(visitor: &mut cljrs_gc::MarkVisitor) {
 /// Trace all namespaces and their contents.
 #[cfg(not(feature = "no-gc"))]
 fn trace_globals(globals: &GlobalEnv, visitor: &mut cljrs_gc::MarkVisitor) {
-    use cljrs_gc::GcVisitor as _;
+    use cljrs_gc::{GcVisitor as _, Trace};
     let namespaces = globals.namespaces.read().unwrap();
     for (_name, ns_ptr) in namespaces.iter() {
         visitor.visit(ns_ptr);
+    }
+    drop(namespaces);
+    // Values resolved at a pinned commit may live only in the version cache
+    // (e.g. native HEAD fallbacks) — without this they would be collected.
+    let version_cache = globals.version_cache.lock().unwrap();
+    for (_key, val) in version_cache.iter() {
+        val.trace(visitor);
     }
 }
 

--- a/crates/cljrs-env/src/lib.rs
+++ b/crates/cljrs-env/src/lib.rs
@@ -10,6 +10,8 @@ pub mod error;
 pub mod gc_roots;
 pub mod loader;
 pub mod taps;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod versioned;
 
 pub use async_hook::AsyncRuntime;
 

--- a/crates/cljrs-env/src/loader.rs
+++ b/crates/cljrs-env/src/loader.rs
@@ -73,7 +73,7 @@ pub fn load_ns(globals: Arc<GlobalEnv>, spec: &RequireSpec, current_ns: &str) ->
 /// Returns `Ok(true)` if the caller claimed the namespace and must load it.
 /// Returns `Ok(false)` if another thread loaded it while we waited.
 /// Returns `Err` on a genuine circular require (same thread).
-fn claim_or_wait(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<bool> {
+pub(crate) fn claim_or_wait(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<bool> {
     let tid = std::thread::current().id();
     loop {
         let mut loading = globals.loading.lock().unwrap();
@@ -168,7 +168,9 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
 /// `"<spec.ns>@<commit>"` in the global namespace table.
 ///
 /// Idempotent: if the versioned namespace is already loaded, only applies the
-/// alias/refer from `spec` in `current_ns`.
+/// alias/refer from `spec` in `current_ns`.  The actual loading lives in
+/// `crate::versioned::ensure_versioned_ns_loaded`, shared with the per-symbol
+/// resolver used by all execution tiers.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_versioned_ns(
     globals: Arc<GlobalEnv>,
@@ -176,86 +178,8 @@ pub fn load_versioned_ns(
     commit: &str,
     current_ns: &str,
 ) -> EvalResult<()> {
-    let base_ns = &spec.ns;
-    let versioned_ns_name: Arc<str> = Arc::from(format!("{base_ns}@{commit}"));
-
-    if globals.is_loaded(&versioned_ns_name) {
-        apply_alias_refer(&globals, &versioned_ns_name, current_ns, spec);
-        return Ok(());
-    }
-
-    // Locate the source file for the base namespace.
-    let rel_path = base_ns.replace('.', "/").replace('-', "_");
-    let src_paths = globals.source_paths.read().unwrap().clone();
-    let (_, file_path) = find_source_file(&rel_path, &src_paths).ok_or_else(|| {
-        EvalError::Runtime(format!(
-            "Cannot find source for namespace {base_ns} (needed for {base_ns}@{commit})"
-        ))
-    })?;
-
-    // Locate the git repository.
-    let repo_root = cljrs_vcs::find_repo_root(Path::new(&file_path)).ok_or_else(|| {
-        EvalError::Runtime(format!(
-            "Namespace {base_ns} (file {file_path}) is not in a git repository; \
-             cannot resolve {base_ns}@{commit}"
-        ))
-    })?;
-
-    // Verify commit signature before loading any historical code.
-    globals.check_commit_signature(&repo_root.to_string_lossy(), commit)?;
-
-    // Compute the path relative to the repo root.
-    let abs_file = std::path::Path::new(&file_path);
-    let rel_file = abs_file.strip_prefix(&repo_root).map_err(|_| {
-        EvalError::Runtime(format!(
-            "Cannot compute relative path for {file_path} within {}",
-            repo_root.display()
-        ))
-    })?;
-    let rel_file_str = rel_file.to_string_lossy();
-
-    // Fetch the source at the requested commit.
-    let src = cljrs_vcs::get_file_at_commit(&repo_root, &rel_file_str, commit)
-        .map_err(|e| EvalError::Runtime(format!("{e}")))?;
-
-    // Create the versioned namespace (immutable).
-    {
-        use cljrs_value::Namespace;
-        let ns = cljrs_gc::GcPtr::new(Namespace::new_versioned(versioned_ns_name.as_ref()));
-        ns.get()
-            .set_source_location(&file_path, Some(&repo_root.display().to_string()));
-        let mut map = globals.namespaces.write().unwrap();
-        map.entry(versioned_ns_name.clone()).or_insert(ns);
-    }
-
-    // Pre-refer clojure.core.
-    globals.refer_all(&versioned_ns_name, "clojure.core");
-
-    // Evaluate all forms with a versioned commit context so that
-    // same-namespace calls inside the historical source also resolve at
-    // `commit` rather than HEAD.
-    let saved_ns = globals
-        .lookup_var("clojure.core", "*ns*")
-        .and_then(|v| crate::dynamics::deref_var(&v));
-    {
-        let mut env = Env::new_versioned(globals.clone(), &versioned_ns_name, commit);
-        let file_label = format!("<{base_ns}@{commit}>");
-        let mut parser = cljrs_reader::Parser::new(src, file_label);
-        let forms = parser.parse_all().map_err(EvalError::Read)?;
-        for form in forms {
-            let _alloc_frame = cljrs_gc::push_alloc_frame();
-            globals
-                .eval(&form, &mut env)
-                .map_err(|e| annotate(e, &versioned_ns_name))?;
-        }
-    }
-    if let Some(saved) = saved_ns
-        && let Some(var) = globals.lookup_var("clojure.core", "*ns*")
-    {
-        var.get().bind(saved);
-    }
-
-    globals.mark_loaded(&versioned_ns_name);
+    let versioned_ns_name =
+        crate::versioned::ensure_versioned_ns_loaded(&globals, &spec.ns, commit)?;
     apply_alias_refer(&globals, &versioned_ns_name, current_ns, spec);
     Ok(())
 }
@@ -279,7 +203,10 @@ fn apply_alias_refer(
     }
 }
 
-fn find_source_file(rel: &str, src_paths: &[std::path::PathBuf]) -> Option<(String, String)> {
+pub(crate) fn find_source_file(
+    rel: &str,
+    src_paths: &[std::path::PathBuf],
+) -> Option<(String, String)> {
     for dir in src_paths {
         for ext in &[".cljrs", ".cljc"] {
             let path = dir.join(format!("{rel}{ext}"));
@@ -295,7 +222,7 @@ fn find_source_file(rel: &str, src_paths: &[std::path::PathBuf]) -> Option<(Stri
 /// Wrap an EvalError with namespace context.  Read errors (which carry
 /// file/line/col in CljxError) are passed through unchanged so the CLI can
 /// render them with full location information.
-fn annotate(e: EvalError, ns_name: &Arc<str>) -> EvalError {
+pub(crate) fn annotate(e: EvalError, ns_name: &Arc<str>) -> EvalError {
     match e {
         // Preserve read errors — they carry source location.
         EvalError::Read(_) => e,

--- a/crates/cljrs-env/src/versioned.rs
+++ b/crates/cljrs-env/src/versioned.rs
@@ -1,0 +1,294 @@
+//! Shared versioned-symbol/namespace resolution service.
+//!
+//! This is the single implementation used by every execution tier — the
+//! tree-walking interpreter, the IR interpreter, JIT-compiled code (via the
+//! `rt_load_global*` runtime bridges), and AOT binaries.
+//!
+//! ## Model
+//!
+//! Resolving `ns/name@commit` means: ensure the **versioned namespace**
+//! `"ns@commit"` is loaded (lazily, from an embedded builtin source or from
+//! git history), then perform a plain `lookup_in_ns("ns@commit", name)`.
+//! Versioned namespaces are immutable once loaded, so a resolved value never
+//! changes for the lifetime of the process.
+//!
+//! ## Native (Rust-backed) functions
+//!
+//! Native functions registered via `cljrs-interop::Registry` have no Clojure
+//! source to fetch, and the binary is a single unit at runtime — we can't
+//! "go back in time" to a previous compiled implementation.  The current
+//! contract is: versioned lookups of a native symbol resolve to the HEAD
+//! (current) implementation regardless of the requested commit (see
+//! `native_head_fallback`).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::env::{Env, GlobalEnv};
+use crate::error::{EvalError, EvalResult};
+use cljrs_value::Value;
+
+/// Strip a trailing `@<commit>` suffix from a namespace name, returning the
+/// base namespace.  `"my.lib@abc1234"` → `"my.lib"`; names without a valid
+/// commit-hash suffix are returned unchanged.
+pub fn base_ns_name(ns: &str) -> &str {
+    cljrs_value::symbol::split_version(ns).0
+}
+
+/// Resolve the value of `name` pinned at `commit`.
+///
+/// - `defining_ns` — the namespace the reference appears in (used for alias
+///   resolution and for unqualified symbols).
+/// - `ns_part` — the symbol's namespace qualifier, if any (may be an alias).
+///
+/// Resolution order:
+/// 1. Determine the base namespace (alias-resolved, `@`-suffix stripped).
+/// 2. Fast path: the versioned namespace `"base@commit"` already has the
+///    binding (it is loaded, or is being loaded right now by this thread).
+/// 3. Version-cache hit (caches native HEAD fallbacks).
+/// 4. Load the versioned namespace (embedded source or git), then look up.
+/// 5. Fall back to the HEAD native binding when no Clojure source exists.
+pub fn resolve_versioned_value(
+    globals: &Arc<GlobalEnv>,
+    defining_ns: &str,
+    ns_part: Option<&str>,
+    name: &str,
+    commit: &str,
+) -> EvalResult {
+    // 1. Base namespace: resolve alias if qualified, else the defining ns.
+    //    Strip any existing `@hash` so an explicit version always wins (e.g.
+    //    a qualified self-reference inside an already-versioned namespace).
+    let base_ns: Arc<str> = match ns_part {
+        Some(p) => {
+            let resolved = globals
+                .resolve_alias(defining_ns, p)
+                .unwrap_or_else(|| Arc::from(p));
+            Arc::from(base_ns_name(&resolved))
+        }
+        None => Arc::from(base_ns_name(defining_ns)),
+    };
+    let versioned_ns: Arc<str> = Arc::from(format!("{base_ns}@{commit}"));
+
+    // 2. Fast path: binding already present in the versioned namespace.
+    //    This also serves lookups made *while* the namespace is being loaded
+    //    on this thread (defs intern sequentially during load).
+    if let Some(val) = globals.lookup_in_ns(&versioned_ns, name) {
+        return Ok(val);
+    }
+
+    // 3. Cached native fallback from a previous resolution.
+    if let Some(cached) = globals.get_cached_versioned(&base_ns, name, commit) {
+        return Ok(cached);
+    }
+
+    // 4. Load the versioned namespace if we have any source for it.  When no
+    //    source exists at all (pure-Rust namespace), go straight to the
+    //    native fallback; load *failures* (bad commit, signature rejection,
+    //    parse error) propagate rather than being masked by the fallback.
+    if !globals.is_loaded(&versioned_ns) {
+        if !versioned_source_available(globals, &base_ns, &versioned_ns) {
+            return native_head_fallback(globals, &base_ns, name, commit);
+        }
+        ensure_versioned_ns_loaded(globals, &base_ns, commit)?;
+    }
+
+    if let Some(val) = globals.lookup_in_ns(&versioned_ns, name) {
+        return Ok(val);
+    }
+
+    // 5. The historical source exists but does not define `name`: the var may
+    //    be backed by a native Rust function rather than Clojure source.
+    native_head_fallback(globals, &base_ns, name, commit)
+}
+
+/// True if source for `base_ns` at some commit could be obtained: either an
+/// embedded builtin source registered under the versioned name, or a source
+/// file on the source path that lives inside a git repository.
+fn versioned_source_available(globals: &GlobalEnv, base_ns: &str, versioned_ns: &str) -> bool {
+    if globals.builtin_source(versioned_ns).is_some() {
+        return true;
+    }
+    let rel_path = base_ns.replace('.', "/").replace('-', "_");
+    let src_paths = globals.source_paths.read().unwrap().clone();
+    match crate::loader::find_source_file(&rel_path, &src_paths) {
+        Some((_, file_path)) => cljrs_vcs::find_repo_root(Path::new(&file_path)).is_some(),
+        None => false,
+    }
+}
+
+/// Ensure the versioned namespace `"<base_ns>@<commit>"` is loaded, returning
+/// its name.
+///
+/// Source is taken from the embedded builtin registry first (AOT binaries
+/// embed pinned sources under the versioned name; embedded sources were
+/// signature-checked at compile time), falling back to fetching the file from
+/// git history.  Idempotent, with the same same-thread cycle detection and
+/// cross-thread coordination as the unversioned loader.
+pub fn ensure_versioned_ns_loaded(
+    globals: &Arc<GlobalEnv>,
+    base_ns: &str,
+    commit: &str,
+) -> EvalResult<Arc<str>> {
+    let versioned_ns_name: Arc<str> = Arc::from(format!("{base_ns}@{commit}"));
+
+    if globals.is_loaded(&versioned_ns_name) {
+        return Ok(versioned_ns_name);
+    }
+
+    let should_load = crate::loader::claim_or_wait(globals, &versioned_ns_name)?;
+    if !should_load {
+        return Ok(versioned_ns_name);
+    }
+
+    let result = do_versioned_load(globals, base_ns, commit, &versioned_ns_name);
+
+    globals
+        .loading
+        .lock()
+        .unwrap()
+        .remove(versioned_ns_name.as_ref());
+    if result.is_ok() {
+        globals.mark_loaded(&versioned_ns_name);
+    }
+    globals.loading_done.notify_all();
+
+    result?;
+    Ok(versioned_ns_name)
+}
+
+/// Fetch (or look up) the pinned source and evaluate it into the versioned
+/// namespace.  The caller owns the loading claim.
+fn do_versioned_load(
+    globals: &Arc<GlobalEnv>,
+    base_ns: &str,
+    commit: &str,
+    versioned_ns_name: &Arc<str>,
+) -> EvalResult<()> {
+    // Embedded source first: AOT binaries register pinned sources under the
+    // versioned namespace name.  These were fetched and (optionally)
+    // signature-verified at compile time, so the git path is skipped
+    // entirely.
+    let (src, git_location): (String, Option<(String, String)>) =
+        if let Some(builtin) = globals.builtin_source(versioned_ns_name) {
+            (builtin.to_owned(), None)
+        } else {
+            let (src, location) = fetch_versioned_source(globals, base_ns, commit)?;
+            (src, Some(location))
+        };
+
+    // Create the versioned namespace (immutable).
+    {
+        use cljrs_value::Namespace;
+        let ns = cljrs_gc::GcPtr::new(Namespace::new_versioned(versioned_ns_name.as_ref()));
+        if let Some((ref file_path, ref repo_root)) = git_location {
+            ns.get().set_source_location(file_path, Some(repo_root));
+        }
+        let mut map = globals.namespaces.write().unwrap();
+        map.entry(versioned_ns_name.clone()).or_insert(ns);
+    }
+
+    // Pre-refer clojure.core.
+    globals.refer_all(versioned_ns_name, "clojure.core");
+
+    // Evaluate all forms with a versioned commit context so that
+    // same-namespace calls inside the historical source also resolve at
+    // `commit` rather than HEAD.
+    let saved_ns = globals
+        .lookup_var("clojure.core", "*ns*")
+        .and_then(|v| crate::dynamics::deref_var(&v));
+    {
+        let mut env = Env::new_versioned(globals.clone(), versioned_ns_name, commit);
+        let file_label = format!("<{base_ns}@{commit}>");
+        let mut parser = cljrs_reader::Parser::new(src, file_label);
+        let forms = parser.parse_all().map_err(EvalError::Read)?;
+        for form in forms {
+            let _alloc_frame = cljrs_gc::push_alloc_frame();
+            globals
+                .eval(&form, &mut env)
+                .map_err(|e| crate::loader::annotate(e, versioned_ns_name))?;
+        }
+    }
+    if let Some(saved) = saved_ns
+        && let Some(var) = globals.lookup_var("clojure.core", "*ns*")
+    {
+        var.get().bind(saved);
+    }
+
+    Ok(())
+}
+
+/// Fetch the source of `base_ns` at `commit` from git history, returning
+/// `(source_text, (file_path, repo_root))`.  Records the fetched text in
+/// `GlobalEnv::versioned_sources` so the AOT compiler can embed it.
+fn fetch_versioned_source(
+    globals: &Arc<GlobalEnv>,
+    base_ns: &str,
+    commit: &str,
+) -> EvalResult<(String, (String, String))> {
+    // Locate the source file for the base namespace.
+    let rel_path = base_ns.replace('.', "/").replace('-', "_");
+    let src_paths = globals.source_paths.read().unwrap().clone();
+    let (_, file_path) =
+        crate::loader::find_source_file(&rel_path, &src_paths).ok_or_else(|| {
+            EvalError::Runtime(format!(
+                "Cannot find source for namespace {base_ns} (needed for {base_ns}@{commit})"
+            ))
+        })?;
+
+    // Locate the git repository.
+    let repo_root = cljrs_vcs::find_repo_root(Path::new(&file_path)).ok_or_else(|| {
+        EvalError::Runtime(format!(
+            "Namespace {base_ns} (file {file_path}) is not in a git repository; \
+             cannot resolve {base_ns}@{commit}"
+        ))
+    })?;
+
+    // Verify commit signature before loading any historical code.
+    globals.check_commit_signature(&repo_root.to_string_lossy(), commit)?;
+
+    // Compute the path relative to the repo root.
+    let abs_file = Path::new(&file_path);
+    let rel_file = abs_file.strip_prefix(&repo_root).map_err(|_| {
+        EvalError::Runtime(format!(
+            "Cannot compute relative path for {file_path} within {}",
+            repo_root.display()
+        ))
+    })?;
+    let rel_file_str = rel_file.to_string_lossy();
+
+    // Fetch the source at the requested commit.
+    let src = cljrs_vcs::get_file_at_commit(&repo_root, &rel_file_str, commit)
+        .map_err(|e| EvalError::Runtime(format!("{e}")))?;
+
+    // Record for AOT embedding.
+    globals.record_versioned_source(&format!("{base_ns}@{commit}"), &src);
+
+    Ok((src, (file_path, repo_root.display().to_string())))
+}
+
+/// Fall back to the HEAD value for a native Rust function when no Clojure
+/// source definition exists for the symbol at the requested commit.
+///
+/// Native functions live in the running binary; we can't fetch and execute a
+/// historical compiled implementation, so versioned lookups of a native
+/// symbol resolve to the current implementation.
+///
+/// Returns the HEAD `NativeFunction` value (caching it under the requested
+/// commit so later lookups are fast), or a descriptive `EvalError` otherwise.
+fn native_head_fallback(
+    globals: &GlobalEnv,
+    base_ns: &str,
+    name: &str,
+    commit: &str,
+) -> EvalResult {
+    match globals.lookup_in_ns(base_ns, name) {
+        Some(val) if matches!(val, Value::NativeFunction(_)) => {
+            globals.cache_versioned(base_ns, name, commit, val.clone());
+            Ok(val)
+        }
+        Some(_) => Err(EvalError::Runtime(format!(
+            "Cannot find definition of `{name}` in `{base_ns}@{commit}`"
+        ))),
+        None => Err(EvalError::UnboundSymbol(format!("{base_ns}/{name}"))),
+    }
+}

--- a/crates/cljrs-env/src/versioned.rs
+++ b/crates/cljrs-env/src/versioned.rs
@@ -323,6 +323,7 @@ fn native_head_fallback(
 ) -> EvalResult {
     match globals.lookup_in_ns(base_ns, name) {
         Some(val) if matches!(val, Value::NativeFunction(_)) => {
+            check_native_provenance(globals, base_ns, commit)?;
             globals.cache_versioned(base_ns, name, commit, val.clone());
             Ok(val)
         }
@@ -331,6 +332,46 @@ fn native_head_fallback(
         ))),
         None => Err(EvalError::UnboundSymbol(format!("{base_ns}/{name}"))),
     }
+}
+
+/// Verify the recorded provenance of a native package against a pinned
+/// commit ("verified HEAD binding").
+///
+/// Native functions always come from the current binary; this check makes
+/// the fallback explicit and auditable instead of silent.  The recorded and
+/// requested hashes match when either is a prefix of the other (either side
+/// may be abbreviated).  Mismatching or missing provenance warns once per
+/// `ns@commit` by default, and is an error when
+/// `GlobalEnv::enforce_native_versions` is set.
+fn check_native_provenance(globals: &GlobalEnv, base_ns: &str, commit: &str) -> EvalResult<()> {
+    let recorded = globals.native_provenance_for(base_ns);
+    if let Some(ref rec) = recorded {
+        let matches = rec.starts_with(commit) || commit.starts_with(rec.as_ref());
+        if matches {
+            return Ok(());
+        }
+    }
+
+    let described = match &recorded {
+        Some(rec) => format!("is built from commit {rec}"),
+        None => "has no recorded provenance".to_string(),
+    };
+    if globals.enforce_native_versions() {
+        return Err(EvalError::Runtime(format!(
+            "native package `{base_ns}` {described}; cannot satisfy pinned \
+             `{base_ns}@{commit}` (native functions always come from the current binary)"
+        )));
+    }
+
+    let warn_key: Arc<str> = Arc::from(format!("{base_ns}@{commit}"));
+    if globals.provenance_warned.lock().unwrap().insert(warn_key) {
+        eprintln!(
+            "cljrs: warning: native package `{base_ns}` {described}; pinned \
+             `{base_ns}@{commit}` resolves to the current binary's implementation \
+             (use --enforce-native-versions to make this an error)"
+        );
+    }
+    Ok(())
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/cljrs-env/src/versioned.rs
+++ b/crates/cljrs-env/src/versioned.rs
@@ -87,7 +87,19 @@ pub fn resolve_versioned_value(
     //    parse error) propagate rather than being masked by the fallback.
     if !globals.is_loaded(&versioned_ns) {
         if !versioned_source_available(globals, &base_ns, &versioned_ns) {
-            return native_head_fallback(globals, &base_ns, name, commit);
+            // In an AOT binary a missing embedded source most likely means
+            // the pin was not visible at compile time — make the fallback's
+            // failure say so instead of a bare "unbound symbol".
+            return native_head_fallback(globals, &base_ns, name, commit).map_err(|e| {
+                if globals.versioned_offline() {
+                    EvalError::Runtime(format!(
+                        "versioned namespace {versioned_ns} was not embedded at compile \
+                         time; AOT binaries cannot fetch from git at runtime ({e})"
+                    ))
+                } else {
+                    e
+                }
+            });
         }
         ensure_versioned_ns_loaded(globals, &base_ns, commit)?;
     }
@@ -101,12 +113,35 @@ pub fn resolve_versioned_value(
     native_head_fallback(globals, &base_ns, name, commit)
 }
 
+/// Pin `base_ns@commit` if any source for it is locatable, returning whether
+/// it was loaded.
+///
+/// Used by the AOT compiler's discovery pass: every versioned symbol found in
+/// the program is force-loaded at compile time so its source lands in
+/// `GlobalEnv::versioned_sources` for embedding.  Namespaces with no
+/// locatable Clojure source (pure-Rust packages, or quoted symbols that
+/// merely look versioned) are skipped — their resolution is a runtime
+/// concern.  Genuine load failures (missing commit, signature rejection,
+/// parse error) propagate.
+pub fn pin_if_available(globals: &Arc<GlobalEnv>, base_ns: &str, commit: &str) -> EvalResult<bool> {
+    let versioned_ns = format!("{base_ns}@{commit}");
+    if !versioned_source_available(globals, base_ns, &versioned_ns) {
+        return Ok(false);
+    }
+    ensure_versioned_ns_loaded(globals, base_ns, commit)?;
+    Ok(true)
+}
+
 /// True if source for `base_ns` at some commit could be obtained: either an
 /// embedded builtin source registered under the versioned name, or a source
 /// file on the source path that lives inside a git repository.
 fn versioned_source_available(globals: &GlobalEnv, base_ns: &str, versioned_ns: &str) -> bool {
     if globals.builtin_source(versioned_ns).is_some() {
         return true;
+    }
+    // Offline (AOT) binaries may only use embedded sources.
+    if globals.versioned_offline() {
+        return false;
     }
     let rel_path = base_ns.replace('.', "/").replace('-', "_");
     let src_paths = globals.source_paths.read().unwrap().clone();
@@ -171,6 +206,11 @@ fn do_versioned_load(
     let (src, git_location): (String, Option<(String, String)>) =
         if let Some(builtin) = globals.builtin_source(versioned_ns_name) {
             (builtin.to_owned(), None)
+        } else if globals.versioned_offline() {
+            return Err(EvalError::Runtime(format!(
+                "versioned namespace {versioned_ns_name} was not embedded at compile time; \
+                 AOT binaries cannot fetch from git at runtime"
+            )));
         } else {
             let (src, location) = fetch_versioned_source(globals, base_ns, commit)?;
             (src, Some(location))
@@ -290,5 +330,53 @@ fn native_head_fallback(
             "Cannot find definition of `{name}` in `{base_ns}@{commit}`"
         ))),
         None => Err(EvalError::UnboundSymbol(format!("{base_ns}/{name}"))),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cljrs_reader::Form;
+    use cljrs_value::CljxFn;
+
+    fn dummy_eval(_: &Form, _: &mut Env) -> EvalResult {
+        Ok(Value::Nil)
+    }
+    fn dummy_call(_: &CljxFn, _: &[Value], _: &mut Env) -> EvalResult {
+        Ok(Value::Nil)
+    }
+
+    /// In offline (AOT) mode a versioned namespace with no embedded source
+    /// fails with the clear "not embedded at compile time" error — never a
+    /// git fetch.
+    #[test]
+    fn offline_load_without_embedded_source_errors() {
+        let _mutator = cljrs_gc::register_mutator();
+        let globals = GlobalEnv::new(dummy_eval, dummy_call, None);
+        globals.set_versioned_offline(true);
+
+        let err = ensure_versioned_ns_loaded(&globals, "mylib", "abc1234abcdef")
+            .expect_err("offline load must fail without an embedded source");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("was not embedded at compile time"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// Embedded sources satisfy offline mode (the AOT binary path).
+    #[test]
+    fn offline_load_with_embedded_source_succeeds() {
+        let _mutator = cljrs_gc::register_mutator();
+        let globals = GlobalEnv::new(dummy_eval, dummy_call, None);
+        globals.set_versioned_offline(true);
+        globals.register_builtin_source("mylib@abc1234abcdef", "(def x 1)");
+
+        let ns = ensure_versioned_ns_loaded(&globals, "mylib", "abc1234abcdef")
+            .expect("embedded source must load offline");
+        assert_eq!(ns.as_ref(), "mylib@abc1234abcdef");
+        assert!(globals.is_loaded("mylib@abc1234abcdef"));
     }
 }

--- a/crates/cljrs-env/src/versioned.rs
+++ b/crates/cljrs-env/src/versioned.rs
@@ -90,16 +90,17 @@ pub fn resolve_versioned_value(
             // In an AOT binary a missing embedded source most likely means
             // the pin was not visible at compile time — make the fallback's
             // failure say so instead of a bare "unbound symbol".
-            return native_head_fallback(globals, &base_ns, name, commit).map_err(|e| {
-                if globals.versioned_offline() {
-                    EvalError::Runtime(format!(
-                        "versioned namespace {versioned_ns} was not embedded at compile \
-                         time; AOT binaries cannot fetch from git at runtime ({e})"
-                    ))
-                } else {
-                    e
-                }
-            });
+            return pinned_native_or_head_fallback(globals, &base_ns, &versioned_ns, name, commit)
+                .map_err(|e| {
+                    if globals.versioned_offline() {
+                        EvalError::Runtime(format!(
+                            "versioned namespace {versioned_ns} was not embedded at compile \
+                             time; AOT binaries cannot fetch from git at runtime ({e})"
+                        ))
+                    } else {
+                        e
+                    }
+                });
         }
         ensure_versioned_ns_loaded(globals, &base_ns, commit)?;
     }
@@ -110,7 +111,33 @@ pub fn resolve_versioned_value(
 
     // 5. The historical source exists but does not define `name`: the var may
     //    be backed by a native Rust function rather than Clojure source.
-    native_head_fallback(globals, &base_ns, name, commit)
+    pinned_native_or_head_fallback(globals, &base_ns, &versioned_ns, name, commit)
+}
+
+/// Resolve a pinned native symbol: first through the opt-in pinned-native
+/// package loader (`:rust/load :dylib`, installed by `cljrs-dylib`), then
+/// through the verified HEAD binding.
+///
+/// When the loader reports it registered the package at the pinned commit,
+/// the symbol is looked up in the versioned namespace and the HEAD fallback
+/// is *not* consulted — a pinned package that doesn't define the symbol is
+/// an error.
+fn pinned_native_or_head_fallback(
+    globals: &Arc<GlobalEnv>,
+    base_ns: &str,
+    versioned_ns: &str,
+    name: &str,
+    commit: &str,
+) -> EvalResult {
+    let loader = globals.pinned_native_loader.read().unwrap().clone();
+    if let Some(loader) = loader
+        && loader(globals, base_ns, commit)?
+    {
+        return globals
+            .lookup_in_ns(versioned_ns, name)
+            .ok_or_else(|| EvalError::UnboundSymbol(format!("{versioned_ns}/{name}")));
+    }
+    native_head_fallback(globals, base_ns, name, commit)
 }
 
 /// Pin `base_ns@commit` if any source for it is locatable, returning whether

--- a/crates/cljrs-eval/Cargo.toml
+++ b/crates/cljrs-eval/Cargo.toml
@@ -20,3 +20,6 @@ cljrs-env      = { workspace = true }
 cljrs-builtins = { workspace = true }
 cljrs-interp   = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3"
+

--- a/crates/cljrs-eval/README.md
+++ b/crates/cljrs-eval/README.md
@@ -29,7 +29,10 @@ src/
                     register_compiler_sources, ensure_compiler_loaded
   apply.rs        — IR-aware function dispatch: tries IR cache, falls back to cljrs_interp::apply
   ir_interp.rs    — tier-1 IR interpreter: executes IrFunction over a VarId→Value register file;
-                    counts loop back-edges and transfers into compiled OSR entries (Phase 10.4)
+                    counts loop back-edges and transfers into compiled OSR entries (Phase 10.4);
+                    LoadGlobal is version-aware: `name@<sha>` resolves via
+                    cljrs_env::versioned, and lookups into a not-yet-loaded
+                    `ns@<sha>` namespace trigger a lazy versioned load
   ir_cache.rs     — thread-safe cache of lowered IR keyed by arity ID (NotAttempted/Cached/Unsupported);
                     invalidate(id) drops an entry back to NotAttempted (cross-defn invalidation)
   ir_convert.rs   — converts Clojure Value data structures (maps/vectors/keywords) → Rust IR types

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -746,7 +746,26 @@ fn const_to_value(c: &Const) -> Value {
 
 // ── Global value lookup ─────────────────────────────────────────────────────
 
-fn load_global_value(globals: &GlobalEnv, ns: &str, name: &str, defining_ns: &str) -> EvalResult {
+fn load_global_value(
+    globals: &Arc<GlobalEnv>,
+    ns: &str,
+    name: &str,
+    defining_ns: &str,
+) -> EvalResult {
+    // Versioned reference (`name@hash`): resolve through the shared service,
+    // which lazily loads the immutable `ns@hash` namespace and looks up the
+    // base name in it (with the native HEAD fallback).
+    #[cfg(not(target_arch = "wasm32"))]
+    if let (base_name, Some(commit)) = cljrs_value::symbol::split_version(name) {
+        return cljrs_env::versioned::resolve_versioned_value(
+            globals,
+            defining_ns,
+            Some(ns),
+            base_name,
+            commit,
+        );
+    }
+
     // Try direct namespace lookup first, then resolve as alias.
     let resolved_ns = globals
         .resolve_alias(defining_ns, ns)
@@ -760,6 +779,21 @@ fn load_global_value(globals: &GlobalEnv, ns: &str, name: &str, defining_ns: &st
             "IR interpreter: unbound var {resolved_ns}/{name}"
         )));
     }
+
+    // Reference into a versioned namespace (`lib@hash`/name) that has not
+    // been loaded this session: load it lazily and retry the lookup.
+    #[cfg(not(target_arch = "wasm32"))]
+    if let (base, Some(commit)) = cljrs_value::symbol::split_version(&resolved_ns)
+        && !globals.is_loaded(&resolved_ns)
+    {
+        cljrs_env::versioned::ensure_versioned_ns_loaded(globals, base, commit)?;
+        if let Some(var) = globals.lookup_var_in_ns(&resolved_ns, name)
+            && let Some(val) = cljrs_env::dynamics::deref_var(&var)
+        {
+            return Ok(val);
+        }
+    }
+
     // JVM class names resolve to themselves as symbols, mirroring eval_symbol.
     if cljrs_interp::eval::is_jvm_class_name(name) {
         return Ok(Value::symbol(cljrs_value::Symbol::simple(name)));

--- a/crates/cljrs-eval/tests/versioned_ir.rs
+++ b/crates/cljrs-eval/tests/versioned_ir.rs
@@ -1,0 +1,191 @@
+//! Tier 2 (IR interpreter) versioned symbol resolution.
+//!
+//! Drives the ANF lowering + IR interpreter directly against a real git
+//! fixture, asserting that:
+//!
+//! - a `LoadGlobal` whose name carries an `@<sha>` suffix resolves through
+//!   the shared versioned resolver (`cljrs_env::versioned`) to the pinned
+//!   value, leaving the HEAD binding untouched;
+//! - code lowered *inside* a versioned namespace (`defining_ns = "mylib@sha"`)
+//!   resolves both unqualified and base-qualified same-namespace references
+//!   at the pinned commit, including lazily loading the versioned namespace
+//!   on first use.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use cljrs_env::env::GlobalEnv;
+use cljrs_eval::{Env, ir_interp::interpret_ir};
+use cljrs_ir::lower::lower_fn_body;
+use cljrs_reader::{Form, Parser};
+use cljrs_value::Value;
+
+// ── Git fixture helpers ───────────────────────────────────────────────────────
+
+fn git_cmd(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .expect("git command failed to start")
+}
+
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = git_cmd(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_sha(dir: &Path, rev: &str) -> String {
+    let out = git_cmd(dir, &["rev-parse", rev]);
+    assert!(out.status.success(), "git rev-parse {rev} failed");
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+struct LibRepo {
+    _dir: tempfile::TempDir,
+    src_dir: PathBuf,
+    commit_v1: String,
+}
+
+/// `src/mylib.cljrs` — v1: `the-answer` = 1; v2 (HEAD): `the-answer` = 2.
+fn make_lib_repo() -> LibRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let src_dir = root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    git_ok(&root, &["init", "-q", "-b", "main"]);
+    // Override any global commit.gpgsign so test commits don't invoke a
+    // signing server.
+    git_ok(&root, &["config", "commit.gpgsign", "false"]);
+
+    let lib_file = src_dir.join("mylib.cljrs");
+    std::fs::write(&lib_file, "(def the-answer 1)\n").unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v1"]);
+    let commit_v1 = git_sha(&root, "HEAD");
+
+    std::fs::write(&lib_file, "(def the-answer 2)\n").unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v2"]);
+
+    LibRepo {
+        _dir: dir,
+        src_dir,
+        commit_v1,
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn parse_body(src: &str) -> Vec<Form> {
+    let mut p = Parser::new(src.to_string(), "<test>".to_string());
+    p.parse_all().expect("parse")
+}
+
+fn make_globals(src_dir: &Path) -> Arc<GlobalEnv> {
+    cljrs_interp::standard_env_with_paths(None, None, None, vec![src_dir.to_path_buf()])
+}
+
+fn eval_tree_walk(globals: &Arc<GlobalEnv>, src: &str) -> Value {
+    let mut env = Env::new(globals.clone(), "user");
+    let forms = parse_body(src);
+    let mut last = Value::Nil;
+    for form in &forms {
+        let _alloc_frame = cljrs_gc::push_alloc_frame();
+        last = cljrs_interp::eval::eval(form, &mut env)
+            .unwrap_or_else(|e| panic!("eval of {src:?} failed: {e:?}"));
+    }
+    last
+}
+
+/// Lower `body_src` as a zero-arg fn body in namespace `ns`, then run it
+/// through the IR interpreter.
+fn run_ir(globals: &Arc<GlobalEnv>, ns: &str, body_src: &str) -> Value {
+    let _mutator = cljrs_gc::register_mutator();
+    let body = parse_body(body_src);
+    let ir = lower_fn_body(Some("test"), ns, &[], &body, false).expect("lower");
+
+    let mut env = Env::new(globals.clone(), ns);
+    let ns_arc: Arc<str> = Arc::from(ns);
+    cljrs_env::callback::push_eval_context(&env);
+    let result = interpret_ir(&ir, vec![], globals, &ns_arc, &mut env);
+    cljrs_env::callback::pop_eval_context();
+    result.unwrap_or_else(|e| panic!("IR interpret of {body_src:?} failed: {e:?}"))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// An explicitly versioned reference in IR (`LoadGlobal` with `name@sha`)
+/// resolves to the pinned value without clobbering HEAD.
+#[test]
+fn ir_resolves_pinned_symbol() {
+    let repo = make_lib_repo();
+    let globals = make_globals(&repo.src_dir);
+
+    eval_tree_walk(&globals, "(require 'mylib)");
+    assert_eq!(eval_tree_walk(&globals, "mylib/the-answer"), Value::Long(2));
+
+    let pinned = run_ir(
+        &globals,
+        "user",
+        &format!("mylib/the-answer@{}", repo.commit_v1),
+    );
+    assert_eq!(pinned, Value::Long(1), "IR must see the pinned value");
+
+    // HEAD must be untouched, and the IR tier must agree with it.
+    assert_eq!(eval_tree_walk(&globals, "mylib/the-answer"), Value::Long(2));
+    assert_eq!(run_ir(&globals, "user", "mylib/the-answer"), Value::Long(2));
+}
+
+/// IR lowered inside a versioned namespace resolves unqualified same-ns
+/// references at the pinned commit, lazily loading `mylib@sha` on first use.
+#[test]
+fn ir_in_versioned_ns_resolves_unqualified_at_commit() {
+    let repo = make_lib_repo();
+    let globals = make_globals(&repo.src_dir);
+    eval_tree_walk(&globals, "(require 'mylib)");
+
+    let versioned_ns = format!("mylib@{}", repo.commit_v1);
+    // The versioned namespace has not been loaded yet — the IR LoadGlobal
+    // must trigger the lazy load.
+    assert!(!globals.is_loaded(&versioned_ns));
+
+    let val = run_ir(&globals, &versioned_ns, "the-answer");
+    assert_eq!(val, Value::Long(1));
+    assert!(globals.is_loaded(&versioned_ns));
+}
+
+/// IR lowered inside a versioned namespace rewrites base-qualified
+/// self-references (`mylib/x` in `mylib@sha`) to the versioned namespace.
+#[test]
+fn ir_in_versioned_ns_resolves_qualified_self_ref_at_commit() {
+    let repo = make_lib_repo();
+    let globals = make_globals(&repo.src_dir);
+    eval_tree_walk(&globals, "(require 'mylib)");
+
+    let versioned_ns = format!("mylib@{}", repo.commit_v1);
+    let val = run_ir(&globals, &versioned_ns, "mylib/the-answer");
+    assert_eq!(
+        val,
+        Value::Long(1),
+        "qualified self-ref must see the pinned value"
+    );
+
+    // Cross-namespace references from versioned code still see HEAD.
+    let head = run_ir(&globals, "user", "mylib/the-answer");
+    assert_eq!(head, Value::Long(2));
+}

--- a/crates/cljrs-interop/README.md
+++ b/crates/cljrs-interop/README.md
@@ -139,11 +139,20 @@ pub struct Registry { /* wraps Arc<GlobalEnv> */ }
 impl Registry {
     pub fn new(env: Arc<GlobalEnv>) -> Self;
 
+    /// Versioned view: registrations land in "<ns>@<commit>" namespaces.
+    /// Used by cljrs-dylib when loading a pinned native package; does NOT
+    /// auto-register the calling binary's #[export] inventory.
+    pub fn versioned(env: Arc<GlobalEnv>, commit: &str) -> Self;
+
     /// Register f under "my.ns/my-fn" (panics if no '/' present).
     pub fn define(&self, qualified: &str, f: NativeFn);
 
     /// Register f into an explicit namespace under a plain name.
     pub fn define_in(&self, ns: &str, name: &str, f: NativeFn);
+
+    /// Record the commit a native package was built from (no-op on a
+    /// versioned view, which registers a pinned package).
+    pub fn set_provenance(&self, ns: &str, commit: &str);
 
     /// Access the underlying GlobalEnv for advanced operations.
     pub fn env(&self) -> &Arc<GlobalEnv>;

--- a/crates/cljrs-interop/README.md
+++ b/crates/cljrs-interop/README.md
@@ -15,7 +15,8 @@ registration helpers, Registry, `#[export]` proc-macro).
 src/
   lib.rs       — re-exports, crate entry point
   error.rs     — wrap_result: Rust Result → ValueResult<Value>
-  exports.rs   — ExportEntry, inventory::collect!, register_exports
+  exports.rs   — ExportEntry / ProvenanceEntry, inventory::collect!, register_exports,
+                 register_provenance! macro
   marshal.rs   — FromValue / IntoValue traits with impls for common Rust types
   register.rs  — wrap_fn0..wrap_fn3, wrap_fn_variadic: auto-marshalling function wrappers
   registry.rs  — Registry struct and InitFn type alias for cljrs_init convention
@@ -102,6 +103,25 @@ pub struct ExportEntry {
 }
 
 pub fn register_exports(registry: &mut Registry);
+```
+
+### Native provenance (verified HEAD binding)
+
+Pinned lookups of native functions (`math/add@<sha>`) always resolve to the
+current binary's implementation — but the resolver verifies the pin against
+the package's recorded provenance: a match (either side may be an
+abbreviated hash) is silent; a mismatch or missing provenance warns once per
+pin, or errors under `--enforce-native-versions` (cljrs.edn
+`:enforce-native-versions true`).
+
+```rust
+pub struct ProvenanceEntry { pub ns: &'static str, pub commit: &'static str }
+
+// Declare once per exported namespace (commit typically from build.rs):
+cljrs_interop::register_provenance!("math", env!("CLJRS_PKG_COMMIT"));
+
+// Or imperatively inside cljrs_init:
+registry.set_provenance("math", commit);
 ```
 
 ### Registry and InitFn

--- a/crates/cljrs-interop/src/exports.rs
+++ b/crates/cljrs-interop/src/exports.rs
@@ -20,7 +20,9 @@ pub struct ExportEntry {
 
 inventory::collect!(ExportEntry);
 
-/// Intern every `#[export]`-annotated function into `registry`.
+/// Intern every `#[export]`-annotated function into `registry`, and record
+/// every [`ProvenanceEntry`] submitted via
+/// [`register_provenance!`][crate::register_provenance].
 ///
 /// Called automatically by [`Registry::new`]; you only need this directly if
 /// you are constructing a `Registry` by other means or want to re-register
@@ -29,4 +31,43 @@ pub fn register_exports(registry: &Registry) {
     for entry in inventory::iter::<ExportEntry> {
         registry.define(entry.qualified, (entry.make_fn)());
     }
+    for entry in inventory::iter::<ProvenanceEntry> {
+        registry.set_provenance(entry.ns, entry.commit);
+    }
+}
+
+/// Provenance of a native package: the git commit `ns` was built from.
+///
+/// Collected by `inventory` at link time (see
+/// [`register_provenance!`][crate::register_provenance]) and recorded into
+/// the environment whenever a [`Registry`] is constructed.
+pub struct ProvenanceEntry {
+    /// The Clojure namespace the native package registers into.
+    pub ns: &'static str,
+    /// The git commit hash the package was built from.
+    pub commit: &'static str,
+}
+
+inventory::collect!(ProvenanceEntry);
+
+/// Declare the git commit a native package's namespace was built from.
+///
+/// Place once per exported namespace, typically with a commit captured by a
+/// build script:
+///
+/// ```rust,ignore
+/// // build.rs: println!("cargo:rustc-env=CLJRS_PKG_COMMIT={sha}");
+/// cljrs_interop::register_provenance!("math", env!("CLJRS_PKG_COMMIT"));
+/// ```
+///
+/// Pinned lookups (`math/add@<sha>`) that fall back to the native binary
+/// then verify the pin against this commit instead of silently resolving to
+/// whatever is loaded.
+#[macro_export]
+macro_rules! register_provenance {
+    ($ns:expr, $commit:expr) => {
+        $crate::inventory::submit! {
+            $crate::ProvenanceEntry { ns: $ns, commit: $commit }
+        }
+    };
 }

--- a/crates/cljrs-interop/src/lib.rs
+++ b/crates/cljrs-interop/src/lib.rs
@@ -26,7 +26,7 @@ pub use cljrs_value::native_object::{NativeObject, NativeObjectBox, gc_native_ob
 pub use cljrs_value::{Arity, NativeFn, Value, ValueError, ValueResult};
 
 pub use error::wrap_result;
-pub use exports::{ExportEntry, register_exports};
+pub use exports::{ExportEntry, ProvenanceEntry, register_exports};
 pub use marshal::{FromValue, IntoValue};
 pub use register::{wrap_fn_variadic, wrap_fn0, wrap_fn1, wrap_fn2, wrap_fn3};
 pub use registry::{InitFn, Registry};

--- a/crates/cljrs-interop/src/registry.rs
+++ b/crates/cljrs-interop/src/registry.rs
@@ -51,6 +51,9 @@ pub type InitFn = fn(&mut Registry);
 /// access available via [`Registry::env`].
 pub struct Registry {
     env: Arc<GlobalEnv>,
+    /// When set, every `define`/`define_in` registers into the versioned
+    /// namespace `"<ns>@<commit>"` instead of `<ns>` (pinned native code).
+    version: Option<Arc<str>>,
 }
 
 impl Registry {
@@ -60,9 +63,33 @@ impl Registry {
     /// the binary (via `inventory`).  Called by the generated `main.rs`; user
     /// code receives `&mut Registry` and never constructs one directly.
     pub fn new(env: Arc<GlobalEnv>) -> Self {
-        let r = Self { env };
+        let r = Self { env, version: None };
         register_exports(&r);
         r
+    }
+
+    /// Create a **versioned view**: every registration lands in the
+    /// immutable `"<ns>@<commit>"` namespace instead of `<ns>`.
+    ///
+    /// Used when loading a native package built at a pinned commit (the
+    /// `:rust/load :dylib` path), so the pinned implementations never
+    /// collide with the live ones.  Does **not** auto-register the calling
+    /// binary's `#[export]` inventory — the pinned package registers its own
+    /// exports from inside its dylib.
+    pub fn versioned(env: Arc<GlobalEnv>, commit: &str) -> Self {
+        Self {
+            env,
+            version: Some(Arc::from(commit)),
+        }
+    }
+
+    /// The target namespace for a registration, versioned when this is a
+    /// [`versioned`][Self::versioned] view.
+    fn target_ns(&self, ns: &str) -> Arc<str> {
+        match &self.version {
+            Some(commit) => Arc::from(format!("{ns}@{commit}")),
+            None => Arc::from(ns),
+        }
     }
 
     /// Register `f` under the fully-qualified Clojure name `"my.ns/my-fn"`.
@@ -75,8 +102,11 @@ impl Registry {
     pub fn define(&self, qualified: &str, f: NativeFn) {
         let (ns, sym) = split_qualified(qualified)
             .unwrap_or_else(|| panic!("Registry::define: {qualified:?} has no '/' separator"));
-        self.env
-            .intern(ns, Arc::from(sym), Value::NativeFunction(GcPtr::new(f)));
+        self.env.intern(
+            &self.target_ns(ns),
+            Arc::from(sym),
+            Value::NativeFunction(GcPtr::new(f)),
+        );
     }
 
     /// Register `f` into an explicit namespace under a plain (unqualified) name.
@@ -84,8 +114,11 @@ impl Registry {
     /// Equivalent to `define("ns/name", f)` but avoids string formatting when
     /// the parts are already separate.
     pub fn define_in(&self, ns: &str, name: &str, f: NativeFn) {
-        self.env
-            .intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(f)));
+        self.env.intern(
+            &self.target_ns(ns),
+            Arc::from(name),
+            Value::NativeFunction(GcPtr::new(f)),
+        );
     }
 
     /// Record the git commit the native package providing namespace `ns` was
@@ -98,6 +131,11 @@ impl Registry {
     /// [`register_provenance!`][crate::register_provenance] macro with a
     /// build-script-provided commit, e.g. `env!("CLJRS_PKG_COMMIT")`.
     pub fn set_provenance(&self, ns: &str, commit: &str) {
+        // A versioned view registers a *pinned* package; its provenance must
+        // not overwrite the host binary's record for the base namespace.
+        if self.version.is_some() {
+            return;
+        }
         self.env.set_native_provenance(ns, commit);
     }
 

--- a/crates/cljrs-interop/src/registry.rs
+++ b/crates/cljrs-interop/src/registry.rs
@@ -88,6 +88,19 @@ impl Registry {
             .intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(f)));
     }
 
+    /// Record the git commit the native package providing namespace `ns` was
+    /// built from.
+    ///
+    /// The versioned resolver consults this when a pinned symbol
+    /// (`ns/name@<sha>`) falls back to a native function: a matching
+    /// provenance is silent; a mismatch warns (or errors under
+    /// `--enforce-native-versions`).  Typically driven by the
+    /// [`register_provenance!`][crate::register_provenance] macro with a
+    /// build-script-provided commit, e.g. `env!("CLJRS_PKG_COMMIT")`.
+    pub fn set_provenance(&self, ns: &str, commit: &str) {
+        self.env.set_native_provenance(ns, commit);
+    }
+
     /// Access the underlying `GlobalEnv` for operations beyond simple `define`
     /// (e.g. registering builtin namespace sources, setting aliases).
     pub fn env(&self) -> &Arc<GlobalEnv> {

--- a/crates/cljrs-interp/Cargo.toml
+++ b/crates/cljrs-interp/Cargo.toml
@@ -21,3 +21,6 @@ uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cljrs-vcs = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/cljrs-interp/README.md
+++ b/crates/cljrs-interp/README.md
@@ -37,12 +37,16 @@ src/
   macros.rs      — macro expansion helpers
   syntax_quote.rs — syntax-quote (backtick) expansion
   virtualize.rs  — let-chain virtualization: assoc/conj chains → transients
-  versioned.rs   — versioned symbol resolution: git-source fetch, native version
-                   registry lookup, HEAD fallback for stable native functions
+  versioned.rs   — tree-walker entry point for versioned symbol resolution;
+                   thin shim over the shared resolver in `cljrs_env::versioned`
+                   (whole-namespace `ns@commit` loading, native HEAD fallback)
 tests/
   no_gc_eval.rs  — (no-gc mode) integration tests: arithmetic, def/defn provenance,
                    function-call region stack, loop/recur accumulation,
                    atom/reset!/swap! static-sink correctness
+  versioned_resolution.rs — end-to-end versioned resolution against a real git
+                   fixture: pinned symbols, HEAD-clobber regression, versioned
+                   require, GC survival of versioned values
 ```
 
 ---

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -191,11 +191,14 @@ fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
 
     // Inherited versioned context: if we are evaluating inside a versioned
     // function body, unversioned same-namespace symbols resolve at the inherited
-    // commit rather than HEAD.
+    // commit rather than HEAD.  "Same namespace" includes a qualified
+    // self-reference written with the base name (`mylib/x` inside `mylib@hash`).
     #[cfg(not(target_arch = "wasm32"))]
     if let Some(commit) = env.versioned_eval_commit.clone() {
-        let is_same_ns =
-            sym.namespace.is_none() || sym.namespace.as_deref() == Some(env.current_ns.as_ref());
+        let is_same_ns = sym.namespace.is_none()
+            || sym.namespace.as_deref() == Some(env.current_ns.as_ref())
+            || sym.namespace.as_deref()
+                == Some(cljrs_env::versioned::base_ns_name(&env.current_ns));
         if is_same_ns {
             return crate::versioned::resolve_versioned_symbol(&sym, &commit, env);
         }
@@ -215,6 +218,17 @@ fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
             .globals
             .resolve_alias(&env.current_ns, ns_part)
             .unwrap_or_else(|| Arc::from(ns_part.as_ref()));
+        // Qualified self-reference inside a versioned namespace: `mylib/x`
+        // written in `mylib@hash`'s own source resolves at the pinned commit,
+        // i.e. inside the versioned namespace itself.
+        #[cfg(not(target_arch = "wasm32"))]
+        let resolved: Arc<str> = if env.current_ns.as_ref() != resolved.as_ref()
+            && cljrs_env::versioned::base_ns_name(&env.current_ns) == resolved.as_ref()
+        {
+            env.current_ns.clone()
+        } else {
+            resolved
+        };
         return env
             .globals
             .lookup_in_ns(&resolved, &sym.name)

--- a/crates/cljrs-interp/src/versioned.rs
+++ b/crates/cljrs-interp/src/versioned.rs
@@ -103,4 +103,84 @@ mod tests {
             "expected UnboundSymbol, got {err:?}"
         );
     }
+
+    // ── Native provenance (verified HEAD binding) ─────────────────────────────
+
+    fn versioned_sym(ns: &str, name: &str, commit: &str) -> cljrs_value::Symbol {
+        cljrs_value::Symbol {
+            namespace: Some(Arc::from(ns)),
+            name: Arc::from(name),
+            version: Some(Arc::from(commit)),
+        }
+    }
+
+    /// Matching provenance (either side may be abbreviated) resolves silently
+    /// — no entry lands in the warned set.
+    #[test]
+    fn matching_provenance_is_silent() {
+        let (globals, mut env) = make_env("provlib");
+        let full_commit = "deadbeef0123456789abcdef0123456789abcdef";
+
+        globals.intern(
+            "provlib",
+            Arc::from("f"),
+            Value::NativeFunction(GcPtr::new(const_native(1))),
+        );
+        globals.set_native_provenance("provlib", full_commit);
+
+        // Pin with an abbreviated prefix of the recorded commit.
+        let sym = versioned_sym("provlib", "f", "deadbeef012");
+        super::resolve_versioned_symbol(&sym, "deadbeef012", &mut env).expect("should resolve");
+
+        assert!(
+            globals.provenance_warned.lock().unwrap().is_empty(),
+            "matching provenance must not warn"
+        );
+    }
+
+    /// Mismatching provenance still resolves (HEAD binding) but records a
+    /// once-per-pin warning.
+    #[test]
+    fn mismatched_provenance_warns_once() {
+        let (globals, mut env) = make_env("provlib2");
+        globals.intern(
+            "provlib2",
+            Arc::from("f"),
+            Value::NativeFunction(GcPtr::new(const_native(2))),
+        );
+        globals.set_native_provenance("provlib2", "1111111111111111");
+
+        let commit = "2222222222222222";
+        let sym = versioned_sym("provlib2", "f", commit);
+        let val = super::resolve_versioned_symbol(&sym, commit, &mut env)
+            .expect("mismatch still resolves to HEAD by default");
+        assert!(matches!(val, Value::NativeFunction(_)));
+
+        let warned = globals.provenance_warned.lock().unwrap();
+        assert_eq!(warned.len(), 1, "exactly one warning per pin");
+        assert!(warned.contains(&Arc::<str>::from("provlib2@2222222222222222")));
+    }
+
+    /// Under --enforce-native-versions a provenance mismatch is an error.
+    #[test]
+    fn enforce_native_versions_makes_mismatch_an_error() {
+        let (globals, mut env) = make_env("provlib3");
+        globals.intern(
+            "provlib3",
+            Arc::from("f"),
+            Value::NativeFunction(GcPtr::new(const_native(3))),
+        );
+        globals.set_native_provenance("provlib3", "1111111111111111");
+        globals.set_enforce_native_versions(true);
+
+        let commit = "2222222222222222";
+        let sym = versioned_sym("provlib3", "f", commit);
+        let err = super::resolve_versioned_symbol(&sym, commit, &mut env)
+            .expect_err("strict mode must reject a provenance mismatch");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("provlib3") && msg.contains("1111111111111111"),
+            "error should describe the mismatch: {msg}"
+        );
+    }
 }

--- a/crates/cljrs-interp/src/versioned.rs
+++ b/crates/cljrs-interp/src/versioned.rs
@@ -1,210 +1,26 @@
-//! Versioned symbol and namespace resolution.
+//! Versioned symbol resolution — tree-walker entry point.
 //!
-//! When a symbol carries an `@<commit>` suffix — or when evaluation is
-//! happening inside a versioned namespace body — this module fetches the
-//! historical source from git and evaluates the relevant definition in a
-//! snapshot environment.
-//!
-//! ## Native (Rust-backed) functions
-//!
-//! Native functions registered via `cljrs-interop::Registry` have no
-//! Clojure source to fetch, and the binary is a single unit at runtime —
-//! we can't "go back in time" to a previous compiled implementation.
-//! The current contract is: versioned lookups of a native symbol resolve
-//! to the HEAD (current) implementation regardless of the requested
-//! commit.  A future design may fetch Rust source at the commit, compile
-//! it, and `dlopen` the result; that path would slot in where
-//! `native_head_fallback` is invoked today.
-
-use std::path::Path;
-use std::sync::Arc;
+//! The implementation lives in `cljrs_env::versioned` so that every execution
+//! tier (tree-walker, IR interpreter, JIT/AOT runtime bridges) shares one
+//! resolver.  Resolving `ns/name@commit` loads the whole versioned namespace
+//! `"ns@commit"` (from embedded source or git history) and then performs a
+//! plain lookup in it; native (Rust-backed) functions with no Clojure source
+//! fall back to the HEAD implementation.
 
 use cljrs_env::env::Env;
-use cljrs_env::error::{EvalError, EvalResult};
-use cljrs_reader::Form;
-use cljrs_reader::form::FormKind;
-use cljrs_value::{Symbol, Value};
-
-// ── Public entry points ───────────────────────────────────────────────────────
+use cljrs_env::error::EvalResult;
+use cljrs_value::Symbol;
 
 /// Resolve `sym` (which may or may not carry a version) at `commit` within
 /// `env`.
-///
-/// Resolution order:
-/// 1. Version cache hit → return immediately.
-/// 2. Determine the owning namespace for the symbol.
-/// 3. Fetch the source file at `commit` via `cljrs-vcs`.
-/// 4. Scan forms for `(def name …)` / `(defn name …)` / `(defmacro name …)`.
-/// 5. Evaluate the found form in a snapshot env with `versioned_eval_commit`
-///    set to `commit`, so that same-namespace helpers also resolve historically.
-/// 6. Cache the result.
 pub fn resolve_versioned_symbol(sym: &Symbol, commit: &str, env: &mut Env) -> EvalResult {
-    // Determine the owning namespace.
-    let ns_name: Arc<str> = match &sym.namespace {
-        Some(ns_part) => env
-            .globals
-            .resolve_alias(&env.current_ns, ns_part)
-            .unwrap_or_else(|| Arc::clone(ns_part)),
-        None => Arc::clone(&env.current_ns),
-    };
-
-    let name = sym.name.as_ref();
-
-    // Cache check.
-    if let Some(cached) = env.globals.get_cached_versioned(&ns_name, name, commit) {
-        return Ok(cached);
-    }
-
-    // Get git context for the owning namespace.  If the namespace hasn't been
-    // loaded yet, try to load it so the context gets populated.
-    // For pure-Rust namespaces with no Clojure source this may fail; in that
-    // case fall back to the HEAD native binding (if any).
-    let git_ctx = git_context_for_ns(&ns_name, env);
-    let (source_file, repo_root) = match git_ctx {
-        Ok(ctx) => ctx,
-        Err(_) => return native_head_fallback(&ns_name, name, commit, env),
-    };
-
-    // Verify commit signature before loading any historical code.
-    env.globals.check_commit_signature(&repo_root, commit)?;
-
-    // Compute repo-relative path.
-    let abs_file = Path::new(source_file.as_ref());
-    let repo_path = Path::new(repo_root.as_ref());
-    let rel_file = abs_file.strip_prefix(repo_path).map_err(|_| {
-        EvalError::Runtime(format!(
-            "Cannot compute relative path for {source_file} within {repo_root}"
-        ))
-    })?;
-    let rel_file_str = rel_file.to_string_lossy();
-
-    // Fetch source at commit.
-    let src = cljrs_vcs::get_file_at_commit(repo_path, &rel_file_str, commit)
-        .map_err(|e| EvalError::Runtime(format!("{e}")))?;
-
-    // Parse.
-    let file_label = format!("<{ns_name}@{commit}>");
-    let mut parser = cljrs_reader::Parser::new(src, file_label);
-    let forms = parser.parse_all().map_err(EvalError::Read)?;
-
-    // Find the definition of `name`.  If it's absent, the var may be backed
-    // by a native Rust function rather than Clojure source; try the HEAD
-    // fallback before giving up.
-    let Some(def_form) = find_def_form(&forms, name) else {
-        return native_head_fallback(&ns_name, name, commit, env);
-    };
-
-    // Evaluate in a snapshot env: same namespace, versioned commit.
-    let val = eval_in_snapshot(def_form, &ns_name, commit, env)?;
-
-    // Cache and return.
-    env.globals
-        .cache_versioned(&ns_name, name, commit, val.clone());
-    Ok(val)
-}
-
-/// Fall back to the HEAD value for a native Rust function when no Clojure
-/// source definition exists for the symbol at the requested commit.
-///
-/// Native functions live in the running binary; we can't fetch and execute a
-/// historical compiled implementation, so versioned lookups of a native
-/// symbol resolve to the current implementation.  A future design may
-/// fetch Rust source at `commit`, compile it, and `dlopen` the result —
-/// that codepath would replace this fallback.
-///
-/// Returns the HEAD `NativeFunction` value (caching it under the requested
-/// commit so later lookups are fast), or a descriptive `EvalError` otherwise.
-fn native_head_fallback(ns_name: &Arc<str>, name: &str, commit: &str, env: &mut Env) -> EvalResult {
-    match env.globals.lookup_in_ns(ns_name, name) {
-        Some(val) if matches!(val, Value::NativeFunction(_)) => {
-            env.globals
-                .cache_versioned(ns_name, name, commit, val.clone());
-            Ok(val)
-        }
-        Some(_) => Err(EvalError::Runtime(format!(
-            "Cannot find definition of `{name}` in `{ns_name}@{commit}`"
-        ))),
-        None => Err(EvalError::UnboundSymbol(format!("{ns_name}/{name}"))),
-    }
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/// Return `(source_file, git_repo_root)` for `ns_name`, triggering a load of
-/// the namespace if it has not yet been loaded (so the loader can populate the
-/// git context fields).
-fn git_context_for_ns(ns_name: &Arc<str>, env: &mut Env) -> EvalResult<(Arc<str>, Arc<str>)> {
-    // Fast path: already populated.
-    if let Some(ctx) = env.globals.get_ns_git_context(ns_name) {
-        return Ok(ctx);
-    }
-
-    // Try loading the namespace (idempotent if already loaded).
-    let spec = cljrs_env::env::RequireSpec {
-        ns: Arc::clone(ns_name),
-        version: None,
-        alias: None,
-        refer: cljrs_env::env::RequireRefer::None,
-    };
-    cljrs_env::loader::load_ns(Arc::clone(&env.globals), &spec, &env.current_ns)?;
-
-    // Try again after load.
-    env.globals.get_ns_git_context(ns_name).ok_or_else(|| {
-        EvalError::Runtime(format!(
-            "Namespace `{ns_name}` has no git context (built-in or not in a git repo); \
-             cannot resolve versioned symbols from it"
-        ))
-    })
-}
-
-/// Evaluate `form` inside a snapshot environment: the current namespace is set
-/// to `ns_name` and `versioned_eval_commit` is set to `commit`.
-fn eval_in_snapshot(form: &Form, ns_name: &str, commit: &str, env: &mut Env) -> EvalResult {
-    let mut snap = Env::new_versioned(Arc::clone(&env.globals), ns_name, commit);
-    (env.globals.eval_fn)(form, &mut snap)
-}
-
-/// Scan `forms` for the first top-level `def`-like form that binds `name`.
-///
-/// Recognises: `(def name …)`, `(defn name …)`, `(defmacro name …)`,
-/// `(defn- name …)`, `(def- name …)`.
-fn find_def_form<'a>(forms: &'a [Form], name: &str) -> Option<&'a Form> {
-    for form in forms {
-        if let FormKind::List(items) = &form.kind {
-            if items.len() < 2 {
-                continue;
-            }
-            let head = match &items[0].kind {
-                FormKind::Symbol(s) => s.as_str(),
-                _ => continue,
-            };
-            let is_def_like = matches!(
-                head,
-                "def" | "defn" | "defn-" | "def-" | "defmacro" | "defmulti"
-            );
-            if !is_def_like {
-                continue;
-            }
-            // The name is the second element, possibly wrapped in metadata.
-            let name_form = &items[1];
-            let actual_name = def_form_name(name_form);
-            if actual_name.as_deref() == Some(name) {
-                return Some(form);
-            }
-        }
-    }
-    None
-}
-
-/// Extract the symbol name from the second element of a `def`-like form.
-/// Handles `^metadata name` wrapping.
-fn def_form_name(form: &Form) -> Option<String> {
-    match &form.kind {
-        FormKind::Symbol(s) => Some(s.clone()),
-        // `^{:doc "…"} name`  or  `^:private name`
-        FormKind::Meta(_, inner) => def_form_name(inner),
-        _ => None,
-    }
+    cljrs_env::versioned::resolve_versioned_value(
+        &env.globals,
+        &env.current_ns,
+        sym.namespace.as_deref(),
+        &sym.name,
+        commit,
+    )
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/cljrs-interp/tests/versioned_resolution.rs
+++ b/crates/cljrs-interp/tests/versioned_resolution.rs
@@ -75,7 +75,9 @@ fn make_lib_repo() -> LibRepo {
     let lib_file = src_dir.join("mylib.cljrs");
     std::fs::write(
         &lib_file,
-        "(def the-answer 1)\n(defn describe [] (str \"v\" the-answer))\n",
+        "(def the-answer 1)\n\
+         (defn describe [] (str \"v\" the-answer))\n\
+         (defn qdescribe [] (str \"q\" mylib/the-answer))\n",
     )
     .unwrap();
     git_ok(&root, &["add", "."]);
@@ -84,7 +86,9 @@ fn make_lib_repo() -> LibRepo {
 
     std::fs::write(
         &lib_file,
-        "(def the-answer 2)\n(defn describe [] (str \"v\" the-answer))\n",
+        "(def the-answer 2)\n\
+         (defn describe [] (str \"v\" the-answer))\n\
+         (defn qdescribe [] (str \"q\" mylib/the-answer))\n",
     )
     .unwrap();
     git_ok(&root, &["add", "."]);
@@ -155,6 +159,22 @@ fn pinned_fn_sees_same_ns_helpers_at_commit() {
 
     let pinned = eval_str(&mut env, &format!("(mylib/describe@{})", repo.commit_v1));
     assert_eq!(pinned, Value::string("v1"));
+}
+
+/// A pinned function's *qualified* same-namespace references (`mylib/x`
+/// written inside mylib's own source) also resolve at the pinned commit —
+/// a namespace self-reference at commit C means that file's binding, not
+/// HEAD's.
+#[test]
+fn pinned_fn_sees_qualified_self_refs_at_commit() {
+    let repo = make_lib_repo();
+    let (_globals, mut env) = make_env(&repo.src_dir);
+
+    eval_str(&mut env, "(require 'mylib)");
+    assert_eq!(eval_str(&mut env, "(mylib/qdescribe)"), Value::string("q2"));
+
+    let pinned = eval_str(&mut env, &format!("(mylib/qdescribe@{})", repo.commit_v1));
+    assert_eq!(pinned, Value::string("q1"));
 }
 
 /// A versioned require pins the whole namespace under an alias.

--- a/crates/cljrs-interp/tests/versioned_resolution.rs
+++ b/crates/cljrs-interp/tests/versioned_resolution.rs
@@ -1,0 +1,212 @@
+//! End-to-end versioned symbol resolution through the tree-walking
+//! interpreter, against a real git repository fixture.
+//!
+//! Guards the core semantics of the shared resolver in
+//! `cljrs_env::versioned`:
+//!
+//! - a pinned symbol (`ns/name@sha`) resolves to the value at that commit;
+//! - resolving a pinned symbol must NOT clobber the HEAD binding (the
+//!   historical `def` interns into the immutable `ns@sha` namespace, never
+//!   into the live one);
+//! - same-namespace helpers referenced by a pinned function resolve at the
+//!   pinned commit (structural inheritance via the versioned namespace);
+//! - resolved versioned values survive a forced GC.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+// ── Git fixture helpers ───────────────────────────────────────────────────────
+
+fn git_cmd(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .expect("git command failed to start")
+}
+
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = git_cmd(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_sha(dir: &Path, rev: &str) -> String {
+    let out = git_cmd(dir, &["rev-parse", rev]);
+    assert!(out.status.success(), "git rev-parse {rev} failed");
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+struct LibRepo {
+    _dir: tempfile::TempDir,
+    src_dir: PathBuf,
+    commit_v1: String,
+}
+
+/// Library repo with two commits of `src/mylib.cljrs`:
+/// v1: `the-answer` = 1; v2 (HEAD): `the-answer` = 2.
+/// `describe` returns `"v" + the-answer` via an unqualified same-ns ref.
+fn make_lib_repo() -> LibRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let src_dir = root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    git_ok(&root, &["init", "-q", "-b", "main"]);
+    // Override any global commit.gpgsign so test commits don't invoke a
+    // signing server.
+    git_ok(&root, &["config", "commit.gpgsign", "false"]);
+
+    let lib_file = src_dir.join("mylib.cljrs");
+    std::fs::write(
+        &lib_file,
+        "(def the-answer 1)\n(defn describe [] (str \"v\" the-answer))\n",
+    )
+    .unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v1"]);
+    let commit_v1 = git_sha(&root, "HEAD");
+
+    std::fs::write(
+        &lib_file,
+        "(def the-answer 2)\n(defn describe [] (str \"v\" the-answer))\n",
+    )
+    .unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v2"]);
+
+    LibRepo {
+        _dir: dir,
+        src_dir,
+        commit_v1,
+    }
+}
+
+// ── Eval helpers ──────────────────────────────────────────────────────────────
+
+fn make_env(src_dir: &Path) -> (Arc<GlobalEnv>, Env) {
+    let globals =
+        cljrs_interp::standard_env_with_paths(None, None, None, vec![src_dir.to_path_buf()]);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_str(env: &mut Env, src: &str) -> Value {
+    let mut parser = cljrs_reader::Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse");
+    let mut last = Value::Nil;
+    for form in &forms {
+        let _alloc_frame = cljrs_gc::push_alloc_frame();
+        last = cljrs_interp::eval::eval(form, env)
+            .unwrap_or_else(|e| panic!("eval of {src:?} failed: {e:?}"));
+    }
+    last
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Resolving a pinned symbol returns the historical value and leaves the
+/// HEAD binding untouched (regression: the historical `def` used to intern
+/// into the live namespace, clobbering HEAD).
+#[test]
+fn pinned_symbol_does_not_clobber_head() {
+    let repo = make_lib_repo();
+    let (_globals, mut env) = make_env(&repo.src_dir);
+
+    eval_str(&mut env, "(require 'mylib)");
+    assert_eq!(eval_str(&mut env, "mylib/the-answer"), Value::Long(2));
+
+    let pinned = eval_str(&mut env, &format!("mylib/the-answer@{}", repo.commit_v1));
+    assert_eq!(pinned, Value::Long(1), "pinned symbol must see v1");
+
+    // HEAD must still be v2 after the versioned resolution.
+    assert_eq!(
+        eval_str(&mut env, "mylib/the-answer"),
+        Value::Long(2),
+        "resolving a pinned symbol must not clobber the HEAD binding"
+    );
+}
+
+/// A pinned function's unqualified same-namespace references resolve at the
+/// pinned commit (the whole namespace is loaded as `mylib@sha`).
+#[test]
+fn pinned_fn_sees_same_ns_helpers_at_commit() {
+    let repo = make_lib_repo();
+    let (_globals, mut env) = make_env(&repo.src_dir);
+
+    eval_str(&mut env, "(require 'mylib)");
+    let head = eval_str(&mut env, "(mylib/describe)");
+    assert_eq!(head, Value::string("v2"));
+
+    let pinned = eval_str(&mut env, &format!("(mylib/describe@{})", repo.commit_v1));
+    assert_eq!(pinned, Value::string("v1"));
+}
+
+/// A versioned require pins the whole namespace under an alias.
+#[test]
+fn versioned_require_pins_namespace() {
+    let repo = make_lib_repo();
+    let (_globals, mut env) = make_env(&repo.src_dir);
+
+    eval_str(
+        &mut env,
+        &format!("(require '[mylib@{} :as v1])", repo.commit_v1),
+    );
+    assert_eq!(eval_str(&mut env, "v1/the-answer"), Value::Long(1));
+    assert_eq!(eval_str(&mut env, "(v1/describe)"), Value::string("v1"));
+}
+
+/// Versioned values survive a forced collection: vars in the versioned
+/// namespace are traced via the namespace table, and native-fallback values
+/// are traced via the version cache.
+#[test]
+fn versioned_values_survive_gc() {
+    let repo = make_lib_repo();
+    let (globals, mut env) = make_env(&repo.src_dir);
+
+    eval_str(&mut env, "(require 'mylib)");
+    let pinned_expr = format!("(mylib/describe@{})", repo.commit_v1);
+    assert_eq!(eval_str(&mut env, &pinned_expr), Value::string("v1"));
+
+    // Native fallback path: a pure-Rust namespace with no Clojure source.
+    let nf = cljrs_value::NativeFn {
+        name: Arc::from("native-fn"),
+        arity: cljrs_value::Arity::Fixed(0),
+        func: Arc::new(|_args| Ok(Value::Long(7))),
+    };
+    globals.get_or_create_ns("purelib");
+    globals.intern(
+        "purelib",
+        Arc::from("native-fn"),
+        Value::NativeFunction(cljrs_gc::GcPtr::new(nf)),
+    );
+    assert_eq!(
+        eval_str(&mut env, "(purelib/native-fn@abcdef1234567)"),
+        Value::Long(7)
+    );
+
+    cljrs_env::gc_roots::force_collect(&env);
+
+    // Both the versioned-namespace value and the cache-only native fallback
+    // must still be alive and callable after collection.
+    assert_eq!(eval_str(&mut env, &pinned_expr), Value::string("v1"));
+    assert_eq!(
+        eval_str(&mut env, "(purelib/native-fn@abcdef1234567)"),
+        Value::Long(7)
+    );
+}

--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -113,6 +113,11 @@ pub struct Block {
 
 ### Instructions (`Inst`)
 
+Versioned symbols need no dedicated instruction: the `@<sha>` suffix rides in
+the `LoadGlobal` name string, and lowering inside a versioned namespace
+(`"base@sha"`) rewrites base-qualified self-references (`base/x`) to the
+versioned namespace (see `split_sym` in `lower/anf.rs`).
+
 `Const`, `LoadLocal`, `LoadGlobal`, `LoadVar`, `AllocVector`, `AllocMap`,
 `AllocSet`, `AllocList`, `AllocCons`, `AllocClosure`, `CallKnown`, `Call`,
 `CallDirect`, `Deref`, `DefVar`, `SetBang`, `Throw`, `Phi`, `Recur`,

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -2375,8 +2375,33 @@ fn split_sym(s: &str, current_ns: &Arc<str>) -> (Arc<str>, Arc<str>) {
         return (current_ns.clone(), Arc::from("/"));
     }
     match s.find('/') {
-        Some(pos) => (Arc::from(&s[..pos]), Arc::from(&s[pos + 1..])),
+        Some(pos) => {
+            let ns_part = &s[..pos];
+            // Inside a versioned namespace ("base@hash"), a qualified
+            // self-reference written with the base name ("base/x") must
+            // resolve at the pinned commit, i.e. inside the versioned
+            // namespace itself — mirroring the tree-walker's eval_symbol.
+            if let Some(base) = versioned_ns_base(current_ns)
+                && ns_part == base
+            {
+                return (current_ns.clone(), Arc::from(&s[pos + 1..]));
+            }
+            (Arc::from(ns_part), Arc::from(&s[pos + 1..]))
+        }
         None => (current_ns.clone(), Arc::from(s)),
+    }
+}
+
+/// If `ns` is a versioned namespace name (`"base@<7-40 hex>"`), return the
+/// base part.  Mirrors `cljrs_value::symbol::split_version` (cljrs-ir cannot
+/// depend on cljrs-value).
+fn versioned_ns_base(ns: &str) -> Option<&str> {
+    let pos = ns.rfind('@')?;
+    let hash = &ns[pos + 1..];
+    if (7..=40).contains(&hash.len()) && hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+        Some(&ns[..pos])
+    } else {
+        None
     }
 }
 

--- a/crates/cljrs-jit/Cargo.toml
+++ b/crates/cljrs-jit/Cargo.toml
@@ -32,3 +32,4 @@ cranelift-native   = { workspace = true }
 cljrs-stdlib = { workspace = true }
 cljrs-reader = { workspace = true }
 cljrs-env    = { workspace = true }
+tempfile     = "3"

--- a/crates/cljrs-jit/README.md
+++ b/crates/cljrs-jit/README.md
@@ -35,6 +35,7 @@ sites compile through per-call-site inline caches (`rt_kw_ic_fill`,
 | `src/jit_worker.rs` | Background worker thread: receives `CompileRequest::Function` and `CompileRequest::Osr` requests, registers each module in `code_cache`, publishes the function pointer + epoch (whole-function: `jit_state::store_native_fn`; OSR: `jit_state::store_osr_fn` with the live-in list). `specs_from_profile` maps the arity's Tier-1 type profile to per-parameter specializations (skipped when banned by deopts or `CLJRS_JIT_NO_SPEC=1`; OSR entries are never specialized). Each compile is wrapped in `catch_unwind` so a codegen panic on one function cannot kill the worker (the function just stays at Tier 1; failed OSR compiles are recorded via `mark_osr_failed`) |
 | `src/code_cache.rs` | Epoch-tagged registry of compiled modules; `mark_stale` on redefinition, `pin_epoch` for modules whose code leaked into a closure value, `reclaim_at_stw` frees stale, unpinned modules with no live frame via `JITModule::free_memory` |
 | `src/osr_integration.rs` | (test-only) end-to-end OSR test: lowers a real `loop*` from source, builds + compiles the OSR entry, and calls the native code with a mid-loop register snapshot |
+| `tests/versioned_jit.rs` | End-to-end versioned-symbol test: pinned references (`mylib/x@<sha>`) inside JIT-compiled functions resolve at the pinned commit through the `rt_load_global_versioned_ic` inline cache, agree with the interpreter tiers, survive a forced GC, and leave HEAD untouched |
 
 ## Public API
 

--- a/crates/cljrs-jit/src/jit_compiler.rs
+++ b/crates/cljrs-jit/src/jit_compiler.rs
@@ -283,6 +283,7 @@ fn register_rt_abi_symbols(builder: &mut JITBuilder) {
         sym!(rt_deopt),
         sym!(rt_kw_ic_fill),
         sym!(rt_call_ic),
+        sym!(rt_load_global_versioned_ic),
     ];
 
     builder.symbols(symbols.iter().map(|&(n, p)| (n, p)));

--- a/crates/cljrs-jit/tests/versioned_jit.rs
+++ b/crates/cljrs-jit/tests/versioned_jit.rs
@@ -1,0 +1,203 @@
+//! Tier 1 (JIT) versioned symbol resolution, end to end.
+//!
+//! Boots the full stdlib environment with the JIT enabled at a tiny
+//! threshold, defines functions whose bodies reference pinned symbols
+//! (`mylib/the-answer@<sha>`), hammers them until the background worker
+//! publishes native code, and asserts:
+//!
+//! - the JIT-native result equals the interpreter result (tier consistency)
+//!   and sees the pinned value, not HEAD;
+//! - the per-call-site inline cache's permanently rooted value survives a
+//!   forced GC;
+//! - the HEAD binding stays untouched throughout.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use cljrs_eval::{Env, eval};
+use cljrs_value::Value;
+
+// ── Git fixture helpers ───────────────────────────────────────────────────────
+
+fn git_cmd(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .expect("git command failed to start")
+}
+
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = git_cmd(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_sha(dir: &Path, rev: &str) -> String {
+    let out = git_cmd(dir, &["rev-parse", rev]);
+    assert!(out.status.success(), "git rev-parse {rev} failed");
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+struct LibRepo {
+    _dir: tempfile::TempDir,
+    src_dir: PathBuf,
+    commit_v1: String,
+}
+
+/// `src/mylib.cljrs` — v1: `the-answer` = 1; v2 (HEAD): `the-answer` = 2.
+fn make_lib_repo() -> LibRepo {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let src_dir = root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    git_ok(&root, &["init", "-q", "-b", "main"]);
+    // Override any global commit.gpgsign so test commits don't invoke a
+    // signing server.
+    git_ok(&root, &["config", "commit.gpgsign", "false"]);
+
+    let lib_file = src_dir.join("mylib.cljrs");
+    std::fs::write(
+        &lib_file,
+        "(def the-answer 1)\n(defn describe [] (str \"v\" the-answer))\n",
+    )
+    .unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v1"]);
+    let commit_v1 = git_sha(&root, "HEAD");
+
+    std::fs::write(
+        &lib_file,
+        "(def the-answer 2)\n(defn describe [] (str \"v\" the-answer))\n",
+    )
+    .unwrap();
+    git_ok(&root, &["add", "."]);
+    git_ok(&root, &["commit", "-q", "-m", "v2"]);
+
+    LibRepo {
+        _dir: dir,
+        src_dir,
+        commit_v1,
+    }
+}
+
+// ── Eval helpers ──────────────────────────────────────────────────────────────
+
+fn eval_str(env: &mut Env, src: &str) -> Value {
+    let mut parser = cljrs_reader::Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse");
+    let mut last = Value::Nil;
+    for form in &forms {
+        let _alloc_frame = cljrs_gc::push_alloc_frame();
+        last = eval(form, env).unwrap_or_else(|e| panic!("eval of {src:?} failed: {e:?}"));
+    }
+    last
+}
+
+/// The `ir_arity_id` of the sole arity of the fn bound to `user/<name>`.
+fn arity_id_of(env: &Env, name: &str) -> u64 {
+    let val = env
+        .globals
+        .lookup_in_ns("user", name)
+        .unwrap_or_else(|| panic!("user/{name} not bound"));
+    match val {
+        Value::Fn(f) => f.get().arities[0].ir_arity_id,
+        other => panic!("user/{name} is not a fn: {other:?}"),
+    }
+}
+
+/// Call `(fn-name)` repeatedly until the JIT publishes native code for it
+/// (or panic after ~15s).  Returns the last interpreted result.
+fn hammer_until_native(env: &mut Env, fn_name: &str, arity_id: u64) -> Value {
+    let call = format!("({fn_name})");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let mut last = Value::Nil;
+    while cljrs_eval::jit_state::get_native_fn(arity_id).is_none() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "JIT never published native code for {fn_name} (arity {arity_id})"
+        );
+        last = eval_str(env, &call);
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+    last
+}
+
+// ── The test ──────────────────────────────────────────────────────────────────
+
+/// Single test (not one per scenario): `cljrs_jit::init` installs process
+/// globals, so scenarios share the booted environment.
+#[test]
+fn jit_native_code_resolves_pinned_symbols() {
+    let repo = make_lib_repo();
+
+    // Tiny threshold so the worker kicks in after a handful of calls; must be
+    // set before init.  init() also forces eager IR lowering.
+    cljrs_eval::jit_state::set_jit_threshold(3);
+    cljrs_jit::init();
+
+    let _mutator = cljrs_gc::register_mutator();
+    let globals = cljrs_stdlib::standard_env_with_paths(vec![repo.src_dir.clone()]);
+
+    // Wait for the background compiler-namespace load (see
+    // compiler_clojure_tests.rs for why).
+    while !globals
+        .compiler_ready
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let mut env = Env::new(globals.clone(), "user");
+    cljrs_env::callback::push_eval_context(&env);
+
+    eval_str(&mut env, "(require 'mylib)");
+    assert_eq!(eval_str(&mut env, "mylib/the-answer"), Value::Long(2));
+
+    // A fn whose body is a pinned value reference, and one that calls a
+    // pinned fn from the versioned namespace (exercises rt_call through the
+    // versioned-IC-loaded callee).
+    eval_str(
+        &mut env,
+        &format!("(defn hot-val [] mylib/the-answer@{})", repo.commit_v1),
+    );
+    eval_str(
+        &mut env,
+        &format!("(defn hot-call [] (mylib/describe@{}))", repo.commit_v1),
+    );
+
+    // Scenario 1: pinned value reference.
+    let val_id = arity_id_of(&env, "hot-val");
+    let interpreted = hammer_until_native(&mut env, "hot-val", val_id);
+    assert_eq!(interpreted, Value::Long(1), "interpreted tiers see v1");
+    let native = eval_str(&mut env, "(hot-val)");
+    assert_eq!(native, Value::Long(1), "JIT-native code sees v1");
+
+    // Scenario 2: pinned fn call.
+    let call_id = arity_id_of(&env, "hot-call");
+    let interpreted = hammer_until_native(&mut env, "hot-call", call_id);
+    assert_eq!(interpreted, Value::string("v1"));
+    assert_eq!(eval_str(&mut env, "(hot-call)"), Value::string("v1"));
+
+    // The IC-cached values are permanently rooted: a forced collection must
+    // not invalidate what native code reads from its cache slots.
+    cljrs_env::gc_roots::force_collect(&env);
+    assert_eq!(eval_str(&mut env, "(hot-val)"), Value::Long(1));
+    assert_eq!(eval_str(&mut env, "(hot-call)"), Value::string("v1"));
+
+    // HEAD is untouched throughout.
+    assert_eq!(eval_str(&mut env, "mylib/the-answer"), Value::Long(2));
+    assert_eq!(eval_str(&mut env, "(mylib/describe)"), Value::string("v2"));
+
+    cljrs_env::callback::pop_eval_context();
+}

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -113,12 +113,16 @@ and sequential collection equality between `List` and `Vector`.
 ### `Symbol` / `Keyword`
 
 ```rust
-pub struct Symbol   { namespace: Option<Arc<str>>, name: Arc<str> }
+pub struct Symbol   { namespace: Option<Arc<str>>, name: Arc<str>, version: Option<Arc<str>> }
 pub struct Keyword  { namespace: Option<Arc<str>>, name: Arc<str> }
 ```
 
 Both support `simple(name)`, `qualified(ns, name)`, `parse(str)`, and
-`full_name() -> String`.
+`full_name() -> String`. `Symbol` additionally carries an optional git-commit
+`version` (the `@<hash>` suffix) with `versioned_name() -> String`. Free
+helpers used by all execution tiers to detect versioned names:
+`symbol::is_commit_hash(s) -> bool` and
+`symbol::split_version(name) -> (&str, Option<&str>)`.
 
 ### Phase B3 — Shared static arena
 

--- a/crates/cljrs-value/src/symbol.rs
+++ b/crates/cljrs-value/src/symbol.rs
@@ -79,7 +79,7 @@ impl Symbol {
 
 /// Split `name_part` into `(base, Some(hash))` if the last `@` is followed by
 /// a valid commit hash (7–40 hex chars), otherwise return `(name_part, None)`.
-fn split_version(name_part: &str) -> (&str, Option<&str>) {
+pub fn split_version(name_part: &str) -> (&str, Option<&str>) {
     if let Some(at_pos) = name_part.rfind('@') {
         let candidate = &name_part[at_pos + 1..];
         if is_commit_hash(candidate) {

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -43,6 +43,7 @@ cljrs-deps     = { workspace = true }
 cljrs-vcs      = { workspace = true }
 cljrs-lsp      = { workspace = true }
 cljrs-jit      = { workspace = true }
+cljrs-dylib    = { workspace = true }
 clap          = { workspace = true }
 miette        = { workspace = true }
 tracing-subscriber = "0.3.23"

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -573,6 +573,8 @@ fn setup_globals(
     if versioning.enforce_native_versions {
         globals.set_enforce_native_versions(true);
     }
+    // Opt-in pinned native packages (:rust/load :dylib in cljrs.edn).
+    cljrs_dylib::install(&globals);
     if let Ok(cwd) = std::env::current_dir() {
         apply_deps_config(&globals, &cwd);
     }

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -40,6 +40,13 @@ struct Cli {
     #[arg(long, global = true)]
     verify_commit_signatures: bool,
 
+    /// Make pinned lookups of native (Rust-backed) functions an error when
+    /// the package's recorded provenance does not match the requested
+    /// commit (default: warn once per pin).  Can also be enabled
+    /// per-project via `:enforce-native-versions true` in `cljrs.edn`.
+    #[arg(long, global = true)]
+    enforce_native_versions: bool,
+
     /// JIT compilation invocation threshold (default 1000; 0 = disable JIT).
     /// Also read from CLJRS_JIT_THRESHOLD env var.
     #[arg(
@@ -324,13 +331,16 @@ fn run(cli: Cli) -> miette::Result<i32> {
 
     let gc_stats_target = cli.gc_stats.clone();
     let jit_stats_target = cli.jit_stats.clone();
-    let verify_commit_signatures = cli.verify_commit_signatures;
+    let versioning = VersioningFlags {
+        verify_commit_signatures: cli.verify_commit_signatures,
+        enforce_native_versions: cli.enforce_native_versions,
+    };
     let supports_gc_stats = matches!(
         &cli.command,
         Commands::Run { .. } | Commands::Eval { .. } | Commands::Test { .. },
     );
 
-    let result = run_command(cli.command, verify_commit_signatures);
+    let result = run_command(cli.command, versioning);
 
     if supports_gc_stats
         && let Some(target) = gc_stats_target.as_deref()
@@ -379,7 +389,16 @@ fn init_jit(threshold: Option<u32>) {
     cljrs_jit::init();
 }
 
-fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Result<i32> {
+/// CLI-level versioned-symbol policy flags, threaded into `setup_globals`.
+#[derive(Clone, Copy, Default)]
+struct VersioningFlags {
+    /// `--verify-commit-signatures` / `:verify-commit-signatures`.
+    verify_commit_signatures: bool,
+    /// `--enforce-native-versions` / `:enforce-native-versions`.
+    enforce_native_versions: bool,
+}
+
+fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result<i32> {
     match command {
         Commands::Run {
             file,
@@ -392,7 +411,7 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
                 .map_err(|e| miette::miette!("{}: {}", file.display(), e))?;
             let filename = file.display().to_string();
             let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
-            let globals = setup_globals(src_paths, gc_config, verify_commit_signatures);
+            let globals = setup_globals(src_paths, gc_config, versioning);
             run_source(&src, &filename, globals, &args)?;
             Ok(0)
         }
@@ -402,7 +421,7 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
             gc_hard_limit_mb,
         } => {
             let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
-            let globals = setup_globals(src_paths, gc_config, verify_commit_signatures);
+            let globals = setup_globals(src_paths, gc_config, versioning);
             run_repl(globals);
             Ok(0)
         }
@@ -432,7 +451,7 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
                     &out,
                     &src_paths,
                     rust_config.as_ref(),
-                    verify_commit_signatures,
+                    versioning.verify_commit_signatures,
                 )
                 .map_err(|e| miette::miette!("{e}"))?;
             }
@@ -440,7 +459,7 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
         }
         Commands::Eval { expr } => {
             let gc_config = Arc::new(GcConfig::new());
-            let globals = setup_globals(Vec::new(), gc_config, verify_commit_signatures);
+            let globals = setup_globals(Vec::new(), gc_config, versioning);
             let result = eval_source(&expr, "<eval>", globals)?;
             if result != Value::Nil {
                 println!("{}", result);
@@ -465,7 +484,7 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
             verbose,
             gc_soft_limit_mb,
             gc_hard_limit_mb,
-            verify_commit_signatures,
+            versioning,
         ),
         Commands::Deps { command } => match command {
             DepsCommands::Fetch { name } => run_deps_fetch(name),
@@ -543,13 +562,16 @@ fn write_gc_stats(target: &str) -> std::io::Result<()> {
 fn setup_globals(
     src_paths: Vec<PathBuf>,
     gc_config: Arc<GcConfig>,
-    verify_commit_signatures: bool,
+    versioning: VersioningFlags,
 ) -> Arc<GlobalEnv> {
     let globals = cljrs_stdlib::standard_env_with_paths_and_config(src_paths, gc_config);
-    if verify_commit_signatures {
+    if versioning.verify_commit_signatures {
         globals
             .verify_commit_signatures
             .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    if versioning.enforce_native_versions {
+        globals.set_enforce_native_versions(true);
     }
     if let Ok(cwd) = std::env::current_dir() {
         apply_deps_config(&globals, &cwd);
@@ -597,6 +619,9 @@ fn apply_deps_config(globals: &Arc<GlobalEnv>, cwd: &Path) {
                 globals
                     .verify_commit_signatures
                     .store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+            if config.enforce_native_versions {
+                globals.set_enforce_native_versions(true);
             }
             // Load the native shared library (if :rust is configured) so that
             // native functions are registered before any Clojure code runs.
@@ -1067,10 +1092,10 @@ fn run_tests_command(
     verbose: bool,
     gc_soft_limit_mb: Option<usize>,
     gc_hard_limit_mb: Option<usize>,
-    verify_commit_signatures: bool,
+    versioning: VersioningFlags,
 ) -> miette::Result<i32> {
     let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
-    let globals = setup_globals(src_paths, gc_config, verify_commit_signatures);
+    let globals = setup_globals(src_paths, gc_config, versioning);
 
     let namespaces = if namespaces.is_empty() {
         // Read the final source paths (which may include cljrs.edn :paths).

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -427,8 +427,14 @@ fn run_command(command: Commands, verify_commit_signatures: bool) -> miette::Res
                 cljrs_compiler::aot::compile_test_harness(&file, &out, &src_paths)
                     .map_err(|e| miette::miette!("{e}"))?;
             } else {
-                cljrs_compiler::aot::compile_file(&file, &out, &src_paths, rust_config.as_ref())
-                    .map_err(|e| miette::miette!("{e}"))?;
+                cljrs_compiler::aot::compile_file(
+                    &file,
+                    &out,
+                    &src_paths,
+                    rust_config.as_ref(),
+                    verify_commit_signatures,
+                )
+                .map_err(|e| miette::miette!("{e}"))?;
             }
             Ok(0)
         }

--- a/docs/book/src/language/versioned-symbols.md
+++ b/docs/book/src/language/versioned-symbols.md
@@ -39,6 +39,7 @@ following resolution rules apply:
 | Symbol form | Resolved at |
 |---|---|
 | Unqualified or same-namespace, no `@` | The inherited commit (propagated from the caller) |
+| Qualified self-reference (`my.ns/x` written inside `my.ns`) | The inherited commit |
 | Explicitly versioned `foo@D` | Commit `D` |
 | External / cross-namespace, no `@` | HEAD (current) |
 
@@ -46,6 +47,57 @@ This means a versioned call behaves like a logical snapshot: internal helpers
 in the same namespace are drawn from the same commit automatically, but
 cross-namespace dependencies and the standard library use their current values
 unless explicitly pinned.
+
+Resolving any pinned symbol loads the **whole namespace** at that commit into
+an immutable namespace named `my.ns@<commit>`: top-level side effects of the
+pinned file run once (when the snapshot is first loaded), historical
+definitions never overwrite the live (HEAD) bindings, and the snapshot is
+cached for the rest of the session.
+
+## Execution tiers
+
+Versioned symbols behave identically everywhere code runs:
+
+- **Interpreter** — symbols resolve through the shared versioned resolver.
+- **JIT** — hot functions keep their pins: compiled code resolves each pinned
+  reference once through a per-call-site inline cache (versioned bindings are
+  immutable, so the cache never needs invalidation).
+- **AOT (`cljrs compile`)** — pins are resolved *at compile time*: every
+  versioned require and bare versioned symbol is fetched from git during
+  compilation and embedded in the binary. The produced binary is
+  self-contained — no git repository, source tree, or `~/.cljrs` cache is
+  needed where it runs. A pin pointing at a missing commit fails the compile,
+  and a versioned namespace that was not embedded fails at runtime with a
+  clear "was not embedded at compile time" error.
+
+## Native (Rust) functions
+
+Native functions live in the running binary, so there is no historical
+Clojure source to re-evaluate. By default a pinned lookup of a native
+function resolves to the current binary's implementation — a **verified HEAD
+binding**: the runtime compares the pin against the package's recorded
+provenance (the commit it was built from, declared with
+`cljrs_interop::register_provenance!`). A match is silent; a mismatch or
+missing provenance warns once per pin, or errors when
+`--enforce-native-versions` (or `:enforce-native-versions true` in
+`cljrs.edn`) is set.
+
+For true pinned native code, opt in per dependency (experimental; requires a
+Rust toolchain at runtime):
+
+```clojure
+{:deps
+ {my.native.lib {:git/url   "https://github.com/user/my-native-lib"
+                 :git/sha   "abc1234ef"
+                 :rust/init "my_native_lib::cljrs_init"
+                 :rust/load :dylib}}}
+```
+
+The runtime then builds the dependency's crate at the pinned commit as a
+shared library (cached under `~/.cljrs/cache/dylibs/`), verifies an ABI
+fingerprint (cljrs version, rustc version, build profile must match the host
+exactly), and registers the pinned implementations into the immutable
+`my.native.lib@<commit>` namespace.
 
 ## Dependency setup
 

--- a/docs/versioned-namespaces-plan.md
+++ b/docs/versioned-namespaces-plan.md
@@ -1,0 +1,267 @@
+# Versioned Namespaces/Symbols for AOT, JIT, and Native (Rust-Interop) Packages
+
+## Context
+
+Versioned symbols (`foo@abc1234`, `my.ns/foo@abc1234`) and versioned requires
+(`(require '[my.lib@abc1234 :as v1])`) currently work **only in the tree-walking
+interpreter** (Tier 3). The resolution logic lives in
+`crates/cljrs-interp/src/versioned.rs`: fetch source from git at the commit, evaluate,
+cache in `GlobalEnv::version_cache`.
+
+The other execution paths have **zero version awareness** (verified):
+
+- **Tier 2 (IR interpreter)** — `lower_symbol`/`split_sym`
+  (`crates/cljrs-ir/src/lower/anf.rs:2356-2381`) split only on `/`, so `foo@hash`
+  lowers to `Inst::LoadGlobal(ns, "foo@hash")`; `load_global_value`
+  (`crates/cljrs-eval/src/ir_interp.rs:749`) then fails `lookup_var_in_ns` — a hard
+  error, not a graceful Tier-3 fallback.
+- **Tier 1 (JIT) and AOT** — `LoadGlobal` compiles to `rt_load_global`
+  (`crates/cljrs-compiler/src/rt_abi.rs`), same string lookup, same failure. AOT
+  additionally never bundles pinned sources, so even versioned requires that worked
+  at compile time would hit git again at runtime.
+- **Native functions** — versioned lookup of a Rust-native fn silently falls back to
+  the HEAD implementation (`crates/cljrs-interp/src/versioned.rs:117-129`).
+
+**User decisions (locked in):**
+1. **AOT = snapshot at compile time.** Pinned sources are fetched and embedded in the
+   binary; the binary is self-contained (no git/network at runtime). A versioned
+   symbol not embedded at compile time errors clearly at runtime.
+2. **Native fns = hybrid.** Default "verified HEAD binding": native fns come from the
+   current binary, with provenance recorded at registration and a warning (error under
+   a strict flag) on pinned-commit mismatch. Opt-in: build the crate at the pinned
+   commit and dlopen it (or statically link it for AOT).
+
+**Two latent defects found during exploration (fixed by this design; write repro tests first):**
+- (a) Per-symbol resolution (`eval_in_snapshot`, `cljrs-interp/src/versioned.rs:162-165`)
+  evaluates the historical `(def foo …)` with `current_ns` = the *base* (HEAD)
+  namespace — interning the historical value into the live namespace, clobbering HEAD.
+- (b) `trace_globals` (`crates/cljrs-env/src/gc_roots.rs:312-318`) traces only
+  `globals.namespaces`; values cached *only* in `version_cache` are not GC-rooted.
+
+## Core design: normalize everything onto versioned namespaces
+
+Make `"ns@commit"` namespaces the single runtime concept for all tiers:
+
+> Resolving `ns/name@commit` (any tier) = ensure the versioned namespace `ns@commit`
+> is loaded (lazily, from embedded source or git), then a plain
+> `lookup_in_ns("ns@commit", name)` — with the native-provenance fallback when no
+> Clojure source defines the symbol.
+
+This replaces the find-one-def-form snapshot path with whole-file load (already the
+behavior for versioned requires; cached once per `ns@commit`). Consequences:
+
+- Fixes defect (a): historical defs intern into the immutable `ns@commit` namespace.
+  Fixes defect (b): resolved values live in `globals.namespaces` and get traced.
+- **Same-ns commit inheritance becomes structural** for IR/JIT/AOT: fns defined while
+  loading `ns@commit` get `defining_ns = "ns@commit"`; unqualified refs lower to
+  `LoadGlobal("ns@commit", helper)` — a plain namespace hit. No commit threading
+  through IR, `EvalContext`, or codegen. The tree-walker's `versioned_eval_commit`
+  stays for compatibility.
+- Accepted trade-off: per-symbol resolution evaluates the whole file at that commit
+  (top-level side effects run once). Document in VERSIONING.md.
+
+**IR representation: `Inst::LoadGlobal` unchanged; the version rides in the name
+string** (`"foo@abc1234"`), which the lexer already produces. Rationale: `IrFunction`
+is postcard-serialized (format stability), ~12 passes pattern-match `LoadGlobal`
+untouched, and alias-qualified versioned symbols can't be fully resolved at lowering
+time anyway. Runtime lookup points detect a valid `@<7-40 hex>` suffix (reuse
+`cljrs_value::symbol::is_commit_hash`), split, resolve alias → base ns, and call the
+shared resolver. Codegen statically detects the same pattern to emit an inline-cache
+load.
+
+**Feasibility keystone (verified):** `cljrs-env` does not depend on `cljrs-interp`;
+versioned-namespace loading already lives in `cljrs-env/src/loader.rs:173-261` and
+snapshot eval goes through the injected `GlobalEnv::eval_fn` callback (`env.rs:97`).
+The per-symbol resolver can move down into `cljrs-env` with no dependency cycle.
+
+---
+
+## Phase 0 — Move and unify the resolver in `cljrs-env`
+
+- **New `crates/cljrs-env/src/versioned.rs`** (non-wasm, cfg-gated like the loader):
+  - `ensure_versioned_ns_loaded(globals, base_ns, commit) -> EvalResult<Arc<str>>` —
+    returns the `ns@commit` name; refactor `loader::load_versioned_ns` to delegate;
+    idempotent.
+  - `resolve_versioned_value(globals, defining_ns, ns_part, name, commit) -> EvalResult<Value>`
+    — alias resolution, ensure-load, `lookup_in_ns`, then native fallback (moved from
+    `cljrs-interp/src/versioned.rs:117-129`).
+- **`GlobalEnv` additions** (`crates/cljrs-env/src/env.rs`):
+  `versioned_sources: RwLock<HashMap<Arc<str>, Arc<str>>>` (key `"ns@commit"`,
+  value = fetched source text) — populated whenever the loader fetches from git;
+  feeds AOT embedding in Phase 3.
+- **`crates/cljrs-env/src/loader.rs`**: versioned loader checks builtin/embedded
+  sources (`register_builtin_source` registry) **before** the git path — embedded
+  sources skip git, repo-root discovery, and runtime signature checks.
+- **`crates/cljrs-env/src/gc_roots.rs`**: trace `version_cache` values in
+  `trace_globals` (defect (b) fix, landed regardless).
+- **`crates/cljrs-interp/src/versioned.rs`** becomes a thin shim delegating to
+  `cljrs_env::versioned`; call sites in `eval.rs:170-230` unchanged.
+
+**Tests:** existing interp versioned tests + `crates/cljrs-vcs/tests/versioning_harness.rs`
+pass unchanged; new regression test that per-symbol `foo@hash` does **not** clobber the
+HEAD binding of `foo`; GC stress test that a resolved versioned value survives collection.
+
+## Phase 1 — Tier 2 (IR interpreter)
+
+- **`crates/cljrs-eval/src/ir_interp.rs`** `load_global_value` (~line 749): if `name`
+  carries a valid hash suffix → `cljrs_env::versioned::resolve_versioned_value`; if
+  `ns` itself is an `@`-name not yet loaded → lazily `ensure_versioned_ns_loaded`.
+- **`crates/cljrs-ir/src/lower/anf.rs`** (small, optional but recommended): when
+  `ctx.ns()` is `"base@hash"` and a qualified symbol's ns part equals `base`, rewrite
+  to `ctx.ns()` (qualified self-references resolve at the pinned commit, not HEAD).
+  Mirror in the tree-walker for parity; verify current behavior with a test first.
+
+**Tests** (`crates/cljrs-eval/tests/`): temp git repo fixture (reuse `git_cmd`/`git_sha`
+helper patterns from `versioning_harness.rs`); a fn whose body references `lib/f@<sha1>`;
+force the IR path with `CLJRS_EAGER_LOWER=1`; assert pinned result and that the IR cache
+was used.
+
+## Phase 2 — Tier 1 (JIT) + AOT codegen
+
+- **`crates/cljrs-compiler/src/rt_abi.rs`**:
+  - Make `rt_load_global` version-aware as the slow path: detect `@hash`, resolve via
+    `with_eval_context`; report errors through `stash_pending_exception` (the
+    established channel), never silently nil.
+  - New `rt_load_global_versioned_ic(ns_ptr, ns_len, name_ptr, name_len, slot) -> *const Value`,
+    modeled on `rt_kw_ic_fill` (rt_abi.rs:3915): resolve once, box the value,
+    **register it as a permanent GC root**, store the pointer in the per-call-site
+    slot. Check how `rt_kw_ic_fill`'s interned keywords are rooted; if keyword-specific,
+    add `permanent_value_roots: Mutex<Vec<Value>>` to `GlobalEnv`, traced by
+    `trace_globals`. Anchor both in `anchor_rt_symbols`.
+- **`crates/cljrs-compiler/src/codegen.rs`**: in `Inst::LoadGlobal` handling, if the
+  name has a valid version suffix, emit the IC pattern (clone of `emit_keyword_ic`,
+  line 1197, with string args + slot). Register the new FuncId in `RtFuncs`.
+  **No invalidation machinery needed** — versioned bindings are immutable; the slot is
+  fill-once-forever (assert/ignore `@` namespaces in the `on_var_rebind` JIT hook for
+  defense). This is the immutability win.
+
+**Tests** (`crates/cljrs-jit/tests/`): hot loop calling a versioned fn with a low
+`CLJRS_JIT_THRESHOLD` (`set_jit_threshold`); assert pinned result and
+`jit_state::get_native_fn(...).is_some()` after warmup; tier-consistency test (JIT
+result == tree-walker result).
+
+## Phase 3 — AOT snapshot
+
+Files: `crates/cljrs-compiler/src/aot.rs`, small changes in `cljrs-env`
+(`loader.rs`, `env.rs`).
+
+1. **Compile-time verification**: propagate `verify-commit-signatures` from
+   cljrs.edn/CLI onto the macroexpansion `GlobalEnv` in `compile_file` before any
+   require runs — signature checks happen at compile time; embedded sources are then
+   trusted as part of the binary.
+2. **Discovery**: versioned requires already execute during expansion (aot.rs:432-437)
+   and now record into `versioned_sources` (Phase 0). Additionally, walk the final
+   `IrFunction` tree (reuse the `referenced_globals` walker pattern,
+   `cljrs-eval/src/lower.rs:208`) plus interpreted-preamble forms for `@hash` names,
+   forcing `ensure_versioned_ns_loaded` at compile time — catches bare `foo@hash`
+   symbols no require mentions. Transitive versioned requires inside pinned sources
+   are caught automatically (loading a pinned file executes its own requires).
+3. **Embedding**: extend `discover_bundled_sources` (aot.rs:656-681) to append every
+   `versioned_sources` entry as `(ns@commit, source)` — the existing
+   `bundled_N.cljrs` + `register_builtin_source("my.lib@abc1234", include_str!(…))`
+   harness machinery (aot.rs:776-789) needs no structural change. At runtime the
+   loader's builtin-source-first path (Phase 0) means no git, no network.
+4. **Offline mode**: generated harness `main.rs` calls a new
+   `globals.set_versioned_offline(true)` (AtomicBool). When set,
+   `load_versioned_ns` with no builtin source fails immediately:
+   `"versioned namespace my.lib@abc1234 was not embedded at compile time; AOT binaries cannot fetch from git at runtime"`.
+
+**Tests** (extend `crates/cljrs-compiler/tests/aot_e2e.rs`): two-repo fixture; compile
+an app pinning `lib@sha1` (both require-style and bare-symbol-style); run the binary
+from an empty cwd with `HOME` pointed at an empty dir and the lib repo deleted —
+assert pinned output; negative test that a non-embedded `other@sha` produces the
+clear offline error.
+
+## Phase 4 — Native provenance (default hybrid)
+
+- **`GlobalEnv`** (`cljrs-env/src/env.rs`):
+  `native_provenance: RwLock<HashMap<Arc<str> /*ns*/, Arc<str> /*commit*/>>`,
+  `enforce_native_versions: AtomicBool`, `provenance_warned: Mutex<HashSet<Arc<str>>>`
+  (warn once per `ns@commit`). Lives in cljrs-env so the resolver checks it without
+  an interop dependency.
+- **`crates/cljrs-interop`**: `Registry::set_provenance(ns, commit)`; inventory-collected
+  `ProvenanceEntry { ns, commit }` + a `register_provenance!(ns, commit)` macro
+  (typically `commit = env!("CLJRS_PKG_COMMIT")` emitted by the package's build.rs);
+  registered alongside exports.
+- **Resolver hook** (in the Phase-0 native fallback): look up provenance for the base
+  ns; prefix-match in either direction (requested hash may be abbreviated). Match →
+  silent. Mismatch/missing → warn once (default), `EvalError` under the strict flag.
+- **Flags**, mirroring `verify_commit_signatures` style: CLI
+  `--enforce-native-versions`, cljrs.edn `:enforce-native-versions true` (parse in
+  `cljrs-deps`, wire in `cljrs/src/main.rs` next to the existing flag).
+
+**Tests:** matching provenance → silent; mismatch → value returned + warned-set
+populated (assert on the set, not stderr); strict flag → error.
+
+## Phase 5 — Opt-in pinned native code (dlopen / static link)
+
+New crate `crates/cljrs-dylib` (non-wasm; deps: cljrs-env, cljrs-vcs, cljrs-interop,
+cljrs-deps, libloading).
+
+- **Config**: per-dep in cljrs.edn:
+  `{:git/url … :git/sha … :rust/init "my_crate::cljrs_init" :rust/load :dylib}`
+  (extend `Dependency` in `cljrs-deps`).
+- **Flow (interpreter/JIT)**: native fallback, when the dep is `:rust/load :dylib`:
+  `fetch_remote(url, sha)` → generate a thin wrapper cdylib crate in
+  `~/.cljrs/cache/dylibs/<pkg>@<commit>/` (reuse the `resolve_harness_deps` /
+  `HarnessDeps` pattern from aot.rs:962-1110 to pin identical cljrs crate versions) →
+  `cargo build --release` → cache keyed by `(pkg, commit, rustc -V, cljrs version,
+  target)` → dlopen.
+- **ABI discipline**: two exported symbols. (1) C-ABI handshake
+  `cljrs_dylib_abi() -> *const CljrsAbiInfo` (`#[repr(C)]`, carries cljrs-value
+  version + `rustc -V` baked in at wrapper build time; host requires exact equality
+  or refuses with a clear error). (2) Rust-ABI
+  `cljrs_dylib_init(registry: &mut Registry)` — acceptable only because the handshake
+  guarantees identical compiler + crate versions. A full C-ABI vtable is the safer
+  long-term answer; explicitly deferred and documented as experimental.
+- **Versioned registration**: the wrapper's init calls the dep's `cljrs_init` through
+  a `Registry::versioned(commit)` view that rewrites `define("ns/name")` →
+  `define_in("ns@commit", name)`; `inventory` iteration happens *inside the dylib* so
+  its `#[export]` entries don't collide with the host's.
+- **AOT variant**: prefer static linking over runtime dlopen — at compile time add the
+  pinned crate to the harness Cargo.toml as
+  `pkg_abc1234 = { package = "the-crate", path = "<cache checkout>" }` and call its
+  init through the versioned Registry view in generated main.rs.
+  **Open problem (call out in docs/PR):** two statically linked versions of the same
+  crate both submit `#[export]` inventory entries under the unversioned name in
+  nondeterministic order — for the static path, require init-fn-based registration
+  for pinned native deps (error otherwise), or fall back to dlopen for that dep.
+
+**Tests:** heavyweight integration test gated behind an env var (it runs cargo):
+two-commit native crate fixture, pin commit 1, assert the dylib-loaded `pkg@sha1`
+impl differs from HEAD; handshake-mismatch negative test.
+
+## Phase 6 — Documentation (CLAUDE.md mandates README currency)
+
+- `VERSIONING.md`: whole-file snapshot semantics, AOT snapshot model, native hybrid +
+  flags, dlopen opt-in + ABI requirements.
+- `docs/book/src/language/versioned-symbols.md`: same, user-facing.
+- Crate READMEs: cljrs-env (new `versioned` module, GlobalEnv fields), cljrs-interp
+  (shim note), cljrs-eval, cljrs-compiler (new rt symbols, AOT embedding),
+  cljrs-interop (provenance API), new cljrs-dylib.
+- `TODO.md`: update Phase 9 dynamic-loading entry.
+
+## Sequencing, verification, risks
+
+**Order:** 0 → 1 → 2 → 3 (strict); 4 depends only on 0; 5 depends on 4 (+3 for the
+static-link variant). Each phase lands green independently.
+
+**End-to-end verification:**
+- `cargo test` workspace-wide after each phase (notably `versioning_harness.rs`).
+- Tier matrix on one fixture: same pinned call evaluated via tree-walker, via
+  `CLJRS_EAGER_LOWER=1` (Tier 2), via low `CLJRS_JIT_THRESHOLD` (Tier 1), and via a
+  compiled binary — all four must agree and differ from HEAD.
+- AOT offline proof: run the compiled binary with the source repo deleted and `HOME`
+  redirected (no `~/.cljrs/cache`).
+
+**Risks:**
+1. Whole-file snapshot eval changes per-symbol semantics (side effects, load cost) —
+   mitigated by per-`ns@commit` caching + docs.
+2. Permanent rooting of IC-cached values — verify how `rt_kw_ic_fill` roots interned
+   keywords and mirror it before relying on the pattern.
+3. The Rust-ABI dylib boundary stays fragile even with the handshake (feature-flag
+   skew) — ship as experimental, documented.
+4. Inventory collision in static-link AOT native pinning (open question above).
+5. The `version_cache` GC-tracing fix may surface previously-masked lifetime
+   assumptions — land with its own stress test.
+6. Reproduce defect (a) with a test before claiming the fix.

--- a/docs/versioned-namespaces-plan.md
+++ b/docs/versioned-namespaces-plan.md
@@ -1,5 +1,10 @@
 # Versioned Namespaces/Symbols for AOT, JIT, and Native (Rust-Interop) Packages
 
+> **Status:** Implemented (Phases 0–6).  The AOT *static-link* variant for
+> pinned native deps (end of Phase 5) is deferred — pinned native packages
+> use the dlopen path; see `crates/cljrs-dylib/README.md` and TODO.md
+> Phase 9 for the open `#[export]`-inventory-collision problem.
+
 ## Context
 
 Versioned symbols (`foo@abc1234`, `my.ns/foo@abc1234`) and versioned requires


### PR DESCRIPTION
Phase 0 of the versioned-namespaces-for-all-tiers plan (see
docs/versioned-namespaces-plan.md):

- New cljrs_env::versioned module: resolve_versioned_value /
  ensure_versioned_ns_loaded.  Resolving ns/name@commit now loads the
  whole immutable ns@commit namespace and looks the name up in it,
  instead of evaluating a single historical def form.
- Fixes HEAD clobbering: the historical def used to intern into the
  live base namespace via eval_in_snapshot.
- Fixes GC hole: values living only in GlobalEnv::version_cache
  (native HEAD fallbacks) are now traced by trace_globals.
- Versioned loading checks embedded builtin sources before git, and
  records git-fetched sources in GlobalEnv::versioned_sources for
  later AOT embedding.
- loader::load_versioned_ns delegates to the shared service;
  cljrs-interp's versioned module becomes a thin shim.
- cljrs_value::symbol::split_version is now public.
- New end-to-end tests against a real git fixture (pinned symbols,
  HEAD-clobber regression, versioned require, GC survival).

https://claude.ai/code/session_01MwoeeoK6Krnuv36Hg6KdHv