### PR TITLE
Migrate var roots to the shared Arc<ArcSwap<SharedValue>> mechanism (#171)

### DIFF
--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -48,7 +48,10 @@ Done (Phases A–H, A2, B1):
   a `Value` to a `Send + Sync` wire form (`SerializedValue`, defined in `cljrs-value::clone`);
   `IsolateReceiver::recv`/`try_recv` deserializes it into the receiver's GC heap. Non-shareable
   values (mutable state, closures, native resources) are rejected at send time with a typed
-  `CloneError`. The sender may be cloned (multi-producer); the receiver must stay on its isolate
+  `CloneError`. Phase B3 (issue #171): a `Var` with a *promotable* (or unbound) root crosses by
+  sharing its `shared_root` cell, so a value `def`'d in one isolate is observable by value in
+  another; a var bound to a non-promotable root (closure/resource) stays isolate-local and is
+  rejected like any other closure. The sender may be cloned (multi-producer); the receiver must stay on its isolate
   thread (single-consumer). `GcPtr`'s `!Send` bound makes pointer-sharing a compile error —
   the channel is the only sanctioned crossing point. Each accepted send is
   **metered** into the process-global `cljrs_gc::GC_STATS` via

--- a/crates/cljrs-async/src/isolate_channel.rs
+++ b/crates/cljrs-async/src/isolate_channel.rs
@@ -305,6 +305,49 @@ mod tests {
         h.join().unwrap();
     }
 
+    /// A var `def`'d in one isolate is observable by value from another after
+    /// the structured-clone boundary (issue #171). Keyword identity preserved.
+    #[test]
+    fn var_with_value_root_crosses_boundary() {
+        let (tx, rx) = isolate_channel();
+        let hs = Isolate::new("var-sender").spawn(move || async move {
+            let var = cljrs_value::Var::new("user", "answer");
+            var.bind(Value::keyword(Keyword::qualified("ns", "kw")));
+            tx.send(&Value::Var(GcPtr::new(var))).unwrap();
+        });
+        let hr = Isolate::new("var-receiver").spawn(move || async move {
+            let mut rx = rx;
+            let Value::Var(p) = rx.recv().await.unwrap() else {
+                panic!("expected a Var on the receiving side");
+            };
+            assert_eq!(p.get().namespace.as_ref(), "user");
+            assert_eq!(
+                p.get().deref(),
+                Some(Value::keyword(Keyword::qualified("ns", "kw")))
+            );
+        });
+        hs.join().unwrap();
+        hr.join().unwrap();
+    }
+
+    /// A var bound to a closure / native fn is explicitly isolate-local: it is
+    /// rejected at the boundary rather than silently crossing unbound.
+    #[test]
+    fn var_with_fn_root_rejected_at_boundary() {
+        let (tx, _rx) = isolate_channel();
+        let h = Isolate::new("var-fn-sender").spawn(move || async move {
+            let var = cljrs_value::Var::new("user", "f");
+            var.bind(Value::NativeFunction(GcPtr::new(
+                cljrs_value::NativeFn::new("f", cljrs_value::Arity::Fixed(0), |_| Ok(Value::Nil)),
+            )));
+            assert!(matches!(
+                tx.send(&Value::Var(GcPtr::new(var))),
+                Err(CloneError::NotShareable { type_name: "var" })
+            ));
+        });
+        h.join().unwrap();
+    }
+
     /// Sending a value across the boundary meters bytes + crossings into the
     /// shared GC stats. Other tests may also increment the global counters
     /// concurrently, so we assert monotonic *increase*, not exact totals.

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -20,14 +20,14 @@ standard library on top of them.
 ```
 src/
   lib.rs                         — module declarations and re-exports
-  clone.rs                       — SerializedValue (Send+Sync wire form), CloneError, serialize/deserialize for cross-isolate copy boundary (Phase B2); SerializedValue::byte_size for boundary metering; handles SharedAtom/ByteBlob pass-through (B3)
+  clone.rs                       — SerializedValue (Send+Sync wire form), CloneError, serialize/deserialize for cross-isolate copy boundary (Phase B2); SerializedValue::byte_size for boundary metering; handles SharedAtom/ByteBlob/Var pass-through (B3 — Var shares its root cell, issue #171)
   error.rs                       — ValueError enum, ValueResult<T> alias
   hash.rs                        — ClojureHash trait, Murmur3 helpers, JVM-compatible hash_string
   intern.rs                      — (Phase B3) global keyword/symbol intern tables backed by StaticGcPtr; intern_keyword, intern_symbol
   jit_hooks.rs                   — (Phases 10.2/10.5) var-rebind hooks fired by Var::bind; set_var_rebind_hook registers multiple consumers (the JIT stales superseded native code; cljrs-eval invalidates cross-defn-specialized lowerings)
   keyword.rs                     — Keyword { namespace, name }
   publish.rs                     — (Phase 10.5, GC builds; identity stub under no-gc) heap-promotion publish barrier: publish_value(Value) -> Value scans for region-allocated boxes, deep-copies them to the GC heap (via clone.rs), or poisons the active regions when the value is opaque to the scan. Called by Var::bind, Atom::new/reset, Volatile::new/reset, CljxPromise::deliver, and cljrs-async channel puts
-  shared.rs                      — (Phase B3) SharedValue enum, SharedAtom (Arc<ArcSwap<SharedValue>>), promote/demote; PromoteError
+  shared.rs                      — (Phase B3) SharedValue enum, SharedAtom (Arc<ArcSwap<SharedValue>>), promote/demote; PromoteError. Var roots reuse SharedValue via Var::shared_root (issue #171)
   symbol.rs                      — Symbol { namespace, name }
   type_hint.rs                   — TypeHint enum (^long/^double/^longs/… primitive type tags) + from_tag/is_array/element
   native_object.rs               — NativeObject trait, NativeObjectBox wrapper, gc_native_object helper (Phase 9 interop)
@@ -175,6 +175,43 @@ isolate-local `Value`.  `compare_and_set` is the single lock-free CAS that
 backs the Clojure-level `compare-and-set!` and the `swap!` retry loop (callers
 that must run interpreter code between load and store use it instead of the
 closure-based `swap`).
+
+#### Var roots — two-tier, promote-on-`def` (issue #171)
+
+A var's *root* binding uses the **same** cross-isolate mechanism as
+`shared-atom`.  `Var` carries two slots:
+
+```rust
+pub struct Var {
+    pub value: Mutex<Option<Value>>,                          // isolate-local fast path
+    pub shared_root: Arc<ArcSwap<Option<SharedValue>>>,       // cross-isolate mirror (B3)
+    // …namespace, name, is_macro, meta, watches
+}
+
+impl Var {
+    pub fn deref(&self) -> Option<Value>          // reads the local fast path
+    pub fn deref_shared(&self) -> Option<Value>   // demotes the shared cell
+    pub fn bind(&self, v: Value)                  // promote-on-def: updates both slots
+    pub fn from_shared_root(ns, name, is_macro, shared_root) -> Self  // receiver side
+}
+```
+
+- **Reads stay local.** Every var deref, the IR tier, and the JIT/AOT `rt_*`
+  ABI read `value` — promotion never touches it, so inline caches and
+  pointer-identity assumptions in compiled code remain valid (no JIT
+  regression).
+- **`bind` promotes-on-write.** `def` / `alter-var-root` / `set!` all funnel
+  through `Var::bind`, which mirrors the new root into `shared_root` when it is
+  promotable, and clears it to `None` otherwise.  `def` is rare, so this
+  write-path cost is acceptable.
+- **Crossing isolates.** `clone::serialize` passes the `shared_root` `Arc`
+  through (both isolates share the same cell); the receiver rebuilds the var
+  with `from_shared_root`, seeding its local slot from the demoted snapshot.
+  A var bound to a **non-promotable** root (closure / native resource) is
+  *explicitly isolate-local* (ADR option (b)): `serialize` returns
+  `CloneError::NotShareable { type_name: "var" }` — a non-silent boundary
+  error.  Var-root watches stay isolate-local (the shared cell carries no
+  watch callbacks), matching `shared-atom`.
 
 ### `ClojureHash`
 
@@ -436,11 +473,17 @@ Shareable types: all scalars, strings, BigInt/BigDecimal/Ratio, Symbol/Keyword,
 all persistent collections, TypeInstance records, Error chains, primitive and
 object arrays, lazy sequences (realized first), WithMeta/Reduced wrappers.
 
-Non-shareable (returns `CloneError`): Atom, Var, Volatile, Promise, Future,
-Agent (mutable state); Fn, BoundFn, NativeFn, Macro, ProtocolFn, MultiFn
-(closures with isolate-local captures); Namespace, Protocol (global singletons);
-Resource, NativeObject (isolate-bound handles); TransientMap/Set/Vector;
-unforced Delay; Matcher.
+Cross-isolate shared references (Arc passed through, not deep-copied): SharedAtom,
+ByteBlob, and Var — a var crosses by sharing its `shared_root` cell, so a value
+`def`'d in one isolate is observable by value in another (issue #171). A var
+whose current root is non-promotable (closure/resource) is the exception and
+returns `CloneError`.
+
+Non-shareable (returns `CloneError`): Atom, Volatile, Promise, Future, Agent
+(mutable state); Fn, BoundFn, NativeFn, Macro, ProtocolFn, MultiFn (closures
+with isolate-local captures); Namespace, Protocol (global singletons); Resource,
+NativeObject (isolate-bound handles); TransientMap/Set/Vector; unforced Delay;
+Matcher; Var whose root holds a non-promotable value.
 
 ### Dependencies
 

--- a/crates/cljrs-value/src/clone.rs
+++ b/crates/cljrs-value/src/clone.rs
@@ -24,9 +24,20 @@
 //! - Lazy sequences: **realized** first; the realized value is then cloned
 //! - `WithMeta`, `Reduced` wrappers (inner value + meta cloned recursively)
 //!
+//! ## Cross-isolate shared references (Phase B3)
+//!
+//! - `SharedAtom`, `ByteBlob`  — `Arc`-cloned, not deep-copied; both isolates
+//!   share the same underlying cell/buffer.
+//! - `Var`  — the var's *root* binding crosses through its shared cell
+//!   (`Arc<ArcSwap<Option<SharedValue>>>`), so a var `def`'d in one isolate is
+//!   observable by value from another, keyword/symbol identity preserved.  A
+//!   var whose current root holds a non-promotable value (a closure / native
+//!   resource) is **not** shareable and returns `CloneError` — such vars are
+//!   explicitly isolate-local (option (b) of the ADR).
+//!
 //! ## What is *not* shareable (returns `CloneError`)
 //!
-//! - `Atom`, `Var`, `Volatile`, `Promise`, `Future`, `Agent`  (mutable state)
+//! - `Atom`, `Volatile`, `Promise`, `Future`, `Agent`  (mutable state)
 //! - `Fn`, `BoundFn`, `Macro`, `NativeFunction`, `ProtocolFn`, `MultiFn`
 //!   (closures capture isolate-local `GcPtr`s)
 //! - `Namespace`, `Protocol`  (global singletons managed elsewhere)
@@ -37,11 +48,12 @@
 
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use num_bigint::BigInt;
 
 use crate::collections::{PersistentHashSet, PersistentVector, SortedMap, SortedSet};
 use crate::error::ValueError;
-use crate::shared::SharedAtom;
+use crate::shared::{SharedAtom, SharedValue};
 use crate::types::DelayState;
 use crate::{Keyword, MapValue, PersistentList, PersistentQueue, SetValue, Symbol, Value};
 use cljrs_gc::GcPtr;
@@ -159,6 +171,17 @@ pub enum SerializedValue {
     SharedAtom(Arc<SharedAtom>),
     /// `ByteBlob` is an immutable refcounted buffer; clone the `Arc`.
     ByteBlob(Arc<[u8]>),
+    /// A var crosses by sharing its cross-isolate root cell (the `Arc` is
+    /// cloned, so both isolates point at the same `ArcSwap`).  The receiving
+    /// isolate rebuilds a `Var` whose local fast-path slot is the demoted
+    /// current snapshot.  Only vars with a promotable (or unbound) root reach
+    /// here — a non-promotable root is rejected at `serialize` time.
+    Var {
+        namespace: Arc<str>,
+        name: Arc<str>,
+        is_macro: bool,
+        shared_root: Arc<ArcSwap<Option<SharedValue>>>,
+    },
 }
 
 // Compile-time Send + Sync assertions.
@@ -243,6 +266,11 @@ impl SerializedValue {
 
             // Arc-shared: crosses by refcount bump, no structural copy.
             SerializedValue::SharedAtom(_) | SerializedValue::ByteBlob(_) => 0,
+
+            // The var's root cell is Arc-shared; only the ns/name strings copy.
+            SerializedValue::Var {
+                namespace, name, ..
+            } => namespace.len() + name.len(),
         };
 
         NODE + payload
@@ -425,7 +453,26 @@ pub fn serialize(v: &Value) -> Result<SerializedValue, CloneError> {
         Value::ProtocolFn(_) => Err(not_shareable("fn")),
         Value::MultiFn(_) => Err(not_shareable("fn")),
 
-        Value::Var(_) => Err(not_shareable("var")),
+        // ── Phase B3: vars cross by sharing their root cell ──
+        Value::Var(p) => {
+            let var = p.get();
+            // The shared cell is kept in sync by `Var::bind` (promote-on-def).
+            // It is empty when the var is unbound *or* its current root is not
+            // promotable.  Distinguish the two: an unbound var may cross (it
+            // arrives unbound), but a var bound to a non-promotable value
+            // (closure / native resource) is explicitly isolate-local and is
+            // rejected here — a non-silent boundary error, not a silent drop.
+            let shared_empty = var.shared_root.load().is_none();
+            if shared_empty && var.is_bound() {
+                return Err(not_shareable("var"));
+            }
+            Ok(SerializedValue::Var {
+                namespace: var.namespace.clone(),
+                name: var.name.clone(),
+                is_macro: var.is_macro,
+                shared_root: var.shared_root.clone(),
+            })
+        }
         Value::Atom(_) => Err(not_shareable("atom")),
         Value::Volatile(_) => Err(not_shareable("volatile")),
         Value::Promise(_) => Err(not_shareable("promise")),
@@ -656,6 +703,17 @@ pub fn deserialize(sv: SerializedValue) -> Value {
         // Phase B3: cross-isolate shared references — clone the Arc.
         SerializedValue::SharedAtom(a) => Value::SharedAtom(a),
         SerializedValue::ByteBlob(b) => Value::ByteBlob(b),
+        SerializedValue::Var {
+            namespace,
+            name,
+            is_macro,
+            shared_root,
+        } => Value::Var(GcPtr::new(crate::types::Var::from_shared_root(
+            namespace,
+            name,
+            is_macro,
+            shared_root,
+        ))),
     }
 }
 
@@ -873,6 +931,90 @@ mod tests {
         ))))
         .unwrap();
         assert!(large.byte_size() > small.byte_size());
+    }
+
+    #[test]
+    fn var_with_promotable_root_roundtrips() {
+        use crate::types::Var;
+        // A var def'd with a promotable value crosses by value.
+        let var = Var::new("user", "answer");
+        var.bind(Value::Long(42));
+        let v = Value::Var(GcPtr::new(var));
+
+        let crossed = roundtrip(&v);
+        if let Value::Var(p) = crossed {
+            let got = p.get();
+            assert_eq!(got.namespace.as_ref(), "user");
+            assert_eq!(got.name.as_ref(), "answer");
+            // Observable by value on the receiving side.
+            assert_eq!(got.deref(), Some(Value::Long(42)));
+        } else {
+            panic!("expected a Var on the receiving side");
+        }
+    }
+
+    #[test]
+    fn var_keyword_root_preserves_identity() {
+        use crate::types::Var;
+        let var = Var::new("user", "k");
+        var.bind(Value::keyword(Keyword::qualified("ns", "kw")));
+        let v = Value::Var(GcPtr::new(var));
+
+        let crossed = roundtrip(&v);
+        let Value::Var(p) = crossed else {
+            panic!("expected Var")
+        };
+        // Keyword identity preserved through the intern table on demote.
+        assert_eq!(
+            p.get().deref(),
+            Some(Value::keyword(Keyword::qualified("ns", "kw")))
+        );
+    }
+
+    #[test]
+    fn var_shares_root_cell_across_boundary() {
+        use crate::types::Var;
+        // Both isolates point at the *same* shared root cell, so a write on the
+        // sending side is observable through the receiver's shared view.
+        let var = GcPtr::new(Var::new("user", "shared"));
+        var.get().bind(Value::Long(1));
+        let v = Value::Var(var.clone());
+
+        let Value::Var(recv) = roundtrip(&v) else {
+            panic!("expected Var")
+        };
+        assert_eq!(recv.get().deref_shared(), Some(Value::Long(1)));
+
+        // Sender re-defs through the same cell; receiver observes via the cell.
+        var.get().bind(Value::Long(2));
+        assert_eq!(recv.get().deref_shared(), Some(Value::Long(2)));
+    }
+
+    #[test]
+    fn var_with_nonpromotable_root_is_not_shareable() {
+        use crate::types::{Arity, NativeFn, Var};
+        // A var bound to a closure / native fn is explicitly isolate-local.
+        let var = Var::new("user", "f");
+        var.bind(Value::NativeFunction(GcPtr::new(NativeFn::new(
+            "f",
+            Arity::Fixed(0),
+            |_| Ok(Value::Nil),
+        ))));
+        let v = Value::Var(GcPtr::new(var));
+        assert!(matches!(
+            serialize(&v),
+            Err(CloneError::NotShareable { type_name: "var" })
+        ));
+    }
+
+    #[test]
+    fn unbound_var_crosses_as_unbound() {
+        use crate::types::Var;
+        let v = Value::Var(GcPtr::new(Var::new("user", "later")));
+        let Value::Var(p) = roundtrip(&v) else {
+            panic!("expected Var")
+        };
+        assert!(!p.get().is_bound());
     }
 
     #[test]

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -230,11 +230,37 @@ impl cljrs_gc::Trace for MultiFn {
 // ── Var ───────────────────────────────────────────────────────────────────────
 
 /// A Clojure var — a namespace-interned mutable root binding.
+///
+/// ## Two-tier root (Phase B3, issue #171)
+///
+/// A var's *root* binding uses the same two-tier mechanism as `shared-atom`:
+///
+/// - **`value`** — the isolate-local, GC-backed fast path.  Every var deref,
+///   the IR tier, and the JIT/AOT `rt_*` ABI read this slot; promotion never
+///   touches it, so compiled inline caches and pointer-identity assumptions
+///   baked into native code stay valid.
+/// - **`shared_root`** — a `Send + Sync` cross-isolate mirror,
+///   `Arc<ArcSwap<Option<SharedValue>>>`, reusing
+///   [`crate::shared::SharedValue`].  `bind` (i.e. `def` / `alter-var-root` /
+///   `set!`) *promotes-on-write*: if the new root value is promotable the cell
+///   holds `Some(SharedValue)`, otherwise it is cleared to `None` (option (b)
+///   of the ADR — non-promotable roots, e.g. closures, stay isolate-local).
+///
+/// The shared cell is what crosses the structured-clone boundary: a var
+/// `def`'d in one isolate is observable *by value* from another, with keyword
+/// /symbol identity preserved through the intern table.  See
+/// `crate::clone` for the serialize/deserialize seam.
+///
+/// Dynamic `binding` is unchanged — it is already thread-local / per-isolate
+/// and lives on the binding stack, not in the var root.
 #[derive(Debug)]
 pub struct Var {
     pub namespace: Arc<str>,
     pub name: Arc<str>,
     pub value: Mutex<Option<Value>>,
+    /// Cross-isolate mirror of the root binding (Phase B3).  `None` when the
+    /// var is unbound or its current root is not promotable.
+    pub shared_root: Arc<arc_swap::ArcSwap<Option<crate::shared::SharedValue>>>,
     pub is_macro: bool,
     /// Metadata map (e.g. `{:dynamic true}`).
     pub meta: Mutex<Option<Value>>,
@@ -247,7 +273,36 @@ impl Var {
             namespace: namespace.into(),
             name: name.into(),
             value: Mutex::new(None),
+            shared_root: Arc::new(arc_swap::ArcSwap::new(Arc::new(None))),
             is_macro: false,
+            meta: Mutex::new(None),
+            watches: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Reconstruct a var on the receiving side of an isolate boundary.
+    ///
+    /// The `shared_root` cell is the *same* `Arc` as the sending isolate's, so
+    /// both isolates share the cross-isolate root cell.  The local `value`
+    /// fast-path slot is seeded by demoting the current shared snapshot, so an
+    /// immediate `deref` observes the value the var carried at crossing time.
+    pub fn from_shared_root(
+        namespace: impl Into<Arc<str>>,
+        name: impl Into<Arc<str>>,
+        is_macro: bool,
+        shared_root: Arc<arc_swap::ArcSwap<Option<crate::shared::SharedValue>>>,
+    ) -> Self {
+        let local = shared_root
+            .load()
+            .as_ref()
+            .as_ref()
+            .map(crate::shared::demote);
+        Self {
+            namespace: namespace.into(),
+            name: name.into(),
+            value: Mutex::new(local),
+            shared_root,
+            is_macro,
             meta: Mutex::new(None),
             watches: Mutex::new(Vec::new()),
         }
@@ -259,6 +314,18 @@ impl Var {
 
     pub fn deref(&self) -> Option<Value> {
         self.value.lock().unwrap().clone()
+    }
+
+    /// Read the cross-isolate root by demoting the shared cell, ignoring the
+    /// isolate-local fast path.  Returns `None` when the shared root is empty
+    /// (unbound or non-promotable).  Used to observe writes another isolate
+    /// made through the shared cell.
+    pub fn deref_shared(&self) -> Option<Value> {
+        self.shared_root
+            .load()
+            .as_ref()
+            .as_ref()
+            .map(crate::shared::demote)
     }
 
     pub fn bind(&self, v: Value) {
@@ -287,6 +354,13 @@ impl Var {
             let mut slot = self.value.lock().unwrap();
             slot.replace(v.clone())
         };
+        // Promote-on-`def` (Phase B3): mirror the new root into the
+        // cross-isolate cell when it is promotable, else clear the cell so it
+        // never advertises a stale or non-shareable root.  `def` is rare and
+        // global by nature, so this write-path cost is acceptable; the read
+        // path (and the JIT) never touch the shared cell.
+        let shared = crate::shared::promote(&v).ok();
+        self.shared_root.store(Arc::new(shared));
         if let Some(prev) = prev {
             crate::jit_hooks::notify_var_rebind(&prev, &v);
         }
@@ -1131,5 +1205,53 @@ impl cljrs_gc::Trace for Agent {
                 f.trace(visitor);
             }
         }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod var_tests {
+    use super::*;
+    use crate::shared::SharedValue;
+
+    #[test]
+    fn bind_promotable_mirrors_shared_root() {
+        let var = Var::new("user", "x");
+        assert!(var.shared_root.load().is_none());
+        var.bind(Value::Long(7));
+        assert!(matches!(
+            var.shared_root.load().as_ref().as_ref(),
+            Some(SharedValue::Long(7))
+        ));
+        assert_eq!(var.deref(), Some(Value::Long(7)));
+        assert_eq!(var.deref_shared(), Some(Value::Long(7)));
+    }
+
+    #[test]
+    fn bind_nonpromotable_clears_shared_root() {
+        let var = Var::new("user", "f");
+        var.bind(Value::Long(1));
+        assert!(var.shared_root.load().is_some());
+        // Rebinding to a non-promotable value clears the mirror, but the
+        // isolate-local fast path still holds it.
+        let f = Value::NativeFunction(GcPtr::new(NativeFn::new("f", Arity::Fixed(0), |_| {
+            Ok(Value::Nil)
+        })));
+        var.bind(f);
+        assert!(var.shared_root.load().is_none());
+        assert!(var.is_bound());
+        assert_eq!(var.deref_shared(), None);
+    }
+
+    #[test]
+    fn from_shared_root_seeds_local_slot() {
+        let src = Var::new("user", "y");
+        src.bind(Value::Long(99));
+        let recv = Var::from_shared_root("user", "y", false, src.shared_root.clone());
+        assert_eq!(recv.deref(), Some(Value::Long(99)));
+        // Same underlying cell.
+        src.bind(Value::Long(100));
+        assert_eq!(recv.deref_shared(), Some(Value::Long(100)));
     }
 }

--- a/docs/async-worker-pool-plan.md
+++ b/docs/async-worker-pool-plan.md
@@ -132,6 +132,20 @@ A var's root binding is the same shape as a shared mutable cell, so it uses the 
 the promotion cost is acceptable. Dynamic `binding` is already thread-local and maps directly to
 per-isolate — no change.
 
+**Implemented (issue #171), option (b) — hybrid var.** `Var` keeps its isolate-local, GC-backed
+root (`value: Mutex<Option<Value>>`) as the fast path that every deref, the IR tier, and the JIT/AOT
+`rt_*` ABI read — promotion never touches it, so inline caches stay valid and there is no JIT
+regression. Alongside it, `Var::shared_root: Arc<ArcSwap<Option<SharedValue>>>` mirrors the root:
+`Var::bind` (the single choke point for `def`/`alter-var-root`/`set!`) promotes the new value into
+the shared cell when promotable and clears it otherwise. The cell is what crosses the
+structured-clone boundary (`clone::serialize`/`deserialize`), so a var `def`'d in one isolate is
+observable by value from another with keyword/symbol identity preserved. A var whose current root is
+**non-promotable** (a closure / native resource) is explicitly isolate-local: crossing it is a
+non-silent `CloneError`. Var-root watches stay isolate-local (the shared cell carries no callbacks),
+matching `shared-atom`. Option (a) — arena-resident compiled fns addressable as a `SharedValue`
+variant — remains the more complete fix and is deferred until arena-resident code is addressable
+that way.
+
 ### Immortal shared state (orthogonal, also decided)
 
 Code (compiled fns, namespaces), interned keywords/symbols, and large `byte-array` blobs live in the


### PR DESCRIPTION
Phase B3 follow-up: a var's root binding now uses the same cross-isolate
mechanism as `shared-atom`, via option (b) of the ADR — a hybrid `Var`.

- `Var` gains `shared_root: Arc<ArcSwap<Option<SharedValue>>>` alongside the
  existing isolate-local `value` slot. Reads (every deref, the IR tier, and the
  JIT/AOT `rt_*` ABI) keep using the local slot, so inline caches and
  pointer-identity assumptions in compiled code stay valid — no JIT regression.
- `Var::bind` — the single choke point for `def`/`alter-var-root`/`set!` —
  promotes-on-write: it mirrors the new root into the shared cell when
  promotable, and clears it otherwise.
- The structured-clone boundary now passes a var across by sharing its
  `shared_root` cell: a value `def`'d in one isolate is observable by value from
  another, with keyword/symbol identity preserved. A var bound to a
  non-promotable root (closure/native resource) is explicitly isolate-local and
  is rejected with a non-silent `CloneError`.
- Var-root watches stay isolate-local (the shared cell carries no callbacks),
  matching `shared-atom`.

Adds `Var::from_shared_root` / `Var::deref_shared`, a `SerializedValue::Var`
wire variant, unit tests (types/clone) and end-to-end isolate-channel tests,
and updates the cljrs-value/cljrs-async READMEs and the ADR.