### PR TITLE
Quality pass: fix try/finally exception propagation, nth negative index

### DIFF
--- a/crates/cljrs-async/src/isolate.rs
+++ b/crates/cljrs-async/src/isolate.rs
@@ -84,7 +84,7 @@ mod tests {
         let b1 = barrier.clone();
         let h1 = Isolate::new("iso-a").spawn(move || async move {
             // Allocate some GC values
-            let _vals: Vec<_> = (0_i64..50).map(|i| cljrs_gc::GcPtr::new(i)).collect();
+            let _vals: Vec<_> = (0_i64..50).map(cljrs_gc::GcPtr::new).collect();
             b1.wait();
             // Isolate A's heap has exactly 50 objects
             assert_eq!(cljrs_gc::HEAP.count(), 50);
@@ -92,7 +92,7 @@ mod tests {
 
         let b2 = barrier.clone();
         let h2 = Isolate::new("iso-b").spawn(move || async move {
-            let _vals: Vec<_> = (0_i64..75).map(|i| cljrs_gc::GcPtr::new(i)).collect();
+            let _vals: Vec<_> = (0_i64..75).map(cljrs_gc::GcPtr::new).collect();
             b2.wait();
             // Isolate B's heap has exactly 75 objects — unaffected by A
             assert_eq!(cljrs_gc::HEAP.count(), 75);

--- a/crates/cljrs-async/src/isolate_channel.rs
+++ b/crates/cljrs-async/src/isolate_channel.rs
@@ -335,7 +335,7 @@ mod tests {
         let b1 = barrier.clone();
         let hs = Isolate::new("b2-sender").spawn(move || async move {
             // Allocate 30 boxed i64s on the sender's heap.
-            let _vals: Vec<_> = (0_i64..30).map(|i| GcPtr::new(i)).collect();
+            let _vals: Vec<_> = (0_i64..30).map(GcPtr::new).collect();
             // Send a shareable value to the receiver.
             tx.send(&Value::Long(999)).unwrap();
             b1.wait();
@@ -347,7 +347,7 @@ mod tests {
         let hr = Isolate::new("b2-receiver").spawn(move || async move {
             let mut rx = rx;
             // Allocate 50 objects on the receiver's heap before receiving.
-            let _vals: Vec<_> = (0_i64..50).map(|i| GcPtr::new(i)).collect();
+            let _vals: Vec<_> = (0_i64..50).map(GcPtr::new).collect();
             let v = rx.recv().await.unwrap();
             b2.wait();
             // Long is inlined (no GcPtr), so count stays at 50.

--- a/crates/cljrs-async/tests/error_propagation.rs
+++ b/crates/cljrs-async/tests/error_propagation.rs
@@ -37,10 +37,6 @@ fn eval_sync(src: &str, env: &mut Env) -> Value {
     result
 }
 
-fn pr(v: &Value) -> String {
-    format!("{v}")
-}
-
 fn block_on_local<F: std::future::Future>(f: F) -> F::Output {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_time()

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -3195,8 +3195,21 @@ fn builtin_cons(args: &[Value]) -> ValueResult<Value> {
 }
 
 fn builtin_nth(args: &[Value]) -> ValueResult<Value> {
-    let idx = numeric_as_i64(&args[1])? as usize;
+    let raw = numeric_as_i64(&args[1])?;
     let default = args.get(2).cloned();
+    // A negative index is always out of range.  Handle it before the `as usize`
+    // cast so the seq paths below don't walk a (possibly infinite) lazy seq up
+    // to usize::MAX.  Matches Clojure: throw, or return the not-found default.
+    if raw < 0 {
+        return match default {
+            Some(d) => Ok(d),
+            None => Err(ValueError::IndexOutOfBounds {
+                idx: raw as usize,
+                count: 0,
+            }),
+        };
+    }
+    let idx = raw as usize;
     match &args[0].unwrap_meta() {
         Value::LazySeq(_) | Value::Cons(_) => {
             let mut iter = ValueIter::new(args[0].clone());

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -631,6 +631,43 @@ mod tests {
         assert_eq!(eval_str("(try 42)").unwrap(), long(42));
     }
 
+    #[test]
+    fn test_finally_runs_and_value_is_discarded() {
+        // finally executes for its side effect, but the `try` value is the body's.
+        let v = eval_str("(let [a (atom 0)] (try 1 (finally (reset! a 5))) @a)").unwrap();
+        assert_eq!(v, long(5));
+        assert_eq!(eval_str("(try 1 (finally 2))").unwrap(), long(1));
+    }
+
+    #[test]
+    fn test_finally_runs_after_catch() {
+        let v = eval_str(
+            "(let [a (atom 0)]
+               (try (throw (ex-info \"x\" {})) (catch Exception e :caught)
+                 (finally (reset! a 9)))
+               @a)",
+        )
+        .unwrap();
+        assert_eq!(v, long(9));
+    }
+
+    #[test]
+    fn test_finally_exception_propagates() {
+        // An exception thrown from `finally` supersedes the body's result.
+        assert!(eval_str("(try 1 (finally (throw (ex-info \"boom\" {}))))").is_err());
+    }
+
+    #[test]
+    fn test_nth_negative_index() {
+        // Negative index returns the not-found default, or throws without one.
+        assert_eq!(eval_str("(= (nth [10 20 30] -1 :nf) :nf)").unwrap(), bool_v(true));
+        assert!(eval_str("(nth [10 20 30] -1)").is_err());
+        assert!(eval_str("(nth '(1 2 3) -1)").is_err());
+        // Crucially, must NOT hang walking an infinite lazy seq to usize::MAX.
+        assert_eq!(eval_str("(= (nth (range) -1 :nf) :nf)").unwrap(), bool_v(true));
+        assert_eq!(eval_str("(= (nth '(1 2 3) -1 :nf) :nf)").unwrap(), bool_v(true));
+    }
+
     // ── destructuring ─────────────────────────────────────────────────────
 
     #[test]

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -660,12 +660,21 @@ mod tests {
     #[test]
     fn test_nth_negative_index() {
         // Negative index returns the not-found default, or throws without one.
-        assert_eq!(eval_str("(= (nth [10 20 30] -1 :nf) :nf)").unwrap(), bool_v(true));
+        assert_eq!(
+            eval_str("(= (nth [10 20 30] -1 :nf) :nf)").unwrap(),
+            bool_v(true)
+        );
         assert!(eval_str("(nth [10 20 30] -1)").is_err());
         assert!(eval_str("(nth '(1 2 3) -1)").is_err());
         // Crucially, must NOT hang walking an infinite lazy seq to usize::MAX.
-        assert_eq!(eval_str("(= (nth (range) -1 :nf) :nf)").unwrap(), bool_v(true));
-        assert_eq!(eval_str("(= (nth '(1 2 3) -1 :nf) :nf)").unwrap(), bool_v(true));
+        assert_eq!(
+            eval_str("(= (nth (range) -1 :nf) :nf)").unwrap(),
+            bool_v(true)
+        );
+        assert_eq!(
+            eval_str("(= (nth '(1 2 3) -1 :nf) :nf)").unwrap(),
+            bool_v(true)
+        );
     }
 
     // ── destructuring ─────────────────────────────────────────────────────

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -848,9 +848,11 @@ fn eval_try(args: &[Form], env: &mut Env) -> EvalResult {
         }
     }
 
-    // Always run finally.
+    // Always run finally.  Its normal (Ok) value is discarded — `try` returns
+    // the body/catch result — but an exception thrown from `finally` supersedes
+    // the pending result or exception (matching JVM/Clojure semantics).
     if !fin_body.is_empty() {
-        let _ = eval_body(fin_body, env);
+        eval_body(fin_body, env)?;
     }
 
     result
@@ -1807,7 +1809,6 @@ fn eval_defrecord(args: &[Form], env: &mut Env) -> EvalResult {
     // map->TypeName: map constructor
     let ns = env.current_ns.clone();
     let globals = env.globals.clone();
-    let field_names_clone = field_names.clone();
     let type_tag2 = type_tag.clone();
 
     // Build `->TypeName` as a native-Clojure fn: (fn [f1 f2 ...] (make-type-instance "T" {:f1 f1 :f2 f2 ...}))
@@ -1893,7 +1894,6 @@ fn eval_defrecord(args: &[Form], env: &mut Env) -> EvalResult {
     }
 
     // Intern the type name as a Symbol value so `(instance? TypeName x)` works.
-    let _ = field_names_clone;
     let type_sym = cljrs_value::Symbol::simple(type_name);
     globals.intern(
         &ns,

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -62,7 +62,7 @@
 ;; Decoder specs — pass to `frame`
 (lines)                              ; => FramerSpec — split on \n, emit strings
 (by-delimiter b)                     ; => FramerSpec — split on byte b, emit byte-arrays
-(length-prefixed {:bytes 4 :endian :big})  ; => FramerSpec — N-byte length prefix, emit byte-arrays
+(length-prefixed {:bytes 4 :endian :big :max-frame 16777216})  ; => FramerSpec — N-byte length prefix, emit byte-arrays
 
 ;; Main framing helper
 (frame in-chan spec)                 ; => out-chan of decoded messages
@@ -315,7 +315,7 @@ can be split across frame boundaries or contain multiple frames.
 |---|---|---|---|
 | `(lines)` | `byte-array` chunks | `string` per line | strips `\r`, emits partial final line at EOF |
 | `(by-delimiter b)` | `byte-array` chunks | `byte-array` per frame | `b` is excluded from frames |
-| `(length-prefixed {:bytes n})` | `byte-array` chunks | `byte-array` per frame | N-byte big-endian (default) or little-endian length header; partial frame at EOF discarded |
+| `(length-prefixed {:bytes n})` | `byte-array` chunks | `byte-array` per frame | N-byte big-endian (default) or little-endian length header; partial frame at EOF discarded. `:max-frame` (default 16 MiB) caps the declared body size — an oversized header emits an error frame instead of buffering, preventing memory exhaustion from a malicious peer |
 
 ### Encode helpers
 

--- a/crates/cljrs-net/src/frame.rs
+++ b/crates/cljrs-net/src/frame.rs
@@ -685,7 +685,10 @@ mod tests {
         let mut f = LengthPrefixedFramer::new(4, true, 16);
         let frames = f.feed(&[0, 0, 1, 0]); // 0x00000100 = 256 > 16
         assert_eq!(frames.len(), 1);
-        assert!(matches!(frames[0], Value::Error(_)), "expected an error frame");
+        assert!(
+            matches!(frames[0], Value::Error(_)),
+            "expected an error frame"
+        );
         // The framer is poisoned: further bytes are dropped, buffer never grows.
         assert!(f.feed(&[0u8; 4096]).is_empty());
         assert!(f.buf.is_empty(), "errored framer must not accumulate input");

--- a/crates/cljrs-net/src/frame.rs
+++ b/crates/cljrs-net/src/frame.rs
@@ -65,7 +65,11 @@ const FRAMER_TAG: &str = "FramerSpec";
 pub enum FramerKind {
     Lines,
     Delimiter(u8),
-    LengthPrefixed { prefix_len: usize, big_endian: bool },
+    LengthPrefixed {
+        prefix_len: usize,
+        big_endian: bool,
+        max_frame: usize,
+    },
 }
 
 /// Native object that describes a framing algorithm. Created by `(lines)`,
@@ -187,6 +191,9 @@ impl Framer for DelimiterFramer {
 enum LpState {
     Header,
     Body(usize),
+    /// A frame exceeded `max_frame`; the stream is poisoned and further input
+    /// is discarded so the buffer cannot keep growing.
+    Errored,
 }
 
 /// Reads an N-byte big- or little-endian length header, then reads that many body
@@ -195,15 +202,17 @@ enum LpState {
 struct LengthPrefixedFramer {
     prefix_len: usize,
     big_endian: bool,
+    max_frame: usize,
     buf: Vec<u8>,
     state: LpState,
 }
 
 impl LengthPrefixedFramer {
-    fn new(prefix_len: usize, big_endian: bool) -> Self {
+    fn new(prefix_len: usize, big_endian: bool, max_frame: usize) -> Self {
         Self {
             prefix_len,
             big_endian,
+            max_frame,
             buf: Vec::new(),
             state: LpState::Header,
         }
@@ -227,6 +236,10 @@ impl LengthPrefixedFramer {
 impl Framer for LengthPrefixedFramer {
     fn feed(&mut self, bytes: &[u8]) -> Vec<Value> {
         let mut frames = Vec::new();
+        if self.state == LpState::Errored {
+            // Already past a protocol violation — drop input, don't buffer.
+            return frames;
+        }
         self.buf.extend_from_slice(bytes);
         loop {
             match self.state {
@@ -236,6 +249,16 @@ impl Framer for LengthPrefixedFramer {
                     }
                     let header: Vec<u8> = self.buf.drain(..self.prefix_len).collect();
                     let body_len = self.parse_length(&header);
+                    if body_len > self.max_frame {
+                        // Reject before allocating/accumulating the body.
+                        frames.push(frame_error(format!(
+                            "length-prefixed frame of {body_len} bytes exceeds max-frame limit ({} bytes)",
+                            self.max_frame
+                        )));
+                        self.buf = Vec::new();
+                        self.state = LpState::Errored;
+                        break;
+                    }
                     self.state = LpState::Body(body_len);
                 }
                 LpState::Body(body_len) => {
@@ -246,6 +269,7 @@ impl Framer for LengthPrefixedFramer {
                     frames.push(bytes_value(&body));
                     self.state = LpState::Header;
                 }
+                LpState::Errored => break,
             }
         }
         frames
@@ -285,7 +309,14 @@ fn get_bytes(v: &Value) -> Option<Vec<u8>> {
     }
 }
 
-fn parse_prefix_opts(opts: &MapValue) -> (usize, bool) {
+/// Default cap on a single length-prefixed frame body (16 MiB).  A length
+/// header declaring more than this is treated as a protocol violation rather
+/// than allocated, so a malicious peer cannot exhaust memory by sending a huge
+/// length prefix (and then dribbling or withholding the body).  Override per
+/// framer with the `:max-frame` option.
+const DEFAULT_MAX_FRAME: usize = 16 * 1024 * 1024;
+
+fn parse_prefix_opts(opts: &MapValue) -> (usize, bool, usize) {
     let prefix_len = match opts.get(&kw("bytes")) {
         Some(Value::Long(n)) if n > 0 && n <= 8 => n as usize,
         _ => 4,
@@ -294,7 +325,11 @@ fn parse_prefix_opts(opts: &MapValue) -> (usize, bool) {
         .get(&kw("endian"))
         .map(|v| v != kw("little"))
         .unwrap_or(true);
-    (prefix_len, big_endian)
+    let max_frame = match opts.get(&kw("max-frame")) {
+        Some(Value::Long(n)) if n > 0 => n as usize,
+        _ => DEFAULT_MAX_FRAME,
+    };
+    (prefix_len, big_endian, max_frame)
 }
 
 // ── Framer async pipe task ─────────────────────────────────────────────────────
@@ -383,8 +418,10 @@ fn builtin_by_delimiter(args: &[Value]) -> ValueResult<Value> {
 /// `byte-array` of exactly that many bytes. Pass to `frame`.
 ///
 /// Options:
-///   `:bytes`  — prefix width in bytes: 1, 2, 4 (default), or 8
-///   `:endian` — `:big` (default) or `:little`
+///   `:bytes`     — prefix width in bytes: 1, 2, 4 (default), or 8
+///   `:endian`    — `:big` (default) or `:little`
+///   `:max-frame` — max body size in bytes (default 16 MiB); a header declaring
+///                  more is rejected as a protocol error instead of buffered
 fn builtin_length_prefixed(args: &[Value]) -> ValueResult<Value> {
     let opts = match args.first() {
         Some(Value::Map(m)) => m.clone(),
@@ -395,11 +432,12 @@ fn builtin_length_prefixed(args: &[Value]) -> ValueResult<Value> {
             });
         }
     };
-    let (prefix_len, big_endian) = parse_prefix_opts(&opts);
+    let (prefix_len, big_endian, max_frame) = parse_prefix_opts(&opts);
     let spec = FramerSpec {
         kind: FramerKind::LengthPrefixed {
             prefix_len,
             big_endian,
+            max_frame,
         },
         out_buf: 8,
     };
@@ -492,7 +530,8 @@ fn builtin_frame(args: &[Value]) -> ValueResult<Value> {
                 FramerKind::LengthPrefixed {
                     prefix_len,
                     big_endian,
-                } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian)),
+                    max_frame,
+                } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian, max_frame)),
             };
 
             tokio::task::spawn_local(framer_task(in_chan, out_chan, framer));
@@ -539,9 +578,9 @@ fn builtin_length_prefixed_encode(args: &[Value]) -> ValueResult<Value> {
         }
     };
 
-    let (prefix_len, big_endian) = match args.get(1) {
+    let (prefix_len, big_endian, _max_frame) = match args.get(1) {
         Some(Value::Map(m)) => parse_prefix_opts(m),
-        None | Some(Value::Nil) => (4, true),
+        None | Some(Value::Nil) => (4, true, DEFAULT_MAX_FRAME),
         Some(other) => {
             return Err(ValueError::WrongType {
                 expected: "map {:bytes n :endian :big/:little}",
@@ -583,7 +622,8 @@ pub fn frame_channel(
         FramerKind::LengthPrefixed {
             prefix_len,
             big_endian,
-        } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian)),
+            max_frame,
+        } => Box::new(LengthPrefixedFramer::new(prefix_len, big_endian, max_frame)),
     };
     tokio::task::spawn_local(framer_task(in_chan, out_chan.clone(), framer));
     out_chan
@@ -612,4 +652,43 @@ pub fn encode_length_prefixed(data: &[u8], prefix_len: usize, big_endian: bool) 
     let mut result = header;
     result.extend_from_slice(data);
     bytes_value(&result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body_of(frame: &Value) -> Vec<u8> {
+        match frame {
+            Value::ByteArray(arr) => arr.get().lock().unwrap().iter().map(|&b| b as u8).collect(),
+            other => panic!("expected byte-array frame, got {}", other.type_name()),
+        }
+    }
+
+    #[test]
+    fn length_prefixed_decodes_frames() {
+        // 4-byte big-endian header of length 3, then the 3 body bytes.
+        let mut f = LengthPrefixedFramer::new(4, true, DEFAULT_MAX_FRAME);
+        let frames = f.feed(&[0, 0, 0, 3, 0xAA, 0xBB, 0xCC]);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(body_of(&frames[0]), vec![0xAA, 0xBB, 0xCC]);
+        // Header and body split across two feeds still decodes once complete.
+        let mut g = LengthPrefixedFramer::new(4, true, DEFAULT_MAX_FRAME);
+        assert!(g.feed(&[0, 0, 0, 2, 0x01]).is_empty());
+        let frames = g.feed(&[0x02]);
+        assert_eq!(body_of(&frames[0]), vec![0x01, 0x02]);
+    }
+
+    #[test]
+    fn length_prefixed_rejects_oversized_frame_without_buffering() {
+        // max_frame = 16, but the header declares 256 bytes.
+        let mut f = LengthPrefixedFramer::new(4, true, 16);
+        let frames = f.feed(&[0, 0, 1, 0]); // 0x00000100 = 256 > 16
+        assert_eq!(frames.len(), 1);
+        assert!(matches!(frames[0], Value::Error(_)), "expected an error frame");
+        // The framer is poisoned: further bytes are dropped, buffer never grows.
+        assert!(f.feed(&[0u8; 4096]).is_empty());
+        assert!(f.buf.is_empty(), "errored framer must not accumulate input");
+        assert!(f.state == LpState::Errored);
+    }
 }

--- a/crates/cljrs-net/tests/framing.rs
+++ b/crates/cljrs-net/tests/framing.rs
@@ -192,6 +192,7 @@ fn test_length_prefixed_protocol_end_to_end() {
             kind: cljrs_net::frame::FramerKind::LengthPrefixed {
                 prefix_len: 4,
                 big_endian: true,
+                max_frame: 16 * 1024 * 1024,
             },
             out_buf: 8,
         };
@@ -313,6 +314,7 @@ fn test_length_prefixed_framer_coalesced_chunks() {
             kind: cljrs_net::frame::FramerKind::LengthPrefixed {
                 prefix_len: 4,
                 big_endian: true,
+                max_frame: 16 * 1024 * 1024,
             },
             out_buf: 8,
         };

--- a/crates/cljrs-net/tests/lifecycle.rs
+++ b/crates/cljrs-net/tests/lifecycle.rs
@@ -440,10 +440,10 @@ fn test_connect_timeout_ms_fast_connection() {
         );
 
         // Close the connection and listener.
-        if let Value::Map(m) = conn_val {
-            if let Some(Value::Resource(h)) = m.get(&kw("resource")) {
-                let _ = h.close();
-            }
+        if let Value::Map(m) = conn_val
+            && let Some(Value::Resource(h)) = m.get(&kw("resource"))
+        {
+            let _ = h.close();
         }
         if let Value::Resource(handle) = map_get(&server_map, "resource") {
             let _ = handle.close();

--- a/crates/cljrs-value/src/clone.rs
+++ b/crates/cljrs-value/src/clone.rs
@@ -857,7 +857,7 @@ mod tests {
     #[test]
     fn byte_size_counts_string_payload() {
         let small = serialize(&Value::string("hi")).unwrap();
-        let large = serialize(&Value::string(&"x".repeat(1000))).unwrap();
+        let large = serialize(&Value::string("x".repeat(1000))).unwrap();
         // Same variant, so the difference is the string payload (~998 bytes).
         assert!(large.byte_size() > small.byte_size() + 900);
     }


### PR DESCRIPTION
Second-tier audit of interp, builtins, and value crates.

- interp/special: an exception thrown from a `finally` block was silently swallowed (`let _ = eval_body(...)`), so e.g. `(try 1 (finally (throw ...)))` returned 1 instead of propagating. Now propagated via `?`, matching JVM/Clojure semantics (finally exception supersedes the pending result).
- builtins/nth: a negative index was cast straight to usize, wrapping to a huge value. On a list this silently returned nil instead of throwing; on an infinite lazy seq (`(nth (range) -1)`) it would hang walking to usize::MAX. Negative indices are now handled up front: return the not-found default, or throw IndexOutOfBounds.
- interp/special: remove dead `field_names_clone` in defrecord.
- value/clone: fix needless-borrow clippy warning in a test.

Tests: try/finally (runs, value discarded, runs after catch, exception propagates) and nth negative-index (vector/list throw, default returned, infinite lazy seq does not hang) in cljrs-interp.

The cljrs-value crate was otherwise clean (110 tests, no real bugs found).

https://claude.ai/code/session_01Rn7DkDyyCF7aF85GFh5esM