### PR TITLE
B3: wire the cross-isolate shared-atom Clojure surface

### DIFF
--- a/crates/cljrs-builtins/README.md
+++ b/crates/cljrs-builtins/README.md
@@ -8,3 +8,18 @@ Includes the `unchecked-*` integer arithmetic family — `unchecked-add`,
 `unchecked-negate` (and their `-int` aliases) — which wrap on overflow, in
 contrast to the checked `+`/`-`/`*` (which throw on overflow at the IR/compiled
 tiers and promote to BigInt in the tree-walk tier).
+
+## Phase B3 — `shared-atom` (cross-isolate, two-tier atom ADR)
+
+`shared-atom` is the cross-isolate tier of the two-tier atom design in
+`docs/async-worker-pool-plan.md`.  Unlike `atom` (isolate-local, GC-backed),
+its contents are promoted to a `Send + Sync` `SharedValue`
+(`cljrs_value::shared`) behind a lock-free `ArcSwap`, so the reference can cross
+the isolate boundary and be mutated concurrently:
+
+- `(shared-atom x)` — construct, promoting `x` (non-promotable values such as
+  closures and native resources are rejected here).
+- `(shared-atom? x)` — predicate.
+- `deref` / `reset!` / `swap!` / `compare-and-set!` — dispatch on
+  `Value::SharedAtom` alongside the local `atom` path; writes promote, reads
+  demote, and `swap!`/`compare-and-set!` use a single lock-free CAS with retry.

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -24,8 +24,8 @@ use cljrs_value::value::SetValue;
 use cljrs_value::{
     Arity, Atom, CljxCons, CljxPromise, ExceptionInfo, FutureState, Keyword, LazySeq, MapValue,
     Namespace, NativeFn, ObjectArray, PersistentHashMap, PersistentHashSet, PersistentList,
-    PersistentQueue, PersistentVector, SortedSet, Symbol, Thunk, TypeInstance, Value, ValueError,
-    ValueResult, Volatile,
+    PersistentQueue, PersistentVector, SharedAtom, SortedSet, Symbol, Thunk, TypeInstance, Value,
+    ValueError, ValueResult, Volatile, demote, promote,
 };
 use num_bigint::{BigInt, Sign, ToBigInt};
 use num_rational::Ratio;
@@ -357,6 +357,9 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         ("queue", Arity::Variadic { min: 0 }, builtin_queue),
         // Atoms
         ("atom", Arity::Variadic { min: 1 }, builtin_atom),
+        // Phase B3 — cross-isolate shared-atom (two-tier ADR)
+        ("shared-atom", Arity::Fixed(1), builtin_shared_atom),
+        ("shared-atom?", Arity::Fixed(1), builtin_shared_atom_q),
         ("deref", Arity::Variadic { min: 1 }, builtin_deref),
         ("reset!", Arity::Fixed(2), builtin_reset_bang),
         ("get-validator", Arity::Fixed(1), builtin_get_validator),
@@ -4890,6 +4893,25 @@ fn builtin_atom(args: &[Value]) -> ValueResult<Value> {
     Ok(Value::Atom(GcPtr::new(Atom::new(args[0].clone()))))
 }
 
+// ── shared-atom (Phase B3, two-tier ADR) ──────────────────────────────────────
+
+/// `(shared-atom x)` — create a cross-isolate atom holding `x`.
+///
+/// Unlike `atom` (isolate-local, GC-backed), a `shared-atom` stores its contents
+/// as a `SharedValue` behind a lock-free `ArcSwap`, so the same reference can be
+/// handed to another isolate and mutated concurrently.  The initial value is
+/// promoted immediately; non-promotable values (closures, native resources,
+/// isolate-bound collections) are rejected here rather than at first write.
+fn builtin_shared_atom(args: &[Value]) -> ValueResult<Value> {
+    let sv = promote(&args[0]).map_err(|e| ValueError::Other(e.to_string()))?;
+    Ok(Value::SharedAtom(std::sync::Arc::new(SharedAtom::new(sv))))
+}
+
+/// `(shared-atom? x)` — true iff `x` is a `shared-atom`.
+fn builtin_shared_atom_q(args: &[Value]) -> ValueResult<Value> {
+    Ok(Value::Bool(matches!(args[0], Value::SharedAtom(_))))
+}
+
 fn builtin_get_validator(args: &[Value]) -> ValueResult<Value> {
     match &args[0] {
         Value::Atom(a) => Ok(a.get().get_validator().unwrap_or(Value::Nil)),
@@ -4950,6 +4972,7 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
     let with_timeout = args.len() == 3;
     match &args[0] {
         Value::Atom(a) => Ok(a.get().deref()),
+        Value::SharedAtom(sa) => Ok(demote(&sa.deref_val())),
         Value::Var(v) => Ok(v.get().deref().unwrap_or(Value::Nil)),
         Value::Delay(d) => d.get().force().map_err(ValueError::Other),
         Value::Agent(a) => Ok(a.get().get_state()),
@@ -5065,6 +5088,11 @@ fn builtin_deref(args: &[Value]) -> ValueResult<Value> {
 fn builtin_reset_bang(args: &[Value]) -> ValueResult<Value> {
     match &args[0] {
         Value::Atom(a) => Ok(a.get().reset(args[1].clone())),
+        Value::SharedAtom(sa) => {
+            let sv = promote(&args[1]).map_err(|e| ValueError::Other(e.to_string()))?;
+            sa.reset(sv);
+            Ok(args[1].clone())
+        }
         v => Err(ValueError::WrongType {
             expected: "atom",
             got: v.type_name().to_string(),
@@ -6431,6 +6459,16 @@ fn builtin_compare_and_set(args: &[Value]) -> ValueResult<Value> {
             } else {
                 Ok(Value::Bool(false))
             }
+        }
+        Value::SharedAtom(sa) => {
+            // Lock-free CAS: succeed only if the live value still equals the
+            // expected one, by content, at the moment of the atomic store.
+            let cur = sa.deref_val();
+            if demote(&cur) != args[1] {
+                return Ok(Value::Bool(false));
+            }
+            let sv = promote(&args[2]).map_err(|e| ValueError::Other(e.to_string()))?;
+            Ok(Value::Bool(sa.compare_and_set(&cur, sv)))
         }
         v => Err(ValueError::WrongType {
             expected: "atom",

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -2935,6 +2935,13 @@ pub unsafe extern "C" fn rt_atom_reset(atom: *const Value, val: *const Value) ->
     let val = unsafe { val_ref(val) }.clone();
     match atom {
         Value::Atom(a) => box_val(a.get().reset(val)),
+        Value::SharedAtom(sa) => match cljrs_value::promote(&val) {
+            Ok(sv) => {
+                sa.reset(sv);
+                box_val(val)
+            }
+            Err(_) => rt_const_nil(),
+        },
         _ => rt_const_nil(),
     }
 }
@@ -2981,6 +2988,26 @@ pub unsafe extern "C" fn rt_atom_swap(
                         }
                         // CAS failed, retry
                     }
+                    Err(_) => return rt_const_nil(),
+                }
+            }
+        }
+        Value::SharedAtom(sa) => {
+            // Cross-isolate swap!: load → demote → apply f → promote → CAS-retry.
+            loop {
+                let cur = sa.deref_val();
+                let mut args = vec![cljrs_value::demote(&cur)];
+                args.extend(extra.iter().cloned());
+                match cljrs_env::callback::invoke(&f, args) {
+                    Ok(new_val) => match cljrs_value::promote(&new_val) {
+                        Ok(sv) => {
+                            if sa.compare_and_set(&cur, sv) {
+                                return box_val(new_val);
+                            }
+                            // CAS failed, retry
+                        }
+                        Err(_) => return rt_const_nil(),
+                    },
                     Err(_) => return rt_const_nil(),
                 }
             }

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -968,6 +968,49 @@ fn handle_atom_call(arg_forms: &[Form], env: &mut Env) -> EvalResult {
     Ok(Value::Atom(atom))
 }
 
+// ── shared-atom (Phase B3, two-tier ADR) ──────────────────────────────────────
+//
+// `shared-atom` is the cross-isolate tier of the two-tier atom design: its
+// contents live in `SharedValue` (Send + Sync, refcounted) behind a lock-free
+// `ArcSwap`, so the same atom can be observed and mutated from any isolate.
+// `deref`/`reset!`/`swap!`/`compare-and-set!` all route through these helpers
+// when handed a `Value::SharedAtom`, so the surface mirrors a local `atom`
+// except that values are promoted on write and demoted on read.
+
+/// `reset!` on a shared-atom: promote the new value and store it atomically.
+/// Returns the (isolate-local) value that was written.
+fn shared_atom_reset(sa: &Arc<cljrs_value::SharedAtom>, new_val: Value) -> EvalResult {
+    let promoted = cljrs_value::promote(&new_val).map_err(|e| EvalError::Runtime(e.to_string()))?;
+    sa.reset(promoted);
+    Ok(new_val)
+}
+
+/// `swap!` on a shared-atom: CAS-retry loop.  Loads the current value, demotes
+/// it into an isolate-local `Value`, applies `f` (plus any extra args), promotes
+/// the result, and commits with a single compare-and-set — retrying from the
+/// fresh value if another isolate raced us in between.
+fn shared_atom_swap(
+    sa: &Arc<cljrs_value::SharedAtom>,
+    f: &Value,
+    extra: Vec<Value>,
+    env: &mut Env,
+) -> EvalResult {
+    loop {
+        let cur = sa.deref_val();
+        let old_val = cljrs_value::demote(&cur);
+        let mut call_args = Vec::with_capacity(1 + extra.len());
+        call_args.push(old_val);
+        call_args.extend(extra.iter().cloned());
+        let new_val = cljrs_env::apply::apply_value(f, call_args, env)?;
+        let promoted =
+            cljrs_value::promote(&new_val).map_err(|e| EvalError::Runtime(e.to_string()))?;
+        if sa.compare_and_set(&cur, promoted) {
+            return Ok(new_val);
+        }
+        // Lost the race; another writer committed first. Re-read and retry.
+    }
+}
+
 // ── reset! ────────────────────────────────────────────────────────────────────
 
 fn handle_reset_bang(arg_forms: &[Form], env: &mut Env) -> EvalResult {
@@ -987,6 +1030,7 @@ fn handle_reset_bang(arg_forms: &[Form], env: &mut Env) -> EvalResult {
 
     let atom = match &atom_val {
         Value::Atom(a) => a.clone(),
+        Value::SharedAtom(sa) => return shared_atom_reset(sa, new_val),
         v => {
             return Err(EvalError::Runtime(format!(
                 "reset! requires an atom, got {}",
@@ -1037,6 +1081,7 @@ fn handle_swap_call(arg_forms: &[Form], env: &mut Env) -> EvalResult {
 
     let atom = match &atom_val {
         Value::Atom(a) => a.clone(),
+        Value::SharedAtom(sa) => return shared_atom_swap(sa, &f, evaled, env),
         v => {
             return Err(EvalError::Runtime(format!(
                 "swap! requires an atom, got {}",
@@ -1184,6 +1229,7 @@ pub fn eval_reset_bang(args: Vec<Value>, env: &mut Env) -> EvalResult {
     let new_val = args[1].clone();
     let atom = match &atom_val {
         Value::Atom(a) => a.clone(),
+        Value::SharedAtom(sa) => return shared_atom_reset(sa, new_val),
         v => {
             return Err(EvalError::Runtime(format!(
                 "reset! requires an atom, got {}",
@@ -1214,6 +1260,7 @@ pub fn eval_swap_bang(mut args: Vec<Value>, env: &mut Env) -> EvalResult {
     let f = args.remove(0);
     let atom = match &atom_val {
         Value::Atom(a) => a.clone(),
+        Value::SharedAtom(sa) => return shared_atom_swap(sa, &f, args, env),
         v => {
             return Err(EvalError::Runtime(format!(
                 "swap! requires an atom, got {}",

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -297,6 +297,7 @@ pub fn is_special_form(s: &str) -> bool {
 pub fn deref_value(v: Value) -> EvalResult {
     match v {
         Value::Atom(a) => Ok(a.get().deref()),
+        Value::SharedAtom(sa) => Ok(cljrs_value::demote(&sa.deref_val())),
         Value::Var(var) => cljrs_env::dynamics::deref_var(&var)
             .ok_or_else(|| EvalError::Runtime("unbound var".into())),
         Value::Volatile(vol) => Ok(vol.get().deref()),

--- a/crates/cljrs-interp/tests/shared_atom.rs
+++ b/crates/cljrs-interp/tests/shared_atom.rs
@@ -1,0 +1,130 @@
+//! End-to-end tests for the Phase B3 `shared-atom` Clojure surface.
+//!
+//! `shared-atom` is the cross-isolate tier of the two-tier atom ADR
+//! (`docs/async-worker-pool-plan.md`): its contents live in a `Send + Sync`
+//! `SharedValue` behind a lock-free `ArcSwap`, so the reference can cross the
+//! isolate boundary and be mutated concurrently.  These tests pin the
+//! Clojure-visible behaviour — construction, `deref`, `reset!`, `swap!`,
+//! `compare-and-set!`, the `shared-atom?` predicate, and the promotability
+//! restriction — through the tree-walking interpreter (the deterministic,
+//! single-isolate path).
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+/// Evaluate a multi-form source string in a shared env, returning the last value.
+fn eval_src(src: &str, env: &mut Env) -> Value {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, env).expect("eval error");
+    }
+    result
+}
+
+fn eval_fresh(src: &str) -> Value {
+    let (_, mut env) = make_env();
+    eval_src(src, &mut env)
+}
+
+#[test]
+fn shared_atom_construct_and_deref() {
+    assert_eq!(eval_fresh("(deref (shared-atom 41))"), Value::Long(41));
+    assert_eq!(eval_fresh("@(shared-atom 41)"), Value::Long(41));
+}
+
+#[test]
+fn shared_atom_predicate() {
+    assert_eq!(
+        eval_fresh("(shared-atom? (shared-atom 1))"),
+        Value::Bool(true)
+    );
+    assert_eq!(eval_fresh("(shared-atom? (atom 1))"), Value::Bool(false));
+    assert_eq!(eval_fresh("(shared-atom? 1)"), Value::Bool(false));
+    // A shared-atom is not a (local) atom and vice-versa.
+    assert_eq!(eval_fresh("(atom? (shared-atom 1))"), Value::Bool(false));
+}
+
+#[test]
+fn shared_atom_reset() {
+    let mut env = make_env().1;
+    eval_src("(def a (shared-atom 0))", &mut env);
+    assert_eq!(eval_src("(reset! a 99)", &mut env), Value::Long(99));
+    assert_eq!(eval_src("@a", &mut env), Value::Long(99));
+}
+
+#[test]
+fn shared_atom_swap_counts() {
+    let mut env = make_env().1;
+    eval_src("(def a (shared-atom 0))", &mut env);
+    eval_src("(swap! a inc)", &mut env);
+    eval_src("(swap! a inc)", &mut env);
+    assert_eq!(eval_src("(swap! a + 10)", &mut env), Value::Long(12));
+    assert_eq!(eval_src("@a", &mut env), Value::Long(12));
+}
+
+#[test]
+fn shared_atom_compare_and_set() {
+    let mut env = make_env().1;
+    eval_src("(def a (shared-atom 5))", &mut env);
+    // Mismatched expected value: no change.
+    assert_eq!(
+        eval_src("(compare-and-set! a 4 100)", &mut env),
+        Value::Bool(false)
+    );
+    assert_eq!(eval_src("@a", &mut env), Value::Long(5));
+    // Matching expected value: swaps.
+    assert_eq!(
+        eval_src("(compare-and-set! a 5 100)", &mut env),
+        Value::Bool(true)
+    );
+    assert_eq!(eval_src("@a", &mut env), Value::Long(100));
+}
+
+#[test]
+fn shared_atom_promotes_strings_and_keywords() {
+    let mut env = make_env().1;
+    eval_src("(def a (shared-atom \"hi\"))", &mut env);
+    assert_eq!(eval_src("@a", &mut env), Value::string("hi".to_string()));
+    // Keyword identity survives the promote/demote round-trip by content.
+    eval_src("(reset! a :foo)", &mut env);
+    assert_eq!(eval_src("(= @a :foo)", &mut env), Value::Bool(true));
+}
+
+#[test]
+fn shared_atom_rejects_non_promotable() {
+    // A closure captures isolate-local state and cannot be published.
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new("(shared-atom (fn [] 1))".to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut last = Ok(Value::Nil);
+    for form in forms {
+        last = cljrs_interp::eval::eval(&form, &mut env);
+    }
+    assert!(last.is_err(), "publishing a closure should fail");
+}
+
+#[test]
+fn shared_atom_swap_rejects_non_promotable_result() {
+    let mut env = make_env().1;
+    eval_src("(def a (shared-atom 0))", &mut env);
+    let mut parser = Parser::new(
+        "(swap! a (fn [_] (fn [] 1)))".to_string(),
+        "<test>".to_string(),
+    );
+    let forms = parser.parse_all().expect("parse error");
+    let res = cljrs_interp::eval::eval(&forms[0], &mut env);
+    assert!(res.is_err(), "swapping in a closure should fail");
+    // The atom is unchanged after the failed swap.
+    assert_eq!(eval_src("@a", &mut env), Value::Long(0));
+}

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -161,7 +161,8 @@ impl SharedAtom {
     pub fn new(val: SharedValue) -> Self
     pub fn deref_val(&self) -> Arc<SharedValue>     // atomic load
     pub fn reset(&self, val: SharedValue) -> Arc<SharedValue>
-    pub fn swap<F>(&self, f: F) -> Arc<SharedValue> // CAS-retry
+    pub fn swap<F>(&self, f: F) -> Arc<SharedValue> // CAS-retry (closure form)
+    pub fn compare_and_set(&self, current: &Arc<SharedValue>, new: SharedValue) -> bool
 }
 
 pub fn promote(value: &Value)   -> Result<SharedValue, PromoteError>;
@@ -170,7 +171,10 @@ pub fn demote (sv:    &SharedValue) -> Value;
 
 `promote` converts an isolate-local `Value` to `SharedValue` (fails for
 closures, resources, atoms, …).  `demote` converts back into a fresh
-isolate-local `Value`.
+isolate-local `Value`.  `compare_and_set` is the single lock-free CAS that
+backs the Clojure-level `compare-and-set!` and the `swap!` retry loop (callers
+that must run interpreter code between load and store use it instead of the
+closure-based `swap`).
 
 ### `ClojureHash`
 

--- a/crates/cljrs-value/src/shared.rs
+++ b/crates/cljrs-value/src/shared.rs
@@ -221,6 +221,20 @@ impl SharedAtom {
     {
         self.cell.rcu(|old| Arc::new(f(old)))
     }
+
+    /// Single lock-free compare-and-set.  Atomically stores `new` iff the cell
+    /// still holds `current` (by `Arc` identity).  Returns `true` on success.
+    ///
+    /// This is the primitive used by Clojure-level `compare-and-set!` and by the
+    /// retry loop behind `swap!`: a caller that needs to run arbitrary
+    /// (interpreter) code between the load and the store cannot use the closure
+    /// form of [`swap`], so it loads via [`deref_val`](Self::deref_val), computes
+    /// the next value, then commits with this method, retrying on contention.
+    pub fn compare_and_set(&self, current: &Arc<SharedValue>, new: SharedValue) -> bool {
+        let prev = self.cell.compare_and_swap(current, Arc::new(new));
+        // The swap committed iff the value we replaced is the one we expected.
+        std::ptr::eq(Arc::as_ptr(current), Arc::as_ptr(&prev))
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -318,6 +332,18 @@ mod tests {
         });
         let val = atom.deref_val();
         assert!(matches!(val.as_ref(), SharedValue::Long(2)));
+    }
+
+    #[test]
+    fn shared_atom_compare_and_set() {
+        let atom = SharedAtom::new(SharedValue::Long(1));
+        let cur = atom.deref_val();
+        // Stale expectation succeeds while no one races us.
+        assert!(atom.compare_and_set(&cur, SharedValue::Long(2)));
+        assert!(matches!(atom.deref_val().as_ref(), SharedValue::Long(2)));
+        // `cur` is now stale: a second CAS against it must fail and not write.
+        assert!(!atom.compare_and_set(&cur, SharedValue::Long(99)));
+        assert!(matches!(atom.deref_val().as_ref(), SharedValue::Long(2)));
     }
 
     #[test]


### PR DESCRIPTION
The B3 Rust core (intern tables, SharedValue/SharedAtom, promote/demote,
Value::SharedAtom/ByteBlob) landed earlier but had no Clojure surface — a
shared-atom could not be created or used from source. This completes the
two-tier atom ADR's public side.

- cljrs-value/shared: SharedAtom::compare_and_set — a single lock-free CAS
  (load → compute → commit) for callers that must run interpreter code
  between load and store, which the closure-based swap cannot express.

- cljrs-builtins: shared-atom constructor (promote-on-publish), shared-atom?
  predicate; deref/reset!/compare-and-set! gain a Value::SharedAtom arm
  (writes promote, reads demote).

- cljrs-interp: shared_atom_reset / shared_atom_swap helpers; reset!/swap!
  (form, IR, and value entry points) and deref_value dispatch on SharedAtom.
  swap! is a demote → apply f → promote → CAS-retry loop.

- cljrs-compiler/rt_abi: rt_atom_reset/rt_atom_swap handle SharedAtom so
  JIT/AOT-compiled code matches the interpreter (rt_deref already routes
  through deref_value).

- Tests: 8 end-to-end interpreter tests for the Clojure surface; a unit test
  for compare_and_set's stale-CAS behaviour. READMEs updated.

https://claude.ai/code/session_01QNmy85ba6Mf6PBb9Uh3jaD