### PR TITLE
Await ^:async -main in cljrs run

### DIFF
--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -47,6 +47,11 @@ compiled binary calls `-main` after `__cljrs_main` finishes, passing all
 
 If `-main` is not defined the program exits normally without error.
 
+An `^:async` `-main` is supported: calling it returns a `Future` immediately,
+so `cljrs run` awaits that future on the shared async `LocalSet` (see
+implementation notes) before exiting, ensuring the body and anything it spawns
+run to completion. A synchronous `-main` is awaited as a no-op pass-through.
+
 ### Per-subcommand flags
 
 `run`, `repl`, `compile`, `test` accept:

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -738,7 +738,37 @@ fn call_main_if_defined(env: &mut Env, args: &[String]) -> miette::Result<()> {
     }
     let escaped: Vec<String> = args.iter().map(|s| escape_clojure_string(s)).collect();
     let call = format!("(-main {})", escaped.join(" "));
-    eval_in(env, &call, "<main>")?;
+    let result = eval_in(env, &call, "<main>")?;
+    // An `^:async` `-main` returns a `Future` immediately, with its body
+    // queued as a task on the shared `LocalSet`. Await that future so the body
+    // (and anything it spawns) runs to completion before the process exits;
+    // for a synchronous `-main` this is a no-op pass-through.
+    await_main_result(result)?;
+    Ok(())
+}
+
+/// Drive `value` to a settled value on the shared async `LocalSet`. If `value`
+/// is a `Future`/`Promise` (e.g. the result of an `^:async` `-main`), this
+/// yields until it resolves; any other value is returned unchanged.
+#[cfg(feature = "async")]
+fn await_main_result(value: Value) -> miette::Result<()> {
+    ASYNC_DRIVER.with(|d| {
+        let guard = d.borrow();
+        match guard.as_ref() {
+            Some(drv) => {
+                drv.local
+                    .block_on(&drv.rt, cljrs_async::eval_async::await_value(value))
+                    .map_err(format_eval_error)?;
+                Ok(())
+            }
+            // No driver installed: nothing to await against, so leave as-is.
+            None => Ok(()),
+        }
+    })
+}
+
+#[cfg(not(feature = "async"))]
+fn await_main_result(_value: Value) -> miette::Result<()> {
     Ok(())
 }
 

--- a/crates/cljrs/tests/run_main.rs
+++ b/crates/cljrs/tests/run_main.rs
@@ -1,0 +1,71 @@
+//! End-to-end tests for `cljrs run`'s `-main` invocation, covering both
+//! synchronous and `^:async` entry points.
+//!
+//! An `^:async -main` returns a `Future` immediately, with its body queued on
+//! the async `LocalSet`; `run` must await that future so the body runs to
+//! completion before the process exits. These tests drive the built binary
+//! (via the `CARGO_BIN_EXE_cljrs` path Cargo provides) against temp fixtures.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Write `src` to a uniquely named temp `.cljrs` file and return its path.
+fn write_fixture(name: &str, src: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "cljrs-run-main-{}-{}.cljrs",
+        name,
+        std::process::id()
+    ));
+    std::fs::write(&path, src).expect("write fixture");
+    path
+}
+
+fn run_file(path: &PathBuf) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .arg("run")
+        .arg(path)
+        .output()
+        .expect("run cljrs binary")
+}
+
+#[test]
+fn run_invokes_sync_main() {
+    let path = write_fixture("sync", r#"(defn -main [& args] (println "sync-main ran"))"#);
+    let out = run_file(&path);
+    let _ = std::fs::remove_file(&path);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("sync-main ran"), "stdout was: {stdout}");
+}
+
+#[test]
+fn run_awaits_async_main() {
+    // The body runs only if `run` awaits the future returned by the `^:async`
+    // `-main`. Before the fix it returned the future immediately and the body
+    // never executed, so nothing was printed.
+    let path = write_fixture(
+        "async",
+        r#"
+(defn ^:async fetch [x] (* x 2))
+(defn ^:async -main [& args]
+  (let [v (await (fetch 21))]
+    (println "async-main result:" v)))
+"#,
+    );
+    let out = run_file(&path);
+    let _ = std::fs::remove_file(&path);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("async-main result: 42"),
+        "async -main body did not run to completion; stdout was: {stdout}"
+    );
+}


### PR DESCRIPTION
The run command invoked -main via eval_in and discarded the result. An
^:async -main returns a Future immediately, with its body queued as a task
on the shared LocalSet, so the body never ran to completion.

call_main_if_defined now awaits the result on the async driver's LocalSet
(via await_value), mirroring what the AOT-compiled entry point already does.
A synchronous -main is awaited as a no-op pass-through.

Adds tests/run_main.rs covering both sync and async -main entry points and
updates the cljrs README.