### PR TITLE
Catch internal ValueErrors via (catch :default ...) (#168)

### DIFF
--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -386,8 +386,24 @@ fn throw_str(msg: String) -> *const Value {
     unsafe { rt_throw(exc) }
 }
 
-fn array_index_error(idx: i64, len: usize) -> String {
-    format!("array index out of bounds: {idx} (length {len})")
+/// Raise an out-of-bounds condition carrying the structured
+/// `ValueError::IndexOutOfBounds` variant, matching the tree-walk interpreter's
+/// `aget`/`aset`/`nth` errors so a caught value has the same shape and message
+/// (`index out of bounds: {idx} >= {len}`) regardless of execution tier.
+fn throw_index_oob(idx: i64, len: usize) -> *const Value {
+    let err = if idx >= 0 {
+        cljrs_value::ValueError::IndexOutOfBounds {
+            idx: idx as usize,
+            count: len,
+        }
+    } else {
+        cljrs_value::ValueError::Other(format!("index out of bounds: {idx} >= {len}"))
+    };
+    let msg = err.to_string();
+    let exc = box_val(Value::Error(GcPtr::new(
+        cljrs_value::error::ExceptionInfo::new(err, msg, None, None),
+    )));
+    unsafe { rt_throw(exc) }
 }
 
 // ── Primitive array access ──────────────────────────────────────────────────
@@ -429,7 +445,7 @@ pub unsafe extern "C" fn rt_aget_long(arr: *const Value, i: i64) -> i64 {
         Value::LongArray(a) => {
             let v = a.get().lock().unwrap();
             if i < 0 || i as usize >= v.len() {
-                throw_str(array_index_error(i, v.len()));
+                throw_index_oob(i, v.len());
                 return 0;
             }
             v[i as usize]
@@ -452,7 +468,7 @@ pub unsafe extern "C" fn rt_aget_double(arr: *const Value, i: i64) -> f64 {
         Value::DoubleArray(a) => {
             let v = a.get().lock().unwrap();
             if i < 0 || i as usize >= v.len() {
-                throw_str(array_index_error(i, v.len()));
+                throw_index_oob(i, v.len());
                 return 0.0;
             }
             v[i as usize]
@@ -476,7 +492,7 @@ pub unsafe extern "C" fn rt_aset_long(arr: *const Value, i: i64, v: i64) -> *con
         Value::LongArray(a) => {
             let mut g = a.get().lock().unwrap();
             if i < 0 || i as usize >= g.len() {
-                return throw_str(array_index_error(i, g.len()));
+                return throw_index_oob(i, g.len());
             }
             g[i as usize] = v;
             intern_long(v)
@@ -496,7 +512,7 @@ pub unsafe extern "C" fn rt_aset_double(arr: *const Value, i: i64, v: f64) -> *c
         Value::DoubleArray(a) => {
             let mut g = a.get().lock().unwrap();
             if i < 0 || i as usize >= g.len() {
-                return throw_str(array_index_error(i, g.len()));
+                return throw_index_oob(i, g.len());
             }
             g[i as usize] = v;
             box_val(Value::Double(v))
@@ -522,7 +538,7 @@ pub unsafe extern "C" fn rt_aget(arr: *const Value, idx: *const Value) -> *const
         ($a:expr, $map:expr) => {{
             let g = $a.get().lock().unwrap();
             if i < 0 || i as usize >= g.len() {
-                return throw_str(array_index_error(i, g.len()));
+                return throw_index_oob(i, g.len());
             }
             #[allow(clippy::redundant_closure_call)]
             box_val($map(&g[i as usize]))
@@ -532,7 +548,7 @@ pub unsafe extern "C" fn rt_aget(arr: *const Value, idx: *const Value) -> *const
         Value::ObjectArray(a) => {
             let g = a.get().0.lock().unwrap();
             if i < 0 || i as usize >= g.len() {
-                return throw_str(array_index_error(i, g.len()));
+                return throw_index_oob(i, g.len());
             }
             box_val(g[i as usize].clone())
         }
@@ -569,7 +585,7 @@ pub unsafe extern "C" fn rt_aset(
         ($lock:expr, $conv:expr) => {{
             let mut g = $lock;
             if i < 0 || i as usize >= g.len() {
-                return throw_str(array_index_error(i, g.len()));
+                return throw_index_oob(i, g.len());
             }
             match $conv(val_v) {
                 Some(c) => {
@@ -584,7 +600,7 @@ pub unsafe extern "C" fn rt_aset(
         Value::ObjectArray(a) => {
             let mut g = a.get().0.lock().unwrap();
             if i < 0 || i as usize >= g.len() {
-                return throw_str(array_index_error(i, g.len()));
+                return throw_index_oob(i, g.len());
             }
             g[i as usize] = val_v.clone();
             val

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -72,6 +72,19 @@ helpers shared with the Phase 10.6 inline caches:
   `rt_call_ic`'s hot path in `cljrs-compiler`)
 - `dispatch_if_async(callee, args, env)` — spawn `^:async` callees on the async runtime
 
+## error module
+
+`EvalError` / `EvalResult` are the evaluator's error types. Helpers:
+
+- `EvalError::to_error_value(self) -> Value` — convert an error into a Clojure
+  error *value*; `Thrown` is returned unchanged, anything else is wrapped in a
+  fresh `ExceptionInfo`
+- `value_error_to_eval_error(err: ValueError) -> EvalError` — surface a builtin's
+  `ValueError` as a *catchable* `EvalError::Thrown(Value::Error(..))`, preserving
+  the original variant and its plain message (no `runtime error:` prefix) so
+  `(catch :default e ..)` / `ex-message` / `ex-data` behave the same as for a
+  user `throw` / `ex-info`. A `ValueError::Thrown` re-surfaces the exact value.
+
 ## callback module
 
 Thread-local eval context for Rust→Clojure callbacks (`invoke`, `with_eval_context`). The context is pushed automatically around native builtin calls and by the Tier-1 IR executor; rt_abi bridges (`rt_call`, `rt_load_global`, the HOF bridges) dispatch through it. Public API includes:

--- a/crates/cljrs-env/src/apply.rs
+++ b/crates/cljrs-env/src/apply.rs
@@ -139,7 +139,7 @@ pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResul
             // and may trigger GC.
             let _caller_root = crate::gc_roots::push_env_root(env);
             crate::callback::push_eval_context(env);
-            let result = (nf.get().func)(&args).map_err(|e| EvalError::Runtime(e.to_string()));
+            let result = (nf.get().func)(&args).map_err(crate::error::value_error_to_eval_error);
             crate::callback::pop_eval_context();
             result
         }

--- a/crates/cljrs-env/src/error.rs
+++ b/crates/cljrs-env/src/error.rs
@@ -1,6 +1,7 @@
 //! Evaluation-time error types.
 
 use cljrs_value::Value;
+use cljrs_value::ValueError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum EvalError {
@@ -60,6 +61,27 @@ impl EvalError {
                     None,
                 )))
             }
+        }
+    }
+}
+
+/// Surface a builtin's `ValueError` to the evaluator as a *catchable* condition.
+///
+/// Internal runtime errors (`IndexOutOfBounds`, `WrongType`, `ArityError`, …)
+/// are normalized into an `EvalError::Thrown(Value::Error(..))` carrying the
+/// original `ValueError` variant and its plain display message — no
+/// `runtime error:` prefix — so that `(catch :default e ..)` /
+/// `(catch Throwable e ..)` bind a value on which `ex-message` / `ex-data`
+/// behave the same as for a user `throw` / `ex-info`. A `ValueError::Thrown`
+/// (a builtin re-throwing a Clojure value) is surfaced as that exact value.
+pub fn value_error_to_eval_error(err: ValueError) -> EvalError {
+    match err {
+        ValueError::Thrown(v) => EvalError::Thrown(v),
+        other => {
+            let msg = other.to_string();
+            EvalError::Thrown(Value::Error(cljrs_gc::GcPtr::new(
+                cljrs_value::ExceptionInfo::new(other, msg, None, None),
+            )))
         }
     }
 }

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -632,6 +632,30 @@ mod tests {
     }
 
     #[test]
+    fn test_catch_default_catches_internal_value_errors() {
+        // Regression for #168: internal `ValueError`s (IndexOutOfBounds, WrongType)
+        // raised by core ops must be caught by the ClojureScript `:default` keyword,
+        // not just by symbol catch types.
+        for src in [
+            "(try (nth [1 2 3] 10) (catch :default e \"caught\"))",
+            "(try (aget (long-array 3) 10) (catch :default e \"caught\"))",
+            "(try (aset (long-array 3) 10 5) (catch :default e \"caught\"))",
+        ] {
+            let v = eval_str(src).unwrap();
+            assert_eq!(v, Value::string("caught"), "{src}");
+        }
+    }
+
+    #[test]
+    fn test_catch_default_binds_clean_ex_message() {
+        // The caught value is a normalized exception: `ex-message` returns the
+        // plain `ValueError` text with no `runtime error:` prefix, matching how a
+        // user `throw` / `ex-info` value behaves.
+        let v = eval_str("(try (nth [1 2 3] 10) (catch :default e (ex-message e)))").unwrap();
+        assert_eq!(v, Value::string("index out of bounds: 10 >= 3"));
+    }
+
+    #[test]
     fn test_finally_runs_and_value_is_discarded() {
         // finally executes for its side effect, but the `try` value is the body's.
         let v = eval_str("(let [a (atom 0)] (try 1 (finally (reset! a 5))) @a)").unwrap();

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -801,7 +801,9 @@ pub fn catch_type_matches(type_name: &str, val: &Value) -> bool {
     let short = type_name.rsplit('.').next().unwrap_or(type_name);
     match short {
         // Catch-all (matches any value, error or not — back-compat).
-        "Object" | "Exception" | "Throwable" | "Error" => true,
+        // `:default` is the ClojureScript universal catch keyword; it arrives
+        // here as the keyword's name ("default") via `parse_try_args`.
+        "Object" | "Exception" | "Throwable" | "Error" | "default" => true,
         // ExceptionInfo only matches actual ex-info / Exception values.
         "ExceptionInfo" => matches!(val, Value::Error(_)),
         _ => false,
@@ -874,8 +876,11 @@ pub fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form])
                 if i < body_end {
                     body_end = i;
                 }
+                // The catch type may be a symbol (`Throwable`, `java.lang.Exception`)
+                // or the ClojureScript `:default` catch-all keyword.
                 let type_sym = match parts.get(1).map(|f| &f.kind) {
                     Some(FormKind::Symbol(s)) => s.as_str(),
+                    Some(FormKind::Keyword(s)) => s.as_str(),
                     _ => continue,
                 };
                 let binding = match parts.get(2).map(|f| &f.kind) {


### PR DESCRIPTION
Internal runtime errors raised as `ValueError` (IndexOutOfBounds, WrongType,
etc.) from `nth`/`aget`/`aset` and other core ops were not caught by a
`(catch :default e ...)` clause, and even via a symbol catch type they
surfaced with a `runtime error:` prefix and no `ex-data`.

Two root causes:

1. The tree-walking `try`/`catch` parser only accepted a *symbol* catch type,
   so the ClojureScript `:default` catch-all keyword was silently dropped and
   matched nothing. `parse_try_args` now also accepts a keyword, and
   `catch_type_matches` treats `:default` as a universal catch.

2. A builtin's `ValueError` was flattened to `EvalError::Runtime(string)`,
   losing the structured variant and prepending `runtime error:`. New helper
   `value_error_to_eval_error` normalizes it into a catchable
   `EvalError::Thrown(Value::Error(..))` carrying the original variant and its
   plain message, so `ex-message`/`ex-data` behave like a user `throw`/`ex-info`.
   A `ValueError::Thrown` re-surfaces the exact thrown value.

Also aligned the compiled array-bridge out-of-bounds error with the tree-walk
`IndexOutOfBounds` shape and message (`index out of bounds: {idx} >= {len}`) so
a caught value is identical across execution tiers.

Adds regression tests and updates the cljrs-env README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013fJYBXxtjeqWFb44Cq2bu4