### PR TITLE
Add cljrs-nrepl crate and `cljrs nrepl` subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ cljrs repl                   # start interactive REPL
 cljrs compile <file> -o <bin> # AOT compile to binary
 cljrs eval '<expr>'          # evaluate expression from shell
 cljrs test --src-path ...  # run clojure.test namespaces
+cljrs nrepl [--port N]       # start an nREPL server for editor integration
+
 ```
 
 ## Tooling
@@ -75,6 +77,7 @@ The project is a library crate (`src/lib.rs`) with a binary entry point (`src/ma
 | `interop` | Rust↔Clojure FFI; `#[cljx::export]` proc-macro; type marshalling; `NativeObject` |
 | `cli` | `cljx` command entry point; REPL; file runner; project tooling |
 | `lsp` | Language Server Protocol server (`cljrs-lsp` crate, `cljrs lsp` subcommand); parse diagnostics + document symbols |
+| `nrepl` | nREPL server (`cljrs-nrepl` crate, `cljrs nrepl` subcommand); bencode over TCP for editor integration |
 
 ### Key design constraints
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
  "cljrs-logging",
  "cljrs-lsp",
  "cljrs-net",
+ "cljrs-nrepl",
  "cljrs-reader",
  "cljrs-runtime",
  "cljrs-stdlib",
@@ -682,6 +683,22 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "cljrs-nrepl"
+version = "0.1.0"
+dependencies = [
+ "cljrs-builtins",
+ "cljrs-env",
+ "cljrs-eval",
+ "cljrs-gc",
+ "cljrs-reader",
+ "cljrs-stdlib",
+ "cljrs-value",
+ "miette",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/cljrs-net",
     "crates/cljrs-charset",
     "crates/cljrs-lsp",
+    "crates/cljrs-nrepl",
     "crates/cljrs-base64",
     "crates/cljrs-jit",
     "crates/cljrs-dylib"]
@@ -62,6 +63,7 @@ cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
 cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
 cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0" }
 cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.0" }
+cljrs-nrepl        = { path = "crates/cljrs-nrepl",        version = "0.1.0" }
 cljrs-jit          = { path = "crates/cljrs-jit",          version = "0.1.0" }
 cljrs-dylib        = { path = "crates/cljrs-dylib",        version = "0.1.0" }
 

--- a/TODO.md
+++ b/TODO.md
@@ -455,7 +455,7 @@ Foundations already in place:
 ## Phase 12 — REPL & Tooling
 
 - [x] Interactive REPL (`cljx repl`): read–eval–print loop (basic; readline deferred)
-- [ ] nREPL-compatible server for editor integration
+- [x] nREPL-compatible server for editor integration (`cljrs nrepl`, `cljrs-nrepl` crate)
 - [x] `cljx run <file>` — execute a `.cljrs` or `.cljc` source file
 - [x] `cljx eval '<expr>'` — evaluate expression from command line
 - [ ] Project / build system (`cljx.edn` project descriptor, dependency resolution)

--- a/crates/cljrs-nrepl/Cargo.toml
+++ b/crates/cljrs-nrepl/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cljrs-nrepl"
+version = "0.1.0"
+edition = "2024"
+description = "nREPL server for clojurust — bencode wire protocol for editor integration"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+cljrs-gc       = { workspace = true }
+cljrs-value    = { workspace = true }
+cljrs-reader   = { workspace = true }
+cljrs-env      = { workspace = true }
+cljrs-eval     = { workspace = true }
+cljrs-builtins = { workspace = true }
+miette    = { workspace = true }
+thiserror = { workspace = true }
+# The server needs async TCP plus a runtime; pin a richer tokio feature set
+# than the workspace default (which omits net/io-util), same as cljrs-lsp.
+tokio = { version = "1.50.0", features = ["rt", "net", "io-util", "sync", "macros", "time"] }
+
+[dev-dependencies]
+cljrs-stdlib = { workspace = true }

--- a/crates/cljrs-nrepl/README.md
+++ b/crates/cljrs-nrepl/README.md
@@ -1,0 +1,45 @@
+# cljrs-nrepl
+
+**Purpose** — nREPL server for clojurust: speaks the [nREPL protocol](https://nrepl.org) (bencode-encoded messages over TCP) so editors like CIDER, Calva, and Conjure can connect to a running interpreter.
+
+**Status** — Phase 12 (REPL & Tooling). Implemented; exposed as the `cljrs nrepl` subcommand and usable as a library.
+
+## Design
+
+`GcPtr` (and therefore `Value`, `Env`, `GlobalEnv`) is not `Send`, so all interpreter state stays on the thread that created the `GlobalEnv`:
+
+- The **network thread** (spawned by `start`) runs a current-thread tokio runtime with the TCP listener. Per-connection tasks decode bencode frames and answer `describe` and `interrupt` directly.
+- Every other op becomes a `Job` — plain `Send` data (strings, a reply channel, a cancellation flag) — sent over an mpsc channel to the **interpreter thread**, which processes jobs in `Server::serve` / `Server::serve_with`.
+
+Supported ops: `clone`, `close`, `describe`, `eval`, `interrupt`, `load-file`, `lookup`, `ls-sessions`, `completions`.
+
+Each session has its own `Env` (namespace) and its own `*1`/`*2`/`*3`/`*e`, bound via the dynamic-binding stack around each request. Retained values are interned in the hidden `cljrs.nrepl.session-state` namespace so the GC traces them between evals.
+
+### Limitations
+
+- **Interrupt is best-effort.** A queued request is dropped, and a multi-form request stops between forms, but a single form that loops forever cannot be cancelled (the interpreter has no preemption hook).
+- **Output is batched per form**, not streamed incrementally: `out` is delivered when the printing form finishes (it reuses the interpreter's thread-local output-capture stack from `cljrs-builtins`).
+- Requests without a session share a single `"default"` session rather than receiving a transient one.
+
+## File layout
+
+| File | Purpose |
+|---|---|
+| `src/lib.rs` | Public API: `Config`, `start`, `Server`, `ShutdownHandle`, the `Job` bridge type |
+| `src/bencode.rs` | Hand-rolled bencode codec (the nREPL subset) with incremental decoding for TCP framing |
+| `src/protocol.rs` | `Request` decoding and the `Response` builder |
+| `src/server.rs` | Network thread: accept loop, per-connection reader/writer tasks, `describe`/`interrupt`, in-flight registry |
+| `src/engine.rs` | Interpreter thread: session registry, eval with output capture and `*1`/`*2`/`*3`/`*e`, completions, lookup |
+| `tests/nrepl_server.rs` | End-to-end test: full stdlib env + scripted bencode client over TCP |
+
+## Public API
+
+- `struct Config { addr: SocketAddr, port_file: Option<PathBuf> }` — bind address (port 0 = OS-assigned) and optional `.nrepl-port` file; `Default` binds `127.0.0.1:0`.
+- `fn start(config: Config, globals: Arc<GlobalEnv>) -> miette::Result<Server>` — binds the listener, writes the port file, spawns the network thread. Must be called on the thread that owns `globals`.
+- `Server::port(&self) -> u16`
+- `Server::serve(self) -> miette::Result<()>` — blocks the calling (interpreter) thread processing requests until shutdown; evaluates with `cljrs_eval::eval`.
+- `Server::serve_with(self, eval_form: impl EvalForm) -> miette::Result<()>` — like `serve`, but each top-level form goes through the supplied evaluator (the CLI passes its async `LocalSet` driver).
+- `Server::shutdown_handle(&self) -> ShutdownHandle` — `Send + Clone`; `shutdown()` stops the network thread and ends `serve`.
+- `trait EvalForm: FnMut(&Form, &mut Env) -> Result<Value, EvalError>` — evaluator signature for `serve_with`.
+- `mod bencode` — `Bencode`, `encode`, `encode_to_vec`, `decode` (public for tests/clients).
+- `mod protocol` — `Request`, `Response`.

--- a/crates/cljrs-nrepl/src/bencode.rs
+++ b/crates/cljrs-nrepl/src/bencode.rs
@@ -1,0 +1,277 @@
+//! Minimal bencode codec for the nREPL wire protocol.
+//!
+//! nREPL messages are bencode dictionaries; the protocol only ever uses the
+//! four core bencode types (integers, byte strings, lists, dictionaries), so
+//! this hand-rolled codec stays deliberately small instead of pulling in a
+//! BitTorrent-oriented dependency.
+//!
+//! Decoding is incremental: a message that is still in flight on the TCP
+//! stream decodes to `Ok(None)` ("need more bytes"), which is what the
+//! per-connection read loop uses for framing.
+
+use std::collections::BTreeMap;
+
+/// A bencode value. Dictionary keys are byte strings sorted lexicographically
+/// (`BTreeMap` gives us canonical encoding order for free).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Bencode {
+    Int(i64),
+    Bytes(Vec<u8>),
+    List(Vec<Bencode>),
+    Dict(BTreeMap<Vec<u8>, Bencode>),
+}
+
+impl Bencode {
+    /// Byte string from UTF-8 text (the common case for nREPL).
+    pub fn str(s: impl AsRef<str>) -> Self {
+        Bencode::Bytes(s.as_ref().as_bytes().to_vec())
+    }
+
+    /// View a byte string as UTF-8 text.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Bencode::Bytes(b) => std::str::from_utf8(b).ok(),
+            _ => None,
+        }
+    }
+
+    pub fn as_dict(&self) -> Option<&BTreeMap<Vec<u8>, Bencode>> {
+        match self {
+            Bencode::Dict(d) => Some(d),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BencodeError {
+    #[error("invalid bencode: {0}")]
+    Invalid(&'static str),
+}
+
+// ── Encoding ──────────────────────────────────────────────────────────────────
+
+pub fn encode(v: &Bencode, out: &mut Vec<u8>) {
+    match v {
+        Bencode::Int(i) => {
+            out.push(b'i');
+            out.extend_from_slice(i.to_string().as_bytes());
+            out.push(b'e');
+        }
+        Bencode::Bytes(b) => {
+            out.extend_from_slice(b.len().to_string().as_bytes());
+            out.push(b':');
+            out.extend_from_slice(b);
+        }
+        Bencode::List(items) => {
+            out.push(b'l');
+            for item in items {
+                encode(item, out);
+            }
+            out.push(b'e');
+        }
+        Bencode::Dict(entries) => {
+            out.push(b'd');
+            for (k, val) in entries {
+                encode(&Bencode::Bytes(k.clone()), out);
+                encode(val, out);
+            }
+            out.push(b'e');
+        }
+    }
+}
+
+pub fn encode_to_vec(v: &Bencode) -> Vec<u8> {
+    let mut out = Vec::new();
+    encode(v, &mut out);
+    out
+}
+
+// ── Decoding ──────────────────────────────────────────────────────────────────
+
+/// Internal parse error: distinguishes "buffer ends mid-value" (recoverable —
+/// wait for more bytes) from genuinely malformed input.
+enum ParseError {
+    Incomplete,
+    Invalid(&'static str),
+}
+
+/// Decode one bencode value from the front of `buf`.
+///
+/// Returns `Ok(Some((value, consumed)))` on success, `Ok(None)` when `buf`
+/// holds only a prefix of a value (read more bytes and retry), and `Err` when
+/// the input cannot be valid bencode no matter what bytes follow.
+pub fn decode(buf: &[u8]) -> Result<Option<(Bencode, usize)>, BencodeError> {
+    let mut pos = 0;
+    match parse_value(buf, &mut pos) {
+        Ok(v) => Ok(Some((v, pos))),
+        Err(ParseError::Incomplete) => Ok(None),
+        Err(ParseError::Invalid(msg)) => Err(BencodeError::Invalid(msg)),
+    }
+}
+
+fn parse_value(buf: &[u8], pos: &mut usize) -> Result<Bencode, ParseError> {
+    match buf.get(*pos) {
+        None => Err(ParseError::Incomplete),
+        Some(b'i') => parse_int(buf, pos),
+        Some(b'l') => {
+            *pos += 1;
+            let mut items = Vec::new();
+            loop {
+                if buf.get(*pos) == Some(&b'e') {
+                    *pos += 1;
+                    return Ok(Bencode::List(items));
+                }
+                items.push(parse_value(buf, pos)?);
+            }
+        }
+        Some(b'd') => {
+            *pos += 1;
+            let mut entries = BTreeMap::new();
+            loop {
+                if buf.get(*pos) == Some(&b'e') {
+                    *pos += 1;
+                    return Ok(Bencode::Dict(entries));
+                }
+                let key = match parse_value(buf, pos)? {
+                    Bencode::Bytes(k) => k,
+                    _ => return Err(ParseError::Invalid("dict key must be a byte string")),
+                };
+                let val = parse_value(buf, pos)?;
+                entries.insert(key, val);
+            }
+        }
+        Some(b'0'..=b'9') => parse_bytes(buf, pos),
+        Some(_) => Err(ParseError::Invalid("unexpected type marker")),
+    }
+}
+
+fn parse_int(buf: &[u8], pos: &mut usize) -> Result<Bencode, ParseError> {
+    let start = *pos + 1; // skip 'i'
+    let mut end = start;
+    loop {
+        match buf.get(end) {
+            None => return Err(ParseError::Incomplete),
+            Some(b'e') => break,
+            Some(b'-') if end == start => end += 1,
+            Some(b'0'..=b'9') => end += 1,
+            Some(_) => return Err(ParseError::Invalid("non-digit in integer")),
+        }
+    }
+    let text = std::str::from_utf8(&buf[start..end])
+        .map_err(|_| ParseError::Invalid("non-UTF-8 integer"))?;
+    let n: i64 = text
+        .parse()
+        .map_err(|_| ParseError::Invalid("integer out of range or empty"))?;
+    *pos = end + 1; // consume 'e'
+    Ok(Bencode::Int(n))
+}
+
+fn parse_bytes(buf: &[u8], pos: &mut usize) -> Result<Bencode, ParseError> {
+    let start = *pos;
+    let mut colon = start;
+    loop {
+        match buf.get(colon) {
+            None => return Err(ParseError::Incomplete),
+            Some(b':') => break,
+            Some(b'0'..=b'9') => colon += 1,
+            Some(_) => return Err(ParseError::Invalid("non-digit in string length")),
+        }
+    }
+    let len: usize = std::str::from_utf8(&buf[start..colon])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .ok_or(ParseError::Invalid("bad string length"))?;
+    let data_start = colon + 1;
+    let data_end = data_start
+        .checked_add(len)
+        .ok_or(ParseError::Invalid("string length overflow"))?;
+    if buf.len() < data_end {
+        return Err(ParseError::Incomplete);
+    }
+    *pos = data_end;
+    Ok(Bencode::Bytes(buf[data_start..data_end].to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(v: &Bencode) {
+        let bytes = encode_to_vec(v);
+        let (decoded, consumed) = decode(&bytes).unwrap().unwrap();
+        assert_eq!(&decoded, v);
+        assert_eq!(consumed, bytes.len());
+    }
+
+    #[test]
+    fn roundtrip_scalars() {
+        roundtrip(&Bencode::Int(0));
+        roundtrip(&Bencode::Int(-42));
+        roundtrip(&Bencode::Int(i64::MAX));
+        roundtrip(&Bencode::str(""));
+        roundtrip(&Bencode::str("hello"));
+        roundtrip(&Bencode::Bytes(vec![0, 255, 128]));
+    }
+
+    #[test]
+    fn roundtrip_nested() {
+        let mut dict = BTreeMap::new();
+        dict.insert(b"op".to_vec(), Bencode::str("eval"));
+        dict.insert(b"code".to_vec(), Bencode::str("(+ 1 2)"));
+        dict.insert(
+            b"status".to_vec(),
+            Bencode::List(vec![Bencode::str("done"), Bencode::Int(7)]),
+        );
+        dict.insert(b"nested".to_vec(), Bencode::Dict(dict.clone()));
+        roundtrip(&Bencode::Dict(dict));
+    }
+
+    #[test]
+    fn encoded_form_matches_spec() {
+        assert_eq!(encode_to_vec(&Bencode::Int(42)), b"i42e");
+        assert_eq!(encode_to_vec(&Bencode::str("spam")), b"4:spam");
+        let mut dict = BTreeMap::new();
+        dict.insert(b"a".to_vec(), Bencode::Int(1));
+        assert_eq!(encode_to_vec(&Bencode::Dict(dict)), b"d1:ai1ee");
+    }
+
+    #[test]
+    fn incomplete_input_returns_none() {
+        for full in [
+            encode_to_vec(&Bencode::Int(12345)),
+            encode_to_vec(&Bencode::str("hello world")),
+            {
+                let mut d = BTreeMap::new();
+                d.insert(b"key".to_vec(), Bencode::List(vec![Bencode::str("v")]));
+                encode_to_vec(&Bencode::Dict(d))
+            },
+        ] {
+            for cut in 0..full.len() {
+                assert!(
+                    decode(&full[..cut]).unwrap().is_none(),
+                    "prefix of length {cut} should be incomplete"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn decode_leaves_trailing_bytes() {
+        let mut bytes = encode_to_vec(&Bencode::Int(1));
+        bytes.extend_from_slice(b"i2e");
+        let (v, consumed) = decode(&bytes).unwrap().unwrap();
+        assert_eq!(v, Bencode::Int(1));
+        assert_eq!(consumed, 3);
+        let (v2, _) = decode(&bytes[consumed..]).unwrap().unwrap();
+        assert_eq!(v2, Bencode::Int(2));
+    }
+
+    #[test]
+    fn invalid_input_errors() {
+        assert!(decode(b"x").is_err());
+        assert!(decode(b"i4x2e").is_err());
+        assert!(decode(b"d3:key").unwrap().is_none()); // incomplete, not invalid
+        assert!(decode(b"di1ei2ee").is_err()); // non-string dict key
+    }
+}

--- a/crates/cljrs-nrepl/src/engine.rs
+++ b/crates/cljrs-nrepl/src/engine.rs
@@ -1,0 +1,554 @@
+//! Interpreter-thread side of the server: session registry and op handlers.
+//!
+//! Runs on the thread that owns the `GlobalEnv` (GC'd values are not `Send`).
+//! Jobs arrive from the network thread one at a time; replies go back as
+//! ready-made bencode messages over the connection's reply channel.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use cljrs_env::dynamics;
+use cljrs_eval::{EvalError, GlobalEnv};
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, Value, Var};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::bencode::Bencode;
+use crate::protocol::{Request, Response};
+use crate::{EvalForm, Job};
+
+/// Hidden namespace holding each session's retained values (`*1`/`*2`/`*3`/
+/// `*e`) as interned vars. Namespaces are GC roots, so this keeps values
+/// alive between evals — nothing else traces values held by Rust across
+/// evaluations.
+const STATE_NS: &str = "cljrs.nrepl.session-state";
+
+/// Slot names used for the per-session state vars in [`STATE_NS`].
+const STAR_SLOTS: [&str; 4] = ["1", "2", "3", "e"];
+
+pub(crate) struct Engine {
+    globals: Arc<GlobalEnv>,
+    sessions: HashMap<String, Session>,
+    /// `clojure.core`'s `*1`/`*2`/`*3`/`*e` vars, bound per-request via the
+    /// dynamics stack so user code sees session-correct values.
+    star_vars: Option<[GcPtr<Var>; 4]>,
+    session_counter: u64,
+}
+
+struct Session {
+    env: cljrs_eval::Env,
+    /// Most recent values, indexed as [*1, *2, *3, *e].
+    stars: [Value; 4],
+}
+
+impl Session {
+    fn new(globals: Arc<GlobalEnv>) -> Session {
+        Session {
+            env: cljrs_eval::Env::new(globals, "user"),
+            stars: [Value::Nil, Value::Nil, Value::Nil, Value::Nil],
+        }
+    }
+}
+
+impl Engine {
+    pub(crate) fn new(globals: Arc<GlobalEnv>) -> Engine {
+        let star_var = |name: &str| globals.lookup_var_in_ns("clojure.core", name);
+        let star_vars = match (
+            star_var("*1"),
+            star_var("*2"),
+            star_var("*3"),
+            star_var("*e"),
+        ) {
+            (Some(v1), Some(v2), Some(v3), Some(ve)) => Some([v1, v2, v3, ve]),
+            _ => None, // stdlib without REPL vars — *1/*2/*3/*e support disabled
+        };
+        Engine {
+            globals,
+            sessions: HashMap::new(),
+            star_vars,
+            session_counter: 0,
+        }
+    }
+
+    pub(crate) fn handle(&mut self, job: Job, eval_form: &mut impl EvalForm) {
+        let Job {
+            req,
+            replies,
+            cancelled,
+            pending_key,
+            pending,
+        } = job;
+        if cancelled.load(Ordering::SeqCst) {
+            // Interrupted while still queued: drop the work entirely.
+            let sid = req.session.clone().unwrap_or_default();
+            let _ = replies.send(
+                Response::for_request(&req, &sid)
+                    .status(&["done", "interrupted"])
+                    .build(),
+            );
+        } else {
+            match req.op.as_str() {
+                "clone" => self.op_clone(&req, &replies),
+                "close" => self.op_close(&req, &replies),
+                "ls-sessions" => self.op_ls_sessions(&req, &replies),
+                "eval" => self.op_eval(&req, &replies, eval_form, &cancelled),
+                "load-file" => self.op_load_file(&req, &replies, eval_form, &cancelled),
+                "completions" => self.op_completions(&req, &replies),
+                "lookup" => self.op_lookup(&req, &replies),
+                _ => {
+                    let sid = self.ensure_session(req.session.as_deref());
+                    let _ = replies.send(
+                        Response::for_request(&req, &sid)
+                            .str_field("op", &req.op)
+                            .status(&["error", "unknown-op", "done"])
+                            .build(),
+                    );
+                }
+            }
+        }
+        if let Some(key) = &pending_key {
+            pending.remove(key);
+        }
+    }
+
+    // ── Sessions ──────────────────────────────────────────────────────────────
+
+    /// Resolve the request's session, creating it if unknown. Requests that
+    /// carry no session share a `"default"` session (real nREPL hands each a
+    /// transient one; a stable default is simpler and friendlier to scripted
+    /// clients).
+    fn ensure_session(&mut self, sid: Option<&str>) -> String {
+        let sid = sid.unwrap_or("default").to_string();
+        if !self.sessions.contains_key(&sid) {
+            self.sessions
+                .insert(sid.clone(), Session::new(self.globals.clone()));
+        }
+        sid
+    }
+
+    fn new_session_id(&mut self) -> String {
+        self.session_counter += 1;
+        let micros = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_micros())
+            .unwrap_or(0);
+        format!("session-{micros:x}-{:x}", self.session_counter)
+    }
+
+    fn op_clone(&mut self, req: &Request, replies: &UnboundedSender<Bencode>) {
+        // The new session inherits the source session's namespace.
+        let source_ns = req
+            .session
+            .as_deref()
+            .and_then(|s| self.sessions.get(s))
+            .map(|s| s.env.current_ns.clone());
+        let new_sid = self.new_session_id();
+        let mut session = Session::new(self.globals.clone());
+        if let Some(ns) = source_ns {
+            session.env.current_ns = ns;
+        }
+        self.sessions.insert(new_sid.clone(), session);
+        let sid = req.session.clone().unwrap_or_else(|| new_sid.clone());
+        let _ = replies.send(
+            Response::for_request(req, &sid)
+                .str_field("new-session", &new_sid)
+                .status(&["done"])
+                .build(),
+        );
+    }
+
+    fn op_close(&mut self, req: &Request, replies: &UnboundedSender<Bencode>) {
+        let sid = req.session.clone().unwrap_or_default();
+        self.sessions.remove(&sid);
+        // Drop the session's retained values so the GC can reclaim them.
+        if let Some(ns) = self.globals.namespaces.read().unwrap().get(STATE_NS) {
+            let mut interns = ns.get().interns.lock().unwrap();
+            for slot in STAR_SLOTS {
+                interns.remove(format!("{sid}-{slot}").as_str());
+            }
+        }
+        let _ = replies.send(
+            Response::for_request(req, &sid)
+                .status(&["done", "session-closed"])
+                .build(),
+        );
+    }
+
+    fn op_ls_sessions(&mut self, req: &Request, replies: &UnboundedSender<Bencode>) {
+        let sessions: Vec<Bencode> = self.sessions.keys().map(Bencode::str).collect();
+        let sid = req.session.clone().unwrap_or_default();
+        let _ = replies.send(
+            Response::for_request(req, &sid)
+                .field("sessions", Bencode::List(sessions))
+                .status(&["done"])
+                .build(),
+        );
+    }
+
+    // ── Evaluation ────────────────────────────────────────────────────────────
+
+    fn op_eval(
+        &mut self,
+        req: &Request,
+        replies: &UnboundedSender<Bencode>,
+        eval_form: &mut impl EvalForm,
+        cancelled: &AtomicBool,
+    ) {
+        let Some(code) = req.code.clone() else {
+            let sid = self.ensure_session(req.session.as_deref());
+            let _ = replies.send(
+                Response::for_request(req, &sid)
+                    .status(&["error", "no-code", "done"])
+                    .build(),
+            );
+            return;
+        };
+        self.eval_code(req, replies, eval_form, cancelled, &code, "<nrepl>");
+    }
+
+    fn op_load_file(
+        &mut self,
+        req: &Request,
+        replies: &UnboundedSender<Bencode>,
+        eval_form: &mut impl EvalForm,
+        cancelled: &AtomicBool,
+    ) {
+        let Some(file) = req.file.clone() else {
+            let sid = self.ensure_session(req.session.as_deref());
+            let _ = replies.send(
+                Response::for_request(req, &sid)
+                    .status(&["error", "no-file", "done"])
+                    .build(),
+            );
+            return;
+        };
+        let filename = req
+            .file_name
+            .clone()
+            .unwrap_or_else(|| "<load-file>".into());
+        self.eval_code(req, replies, eval_form, cancelled, &file, &filename);
+    }
+
+    /// Shared body of `eval` and `load-file`: evaluate all forms in `code`,
+    /// streaming `out`/`value`/`err` messages, then a final `done`.
+    fn eval_code(
+        &mut self,
+        req: &Request,
+        replies: &UnboundedSender<Bencode>,
+        eval_form: &mut impl EvalForm,
+        cancelled: &AtomicBool,
+        code: &str,
+        filename: &str,
+    ) {
+        let sid = self.ensure_session(req.session.as_deref());
+        let globals = self.globals.clone();
+        let star_vars = self.star_vars.clone();
+        let session = self.sessions.get_mut(&sid).expect("session just ensured");
+
+        // Honor the request's namespace when it exists; an unknown namespace
+        // would be created empty (no clojure.core refers) and break
+        // resolution, so fall back to the session's namespace instead.
+        if let Some(ns) = &req.ns
+            && globals.namespaces.read().unwrap().contains_key(ns.as_str())
+        {
+            session.env.current_ns = Arc::from(ns.as_str());
+        }
+
+        let mut parser = cljrs_reader::Parser::new(code.to_string(), filename.to_string());
+        let forms = match parser.parse_all() {
+            Ok(forms) => forms,
+            Err(e) => {
+                let msg = format!("{e}");
+                let _ = replies.send(
+                    Response::for_request(req, &sid)
+                        .str_field("err", format!("{msg}\n"))
+                        .build(),
+                );
+                let _ = replies.send(
+                    Response::for_request(req, &sid)
+                        .str_field("ex", &msg)
+                        .status(&["eval-error"])
+                        .build(),
+                );
+                let _ = replies.send(Response::for_request(req, &sid).status(&["done"]).build());
+                return;
+            }
+        };
+
+        // Bind *1/*2/*3/*e to this session's values for the duration of the
+        // request (updated after each form so `(+ 1 2) *1` works within one
+        // message). The dynamics stack is also a GC root for the bound values.
+        let guard = star_vars.as_ref().map(|vars| {
+            let mut frame = HashMap::new();
+            for (var, val) in vars.iter().zip(session.stars.iter()) {
+                frame.insert(dynamics::var_key_of(var), val.clone());
+            }
+            dynamics::push_frame(frame)
+        });
+
+        let mut interrupted = false;
+        for form in &forms {
+            // Best-effort interrupt between top-level forms; a single form
+            // that loops forever cannot be stopped.
+            if cancelled.load(Ordering::SeqCst) {
+                interrupted = true;
+                break;
+            }
+            let _alloc_frame = cljrs_gc::push_alloc_frame();
+            cljrs_builtins::builtins::push_output_capture();
+            let result = eval_form(form, &mut session.env);
+            let out = cljrs_builtins::builtins::pop_output_capture().unwrap_or_default();
+            if !out.is_empty() {
+                let _ = replies.send(
+                    Response::for_request(req, &sid)
+                        .str_field("out", &out)
+                        .build(),
+                );
+            }
+            match result {
+                Ok(value) => {
+                    let _ = replies.send(
+                        Response::for_request(req, &sid)
+                            .str_field("value", format!("{value}"))
+                            .str_field("ns", session.env.current_ns.as_ref())
+                            .build(),
+                    );
+                    session.stars[2] = session.stars[1].clone();
+                    session.stars[1] = session.stars[0].clone();
+                    session.stars[0] = value;
+                    if let Some(vars) = &star_vars {
+                        for (var, val) in vars.iter().zip(session.stars.iter()).take(3) {
+                            dynamics::set_thread_local(var, val.clone());
+                        }
+                    }
+                }
+                Err(e) => {
+                    let msg = eval_error_message(&e);
+                    let _ = replies.send(
+                        Response::for_request(req, &sid)
+                            .str_field("err", format!("{msg}\n"))
+                            .build(),
+                    );
+                    let _ = replies.send(
+                        Response::for_request(req, &sid)
+                            .str_field("ex", &msg)
+                            .status(&["eval-error"])
+                            .build(),
+                    );
+                    session.stars[3] = e.to_error_value();
+                    if let Some(vars) = &star_vars {
+                        dynamics::set_thread_local(&vars[3], session.stars[3].clone());
+                    }
+                    break;
+                }
+            }
+        }
+        drop(guard);
+
+        // Persist the retained values where the GC will trace them.
+        let stars = session.stars.clone();
+        for (slot, val) in STAR_SLOTS.iter().zip(stars) {
+            globals.intern(STATE_NS, format!("{sid}-{slot}").into(), val);
+        }
+
+        let status: &[&str] = if interrupted {
+            &["done", "interrupted"]
+        } else {
+            &["done"]
+        };
+        let _ = replies.send(Response::for_request(req, &sid).status(status).build());
+    }
+
+    // ── Tooling ops ───────────────────────────────────────────────────────────
+
+    fn op_completions(&mut self, req: &Request, replies: &UnboundedSender<Bencode>) {
+        let sid = self.ensure_session(req.session.as_deref());
+        let session = &self.sessions[&sid];
+        let prefix = req.prefix.clone().unwrap_or_default();
+        let context_ns: Arc<str> = match &req.ns {
+            Some(ns)
+                if self
+                    .globals
+                    .namespaces
+                    .read()
+                    .unwrap()
+                    .contains_key(ns.as_str()) =>
+            {
+                Arc::from(ns.as_str())
+            }
+            _ => session.env.current_ns.clone(),
+        };
+
+        // (candidate, ns, kind) triples, sorted for stable output.
+        let mut items: Vec<(String, String, &'static str)> = Vec::new();
+        let namespaces = self.globals.namespaces.read().unwrap();
+
+        if let Some((alias, name_prefix)) = prefix.split_once('/') {
+            // Qualified prefix: complete interns of the aliased/named namespace.
+            let full = self
+                .globals
+                .resolve_alias(&context_ns, alias)
+                .unwrap_or_else(|| Arc::from(alias));
+            if let Some(ns) = namespaces.get(&full) {
+                for (name, var) in ns.get().interns.lock().unwrap().iter() {
+                    if name.starts_with(name_prefix) {
+                        items.push((format!("{alias}/{name}"), full.to_string(), var_kind(var)));
+                    }
+                }
+            }
+        } else {
+            if let Some(ns) = namespaces.get(&context_ns) {
+                let ns = ns.get();
+                for map in [&ns.interns, &ns.refers] {
+                    for (name, var) in map.lock().unwrap().iter() {
+                        if name.starts_with(prefix.as_str()) {
+                            items.push((
+                                name.to_string(),
+                                var.get().namespace.to_string(),
+                                var_kind(var),
+                            ));
+                        }
+                    }
+                }
+            }
+            for ns_name in namespaces.keys() {
+                if ns_name.starts_with(prefix.as_str()) && ns_name.as_ref() != STATE_NS {
+                    items.push((ns_name.to_string(), ns_name.to_string(), "namespace"));
+                }
+            }
+        }
+        drop(namespaces);
+
+        items.sort();
+        items.dedup();
+        let completions: Vec<Bencode> = items
+            .into_iter()
+            .map(|(candidate, ns, kind)| {
+                let mut dict = BTreeMap::new();
+                dict.insert(b"candidate".to_vec(), Bencode::str(candidate));
+                dict.insert(b"ns".to_vec(), Bencode::str(ns));
+                dict.insert(b"type".to_vec(), Bencode::str(kind));
+                Bencode::Dict(dict)
+            })
+            .collect();
+
+        let _ = replies.send(
+            Response::for_request(req, &sid)
+                .field("completions", Bencode::List(completions))
+                .status(&["done"])
+                .build(),
+        );
+    }
+
+    fn op_lookup(&mut self, req: &Request, replies: &UnboundedSender<Bencode>) {
+        let sid = self.ensure_session(req.session.as_deref());
+        let session = &self.sessions[&sid];
+        let context_ns: Arc<str> = match &req.ns {
+            Some(ns)
+                if self
+                    .globals
+                    .namespaces
+                    .read()
+                    .unwrap()
+                    .contains_key(ns.as_str()) =>
+            {
+                Arc::from(ns.as_str())
+            }
+            _ => session.env.current_ns.clone(),
+        };
+
+        let sym = req.sym.clone().unwrap_or_default();
+        let var = match sym.split_once('/') {
+            Some((ns_part, name)) => {
+                let full = self
+                    .globals
+                    .resolve_alias(&context_ns, ns_part)
+                    .unwrap_or_else(|| Arc::from(ns_part));
+                self.globals.lookup_var_in_ns(&full, name)
+            }
+            None => self.globals.lookup_var_in_ns(&context_ns, &sym),
+        };
+
+        let mut info = BTreeMap::new();
+        if let Some(var) = var {
+            let v = var.get();
+            info.insert(b"ns".to_vec(), Bencode::str(v.namespace.as_ref()));
+            info.insert(b"name".to_vec(), Bencode::str(v.name.as_ref()));
+            let meta = v.meta.lock().unwrap().clone();
+            if let Some(meta) = meta {
+                if let Some(Value::Str(doc)) = meta_get(&meta, "doc") {
+                    info.insert(b"doc".to_vec(), Bencode::str(doc.get().as_str()));
+                }
+                if let Some(arglists) = meta_get(&meta, "arglists") {
+                    info.insert(
+                        b"arglists-str".to_vec(),
+                        Bencode::str(format!("{arglists}")),
+                    );
+                }
+                if let Some(Value::Str(file)) = meta_get(&meta, "file") {
+                    info.insert(b"file".to_vec(), Bencode::str(file.get().as_str()));
+                }
+                if let Some(Value::Long(line)) = meta_get(&meta, "line") {
+                    info.insert(b"line".to_vec(), Bencode::Int(line));
+                }
+            }
+        }
+        let status: &[&str] = if info.is_empty() {
+            &["done", "lookup-error"]
+        } else {
+            &["done"]
+        };
+        let _ = replies.send(
+            Response::for_request(req, &sid)
+                .field("info", Bencode::Dict(info))
+                .status(status)
+                .build(),
+        );
+    }
+}
+
+/// Completion kind for a var, mirroring cider-nrepl's categories.
+fn var_kind(var: &GcPtr<Var>) -> &'static str {
+    let v = var.get();
+    if v.is_macro {
+        return "macro";
+    }
+    match v.deref() {
+        Some(Value::Macro(_)) => "macro",
+        Some(
+            Value::Fn(_)
+            | Value::NativeFunction(_)
+            | Value::BoundFn(_)
+            | Value::ProtocolFn(_)
+            | Value::MultiFn(_),
+        ) => "function",
+        _ => "var",
+    }
+}
+
+/// Fetch `key` (as a keyword) from a metadata map value.
+fn meta_get(meta: &Value, key: &str) -> Option<Value> {
+    match meta {
+        Value::Map(m) => m.get(&Value::keyword(Keyword::simple(key))),
+        Value::WithMeta(inner, _) => meta_get(inner, key),
+        _ => None,
+    }
+}
+
+/// User-facing message for an evaluation error (same phrasing as the CLI's
+/// `format_eval_error` in `crates/cljrs/src/main.rs`).
+fn eval_error_message(e: &EvalError) -> String {
+    match e {
+        EvalError::Thrown(val) => format!("Unhandled exception: {val}"),
+        EvalError::UnboundSymbol(s) => format!("Unable to resolve symbol: {s}"),
+        EvalError::Arity {
+            name,
+            expected,
+            got,
+        } => format!("Wrong number of args ({got}) passed to {name}; expected {expected}"),
+        EvalError::NotCallable(s) => format!("Not a function: {s}"),
+        EvalError::Recur(_) => "recur outside of loop/fn".to_string(),
+        other => other.to_string(),
+    }
+}

--- a/crates/cljrs-nrepl/src/lib.rs
+++ b/crates/cljrs-nrepl/src/lib.rs
@@ -1,0 +1,194 @@
+#![allow(clippy::result_large_err)]
+//! nREPL server for clojurust.
+//!
+//! Speaks the [nREPL protocol](https://nrepl.org) — bencode-encoded messages
+//! over TCP — so editors (CIDER, Calva, Conjure, …) can connect to a running
+//! clojurust instance.
+//!
+//! # Architecture
+//!
+//! `GcPtr` (and therefore `Value`, `Env`, `GlobalEnv`) is not `Send`, so all
+//! interpreter state stays on the thread that created the `GlobalEnv`. The
+//! server splits accordingly:
+//!
+//! - the **network thread** (spawned by [`start`]) runs a current-thread tokio
+//!   runtime with the TCP listener; per-connection tasks decode bencode frames
+//!   and answer `describe`/`interrupt` directly,
+//! - every other op is packaged as a [`Job`] (plain `Send` data: strings plus
+//!   a reply channel) and handed over an mpsc channel to the **interpreter
+//!   thread**, which processes jobs in [`Server::serve`] /
+//!   [`Server::serve_with`].
+//!
+//! # Usage
+//!
+//! ```no_run
+//! let globals = cljrs_stdlib::standard_env();
+//! let config = cljrs_nrepl::Config::default();
+//! let server = cljrs_nrepl::start(config, globals).unwrap();
+//! println!("nREPL listening on port {}", server.port());
+//! server.serve().unwrap(); // blocks this thread processing evals
+//! ```
+
+pub mod bencode;
+mod engine;
+pub mod protocol;
+mod server;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc;
+
+use cljrs_eval::{Env, EvalError, GlobalEnv};
+use cljrs_value::Value;
+
+use crate::bencode::Bencode;
+use crate::protocol::Request;
+
+/// Server configuration.
+pub struct Config {
+    /// Address to bind. Port 0 lets the OS pick a free port.
+    pub addr: SocketAddr,
+    /// When set, the bound port is written to this file (the `.nrepl-port`
+    /// convention editors use to auto-connect). Removed again when
+    /// [`Server::serve`] returns.
+    pub port_file: Option<PathBuf>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            addr: ([127, 0, 0, 1], 0).into(),
+            port_file: None,
+        }
+    }
+}
+
+/// A unit of work sent from the network thread to the interpreter thread.
+/// Carries only `Send` data — never GC'd values.
+pub(crate) struct Job {
+    pub req: Request,
+    /// Channel back to the connection's writer task.
+    pub replies: tokio::sync::mpsc::UnboundedSender<Bencode>,
+    /// Set by an `interrupt` op; checked before the job starts evaluating.
+    pub cancelled: Arc<AtomicBool>,
+    /// Entry to clear from the in-flight registry when the job completes.
+    pub pending_key: Option<server::PendingKey>,
+    pub pending: Arc<server::Pending>,
+}
+
+/// Signature of the per-form evaluator the interpreter thread uses.
+///
+/// The CLI passes its own driver (which runs each form on the process-wide
+/// async `LocalSet` so core.async / `^:async` code makes progress); library
+/// embedders can pass [`cljrs_eval::eval`] or their own wrapper.
+pub trait EvalForm: FnMut(&cljrs_reader::Form, &mut Env) -> Result<Value, EvalError> {}
+impl<F: FnMut(&cljrs_reader::Form, &mut Env) -> Result<Value, EvalError>> EvalForm for F {}
+
+/// A running nREPL server. The network thread is already accepting
+/// connections; call [`Server::serve`] on the interpreter thread to start
+/// processing evaluation requests.
+pub struct Server {
+    port: u16,
+    job_rx: mpsc::Receiver<Job>,
+    shutdown: ShutdownHandle,
+    net_thread: Option<std::thread::JoinHandle<()>>,
+    port_file: Option<PathBuf>,
+    globals: Arc<GlobalEnv>,
+}
+
+/// Cloneable, `Send` handle that stops the server: the network thread shuts
+/// down, which in turn ends the interpreter thread's `serve` loop.
+#[derive(Clone)]
+pub struct ShutdownHandle {
+    tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl ShutdownHandle {
+    pub fn shutdown(&self) {
+        let _ = self.tx.send(true);
+    }
+}
+
+/// Bind the listener, write the port file, and spawn the network thread.
+///
+/// Must be called on the thread that owns `globals` — the same thread must
+/// later call [`Server::serve`] (or [`Server::serve_with`]), because
+/// evaluation state cannot move across threads.
+pub fn start(config: Config, globals: Arc<GlobalEnv>) -> miette::Result<Server> {
+    let listener = std::net::TcpListener::bind(config.addr)
+        .map_err(|e| miette::miette!("nrepl: failed to bind {}: {e}", config.addr))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| miette::miette!("nrepl: set_nonblocking failed: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| miette::miette!("nrepl: local_addr failed: {e}"))?
+        .port();
+
+    if let Some(path) = &config.port_file {
+        std::fs::write(path, format!("{port}\n"))
+            .map_err(|e| miette::miette!("nrepl: failed to write {}: {e}", path.display()))?;
+    }
+
+    let (job_tx, job_rx) = mpsc::channel::<Job>();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    let net_thread = std::thread::Builder::new()
+        .name("cljrs-nrepl-net".into())
+        .spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("nrepl: failed to build tokio runtime");
+            rt.block_on(server::run(listener, job_tx, shutdown_rx));
+            // Dropping the runtime aborts connection tasks, which drops their
+            // job senders and unblocks the interpreter thread's recv loop.
+        })
+        .map_err(|e| miette::miette!("nrepl: failed to spawn network thread: {e}"))?;
+
+    Ok(Server {
+        port,
+        job_rx,
+        shutdown: ShutdownHandle { tx: shutdown_tx },
+        net_thread: Some(net_thread),
+        port_file: config.port_file,
+        globals,
+    })
+}
+
+impl Server {
+    /// The port the listener is bound to.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn shutdown_handle(&self) -> ShutdownHandle {
+        self.shutdown.clone()
+    }
+
+    /// Process evaluation jobs on the current thread until the server is shut
+    /// down. Forms are evaluated with the plain tree-walking/IR evaluator.
+    pub fn serve(self) -> miette::Result<()> {
+        self.serve_with(cljrs_eval::eval)
+    }
+
+    /// Like [`Server::serve`], but every top-level form is evaluated through
+    /// `eval_form`, letting the caller drive async forms on its own runtime.
+    pub fn serve_with(mut self, mut eval_form: impl EvalForm) -> miette::Result<()> {
+        let mut engine = engine::Engine::new(self.globals.clone());
+        // recv() errors once every job sender is gone, i.e. the network
+        // thread (and all its connection tasks) has shut down.
+        while let Ok(job) = self.job_rx.recv() {
+            engine.handle(job, &mut eval_form);
+        }
+        if let Some(handle) = self.net_thread.take() {
+            let _ = handle.join();
+        }
+        if let Some(path) = &self.port_file {
+            let _ = std::fs::remove_file(path);
+        }
+        Ok(())
+    }
+}

--- a/crates/cljrs-nrepl/src/protocol.rs
+++ b/crates/cljrs-nrepl/src/protocol.rs
@@ -1,0 +1,90 @@
+//! nREPL message types: decoded requests and response builders.
+
+use std::collections::BTreeMap;
+
+use crate::bencode::Bencode;
+
+/// A decoded client request. Fields not present in the message are `None`;
+/// unknown keys are ignored.
+#[derive(Debug, Clone, Default)]
+pub struct Request {
+    pub op: String,
+    pub id: Option<String>,
+    pub session: Option<String>,
+    /// `eval`: the code to evaluate.
+    pub code: Option<String>,
+    /// `eval` / `completions` / `lookup`: namespace context.
+    pub ns: Option<String>,
+    /// `load-file`: full file contents.
+    pub file: Option<String>,
+    /// `load-file`: display name for the file.
+    pub file_name: Option<String>,
+    /// `completions`: the prefix to complete.
+    pub prefix: Option<String>,
+    /// `lookup`: the symbol to look up.
+    pub sym: Option<String>,
+    /// `interrupt`: id of the eval message to interrupt.
+    pub interrupt_id: Option<String>,
+}
+
+impl Request {
+    /// Decode a request from a bencode dictionary. Returns `None` when the
+    /// message has no `op` (nothing we could ever dispatch).
+    pub fn from_bencode(msg: &Bencode) -> Option<Request> {
+        let dict = msg.as_dict()?;
+        let get = |key: &str| -> Option<String> {
+            dict.get(key.as_bytes())
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        };
+        Some(Request {
+            op: get("op")?,
+            id: get("id"),
+            session: get("session"),
+            code: get("code"),
+            ns: get("ns"),
+            file: get("file"),
+            file_name: get("file-name"),
+            prefix: get("prefix"),
+            sym: get("sym"),
+            interrupt_id: get("interrupt-id"),
+        })
+    }
+}
+
+/// Builder for response messages. Every response echoes the request `id` and
+/// the session it belongs to, per the nREPL protocol.
+pub struct Response {
+    entries: BTreeMap<Vec<u8>, Bencode>,
+}
+
+impl Response {
+    pub fn for_request(req: &Request, session: &str) -> Response {
+        let mut entries = BTreeMap::new();
+        if let Some(id) = &req.id {
+            entries.insert(b"id".to_vec(), Bencode::str(id));
+        }
+        entries.insert(b"session".to_vec(), Bencode::str(session));
+        Response { entries }
+    }
+
+    pub fn field(mut self, key: &str, value: Bencode) -> Response {
+        self.entries.insert(key.as_bytes().to_vec(), value);
+        self
+    }
+
+    pub fn str_field(self, key: &str, value: impl AsRef<str>) -> Response {
+        self.field(key, Bencode::str(value))
+    }
+
+    pub fn status(self, statuses: &[&str]) -> Response {
+        self.field(
+            "status",
+            Bencode::List(statuses.iter().map(Bencode::str).collect()),
+        )
+    }
+
+    pub fn build(self) -> Bencode {
+        Bencode::Dict(self.entries)
+    }
+}

--- a/crates/cljrs-nrepl/src/server.rs
+++ b/crates/cljrs-nrepl/src/server.rs
@@ -1,0 +1,228 @@
+//! Network side of the server: TCP accept loop and per-connection tasks.
+//!
+//! Everything here runs on the dedicated network thread's current-thread
+//! tokio runtime and only ever touches `Send` data. `describe` and
+//! `interrupt` are answered here (an interrupt must not queue behind the
+//! eval it is trying to cancel); all other ops become [`Job`]s for the
+//! interpreter thread.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::watch;
+
+use crate::Job;
+use crate::bencode::{self, Bencode};
+use crate::protocol::{Request, Response};
+
+/// Identifies an in-flight (queued or evaluating) request: `(session, id)`.
+pub(crate) type PendingKey = (String, String);
+
+/// Registry of in-flight requests and their cancellation flags, shared
+/// between connection tasks (which register and interrupt) and the
+/// interpreter thread (which clears entries as jobs finish).
+#[derive(Default)]
+pub(crate) struct Pending {
+    map: Mutex<HashMap<PendingKey, Arc<AtomicBool>>>,
+}
+
+impl Pending {
+    fn insert(&self, key: PendingKey, flag: Arc<AtomicBool>) {
+        self.map.lock().unwrap().insert(key, flag);
+    }
+
+    pub(crate) fn remove(&self, key: &PendingKey) {
+        self.map.lock().unwrap().remove(key);
+    }
+
+    /// Set the cancellation flag for `id` in `session` (any id in the session
+    /// when `id` is `None`). Returns true if something was flagged.
+    fn interrupt(&self, session: &str, id: Option<&str>) -> bool {
+        let map = self.map.lock().unwrap();
+        let mut hit = false;
+        for ((s, i), flag) in map.iter() {
+            if s == session && id.is_none_or(|want| want == i) {
+                flag.store(true, Ordering::SeqCst);
+                hit = true;
+            }
+        }
+        hit
+    }
+}
+
+/// Accept loop. Returns when the shutdown signal fires; dropping the runtime
+/// afterwards aborts the connection tasks spawned here.
+pub(crate) async fn run(
+    listener: std::net::TcpListener,
+    job_tx: mpsc::Sender<Job>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let listener = match TcpListener::from_std(listener) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("nrepl: failed to register listener with tokio: {e}");
+            return;
+        }
+    };
+    let pending = Arc::new(Pending::default());
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok((stream, _peer)) => {
+                        let _ = stream.set_nodelay(true);
+                        let (read_half, write_half) = stream.into_split();
+                        let (reply_tx, reply_rx) =
+                            tokio::sync::mpsc::unbounded_channel::<Bencode>();
+                        tokio::spawn(writer_task(write_half, reply_rx));
+                        tokio::spawn(reader_task(
+                            read_half,
+                            reply_tx,
+                            job_tx.clone(),
+                            pending.clone(),
+                        ));
+                    }
+                    Err(e) => {
+                        eprintln!("nrepl: accept error: {e}");
+                    }
+                }
+            }
+            _ = shutdown.changed() => return,
+        }
+    }
+}
+
+/// Drains response messages and writes their bencode encoding to the socket.
+async fn writer_task(mut write_half: OwnedWriteHalf, mut replies: UnboundedReceiver<Bencode>) {
+    while let Some(msg) = replies.recv().await {
+        let bytes = bencode::encode_to_vec(&msg);
+        if write_half.write_all(&bytes).await.is_err() {
+            return;
+        }
+    }
+}
+
+/// Reads bencode frames off the socket and dispatches each request.
+async fn reader_task(
+    mut read_half: OwnedReadHalf,
+    reply_tx: UnboundedSender<Bencode>,
+    job_tx: mpsc::Sender<Job>,
+    pending: Arc<Pending>,
+) {
+    let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    let mut chunk = [0u8; 8 * 1024];
+    loop {
+        // Decode every complete message currently buffered.
+        loop {
+            match bencode::decode(&buf) {
+                Ok(Some((msg, consumed))) => {
+                    buf.drain(..consumed);
+                    dispatch(&msg, &reply_tx, &job_tx, &pending);
+                }
+                Ok(None) => break, // incomplete — read more bytes
+                Err(e) => {
+                    eprintln!("nrepl: dropping connection ({e})");
+                    return;
+                }
+            }
+        }
+        match read_half.read(&mut chunk).await {
+            Ok(0) | Err(_) => return, // EOF or socket error
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+        }
+    }
+}
+
+fn dispatch(
+    msg: &Bencode,
+    reply_tx: &UnboundedSender<Bencode>,
+    job_tx: &mpsc::Sender<Job>,
+    pending: &Arc<Pending>,
+) {
+    let Some(req) = Request::from_bencode(msg) else {
+        return; // not a dict, or no "op" — nothing to dispatch
+    };
+    match req.op.as_str() {
+        "describe" => {
+            let _ = reply_tx.send(describe_response(&req));
+        }
+        "interrupt" => {
+            let session = req.session.clone().unwrap_or_default();
+            let hit = pending.interrupt(&session, req.interrupt_id.as_deref());
+            let resp = Response::for_request(&req, &session);
+            let resp = if hit {
+                resp.status(&["done"])
+            } else {
+                resp.status(&["done", "session-idle"])
+            };
+            let _ = reply_tx.send(resp.build());
+        }
+        _ => {
+            let cancelled = Arc::new(AtomicBool::new(false));
+            // Only evals are interruptible, and only when addressable.
+            let pending_key = match (req.op.as_str(), &req.session, &req.id) {
+                ("eval" | "load-file", Some(s), Some(i)) => {
+                    let key = (s.clone(), i.clone());
+                    pending.insert(key.clone(), cancelled.clone());
+                    Some(key)
+                }
+                _ => None,
+            };
+            let job = Job {
+                req,
+                replies: reply_tx.clone(),
+                cancelled,
+                pending_key,
+                pending: pending.clone(),
+            };
+            if job_tx.send(job).is_err() {
+                // Interpreter thread is gone; the server is shutting down.
+            }
+        }
+    }
+}
+
+/// The ops this server understands, advertised to clients.
+const OPS: &[&str] = &[
+    "clone",
+    "close",
+    "completions",
+    "describe",
+    "eval",
+    "interrupt",
+    "load-file",
+    "lookup",
+    "ls-sessions",
+];
+
+fn describe_response(req: &Request) -> Bencode {
+    let ops: BTreeMap<Vec<u8>, Bencode> = OPS
+        .iter()
+        .map(|op| (op.as_bytes().to_vec(), Bencode::Dict(BTreeMap::new())))
+        .collect();
+
+    let version = |s: &str| -> Bencode {
+        let mut parts = s.split('.');
+        let mut dict = BTreeMap::new();
+        for key in ["major", "minor", "incremental"] {
+            let n: i64 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+            dict.insert(key.as_bytes().to_vec(), Bencode::Int(n));
+        }
+        dict.insert(b"version-string".to_vec(), Bencode::str(s));
+        Bencode::Dict(dict)
+    };
+    let mut versions = BTreeMap::new();
+    versions.insert(b"cljrs".to_vec(), version(env!("CARGO_PKG_VERSION")));
+    versions.insert(b"nrepl".to_vec(), version("1.0.0"));
+
+    Response::for_request(&req.clone(), req.session.as_deref().unwrap_or("none"))
+        .field("ops", Bencode::Dict(ops))
+        .field("versions", Bencode::Dict(versions))
+        .status(&["done"])
+        .build()
+}

--- a/crates/cljrs-nrepl/tests/nrepl_server.rs
+++ b/crates/cljrs-nrepl/tests/nrepl_server.rs
@@ -1,0 +1,265 @@
+//! End-to-end test: start the server against a full stdlib environment and
+//! exercise the protocol with a minimal bencode client over TCP.
+//!
+//! A single #[test] runs the whole scenario: the interpreter (and its
+//! GlobalEnv) lives on this test's thread, which runs `serve()` while a
+//! client thread drives the socket.
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use cljrs_nrepl::bencode::{self, Bencode};
+
+type Msg = BTreeMap<Vec<u8>, Bencode>;
+
+struct Client {
+    stream: TcpStream,
+    buf: Vec<u8>,
+    next_id: u64,
+}
+
+impl Client {
+    fn connect(port: u16) -> Client {
+        let stream = TcpStream::connect(("127.0.0.1", port)).expect("connect failed");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(60)))
+            .unwrap();
+        Client {
+            stream,
+            buf: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Send a request and collect every response for it up to and including
+    /// the one whose status contains "done".
+    fn request(&mut self, pairs: &[(&str, &str)]) -> Vec<Msg> {
+        self.next_id += 1;
+        let id = format!("t-{}", self.next_id);
+        let mut dict = BTreeMap::new();
+        dict.insert(b"id".to_vec(), Bencode::str(&id));
+        for (k, v) in pairs {
+            dict.insert(k.as_bytes().to_vec(), Bencode::str(v));
+        }
+        let bytes = bencode::encode_to_vec(&Bencode::Dict(dict));
+        self.stream.write_all(&bytes).expect("write failed");
+
+        let mut responses = Vec::new();
+        loop {
+            let msg = self.read_message();
+            let dict = msg.as_dict().expect("response is not a dict").clone();
+            // Only collect responses to this request (defensive; the server
+            // sends nothing unsolicited).
+            if dict.get(b"id".as_slice()).and_then(|v| v.as_str()) != Some(&id) {
+                continue;
+            }
+            let done = statuses(&dict).iter().any(|s| s == "done");
+            responses.push(dict);
+            if done {
+                return responses;
+            }
+        }
+    }
+
+    fn read_message(&mut self) -> Bencode {
+        let mut chunk = [0u8; 4096];
+        loop {
+            if let Some((msg, consumed)) = bencode::decode(&self.buf).expect("bad bencode") {
+                self.buf.drain(..consumed);
+                return msg;
+            }
+            let n = self.stream.read(&mut chunk).expect("read failed");
+            assert!(n > 0, "server closed connection mid-response");
+            self.buf.extend_from_slice(&chunk[..n]);
+        }
+    }
+}
+
+fn statuses(msg: &Msg) -> Vec<String> {
+    match msg.get(b"status".as_slice()) {
+        Some(Bencode::List(items)) => items
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// First occurrence of a string field across a request's responses.
+fn field<'a>(responses: &'a [Msg], key: &str) -> Option<&'a str> {
+    responses
+        .iter()
+        .find_map(|m| m.get(key.as_bytes()).and_then(|v| v.as_str()))
+}
+
+fn eval(client: &mut Client, session: &str, code: &str) -> Vec<Msg> {
+    client.request(&[("op", "eval"), ("session", session), ("code", code)])
+}
+
+#[test]
+fn nrepl_end_to_end() {
+    let globals = cljrs_stdlib::standard_env();
+    let server = cljrs_nrepl::start(cljrs_nrepl::Config::default(), globals).expect("start");
+    let port = server.port();
+    let shutdown = server.shutdown_handle();
+
+    let client_thread = std::thread::spawn(move || {
+        let result = std::panic::catch_unwind(|| client_scenario(port));
+        // Always release the serve() loop, even when assertions failed.
+        shutdown.shutdown();
+        if let Err(panic) = result {
+            std::panic::resume_unwind(panic);
+        }
+    });
+
+    server.serve().expect("serve");
+    client_thread.join().expect("client scenario failed");
+}
+
+fn client_scenario(port: u16) {
+    let mut c = Client::connect(port);
+
+    // describe: advertises the ops we implement.
+    let resp = c.request(&[("op", "describe")]);
+    let ops = resp[0]
+        .get(b"ops".as_slice())
+        .and_then(|v| v.as_dict())
+        .expect("describe has ops");
+    for op in ["clone", "eval", "completions", "lookup", "interrupt"] {
+        assert!(ops.contains_key(op.as_bytes()), "missing op {op}");
+    }
+
+    // clone: two independent sessions.
+    let resp = c.request(&[("op", "clone")]);
+    let session_a = field(&resp, "new-session")
+        .expect("new-session")
+        .to_string();
+    let resp = c.request(&[("op", "clone")]);
+    let session_b = field(&resp, "new-session")
+        .expect("new-session")
+        .to_string();
+    assert_ne!(session_a, session_b);
+
+    // eval: value + ns + done.
+    let resp = eval(&mut c, &session_a, "(+ 1 2)");
+    assert_eq!(field(&resp, "value"), Some("3"));
+    assert_eq!(field(&resp, "ns"), Some("user"));
+    assert!(statuses(resp.last().unwrap()).contains(&"done".to_string()));
+
+    // *1 holds the previous result.
+    let resp = eval(&mut c, &session_a, "*1");
+    assert_eq!(field(&resp, "value"), Some("3"));
+
+    // println output is captured and streamed as "out".
+    let resp = eval(&mut c, &session_a, "(println \"hello nrepl\")");
+    assert_eq!(field(&resp, "out"), Some("hello nrepl\n"));
+    assert_eq!(field(&resp, "value"), Some("nil"));
+
+    // Errors produce err + eval-error, then done (no hang), and set *e.
+    let resp = eval(&mut c, &session_a, "(throw (ex-info \"boom\" {}))");
+    assert!(field(&resp, "err").unwrap_or_default().contains("boom"));
+    assert!(
+        resp.iter()
+            .any(|m| statuses(m).contains(&"eval-error".to_string())),
+        "expected an eval-error status"
+    );
+    let resp = eval(&mut c, &session_a, "(nil? *e)");
+    assert_eq!(field(&resp, "value"), Some("false"));
+
+    // Sessions keep independent namespaces.
+    let resp = eval(&mut c, &session_a, "(ns foo.bar)");
+    assert_eq!(field(&resp, "ns"), Some("foo.bar"));
+    let resp = eval(&mut c, &session_b, "(+ 1 1)");
+    assert_eq!(field(&resp, "ns"), Some("user"));
+
+    // Multiple forms in one message stream multiple values; *1 updates
+    // between forms of the same message.
+    let resp = eval(&mut c, &session_b, "(* 2 3) (inc *1)");
+    let values: Vec<&str> = resp
+        .iter()
+        .filter_map(|m| m.get(b"value".as_slice()).and_then(|v| v.as_str()))
+        .collect();
+    assert_eq!(values, ["6", "7"]);
+
+    // load-file evaluates the payload in the session.
+    let resp = c.request(&[
+        ("op", "load-file"),
+        ("session", &session_b),
+        ("file", "(def loaded-var 99) loaded-var"),
+        ("file-name", "test.cljrs"),
+    ]);
+    let values: Vec<&str> = resp
+        .iter()
+        .filter_map(|m| m.get(b"value".as_slice()).and_then(|v| v.as_str()))
+        .collect();
+    assert_eq!(values.last(), Some(&"99"));
+
+    // completions: core vars show up for a short prefix.
+    let resp = c.request(&[
+        ("op", "completions"),
+        ("session", &session_b),
+        ("prefix", "ma"),
+    ]);
+    let completions = resp[0]
+        .get(b"completions".as_slice())
+        .map(|v| match v {
+            Bencode::List(items) => items
+                .iter()
+                .filter_map(|item| {
+                    item.as_dict()
+                        .and_then(|d| d.get(b"candidate".as_slice()))
+                        .and_then(|c| c.as_str())
+                })
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        })
+        .unwrap_or_default();
+    assert!(
+        completions.contains(&"map"),
+        "completions for \"ma\" missing map: {completions:?}"
+    );
+
+    // lookup: var info for clojure.core/map.
+    let resp = c.request(&[("op", "lookup"), ("session", &session_b), ("sym", "map")]);
+    let info = resp[0]
+        .get(b"info".as_slice())
+        .and_then(|v| v.as_dict())
+        .expect("lookup has info");
+    assert_eq!(
+        info.get(b"name".as_slice()).and_then(|v| v.as_str()),
+        Some("map")
+    );
+    assert_eq!(
+        info.get(b"ns".as_slice()).and_then(|v| v.as_str()),
+        Some("clojure.core")
+    );
+
+    // ls-sessions lists both cloned sessions.
+    let resp = c.request(&[("op", "ls-sessions")]);
+    let sessions: Vec<&str> = match resp[0].get(b"sessions".as_slice()) {
+        Some(Bencode::List(items)) => items.iter().filter_map(|v| v.as_str()).collect(),
+        _ => Vec::new(),
+    };
+    assert!(sessions.contains(&session_a.as_str()));
+    assert!(sessions.contains(&session_b.as_str()));
+
+    // interrupt on an idle session reports session-idle.
+    let resp = c.request(&[("op", "interrupt"), ("session", &session_a)]);
+    assert!(statuses(&resp[0]).contains(&"session-idle".to_string()));
+
+    // close removes the session.
+    let resp = c.request(&[("op", "close"), ("session", &session_a)]);
+    assert!(statuses(&resp[0]).contains(&"session-closed".to_string()));
+    let resp = c.request(&[("op", "ls-sessions")]);
+    let sessions: Vec<&str> = match resp[0].get(b"sessions".as_slice()) {
+        Some(Bencode::List(items)) => items.iter().filter_map(|v| v.as_str()).collect(),
+        _ => Vec::new(),
+    };
+    assert!(!sessions.contains(&session_a.as_str()));
+
+    // unknown op gets a clean error.
+    let resp = c.request(&[("op", "frobnicate")]);
+    assert!(statuses(&resp[0]).contains(&"unknown-op".to_string()));
+}

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -42,6 +42,7 @@ cljrs-logging  = { workspace = true }
 cljrs-deps     = { workspace = true }
 cljrs-vcs      = { workspace = true }
 cljrs-lsp      = { workspace = true }
+cljrs-nrepl    = { workspace = true }
 cljrs-jit      = { workspace = true }
 cljrs-dylib    = { workspace = true }
 clap          = { workspace = true }

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -219,6 +219,28 @@ enum Commands {
     /// integration, providing parse diagnostics and a document-symbol outline
     /// for `.cljrs` / `.cljc` files. Editors normally launch this for you.
     Lsp,
+    /// Start an nREPL server for editor integration (CIDER, Calva, Conjure).
+    ///
+    /// Listens for bencode-encoded nREPL messages over TCP and writes the
+    /// bound port to `.nrepl-port` in the current directory so clients can
+    /// auto-connect. Runs until interrupted.
+    Nrepl {
+        /// Port to listen on (0 = let the OS pick a free port).
+        #[arg(long, default_value_t = 0)]
+        port: u16,
+        /// Address to bind.
+        #[arg(long, default_value = "127.0.0.1")]
+        bind: String,
+        /// Source directories to search when resolving `require`.
+        #[arg(long = "src-path", value_name = "DIR")]
+        src_paths: Vec<PathBuf>,
+        /// GC soft memory limit in MB (triggers collection when exceeded).
+        #[arg(long)]
+        gc_soft_limit_mb: Option<usize>,
+        /// GC hard memory limit in MB (forces collection when exceeded).
+        #[arg(long)]
+        gc_hard_limit_mb: Option<usize>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -496,6 +518,33 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
             // enters the interpreter's async driver runtime.
             cljrs_lsp::run_stdio_blocking()
                 .map_err(|e| miette::miette!("lsp server error: {e}"))?;
+            Ok(0)
+        }
+        Commands::Nrepl {
+            port,
+            bind,
+            src_paths,
+            gc_soft_limit_mb,
+            gc_hard_limit_mb,
+        } => {
+            let gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
+            let globals = setup_globals(src_paths, gc_config, versioning);
+            let addr: std::net::SocketAddr = format!("{bind}:{port}")
+                .parse()
+                .map_err(|e| miette::miette!("invalid bind address {bind}:{port}: {e}"))?;
+            let config = cljrs_nrepl::Config {
+                addr,
+                port_file: Some(PathBuf::from(".nrepl-port")),
+            };
+            let server = cljrs_nrepl::start(config, globals)?;
+            // Editors (CIDER, Calva) parse this exact line to auto-connect.
+            println!(
+                "nREPL server started on port {0} on host {bind} - nrepl://{bind}:{0}",
+                server.port()
+            );
+            // Evaluate forms through the CLI's async driver so core.async /
+            // ^:async code makes progress, exactly like `cljrs repl`.
+            server.serve_with(eval_form)?;
             Ok(0)
         }
     }


### PR DESCRIPTION
An nREPL server (bencode over TCP) so editors like CIDER, Calva, and
Conjure can connect to a running clojurust instance. No Rust nREPL
server implementation exists to reuse (only clients), so the server is
built here; the bencode codec is hand-rolled since nREPL uses only the
tiny core subset of the format.

Because GcPtr (and thus Value/Env/GlobalEnv) is not Send, the server
splits across two threads bridged by channels carrying only Send data:
a network thread (current-thread tokio runtime) owns the listener and
answers describe/interrupt, while the interpreter thread that owns the
GlobalEnv processes all other ops via Server::serve / serve_with. The
CLI passes its async LocalSet driver to serve_with so core.async and
^:async forms make progress, exactly like `cljrs repl`.

Ops: clone, close, describe, eval, interrupt (best-effort: between
top-level forms only), load-file, lookup, ls-sessions, completions.
Sessions get independent namespaces and *1/*2/*3/*e (bound via the
dynamics stack per request; retained values are interned in a hidden
namespace so the GC traces them between evals). Printed output is
captured per form via cljrs-builtins' output-capture stack and
streamed as "out" messages.

The CLI subcommand writes .nrepl-port and prints the startup line
editors parse for auto-connect.

https://claude.ai/code/session_01LnkBjzGfidthqTf4vRYEGT