### PR TITLE
Fix unbalanced parens in add-watch/bound-fn test fixtures

### DIFF
--- a/clojure-test-suite/test/clojure/core_test/add_watch.cljc
+++ b/clojure-test-suite/test/clojure/core_test/add_watch.cljc
@@ -323,4 +323,4 @@
                             {:key :s :old 23 :new 24 :tester 2}
                             {:key :g :old 25 :new 26 :tester 1}}
                           (disj (set @state) {:key :g :old 26 :new 27 :tester 1}))))
-                 (println "Unexpected lack of error"))))])))
+                 (println "Unexpected lack of error")))))])))

--- a/clojure-test-suite/test/clojure/core_test/bound_fn.cljc
+++ b/clojure-test-suite/test/clojure/core_test/bound_fn.cljc
@@ -49,4 +49,4 @@
                      (future (bound-fn [] *x*))))]
            (binding [*x* :derefer]
              (let [derefed-f @f]
-               (is (= :callee (@derefed-f)) "Binding in futures preserved."))))))))
+               (is (= :callee (@derefed-f)) "Binding in futures preserved.")))))))))

--- a/clojure-test-suite/test/clojure/core_test/bound_fn_star.cljc
+++ b/clojure-test-suite/test/clojure/core_test/bound_fn_star.cljc
@@ -51,4 +51,4 @@
                      (future (bound-fn* test-fn))))]
            (binding [*x* :derefer]
              (let [derefed-f @f]
-               (is (= :callee (@derefed-f)) "Binding in futures preserved."))))))))
+               (is (= :callee (@derefed-f)) "Binding in futures preserved.")))))))))


### PR DESCRIPTION
Commit c75ec86 wrapped the future/agent test blocks in
(when-var-exists future ...) / (when-var-exists agent ...) but dropped
the matching closing paren in three files, leaving each one open paren
short. The reader correctly rejected them:

  add-watch     — read error: unexpected closing delimiter
  bound-fn      — read error: unclosed list
  bound-fn-star — read error: unclosed list

bound_fn / bound_fn_star: the outermost (when-var-exists ...) form was
never closed, so append one ) at EOF.

add_watch: the (when-var-exists agent ...) wrapper sits inside the
:default branch of a #?@ splice vector, so its missing ) belongs before
the closing ] — which is why the imbalance surfaced as a stray closing
delimiter at end of file rather than an unclosed list.

All .cljc fixtures now balance and parse cleanly.