### PR TITLE
Quality pass: fix correctness bugs and dead code in compiler, GC, IR

### DIFF
--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -1128,7 +1128,7 @@ pub unsafe extern "C" fn rt_get(coll: *const Value, key: *const Value) -> *const
         Value::TypeInstance(ti) => ti.get().fields.get(key),
         Value::Vector(v) => {
             if let Value::Long(i) = key {
-                v.get().nth(*i as *const () as usize).cloned()
+                v.get().nth(*i as usize).cloned()
             } else {
                 None
             }

--- a/crates/cljrs-compiler/src/typeinfer.rs
+++ b/crates/cljrs-compiler/src/typeinfer.rs
@@ -208,7 +208,7 @@ pub fn infer(func: &IrFunction, specs: &[Repr]) -> HashMap<VarId, Repr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{Block, BlockId};
+    use crate::ir::Block;
     use std::sync::Arc;
 
     /// (fn [n] (loop [i 0 acc 0] (if (< i n) (recur (+ i 1) (+ acc i)) acc)))

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -397,6 +397,25 @@ fn test_vector_ops() {
 
 #[test]
 #[cfg(feature = "aot_full_test")]
+fn test_vector_get_index() {
+    // Exercises the `rt_get` vector-indexing path: an in-range index returns
+    // the element; out-of-range (including negative) returns nil, matching
+    // Clojure's `get` semantics.
+    assert_output(
+        "vector_get_index",
+        r#"
+(let [v [10 20 30]]
+  (println (get v 0))
+  (println (get v 2))
+  (println (get v 3))
+  (println (get v -1)))
+"#,
+        "10\n30\nnil\nnil",
+    );
+}
+
+#[test]
+#[cfg(feature = "aot_full_test")]
 fn test_map_ops() {
     assert_output(
         "map_ops",

--- a/crates/cljrs-gc/src/cancellation.rs
+++ b/crates/cljrs-gc/src/cancellation.rs
@@ -6,38 +6,6 @@
 
 use crate::config::{GC_CANCELLATION as CONFIG_CANCELLATION, GcParked};
 
-/// A guard that marks the current thread as cancellable.
-///
-/// When dropped, the thread is marked as no longer cancellable.
-/// This allows the GC to know which threads are safe to interrupt.
-#[derive(Default)]
-pub struct CancellableGuard {
-    cancelled: bool,
-}
-
-impl CancellableGuard {
-    /// Create a new cancellable guard.
-    pub fn new() -> Self {
-        Self { cancelled: false }
-    }
-
-    /// Check if this guard has been cancelled.
-    pub fn is_cancelled(&self) -> bool {
-        self.cancelled
-    }
-
-    /// Mark this guard as cancelled.
-    pub fn set_cancelled(&mut self) {
-        self.cancelled = true;
-    }
-}
-
-impl Drop for CancellableGuard {
-    fn drop(&mut self) {
-        // Guard is automatically removed from the cancellable set
-    }
-}
-
 /// Check if the current operation should be cancelled due to GC.
 ///
 /// This function checks the global GC cancellation flag. If a GC is in
@@ -145,14 +113,6 @@ impl Drop for StwGuard {
     fn drop(&mut self) {
         CONFIG_CANCELLATION.set_in_progress(false);
     }
-}
-
-/// A helper that wraps a function with cancellation checking.
-pub fn with_cancellation_check<T, E: std::fmt::Debug>(
-    f: impl FnOnce() -> Result<T, E>,
-) -> Result<T, GcParked> {
-    check_cancellation()?;
-    f().map_err(|_| GcParked)
 }
 
 /// Mark the current thread as parked during GC.

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -24,9 +24,9 @@ pub use stats::{CLJRS_GC_STATS_ENV, GC_STATS, GcStats, GcStatsSnapshot, dump_sta
 
 #[cfg(not(feature = "no-gc"))]
 pub use cancellation::{
-    CancellableGuard, MutatorGuard, StwGuard, begin_stw, check_cancellation, gc_requested,
-    park_thread, register_mutator, registered_threads, request_gc, safepoint, take_gc_request,
-    unpark_thread, wait_for_threads_to_park,
+    MutatorGuard, StwGuard, begin_stw, check_cancellation, gc_requested, park_thread,
+    register_mutator, registered_threads, request_gc, safepoint, take_gc_request, unpark_thread,
+    wait_for_threads_to_park,
 };
 #[cfg(not(feature = "no-gc"))]
 pub use config::{GC_CANCELLATION as CONFIG_CANCELLATION, GcConfig, GcParked};
@@ -37,10 +37,10 @@ pub use gc_full::{
 };
 #[cfg(feature = "no-gc")]
 pub use nogc_stubs::{
-    AllocRootGuard, CONFIG_CANCELLATION, CancellableGuard, GcConfig, GcHeap, GcParked, HEAP,
-    MutatorGuard, StwGuard, begin_stw, check_cancellation, gc_requested, park_thread,
-    push_alloc_frame, register_mutator, registered_threads, request_gc, safepoint, take_gc_request,
-    unpark_thread, wait_for_threads_to_park,
+    AllocRootGuard, CONFIG_CANCELLATION, GcConfig, GcHeap, GcParked, HEAP, MutatorGuard, StwGuard,
+    begin_stw, check_cancellation, gc_requested, park_thread, push_alloc_frame, register_mutator,
+    registered_threads, request_gc, safepoint, take_gc_request, unpark_thread,
+    wait_for_threads_to_park,
 };
 
 /// Return `true` if `addr` was allocated by the global `StaticArena`.
@@ -555,6 +555,25 @@ mod gc_full {
         }
     }
 
+    /// Parse a megabyte limit from a (raw) environment value into a byte count,
+    /// falling back to `default` (and warning) on malformed input rather than
+    /// panicking on user misconfiguration. `value` is `None` when the variable
+    /// is unset. Saturates instead of overflowing on absurdly large values.
+    pub(crate) fn parse_limit_mb(var: &str, value: Option<&str>, default: usize) -> usize {
+        match value {
+            Some(s) => match s.trim().parse::<usize>() {
+                Ok(mb) => mb.saturating_mul(1024 * 1024),
+                Err(_) => {
+                    eprintln!(
+                        "[gc] warning: ignoring invalid {var}={s:?} (expected a number of megabytes)"
+                    );
+                    default
+                }
+            },
+            None => default,
+        }
+    }
+
     impl GcHeap {
         pub const fn new() -> Self {
             Self {
@@ -579,14 +598,16 @@ mod gc_full {
             #[cfg(target_arch = "wasm32")]
             let default_soft_limit: usize = 64 * 1024 * 1024;
 
-            let soft_limit_mb: usize = match std::env::var("CLJRS_GC_SOFT_LIMIT_MB").ok() {
-                Some(s) => s.parse::<usize>().unwrap() * (1024 * 1024),
-                None => default_soft_limit,
-            };
-            let hard_limit_mb: usize = match std::env::var("CLJRS_GC_HARD_LIMIT_MB").ok() {
-                Some(s) => s.parse::<usize>().unwrap() * (1024 * 1024),
-                None => soft_limit_mb,
-            };
+            let soft_limit_mb = parse_limit_mb(
+                "CLJRS_GC_SOFT_LIMIT_MB",
+                std::env::var("CLJRS_GC_SOFT_LIMIT_MB").ok().as_deref(),
+                default_soft_limit,
+            );
+            let hard_limit_mb = parse_limit_mb(
+                "CLJRS_GC_HARD_LIMIT_MB",
+                std::env::var("CLJRS_GC_HARD_LIMIT_MB").ok().as_deref(),
+                soft_limit_mb,
+            );
             self.set_config(Arc::new(GcConfig::with_limits(
                 soft_limit_mb,
                 hard_limit_mb,
@@ -978,7 +999,6 @@ mod nogc_stubs {
         fn drop(&mut self) {}
     }
     pub struct GcParked;
-    pub struct CancellableGuard;
 
     pub struct GcCancellationStub;
     impl GcCancellationStub {
@@ -1079,6 +1099,28 @@ mod tests {
         let p = heap.alloc(99i64);
         let q = p.clone();
         assert!(GcPtr::ptr_eq(&p, &q));
+    }
+
+    #[test]
+    fn parse_limit_mb_handles_valid_unset_and_malformed() {
+        // Valid: converts megabytes to bytes.
+        assert_eq!(gc_full::parse_limit_mb("X", Some("4"), 7), 4 * 1024 * 1024);
+        // Surrounding whitespace is tolerated.
+        assert_eq!(
+            gc_full::parse_limit_mb("X", Some(" 4 "), 7),
+            4 * 1024 * 1024
+        );
+        // Unset: falls back to the default.
+        assert_eq!(gc_full::parse_limit_mb("X", None, 7), 7);
+        // Malformed must NOT panic — it falls back to the default.
+        assert_eq!(gc_full::parse_limit_mb("X", Some("foo"), 7), 7);
+        assert_eq!(gc_full::parse_limit_mb("X", Some(""), 7), 7);
+        assert_eq!(gc_full::parse_limit_mb("X", Some("-1"), 7), 7);
+        // Absurdly large value saturates rather than overflowing.
+        assert_eq!(
+            gc_full::parse_limit_mb("X", Some(&usize::MAX.to_string()), 7),
+            usize::MAX
+        );
     }
 
     #[test]

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -217,17 +217,24 @@ fn lower_form(ctx: &mut LowerCtx, form: &Form) -> R {
         FormKind::Bool(b) => Ok(ctx.emit_const(Const::Bool(*b))),
         FormKind::Int(n) => Ok(ctx.emit_const(Const::Long(*n))),
         FormKind::BigInt(s) => {
-            // Parse as i64 if possible, otherwise error.
-            let n: i64 = s.parse().unwrap_or(0);
-            Ok(ctx.emit_const(Const::Long(n)))
+            // No bignum Const exists yet: represent as i64 when it fits, but
+            // surface an error rather than silently truncating an out-of-range
+            // literal to 0 (which would corrupt results).
+            match s.parse::<i64>() {
+                Ok(n) => Ok(ctx.emit_const(Const::Long(n))),
+                Err(_) => Err(LowerError::UnsupportedForm(format!(
+                    "integer literal out of i64 range (bignums are not yet supported): {s}"
+                ))),
+            }
         }
         FormKind::Float(f) => Ok(ctx.emit_const(Const::Double(*f))),
         FormKind::BigDecimal(s) => {
+            // Lossy: no BigDecimal Const exists yet, so approximate as f64.
             let f: f64 = s.parse().unwrap_or(0.0);
             Ok(ctx.emit_const(Const::Double(f)))
         }
         FormKind::Ratio(s) => {
-            // Evaluate a/b ratio as f64.
+            // Lossy: no Ratio Const exists yet, so evaluate a/b as f64.
             if let Some(pos) = s.find('/') {
                 let num: f64 = s[..pos].parse().unwrap_or(0.0);
                 let den: f64 = s[pos + 1..].parse().unwrap_or(1.0);

--- a/crates/cljrs-ir/tests/numeric_literals.rs
+++ b/crates/cljrs-ir/tests/numeric_literals.rs
@@ -1,0 +1,39 @@
+//! Regression tests for numeric-literal lowering.
+//!
+//! No bignum `Const` exists yet, so integer literals are represented as `i64`.
+//! A literal that fits must lower cleanly; one that overflows `i64` must surface
+//! a `LowerError` rather than silently truncating to `0` (which would corrupt
+//! results — see `lower_form`'s `FormKind::BigInt` arm).
+
+use cljrs_ir::lower::{LowerError, lower_fn_body};
+use cljrs_reader::Parser;
+
+fn try_lower(source: &str) -> Result<cljrs_ir::IrFunction, LowerError> {
+    let mut parser = Parser::new(source.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse");
+    lower_fn_body(Some("test"), "user", &[], &forms, false)
+}
+
+#[test]
+fn bigint_literal_within_i64_lowers_ok() {
+    // `42N` lexes to a BigInt token but fits i64 — must lower without error.
+    assert!(try_lower("42N").is_ok());
+    // A large-but-in-range value via the overflow path is also fine.
+    assert!(try_lower("9223372036854775807").is_ok()); // i64::MAX
+}
+
+#[test]
+fn bigint_literal_overflowing_i64_is_an_error() {
+    // Well beyond i64::MAX: previously truncated to 0, now an explicit error.
+    let err = try_lower("99999999999999999999999999999999")
+        .expect_err("out-of-range integer literal should not lower");
+    match err {
+        LowerError::UnsupportedForm(msg) => {
+            assert!(
+                msg.contains("out of i64 range"),
+                "unexpected message: {msg}"
+            );
+        }
+        other => panic!("expected UnsupportedForm, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Targeted fixes from an audit of the high-importance crates:

- compiler/rt_abi: fix `rt_get` vector indexing, which round-tripped the
  i64 index through a raw pointer (`*i as *const () as usize`) instead of
  `*i as usize` like the sibling `rt_nth`/`rt_contains`.
- gc: `set_config_from_env` no longer panics on a malformed
  CLJRS_GC_SOFT_LIMIT_MB / CLJRS_GC_HARD_LIMIT_MB; it warns and falls back
  to the default. Logic extracted into a pure, unit-tested `parse_limit_mb`
  that also saturates instead of overflowing.
- ir/anf: a BigInt literal that overflows i64 now returns a LowerError
  instead of silently truncating to 0; document the lossy BigDecimal/Ratio
  paths.
- gc: remove dead cancellation API (`CancellableGuard` and
  `with_cancellation_check`), unused across the workspace.
- compiler/typeinfer: drop unused `BlockId` import (the lone clippy warning).

Tests: parse_limit_mb edge cases (gc), BigInt overflow lowering (ir),
and a `(get vec idx)` AOT e2e test covering the rt_get fix.

https://claude.ai/code/session_01Rn7DkDyyCF7aF85GFh5esM