### PR TITLE
docs: plan gitoxide migration and native commit-signature verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "bytes",
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +158,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +224,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -186,10 +272,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bigdecimal"
@@ -205,6 +303,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfields"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +336,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,7 +367,55 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -252,13 +440,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
+name = "cast5"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfb-mode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -280,8 +507,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -424,7 +661,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
- "rand",
+ "rand 0.10.1",
  "regex",
  "rpds",
  "uuid",
@@ -492,6 +729,7 @@ dependencies = [
  "cljrs-reader",
  "cljrs-value",
  "cljrs-vcs",
+ "gix",
  "libloading",
  "tempfile",
 ]
@@ -663,7 +901,7 @@ dependencies = [
  "futures",
  "serde_json",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-lsp",
 ]
 
@@ -769,6 +1007,9 @@ dependencies = [
 name = "cljrs-vcs"
 version = "0.1.0"
 dependencies = [
+ "gix",
+ "pgp",
+ "ssh-key",
  "tempfile",
  "thiserror",
 ]
@@ -795,6 +1036,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +1080,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,10 +1100,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -840,6 +1135,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1032,6 +1336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d953932541249c91e3fa70a75ff1e52adc62979a2a8132145d4b9b3e6d1a9b6a"
 
 [[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,10 +1357,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cx448"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
+dependencies = [
+ "crypto-bigint",
+ "elliptic-curve",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
+ "sha3",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dashmap"
@@ -1080,12 +1510,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1097,6 +1622,105 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead",
+ "cipher",
+ "cmac",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "base64ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "serde_json",
+ "serdect 0.2.0",
+ "subtle",
+ "tap",
+ "zeroize",
 ]
 
 [[package]]
@@ -1149,16 +1773,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless 0.8.0",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "fnv"
@@ -1173,6 +1844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1857,18 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1270,14 +1959,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1289,11 +2005,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1315,6 +2041,789 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.84.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
+dependencies = [
+ "bitflags 2.11.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40cd22f0dd71988be12d6e78b1709de2370e1957c5f107ff31e56caeba3745d"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-object",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77bacdd12b7879d2178a80c58c2f319995e4654e1a7a23e3181e5c8a12b824f7"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
+dependencies = [
+ "bitflags 2.11.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.17.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
+dependencies = [
+ "bitflags 2.11.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.17.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55"
+dependencies = [
+ "bitflags 2.11.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.81.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
+dependencies = [
+ "bitflags 2.11.0",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
+ "gix-trace",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
+dependencies = [
+ "bitflags 2.11.0",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f5756abffe0917827aac683b13684ed99875bc398fa1f9b8f479b0681ef9e6"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
+dependencies = [
+ "bitflags 2.11.0",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
+dependencies = [
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+
+[[package]]
+name = "gix-transport"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
+dependencies = [
+ "base64",
+ "bstr",
+ "gix-command",
+ "gix-credentials",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
+dependencies = [
+ "bitflags 2.11.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+dependencies = [
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bffae8b3ca258fdd50370cd51f06deb4c76a3b43db3868bc28dde45ffa77d69"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,10 +2836,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -1347,7 +2895,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1355,6 +2903,22 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1363,10 +2927,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version",
  "serde",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1375,6 +2949,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1386,10 +2984,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1480,6 +3170,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "idea"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +3218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +3234,22 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_ci"
@@ -1540,6 +3270,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,10 +3380,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1562,10 +3427,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "libbz2-rs-sys"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1611,6 +3482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,10 +3519,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miette"
@@ -1678,12 +3585,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1719,6 +3633,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +3667,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +3695,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1770,6 +3727,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1785,6 +3765,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +3789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +3805,54 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -1822,6 +3868,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,10 +3889,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgp"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64",
+ "bitfields",
+ "block-padding",
+ "blowfish",
+ "buffer-redux",
+ "byteorder",
+ "bytes",
+ "bzip2",
+ "camellia",
+ "cast5",
+ "cfb-mode",
+ "cipher",
+ "const-oid",
+ "crc24",
+ "curve25519-dalek",
+ "cx448",
+ "derive_builder",
+ "derive_more",
+ "des",
+ "digest",
+ "dsa",
+ "eax",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "flate2",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "idea",
+ "k256",
+ "log",
+ "md-5",
+ "nom",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "rand 0.8.6",
+ "regex",
+ "replace_with",
+ "ripemd",
+ "rsa",
+ "sha1",
+ "sha1-checked",
+ "sha2",
+ "sha3",
+ "signature",
+ "smallvec",
+ "snafu",
+ "twofish",
+ "x25519-dalek",
+ "zeroize",
+]
 
 [[package]]
 name = "pin-project"
@@ -1864,6 +3999,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,7 +4055,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
+ "heapless 0.7.17",
  "serde",
 ]
 
@@ -1892,6 +4075,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,12 +4094,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1921,9 +4196,21 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -1937,13 +4224,72 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2030,6 +4376,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,12 +4446,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "rpds"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e75f485e819d4d3015e6c0d55d02a4fd3db47c1993d9e603e0361fba2bffb34"
 dependencies = [
  "archery",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2104,6 +4536,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2139,8 +4572,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2148,6 +4609,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2181,6 +4643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +4665,21 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2279,6 +4765,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+ "zeroize",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,10 +4837,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2304,6 +4891,27 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"
@@ -2325,10 +4933,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2375,6 +5040,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +5071,12 @@ dependencies = [
  "rustc_version",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -2496,6 +5176,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,6 +5240,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +5282,39 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2583,7 +5341,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-lsp-macros",
  "tracing",
 ]
@@ -2670,6 +5428,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twofish"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +5474,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2704,6 +5507,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2752,6 +5565,31 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2902,6 +5740,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,6 +5775,37 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -3091,6 +5979,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,6 +6082,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,6 +6135,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,6 +6180,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3275,6 +6227,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,22 @@ arc-swap     = "1"
 tower-lsp     = "0.20"
 dashmap       = "6"
 
+# Pure-Rust git (gitoxide) + native commit-signature verification
+gix      = { version = "0.84", default-features = false, features = [
+    "sha1",
+    "max-performance-safe",
+    "blocking-http-transport-reqwest-rust-tls",
+    "revision",
+    "worktree-mutation",
+] }
+pgp      = "0.19"
+ssh-key  = { version = "0.6", default-features = false, features = [
+    "alloc",
+    "ed25519",
+    "p256",
+    "rsa",
+] }
+
 # Cranelift compiler backend (all crates must be at the same version)
 cranelift-codegen  = "0.129.1"
 cranelift-frontend = "0.129.1"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -108,8 +108,9 @@ name.  The produced binary is **self-contained**:
 - the harness sets `versioned_offline`, so a versioned namespace that was not
   embedded fails with a clear error instead of attempting a fetch;
 - a bad pin (missing commit, failed signature check) fails the *compile*;
-- `--verify-commit-signatures` runs `git verify-commit` at compile time — the
-  binary trusts its embedded sources.
+- `--verify-commit-signatures` verifies signatures natively (against the
+  `:trusted-signers` keys) at compile time — the binary trusts its embedded
+  sources.
 
 ---
 
@@ -167,7 +168,7 @@ inventory entries under the same unversioned names).
 | Crate        | Responsibility |
 |--------------|----------------|
 | `cljrs-deps` | Parse `cljrs.edn`, `DepsConfig` / `Dependency` types, config discovery |
-| `cljrs-vcs`  | Git subprocess helpers: `find_repo_root`, `get_file_at_commit`, commit-hash validation, cache layout |
+| `cljrs-vcs`  | Pure-Rust (gitoxide) git helpers: `find_repo_root`, `get_file_at_commit`, `fetch_remote`, commit-hash validation, cache layout, native PGP/SSH commit-signature verification |
 
 ### Modified crates
 
@@ -187,7 +188,7 @@ inventory entries under the same unversioned names).
 | # | Phase | Crate(s) touched | Status |
 |---|-------|------------------|--------|
 | 1 | `cljrs-deps` crate — config types and `cljrs.edn` parser | `cljrs-deps` (new) | ✅ Done |
-| 2 | `cljrs-vcs` crate — git subprocess helpers | `cljrs-vcs` (new) | ✅ Done |
+| 2 | `cljrs-vcs` crate — pure-Rust (gitoxide) git helpers | `cljrs-vcs` (new) | ✅ Done |
 | 3 | `Symbol.version`, `Namespace` git fields | `cljrs-value` | ✅ Done |
 | 4 | Lexer `@hash` recognition | `cljrs-reader` | ✅ Done |
 | 5 | `RequireSpec.version`, `GlobalEnv` version cache, `Env.versioned_eval_commit` | `cljrs-env` | ✅ Done |

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -214,8 +214,9 @@ self-contained — the generated harness calls
 `globals.set_versioned_offline(true)`, and a versioned namespace that was not
 embedded fails with a clear error instead of attempting a git fetch.  A bad
 pin (missing commit, failed signature check) fails the *compile*.  When
-`verify_commit_signatures` is set, `git verify-commit` runs at compile time;
-the binary trusts its embedded sources.
+`verify_commit_signatures` is set, native PGP/SSH signature verification (against
+the project's `:trusted-signers`) runs at compile time; the binary trusts its
+embedded sources.
 
 The generated harness `main()` calls `-main` (via `resolve`) after
 `__cljrs_main` returns, forwarding all command-line arguments (skipping the

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -414,6 +414,14 @@ pub fn compile_file(
         globals
             .verify_commit_signatures
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        // Load `:trusted-signers` from cljrs.edn so compile-time signature
+        // verification has keys to check pinned commits against.
+        if let Some(config) = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| cljrs_deps::load_config(&cwd).ok().flatten())
+        {
+            globals.load_trusted_signers(&config);
+        }
     }
     // Register clojure.core.async so that (require '[clojure.core.async ...])
     // and the `go`/`alt` macros resolve during macro-expansion. The GC

--- a/crates/cljrs-deps/README.md
+++ b/crates/cljrs-deps/README.md
@@ -35,9 +35,19 @@ pub struct DepsConfig {
     pub deps:                     Vec<(Arc<str>, Dependency)>,
     pub aliases:                  Vec<(Arc<str>, Alias)>,
     pub verify_commit_signatures: bool,
+    pub trusted_signers:          Vec<TrustedSigner>,  // :trusted-signers — keys allowed
+                                         // to sign versioned dependency commits
     pub enforce_native_versions:  bool,  // :enforce-native-versions — pinned-native
                                          // provenance mismatches error instead of warning
     pub rust:                     Option<RustConfig>,
+}
+
+/// A trusted commit signer from `:trusted-signers`: an inline public key
+/// (armored PGP or OpenSSH) or a path to a key file resolved relative to
+/// `cljrs.edn`.
+pub enum TrustedSigner {
+    Inline(String),
+    File(PathBuf),
 }
 
 /// Rust-crate configuration for mixed Rust/Clojure projects.

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -66,6 +66,20 @@ pub enum Dependency {
     },
 }
 
+/// A trusted commit signer declared in `:trusted-signers`.
+///
+/// Used (with `:verify-commit-signatures true`) to decide which keys are
+/// allowed to sign versioned dependency commits. Each entry is either an
+/// inline public key or a path to a key file resolved relative to the
+/// `cljrs.edn` directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustedSigner {
+    /// An inline public key: an armored PGP block or an OpenSSH public key line.
+    Inline(String),
+    /// A path to a public-key file (PGP `.asc` or OpenSSH `.pub`).
+    File(PathBuf),
+}
+
 /// A single alias entry from the `:aliases` map.
 #[derive(Debug, Clone, Default)]
 pub struct Alias {
@@ -120,9 +134,14 @@ pub struct DepsConfig {
     /// Named aliases (e.g. `:dev`, `:test`).
     pub aliases: Vec<(Arc<str>, Alias)>,
     /// When true, every versioned-symbol or versioned-namespace resolution
-    /// must pass `git verify-commit` before historical code is executed.
-    /// Equivalent to the `--verify-commit-signatures` CLI flag.
+    /// must carry a valid commit signature (verified natively against
+    /// `trusted_signers`) before historical code is executed.  Equivalent to
+    /// the `--verify-commit-signatures` CLI flag.
     pub verify_commit_signatures: bool,
+    /// Public keys trusted to sign versioned dependency commits, from
+    /// `:trusted-signers`.  Consulted only when `verify_commit_signatures` is
+    /// on; an empty set means no commit can be verified.
+    pub trusted_signers: Vec<TrustedSigner>,
     /// When true, a pinned lookup of a native (Rust-backed) function whose
     /// recorded provenance does not match the requested commit is an error
     /// instead of a warning.  Equivalent to the `--enforce-native-versions`

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use cljrs_reader::{Form, FormKind, Parser};
 
-use crate::{Alias, Dependency, DepsConfig, GitDep, RustConfig};
+use crate::{Alias, Dependency, DepsConfig, GitDep, RustConfig, TrustedSigner};
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
@@ -56,6 +56,9 @@ fn extract_config(form: &Form, config_dir: &Path) -> Result<DepsConfig, String> 
                 FormKind::Bool(b) => config.verify_commit_signatures = *b,
                 _ => return Err(":verify-commit-signatures must be true or false".to_string()),
             },
+            Some("trusted-signers") => {
+                config.trusted_signers = extract_trusted_signers(val, config_dir)?;
+            }
             Some("enforce-native-versions") => match &val.kind {
                 FormKind::Bool(b) => config.enforce_native_versions = *b,
                 _ => return Err(":enforce-native-versions must be true or false".to_string()),
@@ -81,6 +84,46 @@ fn extract_path_vec(form: &Form, ctx: &str, base: &Path) -> Result<Vec<PathBuf>,
             Ok(base.join(s))
         })
         .collect()
+}
+
+// ── :trusted-signers ──────────────────────────────────────────────────────────
+
+/// Parse `:trusted-signers` — a vector of strings. Each string is either an
+/// inline public key (an armored PGP block or an OpenSSH public key line) or a
+/// path to a key file resolved relative to the config directory.
+fn extract_trusted_signers(form: &Form, base: &Path) -> Result<Vec<TrustedSigner>, String> {
+    let items = require_vec(form, ":trusted-signers")?;
+    items
+        .iter()
+        .map(|f| {
+            let s = require_str(f, ":trusted-signers")?;
+            Ok(if looks_like_inline_key(s) {
+                TrustedSigner::Inline(s.to_string())
+            } else {
+                TrustedSigner::File(base.join(s))
+            })
+        })
+        .collect()
+}
+
+/// Heuristic: an inline key is either an armored PGP block or starts with a
+/// known OpenSSH key-type prefix; anything else is treated as a file path.
+fn looks_like_inline_key(s: &str) -> bool {
+    let t = s.trim_start();
+    t.starts_with("-----BEGIN PGP")
+        || matches!(
+            t.split_whitespace().next(),
+            Some(
+                "ssh-ed25519"
+                    | "ssh-rsa"
+                    | "ssh-dss"
+                    | "ecdsa-sha2-nistp256"
+                    | "ecdsa-sha2-nistp384"
+                    | "ecdsa-sha2-nistp521"
+                    | "sk-ssh-ed25519@openssh.com"
+                    | "sk-ecdsa-sha2-nistp256@openssh.com"
+            )
+        )
 }
 
 // ── :deps ─────────────────────────────────────────────────────────────────────
@@ -291,6 +334,24 @@ mod tests {
     fn no_rust_key_is_none() {
         let cfg = parse(r#"{:paths ["src"]}"#).unwrap();
         assert!(cfg.rust.is_none());
+    }
+
+    #[test]
+    fn trusted_signers_inline_and_file() {
+        let cfg = parse(
+            r#"{:trusted-signers ["ssh-ed25519 AAAAaaaa comment"
+                                  "keys/signer.asc"]}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.trusted_signers.len(), 2);
+        assert_eq!(
+            cfg.trusted_signers[0],
+            TrustedSigner::Inline("ssh-ed25519 AAAAaaaa comment".to_string())
+        );
+        assert_eq!(
+            cfg.trusted_signers[1],
+            TrustedSigner::File(Path::new("/proj/keys/signer.asc").to_path_buf())
+        );
     }
 
     #[test]

--- a/crates/cljrs-dylib/Cargo.toml
+++ b/crates/cljrs-dylib/Cargo.toml
@@ -12,6 +12,7 @@ cljrs-vcs     = { workspace = true }
 cljrs-deps    = { workspace = true }
 cljrs-interop = { workspace = true }
 cljrs-logging = { workspace = true }
+gix           = { workspace = true }
 libloading    = "0.8"
 
 [dev-dependencies]

--- a/crates/cljrs-dylib/README.md
+++ b/crates/cljrs-dylib/README.md
@@ -51,8 +51,9 @@ pub const INIT_SYMBOL: &[u8];  // b"cljrs_dylib_init\0"
    native function.
 2. The loader finds a `:rust/load :dylib` git dep covering the namespace
    (exact or dotted-prefix match) with a `:rust/init` function.
-3. `cljrs_vcs::fetch_remote` + checkout at the pinned commit
-   (`~/.cljrs/cache/dylibs/checkouts/<crate>@<commit>`).
+3. `cljrs_vcs::fetch_remote` + a gitoxide worktree checkout of the pinned
+   commit's tree (`~/.cljrs/cache/dylibs/checkouts/<crate>@<commit>`, no
+   `.git`; a `.cljrs-checkout-complete` sentinel marks a finished checkout).
 4. A wrapper cdylib crate is generated
    (`~/.cljrs/cache/dylibs/<crate>@<commit>/fp-<hash>/`), pinning the same
    `cljrs-interop` as the host (local checkout path when found —

--- a/crates/cljrs-dylib/src/lib.rs
+++ b/crates/cljrs-dylib/src/lib.rs
@@ -199,38 +199,49 @@ fn build_pinned_wrapper(git: &GitDep, commit: &str) -> Result<PathBuf, String> {
     Ok(artifact)
 }
 
-/// Clone the bare cache repo into a working checkout at `commit`.
+/// Materialize the pinned commit's tree into a working checkout (no `.git`).
 fn checkout_at(bare: &Path, crate_name: &str, commit: &str) -> Result<PathBuf, String> {
     let dest = dylib_cache_root()
         .join("checkouts")
         .join(format!("{crate_name}@{commit}"));
-    if dest.join(".git").exists() {
+    // Sentinel marking a previously completed checkout (the worktree has no
+    // `.git`, so we can't probe for one).
+    let sentinel = dest.join(".cljrs-checkout-complete");
+    if sentinel.exists() {
         return Ok(dest);
     }
-    std::fs::create_dir_all(dest.parent().unwrap()).map_err(|e| e.to_string())?;
-    let ok = std::process::Command::new("git")
-        .arg("clone")
-        .arg("--quiet")
-        .arg(bare)
-        .arg(&dest)
-        .status()
+    std::fs::create_dir_all(&dest).map_err(|e| e.to_string())?;
+
+    // Resolve the pinned commit to its tree and check that tree out into `dest`
+    // with gitoxide — just the files needed to build the crate.
+    let repo = gix::open(bare).map_err(|e| format!("open {}: {e}", bare.display()))?;
+    let tree = repo
+        .rev_parse_single(commit)
+        .map_err(|e| format!("resolve {commit}: {e}"))?
+        .object()
         .map_err(|e| e.to_string())?
-        .success();
-    if !ok {
-        return Err(format!("git clone of {} failed", bare.display()));
-    }
-    let ok = std::process::Command::new("git")
-        .arg("-C")
-        .arg(&dest)
-        .arg("checkout")
-        .arg("--quiet")
-        .arg(commit)
-        .status()
-        .map_err(|e| e.to_string())?
-        .success();
-    if !ok {
-        return Err(format!("git checkout {commit} failed"));
-    }
+        .peel_to_tree()
+        .map_err(|e| format!("peel {commit} to tree: {e}"))?;
+    let mut index = repo
+        .index_from_tree(&tree.id)
+        .map_err(|e| format!("index from tree: {e}"))?;
+    let opts = repo
+        .checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)
+        .map_err(|e| e.to_string())?;
+    let odb = repo.objects.clone().into_arc().map_err(|e| e.to_string())?;
+    let should_interrupt = std::sync::atomic::AtomicBool::new(false);
+    gix::worktree::state::checkout(
+        &mut index,
+        &dest,
+        odb,
+        &gix::progress::Discard,
+        &gix::progress::Discard,
+        &should_interrupt,
+        opts,
+    )
+    .map_err(|e| format!("checkout {commit} into {}: {e}", dest.display()))?;
+
+    std::fs::write(&sentinel, commit.as_bytes()).map_err(|e| e.to_string())?;
     Ok(dest)
 }
 

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -106,11 +106,16 @@ pub struct GlobalEnv {
     pub version_cache: Mutex<HashMap<Arc<str>, Value>>,
     /// Parsed `cljrs.edn` config, loaded once at startup.
     pub deps_config: RwLock<Option<Arc<cljrs_deps::DepsConfig>>>,
-    /// When true, every versioned-symbol or versioned-namespace resolution
-    /// must pass `git verify-commit` before the historical code is executed.
-    /// Off by default; enabled via `--verify-commit-signatures` CLI flag or
-    /// `:verify-commit-signatures true` in `cljrs.edn`.
+    /// When true, every versioned-symbol or versioned-namespace resolution must
+    /// carry a valid commit signature (verified natively against `trusted_keys`)
+    /// before the historical code is executed.  Off by default; enabled via
+    /// `--verify-commit-signatures` CLI flag or `:verify-commit-signatures true`
+    /// in `cljrs.edn`.
     pub verify_commit_signatures: AtomicBool,
+    /// Public keys trusted to sign versioned dependency commits, built from
+    /// the `:trusted-signers` config.  Consulted by `check_commit_signature`
+    /// when `verify_commit_signatures` is on.
+    pub trusted_keys: RwLock<Arc<cljrs_vcs::TrustedKeys>>,
     /// Session-scoped cache of commits that have already passed signature
     /// verification this run, keyed by `(repo_root, commit_hash)`.
     pub sig_verify_cache: Mutex<HashSet<(Arc<str>, Arc<str>)>>,
@@ -178,6 +183,7 @@ impl GlobalEnv {
             version_cache: Mutex::new(HashMap::new()),
             deps_config: RwLock::new(None),
             verify_commit_signatures: AtomicBool::new(false),
+            trusted_keys: RwLock::new(Arc::new(cljrs_vcs::TrustedKeys::new())),
             sig_verify_cache: Mutex::new(HashSet::new()),
             versioned_sources: RwLock::new(HashMap::new()),
             versioned_offline: AtomicBool::new(false),
@@ -524,21 +530,49 @@ impl GlobalEnv {
             if self.sig_verify_cache.lock().unwrap().contains(&key) {
                 return Ok(());
             }
-            cljrs_vcs::verify_commit_signature(std::path::Path::new(repo_root), commit).map_err(
-                |e| match e {
-                    cljrs_vcs::VcsError::SignatureVerificationFailed { commit: c, reason } => {
-                        crate::error::EvalError::CommitSignatureVerificationFailed {
-                            commit: c,
-                            reason,
-                        }
-                    }
-                    other => crate::error::EvalError::Runtime(format!("{other}")),
-                },
-            )?;
+            let trusted = self.trusted_keys.read().unwrap().clone();
+            cljrs_vcs::verify_commit_signature(std::path::Path::new(repo_root), commit, &trusted)
+                .map_err(|e| match e {
+                cljrs_vcs::VcsError::SignatureVerificationFailed { commit: c, reason } => {
+                    crate::error::EvalError::CommitSignatureVerificationFailed { commit: c, reason }
+                }
+                other => crate::error::EvalError::Runtime(format!("{other}")),
+            })?;
             self.sig_verify_cache.lock().unwrap().insert(key);
         }
         let _ = (repo_root, commit);
         Ok(())
+    }
+
+    /// Build the trusted-signer key set from a parsed `cljrs.edn` config and
+    /// install it, so subsequent `check_commit_signature` calls verify against
+    /// it.  Inline keys are parsed directly; `File` entries are read from disk.
+    /// Returns the number of keys loaded; warns (to stderr) on any key that
+    /// fails to load rather than aborting.
+    pub fn load_trusted_signers(&self, config: &cljrs_deps::DepsConfig) -> usize {
+        let mut keys = cljrs_vcs::TrustedKeys::new();
+        let mut loaded = 0usize;
+        for signer in &config.trusted_signers {
+            let result = match signer {
+                cljrs_deps::TrustedSigner::Inline(text) => keys.add_key_text(text),
+                cljrs_deps::TrustedSigner::File(path) => match std::fs::read_to_string(path) {
+                    Ok(text) => keys.add_key_text(&text),
+                    Err(e) => {
+                        eprintln!(
+                            "cljrs: warning: could not read trusted signer key {}: {e}",
+                            path.display()
+                        );
+                        continue;
+                    }
+                },
+            };
+            match result {
+                Ok(()) => loaded += 1,
+                Err(e) => eprintln!("cljrs: warning: invalid trusted signer key: {e}"),
+            }
+        }
+        *self.trusted_keys.write().unwrap() = Arc::new(keys);
+        loaded
     }
 }
 

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -114,7 +114,9 @@ pub struct GlobalEnv {
     pub verify_commit_signatures: AtomicBool,
     /// Public keys trusted to sign versioned dependency commits, built from
     /// the `:trusted-signers` config.  Consulted by `check_commit_signature`
-    /// when `verify_commit_signatures` is on.
+    /// when `verify_commit_signatures` is on.  (Not built on wasm, where
+    /// `cljrs-vcs` is unavailable and signature checks are no-ops.)
+    #[cfg(not(target_arch = "wasm32"))]
     pub trusted_keys: RwLock<Arc<cljrs_vcs::TrustedKeys>>,
     /// Session-scoped cache of commits that have already passed signature
     /// verification this run, keyed by `(repo_root, commit_hash)`.
@@ -183,6 +185,7 @@ impl GlobalEnv {
             version_cache: Mutex::new(HashMap::new()),
             deps_config: RwLock::new(None),
             verify_commit_signatures: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
             trusted_keys: RwLock::new(Arc::new(cljrs_vcs::TrustedKeys::new())),
             sig_verify_cache: Mutex::new(HashSet::new()),
             versioned_sources: RwLock::new(HashMap::new()),
@@ -548,7 +551,8 @@ impl GlobalEnv {
     /// install it, so subsequent `check_commit_signature` calls verify against
     /// it.  Inline keys are parsed directly; `File` entries are read from disk.
     /// Returns the number of keys loaded; warns (to stderr) on any key that
-    /// fails to load rather than aborting.
+    /// fails to load rather than aborting.  (Not available on wasm.)
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn load_trusted_signers(&self, config: &cljrs_deps::DepsConfig) -> usize {
         let mut keys = cljrs_vcs::TrustedKeys::new();
         let mut loaded = 0usize;

--- a/crates/cljrs-net/src/tls.rs
+++ b/crates/cljrs-net/src/tls.rs
@@ -460,7 +460,9 @@ pub fn build_client_config(opts: &MapValue) -> ValueResult<Arc<ClientConfig>> {
             }
         }
 
-        ClientConfig::builder()
+        ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| ValueError::Other(format!("tls provider error: {e}")))?
             .with_root_certificates(root_store)
             .with_no_client_auth()
     };
@@ -484,10 +486,13 @@ pub fn build_server_config(opts: &MapValue) -> ValueResult<Arc<ServerConfig>> {
     let certs = load_certs(&cert_path)?;
     let key = load_private_key(&key_path)?;
 
-    let mut config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(certs, key)
-        .map_err(|e| ValueError::Other(format!("server cert/key error: {e}")))?;
+    let mut config =
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| ValueError::Other(format!("tls provider error: {e}")))?
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(|e| ValueError::Other(format!("server cert/key error: {e}")))?;
 
     // ALPN
     if let Some(alpn) = opts_string_vec(opts, "alpn") {

--- a/crates/cljrs-vcs/Cargo.toml
+++ b/crates/cljrs-vcs/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
+gix       = { workspace = true }
+pgp       = { workspace = true }
+ssh-key   = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cljrs-vcs/README.md
+++ b/crates/cljrs-vcs/README.md
@@ -2,23 +2,36 @@
 
 ## Purpose
 
-Thin wrapper around the `git` CLI for versioned symbol resolution: locating
-repository roots, fetching file content at a specific commit, validating commit
-hashes, and managing the local dependency cache at `~/.cljrs/cache/git/`.
+Pure-Rust git helpers for versioned symbol resolution: locating repository
+roots, fetching file content at a specific commit, cloning/fetching remotes,
+validating commit hashes, managing the local dependency cache at
+`~/.cljrs/cache/git/`, and verifying commit signatures natively.
 
 ## Status
 
-Phase 2 (implemented), extended in Phase 8.  All git operations shell out to
-the `git` binary; no libgit2 dependency.  `fetch_remote` is called by
-`cljrs deps fetch`; `cache_path_for_url` is used by `cljrs deps status` to
-check cache presence without network access.
+Phase 2 (implemented), extended in Phase 8. All git operations run in-process
+via [`gix`] (gitoxide) — no `git` binary is required. Commit-signature
+verification is native: PGP signatures are checked with rPGP (`pgp`) and SSH
+signatures with `ssh-key`, against a caller-supplied [`TrustedKeys`] set (there
+is no fallback to the user's GPG keyring or SSH `allowed_signers`).
+
+Remote fetch/clone over the network is HTTPS-only and fully pure-Rust (rustls);
+local filesystem paths and `file://` URLs are also supported. `ssh://`/scp-like
+remotes are rejected with a clear error — pure-Rust SSH transport is planned for
+a later phase. `fetch_remote` is called by `cljrs deps fetch`;
+`cache_path_for_url` is used by `cljrs deps status` to check cache presence
+without network access.
+
+[`gix`]: https://docs.rs/gix
+[`TrustedKeys`]: src/signature.rs
 
 ## File layout
 
 | File | Description |
 |------|-------------|
-| `src/lib.rs` | All public functions and `VcsError` type |
-| `tests/versioning_harness.rs` | Integration test harness — two-repo fixture (library + app) covering all versioned-symbol resolution cases |
+| `src/lib.rs` | Public functions, `VcsError`, and the `gix`-backed git operations |
+| `src/signature.rs` | Native PGP/SSH commit-signature verification and the `TrustedKeys` set |
+| `tests/versioning_harness.rs` | Integration test harness — two-repo fixture (library + app) plus a natively SSH-signed commit, covering all versioned-symbol resolution cases |
 
 ## Public API
 
@@ -26,7 +39,7 @@ check cache presence without network access.
 /// True if `s` is 7–40 lowercase or uppercase hex characters.
 pub fn is_valid_commit_hash(s: &str) -> bool
 
-/// Walk up from `start` to find the git repo root (dir containing `.git`).
+/// Walk up from `start` to find the git working-tree root.
 pub fn find_repo_root(start: &Path) -> Option<PathBuf>
 
 /// Return file contents at `rel_path` (relative to repo root) at `commit`.
@@ -39,9 +52,26 @@ pub fn cache_root() -> PathBuf
 /// Does not touch the network; use to check cache existence before fetching.
 pub fn cache_path_for_url(url: &str) -> PathBuf
 
-/// Clone or fetch `url`, ensuring `sha` is present locally.
+/// Clone or fetch `url` (https/local/file), ensuring `sha` is present locally.
 /// Returns the path to the bare repo in the cache.
 pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf>
+
+/// Verify the PGP or SSH signature on `commit` against `trusted`.
+/// Ok only when the signature is valid AND its key is in the trusted set.
+pub fn verify_commit_signature(repo_root: &Path, commit: &str, trusted: &TrustedKeys) -> VcsResult<()>
+
+/// A cljrs-managed set of public keys trusted to sign commits.
+pub struct TrustedKeys { /* … */ }
+impl TrustedKeys {
+    pub fn new() -> Self
+    pub fn is_empty(&self) -> bool
+    /// Auto-detect PGP-armored vs OpenSSH public-key text.
+    pub fn add_key_text(&mut self, text: &str) -> Result<(), TrustedKeyError>
+    pub fn add_pgp_armored(&mut self, armored: &str) -> Result<(), TrustedKeyError>
+    pub fn add_ssh_openssh(&mut self, openssh: &str) -> Result<(), TrustedKeyError>
+}
+
+pub enum TrustedKeyError { Pgp(String), Ssh(String), Unrecognized }
 
 pub enum VcsError {
     InvalidCommit(String),
@@ -50,5 +80,8 @@ pub enum VcsError {
     Io(std::io::Error),
     Utf8,
     NoRepo(PathBuf),
+    UnsupportedRemote(String),
+    Git(String),
+    SignatureVerificationFailed { commit: String, reason: String },
 }
 ```

--- a/crates/cljrs-vcs/src/lib.rs
+++ b/crates/cljrs-vcs/src/lib.rs
@@ -1,12 +1,21 @@
-//! Git subprocess helpers for versioned symbol resolution.
+//! Pure-Rust git helpers for versioned symbol resolution.
 //!
-//! All git operations are performed by shelling out to the `git` binary.
-//! No network access happens here; callers are responsible for ensuring
-//! that required commits are present locally before calling these functions.
+//! All git operations are performed in-process with [`gix`] (gitoxide); no
+//! `git` binary is required. Commit-signature verification is likewise native
+//! (see [`signature`]): PGP signatures are checked with rPGP and SSH signatures
+//! with `ssh-key`, against a caller-supplied set of [`TrustedKeys`].
+//!
+//! Remote fetch/clone over the network is HTTPS-only and fully pure-Rust
+//! (rustls). Local filesystem paths and `file://` URLs are also supported
+//! (handled in-process). `ssh://`/scp-like remotes are rejected with a clear
+//! error; pure-Rust SSH transport is planned for a later phase.
 
 use std::path::{Path, PathBuf};
 
 use thiserror::Error;
+
+mod signature;
+pub use signature::{TrustedKeyError, TrustedKeys};
 
 #[derive(Debug, Error)]
 pub enum VcsError {
@@ -16,12 +25,18 @@ pub enum VcsError {
     CommitNotFound(String),
     #[error("path {0:?} not found at commit {1:?}")]
     PathNotFound(String, String),
-    #[error("git subprocess error: {0}")]
+    #[error("git error: {0}")]
     Io(#[from] std::io::Error),
     #[error("git output is not valid UTF-8")]
     Utf8,
     #[error("no git repository found at or above {0:?}")]
     NoRepo(PathBuf),
+    #[error(
+        "unsupported remote {0:?}: only https:// URLs and local paths are supported (ssh remotes are not yet supported)"
+    )]
+    UnsupportedRemote(String),
+    #[error("git error: {0}")]
+    Git(String),
     #[error("commit {commit:?} has no valid signature: {reason}")]
     SignatureVerificationFailed { commit: String, reason: String },
 }
@@ -35,7 +50,7 @@ pub fn is_valid_commit_hash(s: &str) -> bool {
 }
 
 /// Walk upward from `start` (a file or directory) to find the root of the
-/// enclosing git repository, i.e. the directory that contains `.git`.
+/// enclosing git repository, i.e. the working-tree root.
 pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
     // Normalise: if `start` is a file, begin from its parent directory.
     let dir: &Path = if start.is_file() {
@@ -44,20 +59,8 @@ pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
         start
     };
 
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .arg("rev-parse")
-        .arg("--show-toplevel")
-        .output()
-        .ok()?;
-
-    if output.status.success() {
-        let s = String::from_utf8(output.stdout).ok()?;
-        Some(PathBuf::from(s.trim()))
-    } else {
-        None
-    }
+    let repo = gix::discover(dir).ok()?;
+    repo.workdir().map(|p| p.to_path_buf())
 }
 
 /// Return the contents of `rel_path` (relative to the repo root) at `commit`.
@@ -69,27 +72,25 @@ pub fn get_file_at_commit(repo_root: &Path, rel_path: &str, commit: &str) -> Vcs
         return Err(VcsError::InvalidCommit(commit.to_string()));
     }
 
-    let spec = format!("{commit}:{rel_path}");
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .arg("show")
-        .arg(&spec)
-        .output()?;
+    let repo = gix::open(repo_root).map_err(|e| VcsError::Git(e.to_string()))?;
+    let object = repo
+        .rev_parse_single(commit)
+        .map_err(|_| VcsError::CommitNotFound(commit.to_string()))?
+        .object()
+        .map_err(|_| VcsError::CommitNotFound(commit.to_string()))?;
+    let tree = object
+        .try_into_commit()
+        .map_err(|_| VcsError::CommitNotFound(commit.to_string()))?
+        .tree()
+        .map_err(|_| VcsError::CommitNotFound(commit.to_string()))?;
 
-    if output.status.success() {
-        String::from_utf8(output.stdout).map_err(|_| VcsError::Utf8)
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("does not exist") || stderr.contains("exists on disk") {
-            Err(VcsError::PathNotFound(
-                rel_path.to_string(),
-                commit.to_string(),
-            ))
-        } else {
-            Err(VcsError::CommitNotFound(commit.to_string()))
-        }
-    }
+    let entry = tree
+        .lookup_entry_by_path(Path::new(rel_path))
+        .map_err(|e| VcsError::Git(e.to_string()))?
+        .ok_or_else(|| VcsError::PathNotFound(rel_path.to_string(), commit.to_string()))?;
+
+    let blob = entry.object().map_err(|e| VcsError::Git(e.to_string()))?;
+    String::from_utf8(blob.data.clone()).map_err(|_| VcsError::Utf8)
 }
 
 /// Returns the path to the local git-dep cache root: `~/.cljrs/cache/git/`.
@@ -106,8 +107,12 @@ pub fn cache_root() -> PathBuf {
 /// This mirrors the slug derivation inside [`fetch_remote`] so callers can
 /// check cache existence without triggering network access.
 pub fn cache_path_for_url(url: &str) -> PathBuf {
-    let slug: String = url
-        .chars()
+    cache_root().join(url_slug(url))
+}
+
+/// Stable cache directory slug derived from a URL (non-alphanumerics → `_`).
+fn url_slug(url: &str) -> String {
+    url.chars()
         .map(|c| {
             if c.is_alphanumeric() || c == '-' {
                 c
@@ -115,13 +120,13 @@ pub fn cache_path_for_url(url: &str) -> PathBuf {
                 '_'
             }
         })
-        .collect();
-    cache_root().join(slug)
+        .collect()
 }
 
-/// Clone or fetch a remote git repository into the local cache.
+/// Clone or fetch a git repository into the local cache.
 ///
-/// `url`  — remote URL (https or ssh)
+/// `url`  — an `https://` URL, a local filesystem path, or a `file://` URL
+///          (ssh remotes are not yet supported)
 /// `sha`  — the commit SHA that must be reachable after the operation
 ///
 /// Returns the path to the bare repository in the cache.
@@ -129,86 +134,111 @@ pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
     if !is_valid_commit_hash(sha) {
         return Err(VcsError::InvalidCommit(sha.to_string()));
     }
+    if matches!(classify_remote(url), RemoteKind::Unsupported) {
+        return Err(VcsError::UnsupportedRemote(url.to_string()));
+    }
 
-    // Stable cache directory derived from the URL (replace non-alphanum with _).
-    let slug: String = url
-        .chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let repo_dir = cache_root().join(&slug);
+    let repo_dir = cache_root().join(url_slug(url));
 
     if repo_dir.exists() {
         // Already cloned — fetch to make sure we have the requested commit.
-        let status = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&repo_dir)
-            .arg("fetch")
-            .arg("--quiet")
-            .arg("origin")
-            .status()?;
-        if !status.success() {
-            return Err(VcsError::Io(std::io::Error::other("git fetch failed")));
-        }
+        fetch_existing(&repo_dir)?;
     } else {
         std::fs::create_dir_all(&repo_dir).map_err(VcsError::Io)?;
-        let status = std::process::Command::new("git")
-            .arg("clone")
-            .arg("--bare")
-            .arg("--quiet")
-            .arg(url)
-            .arg(&repo_dir)
-            .status()?;
-        if !status.success() {
-            return Err(VcsError::Io(std::io::Error::other("git clone failed")));
-        }
+        clone_bare(url, &repo_dir)?;
     }
 
-    // Verify that the requested commit is now present.
-    let check = std::process::Command::new("git")
-        .arg("-C")
-        .arg(&repo_dir)
-        .arg("cat-file")
-        .arg("-e")
-        .arg(sha)
-        .status()?;
-    if !check.success() {
+    // Verify that the requested commit is now present locally.
+    let repo = gix::open(&repo_dir).map_err(|e| VcsError::Git(e.to_string()))?;
+    if repo.rev_parse_single(sha).is_err() {
         return Err(VcsError::CommitNotFound(sha.to_string()));
     }
 
     Ok(repo_dir)
 }
 
-/// Verify the GPG or SSH signature on `commit` inside `repo_root`.
+/// How a remote URL is transported.
+enum RemoteKind {
+    /// `https://` (pure-Rust network) or a local filesystem path / `file://`.
+    Supported,
+    /// `ssh://`, scp-like `git@host:path`, `git://`, `http://`, etc.
+    Unsupported,
+}
+
+/// Classify a remote URL. Network transport is HTTPS-only; local paths and
+/// `file://` are also supported (gitoxide handles them in-process). SSH and
+/// other network transports are rejected.
+fn classify_remote(url: &str) -> RemoteKind {
+    if url.starts_with("https://") || url.starts_with("file://") {
+        return RemoteKind::Supported;
+    }
+    if url.contains("://") {
+        // An explicit non-https/file scheme (ssh://, git://, http://, …).
+        return RemoteKind::Unsupported;
+    }
+    // No scheme: an scp-like `user@host:path` is SSH; otherwise a local path.
+    match url.split_once(':') {
+        Some((host, _)) if !host.is_empty() && !host.contains('/') => RemoteKind::Unsupported,
+        _ => RemoteKind::Supported,
+    }
+}
+
+/// Clone `url` as a bare repository into `repo_dir`.
+fn clone_bare(url: &str, repo_dir: &Path) -> VcsResult<()> {
+    let mut prepare =
+        gix::prepare_clone_bare(url, repo_dir).map_err(|e| VcsError::Git(e.to_string()))?;
+    let (_repo, _outcome) = prepare
+        .fetch_only(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
+        .map_err(|e| VcsError::Git(e.to_string()))?;
+    Ok(())
+}
+
+/// Fetch updates for an already-cloned bare repository at `repo_dir`.
+fn fetch_existing(repo_dir: &Path) -> VcsResult<()> {
+    let repo = gix::open(repo_dir).map_err(|e| VcsError::Git(e.to_string()))?;
+    let remote = repo
+        .find_default_remote(gix::remote::Direction::Fetch)
+        .ok_or_else(|| VcsError::Git("repository has no default remote".to_string()))?
+        .map_err(|e| VcsError::Git(e.to_string()))?;
+    remote
+        .connect(gix::remote::Direction::Fetch)
+        .map_err(|e| VcsError::Git(e.to_string()))?
+        .prepare_fetch(gix::progress::Discard, Default::default())
+        .map_err(|e| VcsError::Git(e.to_string()))?
+        .receive(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
+        .map_err(|e| VcsError::Git(e.to_string()))?;
+    Ok(())
+}
+
+/// Verify the PGP or SSH signature on `commit` inside `repo_root` against the
+/// caller-supplied set of `trusted` keys.
 ///
-/// Delegates entirely to `git verify-commit`; trust is determined by the
-/// caller's GPG keyring or `gpg.program` git config.  Returns `Ok(())` when
-/// the signature is present and valid, `Err(SignatureVerificationFailed)`
-/// otherwise (unsigned commit, expired key, key not in keyring, etc.).
-pub fn verify_commit_signature(repo_root: &Path, commit: &str) -> VcsResult<()> {
+/// Returns `Ok(())` when the commit carries a cryptographically valid signature
+/// whose signing key is present in `trusted`. Returns
+/// `Err(SignatureVerificationFailed)` for an unsigned commit, an invalid
+/// signature, or a signature made by a key that is not trusted.
+pub fn verify_commit_signature(
+    repo_root: &Path,
+    commit: &str,
+    trusted: &TrustedKeys,
+) -> VcsResult<()> {
     if !is_valid_commit_hash(commit) {
         return Err(VcsError::InvalidCommit(commit.to_string()));
     }
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .arg("verify-commit")
-        .arg(commit)
-        .output()?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        let reason = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        Err(VcsError::SignatureVerificationFailed {
+    let repo = gix::open(repo_root).map_err(|e| VcsError::Git(e.to_string()))?;
+    let object = repo
+        .rev_parse_single(commit)
+        .map_err(|_| VcsError::CommitNotFound(commit.to_string()))?
+        .object()
+        .map_err(|_| VcsError::CommitNotFound(commit.to_string()))?;
+    let raw = object.data.clone();
+
+    signature::verify_commit_object(&raw, trusted).map_err(|reason| {
+        VcsError::SignatureVerificationFailed {
             commit: commit.to_string(),
             reason,
-        })
-    }
+        }
+    })
 }
 
 #[cfg(test)]
@@ -224,5 +254,18 @@ mod tests {
         assert!(!is_valid_commit_hash("abc123")); // too short
         assert!(!is_valid_commit_hash("xyz1234")); // non-hex
         assert!(!is_valid_commit_hash(""));
+    }
+
+    #[test]
+    fn remote_classification() {
+        let supported = |u| matches!(classify_remote(u), RemoteKind::Supported);
+        assert!(supported("https://github.com/u/r"));
+        assert!(supported("file:///tmp/repo"));
+        assert!(supported("/tmp/local/repo")); // absolute local path
+        assert!(supported("../relative/repo")); // relative local path
+        assert!(!supported("ssh://git@github.com/u/r"));
+        assert!(!supported("git@github.com:u/r.git")); // scp-like
+        assert!(!supported("git://github.com/u/r"));
+        assert!(!supported("http://github.com/u/r")); // insecure
     }
 }

--- a/crates/cljrs-vcs/src/signature.rs
+++ b/crates/cljrs-vcs/src/signature.rs
@@ -1,0 +1,352 @@
+//! Native commit-signature verification.
+//!
+//! Git commits can be signed in two formats, both stored in the commit
+//! object's `gpgsig` header:
+//!
+//! * **PGP** — `-----BEGIN PGP SIGNATURE-----`, verified here with rPGP.
+//! * **SSH** — `-----BEGIN SSH SIGNATURE-----` (the `SSHSIG` format produced by
+//!   `ssh-keygen -Y sign -n git`), verified with `ssh-key`.
+//!
+//! Trust is *cljrs-managed*: a signature is accepted only when it is
+//! cryptographically valid **and** made by a key present in the caller-supplied
+//! [`TrustedKeys`]. There is no implicit fallback to the user's GPG keyring or
+//! SSH `allowed_signers` file.
+
+use pgp::composed::{Deserializable, DetachedSignature, SignedPublicKey};
+use thiserror::Error;
+
+/// The SSHSIG namespace git uses for commit/tag signatures.
+const SSH_NAMESPACE: &str = "git";
+
+/// Errors raised while loading a trusted public key.
+#[derive(Debug, Error)]
+pub enum TrustedKeyError {
+    #[error("invalid PGP public key: {0}")]
+    Pgp(String),
+    #[error("invalid SSH public key: {0}")]
+    Ssh(String),
+    #[error("unrecognized key format (expected an armored PGP key or an OpenSSH public key)")]
+    Unrecognized,
+}
+
+/// A cljrs-managed set of public keys trusted to sign commits.
+///
+/// Populate it from `cljrs.edn`'s `:trusted-signers` entries (see
+/// `cljrs-deps`), then pass it to [`crate::verify_commit_signature`].
+#[derive(Default)]
+pub struct TrustedKeys {
+    pgp: Vec<SignedPublicKey>,
+    ssh: Vec<ssh_key::PublicKey>,
+}
+
+impl TrustedKeys {
+    /// An empty trust set. Any signature check against it fails.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` when no keys are configured.
+    pub fn is_empty(&self) -> bool {
+        self.pgp.is_empty() && self.ssh.is_empty()
+    }
+
+    /// Add a trusted key from text, auto-detecting PGP vs OpenSSH format.
+    ///
+    /// * Armored PGP public-key blocks (`-----BEGIN PGP PUBLIC KEY BLOCK-----`).
+    /// * OpenSSH public keys (`ssh-ed25519 AAAA… comment`, `ecdsa-…`, `rsa-…`).
+    pub fn add_key_text(&mut self, text: &str) -> Result<(), TrustedKeyError> {
+        let trimmed = text.trim_start();
+        if trimmed.starts_with("-----BEGIN PGP") {
+            self.add_pgp_armored(text)
+        } else if is_openssh_public_key(trimmed) {
+            self.add_ssh_openssh(text)
+        } else {
+            Err(TrustedKeyError::Unrecognized)
+        }
+    }
+
+    /// Add a trusted PGP public key from an armored block.
+    pub fn add_pgp_armored(&mut self, armored: &str) -> Result<(), TrustedKeyError> {
+        let (key, _headers) = SignedPublicKey::from_armor_single(armored.as_bytes())
+            .map_err(|e| TrustedKeyError::Pgp(e.to_string()))?;
+        self.pgp.push(key);
+        Ok(())
+    }
+
+    /// Add a trusted SSH public key in OpenSSH `authorized_keys` format.
+    pub fn add_ssh_openssh(&mut self, openssh: &str) -> Result<(), TrustedKeyError> {
+        let key = ssh_key::PublicKey::from_openssh(openssh.trim())
+            .map_err(|e| TrustedKeyError::Ssh(e.to_string()))?;
+        self.ssh.push(key);
+        Ok(())
+    }
+}
+
+/// Returns `true` when `line` looks like an OpenSSH public key.
+fn is_openssh_public_key(line: &str) -> bool {
+    matches!(
+        line.split_whitespace().next(),
+        Some(
+            "ssh-ed25519"
+                | "ssh-rsa"
+                | "ssh-dss"
+                | "ecdsa-sha2-nistp256"
+                | "ecdsa-sha2-nistp384"
+                | "ecdsa-sha2-nistp521"
+                | "sk-ssh-ed25519@openssh.com"
+                | "sk-ecdsa-sha2-nistp256@openssh.com"
+        )
+    )
+}
+
+/// Verify the signature embedded in a raw commit object (`object.data`, i.e. the
+/// decoded commit text starting with `tree …`, without the `commit <size>\0`
+/// git object header) against `trusted`.
+///
+/// Returns `Ok(())` on a valid, trusted signature; `Err(reason)` otherwise.
+pub(crate) fn verify_commit_object(raw: &[u8], trusted: &TrustedKeys) -> Result<(), String> {
+    let (payload, sig) =
+        split_commit_signature(raw).ok_or_else(|| "commit is not signed".to_string())?;
+    let sig_str =
+        std::str::from_utf8(&sig).map_err(|_| "signature is not valid UTF-8".to_string())?;
+    let banner = sig_str.trim_start();
+
+    if banner.starts_with("-----BEGIN PGP SIGNATURE-----") {
+        verify_pgp(&payload, sig_str, trusted)
+    } else if banner.starts_with("-----BEGIN SSH SIGNATURE-----") {
+        verify_ssh(&payload, sig_str, trusted)
+    } else {
+        Err("unrecognized signature format".to_string())
+    }
+}
+
+/// Verify a PGP-signed commit payload against the trusted PGP keys.
+fn verify_pgp(payload: &[u8], armored_sig: &str, trusted: &TrustedKeys) -> Result<(), String> {
+    let (sig, _headers) = DetachedSignature::from_armor_single(armored_sig.as_bytes())
+        .map_err(|e| format!("malformed PGP signature: {e}"))?;
+
+    if trusted.pgp.is_empty() {
+        return Err("no trusted PGP keys configured".to_string());
+    }
+
+    for key in &trusted.pgp {
+        // Try the primary key, then any signing subkeys.
+        if sig.verify(key, payload).is_ok() {
+            return Ok(());
+        }
+        for subkey in &key.public_subkeys {
+            if sig.verify(subkey, payload).is_ok() {
+                return Ok(());
+            }
+        }
+    }
+    Err("signature is not valid for any trusted PGP key".to_string())
+}
+
+/// Verify an SSH-signed commit payload against the trusted SSH keys.
+fn verify_ssh(payload: &[u8], pem_sig: &str, trusted: &TrustedKeys) -> Result<(), String> {
+    let sshsig =
+        ssh_key::SshSig::from_pem(pem_sig).map_err(|e| format!("malformed SSH signature: {e}"))?;
+
+    if trusted.ssh.is_empty() {
+        return Err("no trusted SSH keys configured".to_string());
+    }
+
+    for key in &trusted.ssh {
+        // `verify` enforces that the signing key equals this trusted key, the
+        // namespace matches, and the signature is cryptographically valid.
+        if key.verify(SSH_NAMESPACE, payload, &sshsig).is_ok() {
+            return Ok(());
+        }
+    }
+    Err("signature is not valid for any trusted SSH key".to_string())
+}
+
+/// Split a raw commit object into `(signed_payload, armored_signature)`.
+///
+/// The signed payload is the commit object with its `gpgsig` header removed —
+/// exactly the bytes git signs. The signature is reconstructed from the
+/// `gpgsig` header line and its space-prefixed continuation lines. Returns
+/// `None` when there is no `gpgsig` header.
+fn split_commit_signature(raw: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    const HEADER: &[u8] = b"gpgsig ";
+    let mut payload = Vec::with_capacity(raw.len());
+    let mut sig = Vec::new();
+    let mut found = false;
+    let mut i = 0;
+
+    while i < raw.len() {
+        let (line, next) = read_line(raw, i);
+
+        // A blank line terminates the header section; copy the message verbatim.
+        if line.is_empty() {
+            payload.extend_from_slice(&raw[i..]);
+            return if found { Some((payload, sig)) } else { None };
+        }
+
+        if !found && line.starts_with(HEADER) {
+            found = true;
+            sig.extend_from_slice(&line[HEADER.len()..]);
+            i = next;
+            // Consume space-prefixed continuation lines, stripping the leading space.
+            while i < raw.len() {
+                let (cont, cnext) = read_line(raw, i);
+                if cont.first() == Some(&b' ') {
+                    sig.push(b'\n');
+                    sig.extend_from_slice(&cont[1..]);
+                    i = cnext;
+                } else {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        // Ordinary header line: keep it in the signed payload.
+        payload.extend_from_slice(line);
+        payload.push(b'\n');
+        i = next;
+    }
+
+    if found { Some((payload, sig)) } else { None }
+}
+
+/// Return the line starting at `start` (without its trailing `\n`) and the index
+/// just past the line terminator.
+fn read_line(raw: &[u8], start: usize) -> (&[u8], usize) {
+    match raw[start..].iter().position(|&b| b == b'\n') {
+        Some(p) => (&raw[start..start + p], start + p + 1),
+        None => (&raw[start..], raw.len()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A static Ed25519 keypair used to exercise the SSH verification path
+    // without generating keys (which would need an RNG feature). Generated once
+    // with `ssh-key`; used only in tests.
+    const TEST_SSH_PRIVATE: &str = "\
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBmFUP3SDH5k28ErT2na8g4asrcsI4STLcmDImAF0WjDwAAAIiFW+7uhVvu
+7gAAAAtzc2gtZWQyNTUxOQAAACBmFUP3SDH5k28ErT2na8g4asrcsI4STLcmDImAF0WjDw
+AAAEAgsZE1vrnYoatnjRDx6BGE9PeOViG9mgDVkCbPj8unnmYVQ/dIMfmTbwStPadryDhq
+ytywjhJMtyYMiYAXRaMPAAAAAAECAwQF
+-----END OPENSSH PRIVATE KEY-----
+";
+    const TEST_SSH_PUBLIC: &str = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGYVQ/dIMfmTbwStPadryDhqytywjhJMtyYMiYAXRaMP cljrs-test";
+
+    /// Build a raw commit object (`object.data` form) carrying `armored_sig` in
+    /// its `gpgsig` header. `payload` must be the no-signature commit text.
+    fn assemble_signed_commit(payload: &[u8], armored_sig: &str) -> Vec<u8> {
+        // Headers end at the first blank line; insert gpgsig as the last header.
+        let split = payload
+            .windows(2)
+            .position(|w| w == b"\n\n")
+            .expect("payload has a header/message separator");
+        let headers = &payload[..=split]; // includes the trailing header newline
+        let message = &payload[split + 1..]; // includes the leading blank line
+
+        let mut out = Vec::new();
+        out.extend_from_slice(headers);
+        out.extend_from_slice(b"gpgsig ");
+        for (i, line) in armored_sig.lines().enumerate() {
+            if i > 0 {
+                out.push(b'\n');
+                out.push(b' ');
+            }
+            out.extend_from_slice(line.as_bytes());
+        }
+        out.push(b'\n');
+        out.extend_from_slice(message);
+        out
+    }
+
+    fn sign_payload_ssh(payload: &[u8]) -> String {
+        let key = ssh_key::PrivateKey::from_openssh(TEST_SSH_PRIVATE).expect("parse private key");
+        let sig = ssh_key::SshSig::sign(&key, SSH_NAMESPACE, ssh_key::HashAlg::Sha512, payload)
+            .expect("sign");
+        sig.to_pem(ssh_key::LineEnding::LF).expect("pem")
+    }
+
+    const PAYLOAD: &[u8] = b"tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+        author Test <t@example.com> 0 +0000\n\
+        committer Test <t@example.com> 0 +0000\n\
+        \n\
+        signed commit\n";
+
+    #[test]
+    fn ssh_signed_commit_verifies_with_trusted_key() {
+        let pem = sign_payload_ssh(PAYLOAD);
+        let raw = assemble_signed_commit(PAYLOAD, &pem);
+
+        let mut trusted = TrustedKeys::new();
+        trusted.add_ssh_openssh(TEST_SSH_PUBLIC).unwrap();
+        assert!(verify_commit_object(&raw, &trusted).is_ok());
+    }
+
+    #[test]
+    fn ssh_signed_commit_fails_with_empty_trust() {
+        let pem = sign_payload_ssh(PAYLOAD);
+        let raw = assemble_signed_commit(PAYLOAD, &pem);
+        let err = verify_commit_object(&raw, &TrustedKeys::new()).unwrap_err();
+        assert!(err.contains("no trusted SSH keys"), "got: {err}");
+    }
+
+    #[test]
+    fn ssh_signed_commit_fails_with_untrusted_key() {
+        let pem = sign_payload_ssh(PAYLOAD);
+        // Tamper with the payload so the signature no longer matches.
+        let mut tampered = PAYLOAD.to_vec();
+        tampered.extend_from_slice(b"extra\n");
+        let raw = assemble_signed_commit(&tampered, &pem);
+
+        let mut trusted = TrustedKeys::new();
+        trusted.add_ssh_openssh(TEST_SSH_PUBLIC).unwrap();
+        assert!(verify_commit_object(&raw, &trusted).is_err());
+    }
+
+    #[test]
+    fn add_key_text_autodetects_ssh() {
+        let mut trusted = TrustedKeys::new();
+        trusted.add_key_text(TEST_SSH_PUBLIC).expect("ssh key");
+        assert!(!trusted.is_empty());
+    }
+
+    #[test]
+    fn unsigned_commit_has_no_signature() {
+        let raw = b"tree 0000000000000000000000000000000000000000\n\
+                    author A <a@example.com> 0 +0000\n\
+                    committer A <a@example.com> 0 +0000\n\
+                    \n\
+                    hello\n";
+        assert!(split_commit_signature(raw).is_none());
+    }
+
+    #[test]
+    fn splits_payload_and_signature() {
+        let raw = b"tree 0000000000000000000000000000000000000000\n\
+                    author A <a@example.com> 0 +0000\n\
+                    committer A <a@example.com> 0 +0000\n\
+                    gpgsig -----BEGIN SSH SIGNATURE-----\n\
+                    \x20line1\n\
+                    \x20line2\n\
+                    \x20-----END SSH SIGNATURE-----\n\
+                    \n\
+                    subject\n";
+        let (payload, sig) = split_commit_signature(raw).expect("signed");
+        // Payload must not contain the gpgsig header.
+        assert!(!payload.windows(6).any(|w| w == b"gpgsig"));
+        // Payload must retain the message and the other headers.
+        assert!(payload.ends_with(b"\nsubject\n"));
+        assert!(payload.starts_with(b"tree "));
+        // Signature is reassembled with continuation lines de-indented.
+        let sig = String::from_utf8(sig).unwrap();
+        assert_eq!(
+            sig,
+            "-----BEGIN SSH SIGNATURE-----\nline1\nline2\n-----END SSH SIGNATURE-----"
+        );
+    }
+}

--- a/crates/cljrs-vcs/tests/versioning_harness.rs
+++ b/crates/cljrs-vcs/tests/versioning_harness.rs
@@ -19,7 +19,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use cljrs_vcs::{
-    VcsError, find_repo_root, get_file_at_commit, is_valid_commit_hash, verify_commit_signature,
+    TrustedKeys, VcsError, find_repo_root, get_file_at_commit, is_valid_commit_hash,
+    verify_commit_signature,
 };
 
 // ---------------------------------------------------------------------------
@@ -170,104 +171,84 @@ fn setup_app(lib: &LibraryRepo) -> AppRepo {
 }
 
 // ---------------------------------------------------------------------------
-// GPG signing fixture
+// Native SSH signing fixture
 // ---------------------------------------------------------------------------
 
-struct GpgSetup {
-    // Keeps the temp GNUPGHOME dir alive.
-    _homedir: tempfile::TempDir,
-    pub fingerprint: String,
-    /// Shell wrapper that calls `gpg --homedir <homedir>` so any git subprocess
-    /// that invokes gpg will use our test keyring.
-    pub wrapper_path: PathBuf,
+// A static Ed25519 keypair (generated once with `ssh-key`) used to produce a
+// natively SSH-signed commit. No external `gpg`/`ssh-keygen` is involved.
+const TEST_SSH_PRIVATE: &str = "\
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBmFUP3SDH5k28ErT2na8g4asrcsI4STLcmDImAF0WjDwAAAIiFW+7uhVvu
+7gAAAAtzc2gtZWQyNTUxOQAAACBmFUP3SDH5k28ErT2na8g4asrcsI4STLcmDImAF0WjDw
+AAAEAgsZE1vrnYoatnjRDx6BGE9PeOViG9mgDVkCbPj8unnmYVQ/dIMfmTbwStPadryDhq
+ytywjhJMtyYMiYAXRaMPAAAAAAECAwQF
+-----END OPENSSH PRIVATE KEY-----
+";
+const TEST_SSH_PUBLIC: &str =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGYVQ/dIMfmTbwStPadryDhqytywjhJMtyYMiYAXRaMP cljrs-test";
+
+/// Sign `payload` with the static SSH key under git's "git" namespace, returning
+/// the armored SSHSIG block.
+fn ssh_sign(payload: &[u8]) -> String {
+    let key = ssh_key::PrivateKey::from_openssh(TEST_SSH_PRIVATE).expect("parse private key");
+    let sig = ssh_key::SshSig::sign(&key, "git", ssh_key::HashAlg::Sha512, payload).expect("sign");
+    sig.to_pem(ssh_key::LineEnding::LF)
+        .expect("pem")
+        .to_string()
 }
 
-/// Generates a temporary ed25519 GPG key in an isolated homedir and returns a
-/// wrapper script that points gpg at that homedir.
-///
-/// Returns `None` when gpg is absent or key generation fails — callers should
-/// skip the test gracefully in that case.
-fn setup_gpg() -> Option<GpgSetup> {
-    Command::new("gpg")
-        .arg("--version")
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
+/// Build a raw commit object embedding `armored_sig` in the `gpgsig` header.
+/// `payload` is the no-signature commit text.
+fn embed_gpgsig(payload: &[u8], armored_sig: &str) -> Vec<u8> {
+    let split = payload
+        .windows(2)
+        .position(|w| w == b"\n\n")
+        .expect("payload has a header/message separator");
+    let headers = &payload[..=split];
+    let message = &payload[split + 1..];
 
-    let homedir = tempfile::TempDir::new().ok()?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(homedir.path(), std::fs::Permissions::from_mode(0o700)).ok()?;
+    let mut out = Vec::new();
+    out.extend_from_slice(headers);
+    out.extend_from_slice(b"gpgsig ");
+    for (i, line) in armored_sig.lines().enumerate() {
+        if i > 0 {
+            out.push(b'\n');
+            out.push(b' ');
+        }
+        out.extend_from_slice(line.as_bytes());
     }
+    out.push(b'\n');
+    out.extend_from_slice(message);
+    out
+}
 
-    let params_file = homedir.path().join("key-params");
-    std::fs::write(
-        &params_file,
-        "%no-protection\n\
-         Key-Type: EdDSA\n\
-         Key-Curve: ed25519\n\
-         Name-Real: Test Signer\n\
-         Name-Email: test@example.com\n\
-         Expire-Date: 0\n\
-         %commit\n",
-    )
-    .ok()?;
-
-    let out = Command::new("gpg")
-        .env("GNUPGHOME", homedir.path())
-        .args(["--batch", "--gen-key"])
-        .arg(&params_file)
-        .output()
-        .ok()?;
-
-    if !out.status.success() {
-        eprintln!(
-            "gpg key generation failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-        return None;
-    }
-
-    // Extract the fingerprint from `gpg --list-secret-keys --with-colons`.
-    let list_out = Command::new("gpg")
-        .env("GNUPGHOME", homedir.path())
-        .args(["--list-secret-keys", "--with-colons"])
-        .output()
-        .ok()?;
-    let list_str = String::from_utf8(list_out.stdout).ok()?;
-    let fingerprint = list_str
-        .lines()
-        .find(|l| l.starts_with("fpr:"))?
-        .split(':')
-        .nth(9)?
-        .to_string();
-
-    // A wrapper script that invokes gpg with our isolated homedir.
-    // Git's `gpg.program` config will point at this script, so both
-    // `git commit -S` and `git verify-commit` use the test keyring.
-    let wrapper_path = homedir.path().join("gpg-wrapper.sh");
-    std::fs::write(
-        &wrapper_path,
-        format!(
-            "#!/bin/sh\nexec gpg --homedir '{}' \"$@\"\n",
-            homedir.path().display()
-        ),
-    )
-    .ok()?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755)).ok()?;
-    }
-
-    Some(GpgSetup {
-        _homedir: homedir,
-        fingerprint,
-        wrapper_path,
-    })
+/// Write a raw object of type `kind` into `dir`'s object store via
+/// `git hash-object -w` (used only to store the fixture; signing/verifying is
+/// native). Returns the object's SHA.
+fn git_write_object(dir: &Path, kind: &str, bytes: &[u8]) -> String {
+    use std::io::Write;
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["hash-object", "-w", "-t", kind, "--stdin"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn git hash-object");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(bytes)
+        .expect("write object to git");
+    let out = child.wait_with_output().expect("git hash-object");
+    assert!(
+        out.status.success(),
+        "git hash-object failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
 }
 
 // ===========================================================================
@@ -410,90 +391,58 @@ fn test_path_not_found_at_commit() {
 fn test_signature_verification_negative() {
     let lib = setup_library();
 
-    let result = verify_commit_signature(&lib.root, &lib.commit_v2);
+    let result = verify_commit_signature(&lib.root, &lib.commit_v2, &TrustedKeys::new());
 
     assert!(result.is_err(), "unsigned commit should fail verification");
     match result {
-        Err(VcsError::SignatureVerificationFailed { commit, .. }) => {
+        Err(VcsError::SignatureVerificationFailed { commit, reason }) => {
             assert_eq!(commit, lib.commit_v2);
+            assert!(reason.contains("not signed"), "reason: {reason}");
         }
         Err(other) => panic!("expected SignatureVerificationFailed, got {other}"),
         Ok(()) => panic!("expected Err, got Ok"),
     }
 }
 
-/// Positive: `verify_commit_signature` succeeds on a commit signed with a
-/// GPG key that git can verify through its `gpg.program` configuration.
-///
-/// This test is skipped automatically when gpg is unavailable or key
-/// generation fails (e.g. restricted CI environments).
+/// Positive: `verify_commit_signature` succeeds on a commit natively signed with
+/// an SSH key, when that key is present in the trusted set. The signed commit
+/// object is constructed and signed in-process (no `gpg`/`ssh-keygen`); git is
+/// used only to store the object in the repository.
 #[test]
 fn test_signature_verification_positive() {
-    let gpg = match setup_gpg() {
-        Some(g) => g,
-        None => {
-            eprintln!("SKIP test_signature_verification_positive: gpg setup unavailable");
-            return;
-        }
-    };
-
-    // A fresh repo so we can configure gpg.program locally without touching
-    // the library or app fixtures.
     let dir = tempfile::TempDir::new().unwrap();
     let root = dir.path().to_path_buf();
-
     git_ok(&root, &["init", "-b", "main"]);
-    git_ok(&root, &["config", "user.email", "test@example.com"]);
-    git_ok(&root, &["config", "user.name", "Test Signer"]);
-    git_ok(&root, &["config", "commit.gpgsign", "false"]);
-    git_ok(&root, &["config", "user.signingkey", &gpg.fingerprint]);
-    // Point gpg.program at the wrapper so both `git commit -S` and
-    // `git verify-commit` use the isolated test keyring.
-    git_ok(
-        &root,
-        &["config", "gpg.program", gpg.wrapper_path.to_str().unwrap()],
+
+    // Store an empty tree so the commit object references a real object.
+    let tree = git_write_object(&root, "tree", b"");
+
+    let payload = format!(
+        "tree {tree}\n\
+         author Test <test@example.com> 0 +0000\n\
+         committer Test <test@example.com> 0 +0000\n\
+         \n\
+         signed commit\n"
     );
+    let sig = ssh_sign(payload.as_bytes());
+    let raw = embed_gpgsig(payload.as_bytes(), &sig);
+    let signed_sha = git_write_object(&root, "commit", &raw);
 
-    std::fs::write(root.join("signed.txt"), "signed content\n").unwrap();
-    git_ok(&root, &["add", "signed.txt"]);
+    let mut trusted = TrustedKeys::new();
+    trusted.add_ssh_openssh(TEST_SSH_PUBLIC).unwrap();
 
-    // Create a signed commit.  -S forces signing regardless of gpg.program config.
-    let sign_out = Command::new("git")
-        .arg("-C")
-        .arg(&root)
-        .args([
-            "-c",
-            "commit.gpgsign=true",
-            "commit",
-            "-S",
-            "-m",
-            "signed commit",
-        ])
-        .env("GIT_AUTHOR_NAME", "Test Signer")
-        .env("GIT_AUTHOR_EMAIL", "test@example.com")
-        .env("GIT_COMMITTER_NAME", "Test Signer")
-        .env("GIT_COMMITTER_EMAIL", "test@example.com")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .expect("git commit -S failed to start");
-
-    if !sign_out.status.success() {
-        eprintln!(
-            "SKIP test_signature_verification_positive: signed commit failed: {}",
-            String::from_utf8_lossy(&sign_out.stderr)
-        );
-        return;
-    }
-
-    let signed_sha = git_sha(&root, "HEAD");
-
-    // verify_commit_signature calls `git verify-commit` which picks up
-    // gpg.program from the repo's local config and uses our test keyring.
-    let result = verify_commit_signature(&root, &signed_sha);
+    let result = verify_commit_signature(&root, &signed_sha, &trusted);
     assert!(
         result.is_ok(),
-        "GPG-signed commit should verify successfully; got: {:?}",
+        "SSH-signed commit should verify; got: {:?}",
         result.err()
+    );
+
+    // The same commit must fail when the signing key is not trusted.
+    let untrusted = verify_commit_signature(&root, &signed_sha, &TrustedKeys::new());
+    assert!(
+        matches!(untrusted, Err(VcsError::SignatureVerificationFailed { .. })),
+        "empty trust set must reject; got {untrusted:?}"
     );
 }
 

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -186,7 +186,7 @@ Build with e.g. `cargo build --release --features enable-rustyline,no-gc`.
 | `tokio` (workspace, optional) | Single-threaded runtime + `LocalSet` driving async; enabled by `async` |
 | `cljrs-logging` (workspace) | `--debug` / `--trace` / `-X` flag handling                        |
 | `cljrs-deps` (workspace)    | `cljrs.edn` parser; `DepsConfig` / `Dependency` types             |
-| `cljrs-vcs` (workspace)     | Git subprocess helpers: `fetch_remote`, `cache_path_for_url`      |
+| `cljrs-vcs` (workspace)     | Pure-Rust (gitoxide) git helpers: `fetch_remote`, `cache_path_for_url`, native signature verification |
 | `clap` (workspace)          | CLI argument parsing                                              |
 | `miette` (workspace)        | Rich terminal error rendering                                     |
 | `tracing` / `tracing-subscriber` | Structured logging output                                    |

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -692,6 +692,7 @@ fn apply_deps_config(globals: &Arc<GlobalEnv>, cwd: &Path) {
                     .verify_commit_signatures
                     .store(true, std::sync::atomic::Ordering::Relaxed);
             }
+            globals.load_trusted_signers(&config);
             if config.enforce_native_versions {
                 globals.set_enforce_native_versions(true);
             }

--- a/docs/book/src/cli/deps.md
+++ b/docs/book/src/cli/deps.md
@@ -88,6 +88,10 @@ valid clojurust EDN:
 
  :verify-commit-signatures true
 
+ ; Keys allowed to sign versioned commits (inline key or path to a key file).
+ :trusted-signers ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5... maintainer@example.com"
+                   "keys/release-signing.asc"]
+
  ; Optional: embed a Rust crate for native interop
  :rust {:crate "."
         :init  "my_project::cljrs_init"}}
@@ -100,7 +104,8 @@ valid clojurust EDN:
 | `:paths` | vector of strings | Directories to add to the source path. Equivalent to `--src-path` on the CLI. |
 | `:deps` | map | Map from dependency name (symbol) to dependency descriptor. |
 | `:aliases` | map | Named alias maps with `:extra-paths` and `:extra-deps`. |
-| `:verify-commit-signatures` | boolean | If `true`, require GPG/SSH signatures on all versioned commits. |
+| `:verify-commit-signatures` | boolean | If `true`, require valid PGP/SSH signatures (verified natively) on all versioned commits. |
+| `:trusted-signers` | vector of strings | Public keys allowed to sign versioned commits. Each entry is an inline key (armored PGP or OpenSSH) or a path to a key file relative to `cljrs.edn`. |
 | `:rust` | map | Embedded Rust crate for native interop. See [Rust Interop](../rust-interop/index.md). |
 
 #### `:rust` key

--- a/docs/book/src/cli/index.md
+++ b/docs/book/src/cli/index.md
@@ -68,9 +68,10 @@ cljrs --gc-stats gc.log run my-program.cljrs # stats to file
 
 ### `--verify-commit-signatures`
 
-Require valid GPG or SSH signatures on every versioned commit before executing
-historical code. Off by default. Can also be enabled per-project in `cljrs.edn`
-via `:verify-commit-signatures true`.
+Require valid PGP or SSH signatures on every versioned commit before executing
+historical code. Verification is native (no `git`/`gpg` subprocess) and checks
+the signature against the keys listed in `:trusted-signers`. Off by default. Can
+also be enabled per-project in `cljrs.edn` via `:verify-commit-signatures true`.
 
 ## Project configuration: `cljrs.edn`
 

--- a/docs/book/src/language/versioned-symbols.md
+++ b/docs/book/src/language/versioned-symbols.md
@@ -128,8 +128,11 @@ error: dependency 'my.lib' is not cached locally.
 
 When `--verify-commit-signatures` is passed on the CLI (or
 `:verify-commit-signatures true` is set in `cljrs.edn`), clojurust verifies
-that every accessed versioned commit carries a valid GPG or SSH signature
-before executing its code.
+that every accessed versioned commit carries a valid PGP or SSH signature
+before executing its code. Verification is native (no `git`/`gpg`/`ssh-keygen`
+subprocess): the signature must be made by a key listed in the project's
+`:trusted-signers`. With verification on but no trusted signers configured, no
+commit can be verified and resolution fails closed.
 
 ## Notes
 

--- a/docs/gitoxide-native-vcs-plan.md
+++ b/docs/gitoxide-native-vcs-plan.md
@@ -1,0 +1,190 @@
+# Plan: Native git (gitoxide) + native commit-signature verification in `cljrs-vcs`
+
+## Context
+
+`cljrs-vcs` is a thin wrapper around the `git` CLI for versioned symbol
+resolution. Every git operation shells out to the `git` binary, and commit
+signature verification shells out to `git verify-commit` (which in turn invokes
+`gpg` or `ssh-keygen`). This makes the toolchain depend on an external `git`
+install at runtime, with no pure-Rust fallback, and inherits git's
+keyring-based trust model implicitly.
+
+This change replaces the git subprocess calls with the **gitoxide** (`gix`)
+pure-Rust git implementation, and replaces signature verification with **native
+PGP/SSH signature checking** against a **cljrs-managed set of trusted keys**.
+The outcome: `cljrs` no longer requires the `git` binary (HTTPS remotes are
+fully pure-Rust), and signature trust is explicit and self-contained rather than
+delegated to the user's GPG keyring.
+
+### Decisions (confirmed with user)
+- **Trust model:** cljrs-managed trusted keys (declared in `cljrs.edn`), not the
+  user's GPG keyring / SSH `allowed_signers`.
+- **Transport:** HTTPS only at first, pure-Rust (rustls). `ssh://` remotes return
+  a clear error (no `ssh` binary spawn). Pure-Rust SSH sync is deferred to a
+  later phase (see Future work).
+- **Scope:** also migrate `cljrs-dylib`'s `checkout_at` worktree checkout off the
+  git binary.
+
+## Current shelling-out sites
+
+`crates/cljrs-vcs/src/lib.rs`:
+| Fn | git call | gitoxide replacement |
+|---|---|---|
+| `find_repo_root` (47) | `rev-parse --show-toplevel` | `gix::discover` + `work_dir()` |
+| `get_file_at_commit` (73) | `show <sha>:<path>` | rev-parse → peel to commit → tree → blob |
+| `fetch_remote` (148/160/173) | `fetch`, `clone --bare`, `cat-file -e` | `gix::prepare_clone_bare` + fetch + object lookup |
+| `verify_commit_signature` (197) | `verify-commit` | native PGP/SSH verification |
+
+`crates/cljrs-dylib/src/lib.rs`:
+| Fn | git call | replacement |
+|---|---|---|
+| `checkout_at` (203) | `clone` (local) + `checkout <sha>` | local `gix` clone + `gix-worktree-state` checkout of the pinned tree |
+
+Callers (signatures must be preserved): `cljrs-env/src/versioned.rs` (`find_repo_root`,
+`get_file_at_commit`), `cljrs-env/src/loader.rs` (`find_repo_root`),
+`cljrs-env/src/env.rs:527` (`verify_commit_signature`), `cljrs/src/main.rs:1099/1140`
+(`fetch_remote`, `cache_path_for_url`), `cljrs-dylib/src/lib.rs:150` (`fetch_remote`).
+
+## Approach
+
+### 1. Dependencies (`Cargo.toml` workspace + `cljrs-vcs/Cargo.toml`)
+Add to `[workspace.dependencies]` and reference with `{ workspace = true }`:
+- `gix` with a minimal feature set: `blocking-http-transport-reqwest-rust-tls`
+  (HTTPS fetch/clone over rustls, consistent with `cljrs-net`'s rustls usage),
+  `revision` (rev-parse), and the object/worktree access that ships in the
+  default features. Disable default features and enable only what is needed to
+  keep the dependency lean; pin an exact version like the other deps.
+- `gix-worktree-state` (or use `gix`'s checkout entry point) for the dylib
+  worktree checkout.
+- `pgp` (rPGP, pure-Rust OpenPGP) for PGP signature verification.
+- `ssh-key` with the `ed25519`/`p256`/`rsa` + signature features for SSHSIG
+  (the `-----BEGIN SSH SIGNATURE-----` format git uses for SSH-signed commits).
+
+Rationale for rPGP + `ssh-key`: both are pure-Rust and align with the
+workspace's existing pure-Rust crypto stance (rustls/ring, blake3). Avoid
+`sequoia-openpgp` (pulls C/nettle by default).
+
+### 2. Rewrite `crates/cljrs-vcs/src/lib.rs` git operations with `gix`
+Keep all public function signatures and `VcsError` variants unchanged so callers
+compile untouched. Preserve `is_valid_commit_hash` validation guards.
+
+- **`find_repo_root`**: `gix::discover(start)` → `repo.workdir()` (map to
+  `Option<PathBuf>`; `None` when discovery fails). Keep the file→parent
+  normalization.
+- **`get_file_at_commit`**: `gix::open(repo_root)` → `repo.rev_parse_single(commit)`
+  → `.object()?.peel_to_commit()?.tree()?` → `lookup_entry_by_path(rel_path)`.
+  Missing entry → `PathNotFound`; unknown rev → `CommitNotFound`; non-UTF-8 blob
+  → `Utf8`. Map gix errors to the existing variants (add `#[from]`/`map_err`
+  conversions in `VcsError`; do not change the public variant set if avoidable —
+  fold gix errors into `Io`/`CommitNotFound`/`PathNotFound`).
+- **`fetch_remote`**: keep the URL→slug cache path logic and the `repo_dir.exists()`
+  branch. New repo → `gix::prepare_clone_bare(url, &repo_dir)` then drive the
+  fetch; existing repo → open and fetch the default remote. After fetch, confirm
+  the sha is present via `repo.find_object(oid)` / `repo.objects.exists(oid)` →
+  `CommitNotFound` when absent. For `ssh://`/`git@` URLs return a clear `Io`/new
+  error (HTTPS-only decision). Keep `cache_root`/`cache_path_for_url` as-is.
+
+### 3. Native signature verification (`crates/cljrs-vcs/src/lib.rs` + new module)
+Replace `verify_commit_signature` body. New helper module (e.g.
+`src/signature.rs`) with:
+- **Extract signature + signed payload from the commit object.** Read the commit
+  via `gix` as raw bytes; use `gix_object::CommitRef` to read the `gpgsig` extra
+  header (the armored signature) and reconstruct the *signed payload* = the
+  commit object text with the `gpgsig` header removed (this is exactly what git
+  signs). gitoxide exposes the extra headers; the payload reconstruction is the
+  canonical "commit without gpgsig" serialization.
+- **Dispatch by armor banner:** `-----BEGIN PGP SIGNATURE-----` → rPGP path;
+  `-----BEGIN SSH SIGNATURE-----` → `ssh-key::SshSig` path. No signature →
+  `SignatureVerificationFailed { reason: "commit is not signed" }`.
+- **Verify against cljrs-managed trusted keys.** New API:
+  `verify_commit_signature(repo_root, commit, trusted: &TrustedKeys) -> VcsResult<()>`
+  where `TrustedKeys` holds parsed PGP public keys and SSH public keys. A valid
+  signature whose key is **not** in `trusted` → `SignatureVerificationFailed`
+  with reason "signing key not in trusted set". (This changes the function
+  signature — see §5 for threading `TrustedKeys` through callers.)
+
+### 4. Trusted-keys configuration (`crates/cljrs-deps`)
+Add a field to `DepsConfig` (`crates/cljrs-deps/src/lib.rs:115`) e.g.
+`trusted_signers: Vec<TrustedSigner>` and parse a new `cljrs.edn` key
+(e.g. `:trusted-signers`) in `crates/cljrs-deps/src/parse.rs` (alongside the
+existing `:verify-commit-signatures` handling at `parse.rs:56`). Each entry is
+either an inline armored public key or a path to a key file (PGP `.asc` / SSH
+`.pub`). Provide a constructor that loads these into the `cljrs-vcs::TrustedKeys`
+type. Document the field in `crates/cljrs-deps/README.md`.
+
+### 5. Thread `TrustedKeys` to the verifier
+`cljrs-env/src/env.rs:517` (`check_commit_signature`) currently calls
+`cljrs_vcs::verify_commit_signature(repo_root, commit)`. Store the loaded
+`TrustedKeys` on the env/globals (next to `verify_commit_signatures: AtomicBool`)
+when the config is parsed, and pass it into the verifier. Same for the AOT path
+in `crates/cljrs-compiler/src/aot.rs:413`. Preserve the per-`(repo_root, commit)`
+success cache.
+
+### 6. Migrate `cljrs-dylib` `checkout_at` (`crates/cljrs-dylib/src/lib.rs:203`)
+Replace the local `git clone` + `git checkout <sha>` with: open the bare repo
+with `gix`, resolve the commit's tree, and check it out into `dest` using
+`gix-worktree-state` (write the index + materialize files). The
+`dest.join(".git").exists()` short-circuit becomes a check for an existing
+populated checkout (e.g. a sentinel file or `dest` non-empty). No network — this
+is a local materialization.
+
+### 7. READMEs & docs
+Update `crates/cljrs-vcs/README.md` (no longer "shells out to git"; document
+gix + native signature verification + `TrustedKeys`), `crates/cljrs/README.md`,
+`crates/cljrs-dylib/README.md`, `crates/cljrs-deps/README.md`, and the
+`cljrs-vcs` rows in `VERSIONING.md`. Per CLAUDE.md, update each crate README in
+the same commit as the code change.
+
+## Critical files
+- `crates/cljrs-vcs/Cargo.toml`, `crates/cljrs-vcs/src/lib.rs`, new `src/signature.rs`
+- `Cargo.toml` (workspace deps)
+- `crates/cljrs-deps/src/lib.rs`, `crates/cljrs-deps/src/parse.rs`
+- `crates/cljrs-env/src/env.rs`, `crates/cljrs-compiler/src/aot.rs`
+- `crates/cljrs-dylib/src/lib.rs`
+- `crates/cljrs-vcs/tests/versioning_harness.rs` (signature tests, see below)
+- READMEs listed in §7
+
+## Test changes
+`crates/cljrs-vcs/tests/versioning_harness.rs` currently builds GPG-signed
+fixtures via the `gpg` binary (`setup_gpg`, lines 176–271). Replace with native
+fixtures:
+- Generate an Ed25519 key in-test with `ssh-key`, build the SSHSIG over a commit
+  payload natively, and write the signed commit object (no `gpg`/`ssh-keygen`).
+  Add the public key to a `TrustedKeys` and assert `verify_commit_signature`
+  passes; assert an unsigned commit and an untrusted-key commit both fail.
+- The non-signature git-operation tests still create fixtures with the `git`
+  binary in test setup; that is acceptable (tests already depend on git for
+  fixture creation). Optionally migrate fixture creation to `gix` later — out of
+  scope here.
+
+## Verification
+1. `cargo build` and `cargo clippy --workspace` — clean.
+2. `cargo test -p cljrs-vcs` — git-op tests pass via gix; native signature
+   tests (positive/negative/untrusted) pass with **no `git`/`gpg` binary needed**
+   for the signature path.
+3. `cargo test -p cljrs-deps` — `:trusted-signers` parsing.
+4. `cargo test -p cljrs-env -p cljrs-dylib` — versioned resolution + pinned
+   native checkout still work.
+5. Manual end-to-end: a `cljrs.edn` with an https git dep + `:verify-commit-signatures true`
+   and a `:trusted-signers` entry → `cljrs run` fetches via gix and verifies
+   natively; with the binary `git` removed from `PATH`, HTTPS fetch + verify
+   still succeed; an `ssh://` dep returns the clear "https-only" error.
+
+## Future work: pure-Rust SSH transport (later phase)
+HTTPS-only is the starting point. A follow-up phase should investigate wiring a
+pure-Rust SSH client — `russh` is the leading candidate — into gitoxide as a
+custom transport so `ssh://`/`git@` remotes fetch without spawning the system
+`ssh` binary. gitoxide's transport layer is pluggable (`gix-transport`'s
+`client::Transport` trait), but it has no built-in pure-Rust SSH backend, so
+this means implementing a `russh`-backed transport that speaks the git
+pack-protocol over an SSH channel (invoking the remote `git-upload-pack`),
+including host-key and key-auth handling. Non-trivial; scoped as its own phase.
+Until then, `ssh://` remotes return the clear "https-only" error from §2.
+
+## Risks / notes
+- `gix` HTTPS fetch feature surface is the main dependency-weight risk; pin the
+  version and enable the minimal feature set.
+- Reconstructing the exact signed payload (commit minus `gpgsig`) must be
+  byte-exact or verification fails — cover with the round-trip native test.
+- Public API change: `verify_commit_signature` gains a `TrustedKeys` parameter;
+  one caller (`cljrs-env/src/env.rs`) and the AOT path must be updated together.


### PR DESCRIPTION
Add an implementation plan for replacing the git-binary subprocess calls
in cljrs-vcs (and cljrs-dylib's checkout) with the pure-Rust gitoxide
(gix) stack, and for verifying commit signatures natively (PGP via rPGP,
SSH via ssh-key) against a cljrs-managed set of trusted keys declared in
cljrs.edn. HTTPS-only transport at first; pure-Rust SSH sync is noted as
later-phase future work.

https://claude.ai/code/session_01Pze2eW5efJq2XDtsffybdN