### PR TITLE
net: implement Q1 QUIC client transport via quinn 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,7 @@ dependencies = [
  "cljrs-stdlib",
  "cljrs-types",
  "cljrs-value",
+ "quinn",
  "rcgen",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ postcard     = "1.1.3"
 rustyline    = "18.0.0"
 libloading   = "0.8"
 arc-swap     = "1"
+quinn        = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 tower-lsp     = "0.20"
 dashmap       = "6"
 

--- a/TODO.md
+++ b/TODO.md
@@ -526,3 +526,26 @@ Foundations already in place:
         go-to-definition, find-references
   - [ ] INCREMENTAL text sync, semantic tokens
 - [ ] Transducers in core collection ops
+
+---
+
+## cljrs-net — QUIC + HTTP/3 (`docs/quic-http3-integration-plan.md`)
+
+Using **quinn 0.11** (rustls-ring backend, no new native build) + `h3`/`h3-quinn`
+for HTTP/3.  Each phase ships new source files + tests in one commit.
+
+- [x] **Q1 — QUIC client transport.** `quic_config.rs` (wraps `tls::build_client_config`
+      into `quinn::ClientConfig` via `QuicClientConfig::try_from`), `quic.rs`
+      (`connect_to`, `open_stream_on`, `connect`/`open-stream`/`close` builtins,
+      pool accept/open loops, `QuicConnectionResource`/`QuicStreamResource`),
+      `clojure_rust_net_quic.cljrs` (sugar: `with-stream`, `drain-stream`).
+      Tests: echo round-trip against a quinn in-test server; connect-failure path.
+- [ ] **Q2 — QUIC server transport.** `quic.rs` `listen`/`listen-close`,
+      `endpoint.accept()` pool loop, `:conns`/`:streams` LocalSet bridges,
+      `QuicListenerResource`.
+- [ ] **Q3 — HTTP/3 client.** `h3.rs` client over `h3-quinn`: `h3/get`/`request`,
+      response-body streaming to a `:body` channel.  Depends on Q1.
+- [ ] **Q4 — HTTP/3 server.** `h3.rs` server: request map + `respond` fn,
+      `send_response`/`send_data`.  Depends on Q2+Q3.
+- [ ] **Q5 (optional) — QUIC datagrams.** `send_datagram`/`read_datagram`;
+      connection-level `:dgram-in`/`:dgram-out` channels.

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -20,6 +20,7 @@ rustls         = { version = "0.23", default-features = false, features = ["ring
 rustls-pemfile = "2"
 webpki-roots   = "0.26"
 rustls-native-certs = "0.8"
+quinn          = { workspace = true }
 
 [dev-dependencies]
 cljrs-stdlib   = { workspace = true }

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -1,8 +1,8 @@
 # cljrs-net
 
-**Purpose**: TCP/Unix/TLS networking for clojurust — channel-oriented sockets delivered as core.async channels.
+**Purpose**: TCP/Unix/TLS/QUIC networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–G + A2 implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics, pool-based I/O).
+**Status**: Phases A–G + A2 + Q1 implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics, pool-based I/O, QUIC client transport).
 
 **Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
 
@@ -12,18 +12,21 @@
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, `clojure.rust.net.unix`, and `clojure.rust.net` |
+| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, `clojure.rust.net.unix`, `clojure.rust.net.quic`, and `clojure.rust.net` |
 | `src/pool_io.rs` | Shared pool tasks and bridge helpers: `ReadMsg`, `PoolStreamSetup`, `pool_reader`, `pool_writer`, `read_bridge`, `write_bridge`, `bytes_value`, `net_error` |
 | `src/tcp.rs` | `TcpStreamResource` (Vec<AbortHandle>), `TcpListenerResource` (Vec<AbortHandle>), pool-based connect/accept, `connect`/`listen`/`close` builtins |
 | `src/frame.rs` | `FramerSpec` native object, stateful framers (`LinesFramer`, `DelimiterFramer`, `LengthPrefixedFramer`), `frame`/encode builtins |
 | `src/udp.rs` | `UdpSocketResource`, reader/writer tasks, `socket`/`close` builtins |
 | `src/tls.rs` | `TlsStreamResource` (Vec<AbortHandle>), `TlsListenerResource` (Vec<AbortHandle>), pool-based TLS connect/accept, `build_client_config`, `build_server_config`, `tls_connect_to`/`tls_listen_on`/`connect`/`listen`/`close` builtins |
 | `src/unix.rs` | `UnixStreamResource`, `UnixListenerResource` (`close` unlinks path), reader/writer loops, accept loop, `connect`/`listen`/`close` builtins; `#[cfg(unix)]` with non-Unix stubs |
+| `src/quic_config.rs` | Build `quinn::ClientConfig`/`ServerConfig` from opts maps; delegates TLS to `tls::build_client_config`/`build_server_config`, wraps via `QuicClientConfig::try_from`; applies QUIC transport params (`:max-idle-ms`, `:keep-alive-ms`, `:max-streams`) |
+| `src/quic.rs` | `QuicConnectionResource` (holds `quinn::Connection` + `Endpoint` + abort handles), `QuicStreamResource` (abort handles for pool reader/writer + LocalSet bridges), pool accept/open loops, LocalSet bridges, `connect_to`/`open_stream_on`, `connect`/`open-stream`/`close`/`stream-close` builtins |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
 | `src/clojure_rust_net_udp.cljrs` | Clojure source for `clojure.rust.net.udp`; usage examples |
 | `src/clojure_rust_net_tls.cljrs` | Clojure source for `clojure.rust.net.tls`; `start-server` sugar |
 | `src/clojure_rust_net_unix.cljrs` | Clojure source for `clojure.rust.net.unix`; `start-server` sugar |
+| `src/clojure_rust_net_quic.cljrs` | Clojure source for `clojure.rust.net.quic`; `with-stream`, `drain-stream` sugar |
 | `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net`; dispatches on `:transport` (`:tcp`, `:tls`, `:unix`) |
 | `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
 | `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |
@@ -32,6 +35,7 @@
 | `tests/tls.rs` | Phase E integration tests (TLS echo round-trip with rcgen self-signed cert, connect failure) |
 | `tests/unix.rs` | Phase F integration tests (Unix echo round-trip, listener unlinks path, stale socket removal) |
 | `tests/lifecycle.rs` | Phase G integration tests (split-err, drain-to, with-open, :connect-timeout-ms) |
+| `tests/quic.rs` | Phase Q1 integration tests (QUIC echo round-trip via quinn in-test server, connect-failure path) |
 
 ## Public API
 
@@ -166,6 +170,29 @@ side. `(close conn)` tears down both halves.
 (close sock)  ;; => nil — closes :in/:out and aborts reader/writer tasks
 ```
 
+### `clojure.rust.net.quic` (Phase Q1 — client)
+
+```clojure
+;; Phase Q1 — QUIC client
+(connect {:host "h" :port 4433 :alpn ["hq-interop"] :insecure-skip-verify true})
+;; => promise-chan — yields {:streams ch :remote-addr str :local-addr str :resource h}
+;;    or Value::Error on failure
+;; Optional keys: :insecure-skip-verify, :alpn, :roots (same as tls/connect)
+;;                :max-idle-ms, :keep-alive-ms, :max-streams (QUIC transport params)
+;;                :streams-buf, :in-buf, :out-buf (default 8)
+
+(open-stream conn)                    ;; => promise-chan yielding stream map
+(open-stream conn {:in-buf N :out-buf N})
+;; stream map: {:in ch :out ch :stream-id long :resource h}
+
+(close conn)                          ;; => nil — sends CONNECTION_CLOSE, aborts tasks
+(stream-close stream)                 ;; => nil — aborts stream tasks (sends RESET/FIN)
+
+;; Clojure sugar:
+(with-stream conn (fn [s] ...))       ;; open, use, close
+(drain-stream stream)                 ;; => byte-array of all :in data (^:async context)
+```
+
 ### Rust
 
 ```rust
@@ -182,9 +209,14 @@ pub fn tls::build_client_config(opts: &MapValue) -> ValueResult<Arc<rustls::Clie
 pub fn tls::build_server_config(opts: &MapValue) -> ValueResult<Arc<rustls::ServerConfig>>
 #[cfg(unix)] pub fn unix::connect_to(path: &str, in_buf: usize, out_buf: usize) -> Value
 #[cfg(unix)] pub fn unix::listen_on(path: &str, conns_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
+pub fn quic::connect_to(host: &str, port: u16, config: quinn::ClientConfig, streams_buf: usize, in_buf: usize, out_buf: usize) -> Value
+pub fn quic::open_stream_on(connection: quinn::Connection, in_buf: usize, out_buf: usize) -> Value
+pub fn quic_config::client_config(opts: &MapValue) -> ValueResult<quinn::ClientConfig>
+pub fn quic_config::server_config(opts: &MapValue) -> ValueResult<quinn::ServerConfig>
+pub const NS_QUIC: &str  // "clojure.rust.net.quic"
 ```
 
-`init` registers all three namespaces, calling `cljrs_async::init` internally. Idempotent.
+`init` registers all namespaces including `clojure.rust.net.quic`, calling `cljrs_async::init` internally. Idempotent.
 
 ### `TcpStreamResource`
 
@@ -209,6 +241,14 @@ Implements `cljrs_value::Resource` (Arc-backed). Holds `Vec<AbortHandle>` for th
 ### `UnixStreamResource` (`#[cfg(unix)]`)
 
 Implements `cljrs_value::Resource` (Arc-backed). Holds `AbortHandle`s for the reader and writer tasks. `close()` aborts both tasks, dropping the Unix stream halves and releasing the FD.
+
+### `QuicConnectionResource`
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds the `quinn::Connection` (for `open_bi`/`close` calls) and the `quinn::Endpoint` (kept alive so the internal UDP driver doesn't shut down while the connection is live). Also holds `Vec<AbortHandle>` for the peer-stream accept loop and LocalSet `:streams` bridge (2 total). `close()` aborts all handles and calls `connection.close(0, b"closed")`, sending a QUIC CONNECTION_CLOSE frame to the peer. `resource_type` → `"QuicConnection"`.
+
+### `QuicStreamResource`
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds `Vec<AbortHandle>` for the pool reader, pool writer, and LocalSet bridge tasks (4 total). `close()` aborts all handles; dropping the `SendStream`/`RecvStream` on the pool causes quinn to send RESET_STREAM / STOP_SENDING to the peer. `resource_type` → `"QuicStream"`.
 
 ### `UnixListenerResource` (`#[cfg(unix)]`)
 

--- a/crates/cljrs-net/src/clojure_rust_net_quic.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_quic.cljrs
@@ -1,0 +1,49 @@
+;; clojure.rust.net.quic — QUIC multiplexed transport client.
+;;
+;; Phase Q1 (QUIC client):
+;;   connect      — (connect opts) => promise-chan -> conn-map
+;;   open-stream  — (open-stream conn) / (open-stream conn opts) => promise-chan -> stream-map
+;;   close        — (close conn) => nil
+;;   stream-close — (stream-close stream) => nil
+;;   start-server — (start-server handler opts) => reserved for Q2
+
+(defn with-stream
+  "Open a stream on `conn`, call `(f stream)`, then close the stream.
+  Returns the return value of `f`.  Use inside a `go` block; both
+  `open-stream` and the stream itself are handled asynchronously.
+
+  Example:
+    (go
+      (let [conn (<! (quic/connect {:host \"h\" :port 4433
+                                    :alpn [\"hq-interop\"]
+                                    :insecure-skip-verify true}))]
+        (quic/with-stream conn
+          (fn [s]
+            (>! (:out s) (.getBytes \"ping\"))
+            (close! (:out s))
+            (<! (:in s))))))"
+  [conn f]
+  (let [stream (await (clojure.core.async/take!
+                        (clojure.rust.net.quic/open-stream conn)))]
+    (try
+      (f stream)
+      (finally
+        (clojure.rust.net.quic/stream-close stream)))))
+
+(defn drain-stream
+  "Drain a stream's `:in` channel to a byte-array, then close the stream.
+  Returns the concatenated bytes as a `byte-array`.  Must be called inside
+  a `go` block (uses `await`)."
+  [stream]
+  (let [in-ch (:in stream)]
+    (loop [acc []]
+      (let [v (await (clojure.core.async/take! in-ch))]
+        (if (nil? v)
+          (let [total (reduce + 0 (map count acc))
+                result (byte-array total)]
+            (loop [i 0 chunks acc]
+              (when-let [chunk (first chunks)]
+                (System/arraycopy chunk 0 result i (count chunk))
+                (recur (+ i (count chunk)) (rest chunks))))
+            result)
+          (recur (conj acc v)))))))

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -18,6 +18,8 @@ use cljrs_async::load_source;
 
 pub mod frame;
 mod pool_io;
+pub mod quic;
+pub mod quic_config;
 pub mod tcp;
 pub mod tls;
 pub mod udp;
@@ -41,12 +43,16 @@ const NET_TLS_SOURCE: &str = include_str!("clojure_rust_net_tls.cljrs");
 /// Clojure source for `clojure.rust.net.unix`.
 const NET_UNIX_SOURCE: &str = include_str!("clojure_rust_net_unix.cljrs");
 
+/// Clojure source for `clojure.rust.net.quic`.
+const NET_QUIC_SOURCE: &str = include_str!("clojure_rust_net_quic.cljrs");
+
 pub const NS_TCP: &str = "clojure.rust.net.tcp";
 pub const NS: &str = "clojure.rust.net";
 pub const NS_FRAME: &str = "clojure.rust.net.frame";
 pub const NS_UDP: &str = "clojure.rust.net.udp";
 pub const NS_TLS: &str = "clojure.rust.net.tls";
 pub const NS_UNIX: &str = "clojure.rust.net.unix";
+pub const NS_QUIC: &str = "clojure.rust.net.quic";
 
 /// Register the networking namespaces.
 ///
@@ -93,6 +99,14 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         unix::register(globals, NS_UNIX);
         load_source(globals, NS_UNIX, NET_UNIX_SOURCE);
         globals.mark_loaded(NS_UNIX);
+    }
+
+    if !globals.is_loaded(NS_QUIC) {
+        globals.get_or_create_ns(NS_QUIC);
+        globals.refer_all(NS_QUIC, "clojure.core");
+        quic::register(globals, NS_QUIC);
+        load_source(globals, NS_QUIC, NET_QUIC_SOURCE);
+        globals.mark_loaded(NS_QUIC);
     }
 
     if !globals.is_loaded(NS) {

--- a/crates/cljrs-net/src/quic.rs
+++ b/crates/cljrs-net/src/quic.rs
@@ -56,7 +56,11 @@ type Builtin = fn(&[Value]) -> ValueResult<Value>;
 pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
     let fns: Vec<(&str, Arity, Builtin)> = vec![
         ("connect", Arity::Fixed(1), builtin_connect),
-        ("open-stream", Arity::Variadic { min: 1 }, builtin_open_stream),
+        (
+            "open-stream",
+            Arity::Variadic { min: 1 },
+            builtin_open_stream,
+        ),
         ("close", Arity::Fixed(1), builtin_close),
         ("stream-close", Arity::Fixed(1), builtin_stream_close),
     ];
@@ -110,8 +114,7 @@ impl Resource for QuicConnectionResource {
         for h in g.abort_handles.drain(..) {
             h.abort();
         }
-        self.connection
-            .close(quinn::VarInt::from_u32(0), b"closed");
+        self.connection.close(quinn::VarInt::from_u32(0), b"closed");
         Ok(())
     }
 
@@ -236,15 +239,12 @@ async fn pool_stream_accept_loop(
     loop {
         match connection.accept_bi().await {
             Err(e) => {
-                let _ = stream_tx
-                    .send(Err(format!("accept_bi: {e}")))
-                    .await;
+                let _ = stream_tx.send(Err(format!("accept_bi: {e}"))).await;
                 break;
             }
             Ok((send, recv)) => {
                 let stream_id = send.id().index();
-                let (read_tx, read_rx) =
-                    mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+                let (read_tx, read_rx) = mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
                 let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
 
                 let reader_jh = tokio::spawn(pool_reader(recv, read_tx));
@@ -285,8 +285,7 @@ async fn pool_open_stream(
         }
         Ok((send, recv)) => {
             let stream_id = send.id().index();
-            let (read_tx, read_rx) =
-                mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+            let (read_tx, read_rx) = mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
             let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
 
             let reader_jh = tokio::spawn(pool_reader(recv, read_tx));
@@ -387,9 +386,9 @@ fn make_quic_connection(
 
     let (stream_tx, stream_rx) = mpsc::channel::<QuicStreamResult>(streams_buf.max(1));
 
-    let pool_jh = WorkerPool::global()
-        .handle()
-        .spawn(pool_stream_accept_loop(connection, stream_tx, in_buf, out_buf));
+    let pool_jh = WorkerPool::global().handle().spawn(pool_stream_accept_loop(
+        connection, stream_tx, in_buf, out_buf,
+    ));
 
     let bridge_jh = tokio::task::spawn_local(local_stream_accept_bridge(
         stream_rx,
@@ -431,7 +430,16 @@ pub fn connect_to(
     let promise = make_chan(1);
     let promise_val = Value::NativeObject(promise.clone());
     spawn_future(async move {
-        do_quic_connect(host, port, quinn_config, streams_buf, in_buf, out_buf, promise).await
+        do_quic_connect(
+            host,
+            port,
+            quinn_config,
+            streams_buf,
+            in_buf,
+            out_buf,
+            promise,
+        )
+        .await
     });
     promise_val
 }
@@ -498,7 +506,10 @@ async fn do_quic_connect(
         };
 
         let remote_addr = connection.remote_address().to_string();
-        let local_addr = endpoint.local_addr().map(|a| a.to_string()).unwrap_or_default();
+        let local_addr = endpoint
+            .local_addr()
+            .map(|a| a.to_string())
+            .unwrap_or_default();
         let _ = conn_tx.send(Ok((connection, endpoint, remote_addr, local_addr)));
     });
 
@@ -506,8 +517,15 @@ async fn do_quic_connect(
         Err(_) => chan_deliver(&promise, net_error("pool task dropped")).await,
         Ok(Err(e)) => chan_deliver(&promise, net_error(e)).await,
         Ok(Ok((connection, endpoint, remote_addr, local_addr))) => {
-            let conn =
-                make_quic_connection(connection, endpoint, remote_addr, local_addr, streams_buf, in_buf, out_buf);
+            let conn = make_quic_connection(
+                connection,
+                endpoint,
+                remote_addr,
+                local_addr,
+                streams_buf,
+                in_buf,
+                out_buf,
+            );
             chan_deliver(&promise, conn).await;
         }
     }
@@ -520,16 +538,10 @@ async fn do_quic_connect(
 ///
 /// Runs `open_bi()` on the `WorkerPool` and returns a promise channel that
 /// yields a stream map on the LocalSet.
-pub fn open_stream_on(
-    connection: quinn::Connection,
-    in_buf: usize,
-    out_buf: usize,
-) -> Value {
+pub fn open_stream_on(connection: quinn::Connection, in_buf: usize, out_buf: usize) -> Value {
     let promise = make_chan(1);
     let promise_val = Value::NativeObject(promise.clone());
-    spawn_future(async move {
-        do_open_stream(connection, in_buf, out_buf, promise).await
-    });
+    spawn_future(async move { do_open_stream(connection, in_buf, out_buf, promise).await });
     promise_val
 }
 
@@ -549,8 +561,7 @@ async fn do_open_stream(
         Err(_) => chan_deliver(&promise, net_error("pool task dropped")).await,
         Ok(Err(e)) => chan_deliver(&promise, net_error(e)).await,
         Ok(Ok(msg)) => {
-            let stream_val =
-                make_quic_stream_from_setup(msg.setup, msg.stream_id, in_buf, out_buf);
+            let stream_val = make_quic_stream_from_setup(msg.setup, msg.stream_id, in_buf, out_buf);
             chan_deliver(&promise, stream_val).await;
         }
     }
@@ -580,7 +591,14 @@ fn builtin_connect(args: &[Value]) -> ValueResult<Value> {
     let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
 
     let config = crate::quic_config::client_config(&opts)?;
-    Ok(connect_to(&host, port, config, streams_buf, in_buf, out_buf))
+    Ok(connect_to(
+        &host,
+        port,
+        config,
+        streams_buf,
+        in_buf,
+        out_buf,
+    ))
 }
 
 /// `(open-stream conn)` or `(open-stream conn {:in-buf N :out-buf N})`
@@ -607,9 +625,7 @@ fn builtin_open_stream(args: &[Value]) -> ValueResult<Value> {
     let resource_handle = match conn_map.get(&kw("resource")) {
         Some(Value::Resource(h)) => h.clone(),
         _ => {
-            return Err(ValueError::Other(
-                "connection map missing :resource".into(),
-            ));
+            return Err(ValueError::Other("connection map missing :resource".into()));
         }
     };
 

--- a/crates/cljrs-net/src/quic.rs
+++ b/crates/cljrs-net/src/quic.rs
@@ -1,0 +1,670 @@
+//! QUIC client transport for `clojure.rust.net.quic`.
+//!
+//! Phase Q1 delivers the client side: `connect`, `open-stream`, and `close`.
+//! A connection is a map:
+//!
+//! ```clojure
+//! {:streams     <chan>     ; yields stream maps for peer-initiated bidi streams
+//!  :remote-addr "ip:port"
+//!  :local-addr  "ip:port"
+//!  :resource    <handle>} ; QuicConnectionResource — deterministic close
+//! ```
+//!
+//! A stream map is:
+//!
+//! ```clojure
+//! {:in        <chan>    ; byte-array chunks; closed at stream FIN
+//!  :out       <chan>    ; put byte-arrays/strings; close! sends FIN
+//!  :stream-id <long>   ; QUIC stream index
+//!  :resource  <handle>} ; QuicStreamResource
+//! ```
+//!
+//! `connect` returns a capacity-1 promise channel; `open-stream` also returns a
+//! promise channel. The QUIC handshake and stream operations run on the
+//! `WorkerPool`; `GcPtr`/`Value` construction and channel bridges run on the
+//! `LocalSet`.
+//!
+//! QUIC streams (`quinn::SendStream` / `quinn::RecvStream`) implement
+//! `tokio::io::AsyncWrite` / `AsyncRead`, so they feed directly into
+//! `pool_writer` / `pool_reader` from `pool_io.rs` with no structural change.
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::AbortHandle;
+
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, make_chan};
+use cljrs_async::eval_async::spawn_future;
+use cljrs_async::worker_pool::WorkerPool;
+use cljrs_env::env::GlobalEnv;
+use cljrs_env::error::EvalResult;
+use cljrs_gc::GcPtr;
+use cljrs_value::{
+    Arity, Keyword, MapValue, NativeFn, NativeObjectBox, Resource, ResourceHandle, Value,
+    ValueError, ValueResult,
+};
+
+use crate::pool_io::{
+    PoolStreamSetup, net_error, pool_reader, pool_writer, read_bridge, write_bridge,
+};
+
+// ── Public entry point ─────────────────────────────────────────────────────────
+
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        ("connect", Arity::Fixed(1), builtin_connect),
+        ("open-stream", Arity::Variadic { min: 1 }, builtin_open_stream),
+        ("close", Arity::Fixed(1), builtin_close),
+        ("stream-close", Arity::Fixed(1), builtin_stream_close),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── QuicConnectionResource ─────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct QuicConnectionInner {
+    closed: bool,
+    abort_handles: Vec<AbortHandle>,
+}
+
+/// `Resource` for a QUIC connection.
+///
+/// Holds the `quinn::Connection` (to call `open_bi` and `close`) and the
+/// `quinn::Endpoint` (kept alive so the driver doesn't shut down while the
+/// connection is live). Abort handles cover the peer-stream accept loop and
+/// the LocalSet `:streams` bridge.
+#[derive(Debug)]
+pub struct QuicConnectionResource {
+    pub connection: quinn::Connection,
+    _endpoint: quinn::Endpoint,
+    inner: Arc<Mutex<QuicConnectionInner>>,
+}
+
+impl QuicConnectionResource {
+    fn new(connection: quinn::Connection, endpoint: quinn::Endpoint) -> Self {
+        Self {
+            connection,
+            _endpoint: endpoint,
+            inner: Arc::new(Mutex::new(QuicConnectionInner {
+                closed: false,
+                abort_handles: Vec::new(),
+            })),
+        }
+    }
+}
+
+impl Resource for QuicConnectionResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        for h in g.abort_handles.drain(..) {
+            h.abort();
+        }
+        self.connection
+            .close(quinn::VarInt::from_u32(0), b"closed");
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "QuicConnection"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── QuicStreamResource ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct QuicStreamInner {
+    closed: bool,
+    abort_handles: Vec<AbortHandle>,
+}
+
+/// `Resource` for a QUIC stream.
+///
+/// Holds abort handles for the pool reader, pool writer, and LocalSet bridge
+/// tasks (4 total). Aborting them drops the `SendStream`/`RecvStream`, which
+/// quinn interprets as a `RESET_STREAM` / `STOP_SENDING` to the peer.
+#[derive(Debug)]
+pub struct QuicStreamResource {
+    inner: Arc<Mutex<QuicStreamInner>>,
+}
+
+impl QuicStreamResource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(QuicStreamInner {
+                closed: false,
+                abort_handles: Vec::new(),
+            })),
+        }
+    }
+}
+
+impl Resource for QuicStreamResource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        for h in g.abort_handles.drain(..) {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "QuicStream"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Internal message types ─────────────────────────────────────────────────────
+
+/// A `PoolStreamSetup` augmented with the QUIC stream index.
+struct QuicStreamSetup {
+    stream_id: u64,
+    setup: PoolStreamSetup,
+}
+
+type QuicStreamResult = Result<QuicStreamSetup, String>;
+
+// ── Value helpers ──────────────────────────────────────────────────────────────
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+// ── Options-map parsing ────────────────────────────────────────────────────────
+
+fn opts_str(opts: &MapValue, key: &str) -> Option<String> {
+    match opts.get(&kw(key))? {
+        Value::Str(s) => Some(s.get().clone()),
+        _ => None,
+    }
+}
+
+fn opts_usize(opts: &MapValue, key: &str) -> Option<usize> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n >= 0 => Some((n as usize).max(1)),
+        _ => None,
+    }
+}
+
+fn opts_port(opts: &MapValue) -> Option<u16> {
+    match opts.get(&kw("port"))? {
+        Value::Long(n) if n > 0 && n <= 65535 => Some(n as u16),
+        _ => None,
+    }
+}
+
+// ── Pool tasks (Send, no GcPtr) ────────────────────────────────────────────────
+
+/// Runs on the pool: loops on `connection.accept_bi()` and, for each
+/// peer-initiated bidirectional stream, spawns pool_reader + pool_writer and
+/// sends a `QuicStreamResult` to the LocalSet bridge.
+async fn pool_stream_accept_loop(
+    connection: quinn::Connection,
+    stream_tx: mpsc::Sender<QuicStreamResult>,
+    in_buf: usize,
+    out_buf: usize,
+) {
+    loop {
+        match connection.accept_bi().await {
+            Err(e) => {
+                let _ = stream_tx
+                    .send(Err(format!("accept_bi: {e}")))
+                    .await;
+                break;
+            }
+            Ok((send, recv)) => {
+                let stream_id = send.id().index();
+                let (read_tx, read_rx) =
+                    mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+                let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
+
+                let reader_jh = tokio::spawn(pool_reader(recv, read_tx));
+                let writer_jh = tokio::spawn(pool_writer(send, write_rx));
+
+                let msg = QuicStreamSetup {
+                    stream_id,
+                    setup: PoolStreamSetup {
+                        remote_addr: String::new(),
+                        local_addr: String::new(),
+                        read_rx,
+                        write_tx,
+                        reader_abort: reader_jh.abort_handle(),
+                        writer_abort: writer_jh.abort_handle(),
+                    },
+                };
+
+                if stream_tx.send(Ok(msg)).await.is_err() {
+                    // LocalSet bridge dropped; abort the just-spawned tasks.
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Runs on the pool: opens a single bidirectional stream on the connection,
+/// spawns pool_reader + pool_writer, and sends the result via oneshot.
+async fn pool_open_stream(
+    connection: quinn::Connection,
+    in_buf: usize,
+    out_buf: usize,
+    stream_tx: oneshot::Sender<QuicStreamResult>,
+) {
+    match connection.open_bi().await {
+        Err(e) => {
+            let _ = stream_tx.send(Err(format!("open_bi: {e}")));
+        }
+        Ok((send, recv)) => {
+            let stream_id = send.id().index();
+            let (read_tx, read_rx) =
+                mpsc::channel::<crate::pool_io::ReadMsg>(in_buf.max(1));
+            let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(out_buf.max(1));
+
+            let reader_jh = tokio::spawn(pool_reader(recv, read_tx));
+            let writer_jh = tokio::spawn(pool_writer(send, write_rx));
+
+            let _ = stream_tx.send(Ok(QuicStreamSetup {
+                stream_id,
+                setup: PoolStreamSetup {
+                    remote_addr: String::new(),
+                    local_addr: String::new(),
+                    read_rx,
+                    write_tx,
+                    reader_abort: reader_jh.abort_handle(),
+                    writer_abort: writer_jh.abort_handle(),
+                },
+            }));
+        }
+    }
+}
+
+// ── LocalSet bridges (touch GcPtr / Value) ────────────────────────────────────
+
+/// Runs on the LocalSet: receives `QuicStreamResult` from `pool_stream_accept_loop`,
+/// builds stream maps, and puts them on the `:streams` channel.
+async fn local_stream_accept_bridge(
+    mut stream_rx: mpsc::Receiver<QuicStreamResult>,
+    streams_chan: GcPtr<NativeObjectBox>,
+    in_buf: usize,
+    out_buf: usize,
+) {
+    while let Some(result) = stream_rx.recv().await {
+        match result {
+            Err(e) => {
+                chan_put(&streams_chan, net_error(e)).await;
+                break;
+            }
+            Ok(msg) => {
+                let stream_val =
+                    make_quic_stream_from_setup(msg.setup, msg.stream_id, in_buf, out_buf);
+                if !chan_put(&streams_chan, stream_val).await {
+                    break;
+                }
+            }
+        }
+    }
+    chan_ref(streams_chan.get()).close();
+}
+
+/// Build a QUIC stream map from a `PoolStreamSetup`, spawning LocalSet bridge tasks.
+/// Called on the LocalSet thread.
+fn make_quic_stream_from_setup(
+    setup: PoolStreamSetup,
+    stream_id: u64,
+    in_buf: usize,
+    out_buf: usize,
+) -> Value {
+    let in_chan = make_chan(in_buf);
+    let out_chan = make_chan(out_buf);
+    let resource = QuicStreamResource::new();
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    let rb_jh = tokio::task::spawn_local(read_bridge(setup.read_rx, in_chan.clone()));
+    let wb_jh = tokio::task::spawn_local(write_bridge(out_chan.clone(), setup.write_tx));
+
+    {
+        let mut g = shared_inner.lock().unwrap();
+        g.abort_handles.push(setup.reader_abort);
+        g.abort_handles.push(setup.writer_abort);
+        g.abort_handles.push(rb_jh.abort_handle());
+        g.abort_handles.push(wb_jh.abort_handle());
+    }
+
+    Value::Map(MapValue::from_pairs(vec![
+        (kw("in"), Value::NativeObject(in_chan)),
+        (kw("out"), Value::NativeObject(out_chan)),
+        (kw("stream-id"), Value::Long(stream_id as i64)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]))
+}
+
+/// Build a QUIC connection map from an established `quinn::Connection`.
+/// Spawns the peer-stream accept loop (pool) and its LocalSet bridge.
+fn make_quic_connection(
+    connection: quinn::Connection,
+    endpoint: quinn::Endpoint,
+    remote_addr: String,
+    local_addr: String,
+    streams_buf: usize,
+    in_buf: usize,
+    out_buf: usize,
+) -> Value {
+    let streams_chan = make_chan(streams_buf);
+
+    let resource = QuicConnectionResource::new(connection.clone(), endpoint);
+    let shared_inner = resource.inner.clone();
+    let resource_handle = ResourceHandle::new(resource);
+
+    let (stream_tx, stream_rx) = mpsc::channel::<QuicStreamResult>(streams_buf.max(1));
+
+    let pool_jh = WorkerPool::global()
+        .handle()
+        .spawn(pool_stream_accept_loop(connection, stream_tx, in_buf, out_buf));
+
+    let bridge_jh = tokio::task::spawn_local(local_stream_accept_bridge(
+        stream_rx,
+        streams_chan.clone(),
+        in_buf,
+        out_buf,
+    ));
+
+    {
+        let mut g = shared_inner.lock().unwrap();
+        g.abort_handles.push(pool_jh.abort_handle());
+        g.abort_handles.push(bridge_jh.abort_handle());
+    }
+
+    Value::Map(MapValue::from_pairs(vec![
+        (kw("streams"), Value::NativeObject(streams_chan)),
+        (kw("remote-addr"), Value::string(remote_addr)),
+        (kw("local-addr"), Value::string(local_addr)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]))
+}
+
+// ── Connect implementation ─────────────────────────────────────────────────────
+
+/// Initiate a QUIC connection to `host:port` and return a promise channel.
+///
+/// The QUIC handshake runs on the `WorkerPool`. On success, delivers a
+/// connection map to the promise channel on the LocalSet. On failure, delivers
+/// a `Value::Error`.
+pub fn connect_to(
+    host: &str,
+    port: u16,
+    quinn_config: quinn::ClientConfig,
+    streams_buf: usize,
+    in_buf: usize,
+    out_buf: usize,
+) -> Value {
+    let host = host.to_string();
+    let promise = make_chan(1);
+    let promise_val = Value::NativeObject(promise.clone());
+    spawn_future(async move {
+        do_quic_connect(host, port, quinn_config, streams_buf, in_buf, out_buf, promise).await
+    });
+    promise_val
+}
+
+async fn do_quic_connect(
+    host: String,
+    port: u16,
+    quinn_config: quinn::ClientConfig,
+    streams_buf: usize,
+    in_buf: usize,
+    out_buf: usize,
+    promise: GcPtr<NativeObjectBox>,
+) -> EvalResult {
+    type ConnResult = Result<(quinn::Connection, quinn::Endpoint, String, String), String>;
+    let (conn_tx, conn_rx) = oneshot::channel::<ConnResult>();
+
+    WorkerPool::global().handle().spawn(async move {
+        let addr_str = format!("{host}:{port}");
+
+        // Resolve host to a SocketAddr (handles both IPs and hostnames).
+        let addr = match tokio::net::lookup_host(&addr_str).await {
+            Ok(mut it) => match it.next() {
+                Some(a) => a,
+                None => {
+                    let _ = conn_tx.send(Err(format!("no address for {addr_str}")));
+                    return;
+                }
+            },
+            Err(e) => {
+                let _ = conn_tx.send(Err(format!("lookup {addr_str}: {e}")));
+                return;
+            }
+        };
+
+        let bind: std::net::SocketAddr = if addr.is_ipv6() {
+            "[::]:0".parse().unwrap()
+        } else {
+            "0.0.0.0:0".parse().unwrap()
+        };
+
+        let mut endpoint = match quinn::Endpoint::client(bind) {
+            Ok(e) => e,
+            Err(e) => {
+                let _ = conn_tx.send(Err(format!("endpoint: {e}")));
+                return;
+            }
+        };
+        endpoint.set_default_client_config(quinn_config);
+
+        let connecting = match endpoint.connect(addr, &host) {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = conn_tx.send(Err(format!("connect: {e}")));
+                return;
+            }
+        };
+
+        let connection = match connecting.await {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = conn_tx.send(Err(format!("handshake: {e}")));
+                return;
+            }
+        };
+
+        let remote_addr = connection.remote_address().to_string();
+        let local_addr = endpoint.local_addr().map(|a| a.to_string()).unwrap_or_default();
+        let _ = conn_tx.send(Ok((connection, endpoint, remote_addr, local_addr)));
+    });
+
+    match conn_rx.await {
+        Err(_) => chan_deliver(&promise, net_error("pool task dropped")).await,
+        Ok(Err(e)) => chan_deliver(&promise, net_error(e)).await,
+        Ok(Ok((connection, endpoint, remote_addr, local_addr))) => {
+            let conn =
+                make_quic_connection(connection, endpoint, remote_addr, local_addr, streams_buf, in_buf, out_buf);
+            chan_deliver(&promise, conn).await;
+        }
+    }
+    Ok(Value::Nil)
+}
+
+// ── Open-stream implementation ─────────────────────────────────────────────────
+
+/// Open a new bidirectional stream on an existing connection.
+///
+/// Runs `open_bi()` on the `WorkerPool` and returns a promise channel that
+/// yields a stream map on the LocalSet.
+pub fn open_stream_on(
+    connection: quinn::Connection,
+    in_buf: usize,
+    out_buf: usize,
+) -> Value {
+    let promise = make_chan(1);
+    let promise_val = Value::NativeObject(promise.clone());
+    spawn_future(async move {
+        do_open_stream(connection, in_buf, out_buf, promise).await
+    });
+    promise_val
+}
+
+async fn do_open_stream(
+    connection: quinn::Connection,
+    in_buf: usize,
+    out_buf: usize,
+    promise: GcPtr<NativeObjectBox>,
+) -> EvalResult {
+    let (stream_tx, stream_rx) = oneshot::channel::<QuicStreamResult>();
+
+    WorkerPool::global()
+        .handle()
+        .spawn(pool_open_stream(connection, in_buf, out_buf, stream_tx));
+
+    match stream_rx.await {
+        Err(_) => chan_deliver(&promise, net_error("pool task dropped")).await,
+        Ok(Err(e)) => chan_deliver(&promise, net_error(e)).await,
+        Ok(Ok(msg)) => {
+            let stream_val =
+                make_quic_stream_from_setup(msg.setup, msg.stream_id, in_buf, out_buf);
+            chan_deliver(&promise, stream_val).await;
+        }
+    }
+    Ok(Value::Nil)
+}
+
+// ── Builtins ───────────────────────────────────────────────────────────────────
+
+/// `(connect {:host h :port p :alpn [...] :insecure-skip-verify bool ...})`
+/// Returns a promise channel yielding the connection map or a `Value::Error`.
+fn builtin_connect(args: &[Value]) -> ValueResult<Value> {
+    let opts = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:host str :port long}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let host = opts_str(&opts, "host").ok_or_else(|| ValueError::Other(":host required".into()))?;
+    let port =
+        opts_port(&opts).ok_or_else(|| ValueError::Other(":port required (1-65535)".into()))?;
+    let streams_buf = opts_usize(&opts, "streams-buf").unwrap_or(8);
+    let in_buf = opts_usize(&opts, "in-buf").unwrap_or(8);
+    let out_buf = opts_usize(&opts, "out-buf").unwrap_or(8);
+
+    let config = crate::quic_config::client_config(&opts)?;
+    Ok(connect_to(&host, port, config, streams_buf, in_buf, out_buf))
+}
+
+/// `(open-stream conn)` or `(open-stream conn {:in-buf N :out-buf N})`
+/// Returns a promise channel yielding a stream map or a `Value::Error`.
+fn builtin_open_stream(args: &[Value]) -> ValueResult<Value> {
+    let conn_map = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "connection map {:resource handle}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    let (in_buf, out_buf) = match args.get(1) {
+        Some(Value::Map(m)) => (
+            opts_usize(m, "in-buf").unwrap_or(8),
+            opts_usize(m, "out-buf").unwrap_or(8),
+        ),
+        _ => (8, 8),
+    };
+
+    let resource_handle = match conn_map.get(&kw("resource")) {
+        Some(Value::Resource(h)) => h.clone(),
+        _ => {
+            return Err(ValueError::Other(
+                "connection map missing :resource".into(),
+            ));
+        }
+    };
+
+    let conn_res = resource_handle
+        .downcast::<QuicConnectionResource>()
+        .ok_or_else(|| ValueError::Other("not a QuicConnectionResource".into()))?;
+
+    let connection = conn_res.connection.clone();
+    Ok(open_stream_on(connection, in_buf, out_buf))
+}
+
+/// `(close conn)` — close a QUIC connection, aborting all tasks and sending
+/// a CONNECTION_CLOSE frame to the peer.
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let conn = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "connection map",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::NativeObject(obj)) = conn.get(&kw("streams")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::Resource(handle)) = conn.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}
+
+/// `(stream-close stream)` — close a QUIC stream, sending FIN/RESET to the peer.
+fn builtin_stream_close(args: &[Value]) -> ValueResult<Value> {
+    let stream = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "stream map",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::NativeObject(obj)) = stream.get(&kw("out")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::NativeObject(obj)) = stream.get(&kw("in")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::Resource(handle)) = stream.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}

--- a/crates/cljrs-net/src/quic.rs
+++ b/crates/cljrs-net/src/quic.rs
@@ -459,58 +459,66 @@ async fn do_quic_connect(
     WorkerPool::global().handle().spawn(async move {
         let addr_str = format!("{host}:{port}");
 
-        // Resolve host to a SocketAddr (handles both IPs and hostnames).
-        let addr = match tokio::net::lookup_host(&addr_str).await {
-            Ok(mut it) => match it.next() {
-                Some(a) => a,
-                None => {
-                    let _ = conn_tx.send(Err(format!("no address for {addr_str}")));
-                    return;
-                }
-            },
+        // Resolve host; prefer IPv4 over IPv6 so that "localhost" works on
+        // runners where /etc/hosts lists ::1 before 127.0.0.1.
+        let addrs: Vec<std::net::SocketAddr> = match tokio::net::lookup_host(&addr_str).await {
+            Ok(it) => {
+                let (v4, v6): (Vec<_>, Vec<_>) = it.partition(|a| a.is_ipv4());
+                v4.into_iter().chain(v6).collect()
+            }
             Err(e) => {
                 let _ = conn_tx.send(Err(format!("lookup {addr_str}: {e}")));
                 return;
             }
         };
 
-        let bind: std::net::SocketAddr = if addr.is_ipv6() {
-            "[::]:0".parse().unwrap()
-        } else {
-            "0.0.0.0:0".parse().unwrap()
-        };
+        if addrs.is_empty() {
+            let _ = conn_tx.send(Err(format!("no address for {addr_str}")));
+            return;
+        }
 
-        let mut endpoint = match quinn::Endpoint::client(bind) {
-            Ok(e) => e,
-            Err(e) => {
-                let _ = conn_tx.send(Err(format!("endpoint: {e}")));
-                return;
+        let mut last_err = String::new();
+        for addr in addrs {
+            let bind: std::net::SocketAddr = if addr.is_ipv6() {
+                "[::]:0".parse().unwrap()
+            } else {
+                "0.0.0.0:0".parse().unwrap()
+            };
+
+            let mut endpoint = match quinn::Endpoint::client(bind) {
+                Ok(e) => e,
+                Err(e) => {
+                    last_err = format!("endpoint: {e}");
+                    continue;
+                }
+            };
+            endpoint.set_default_client_config(quinn_config.clone());
+
+            let connecting = match endpoint.connect(addr, &host) {
+                Ok(c) => c,
+                Err(e) => {
+                    last_err = format!("connect: {e}");
+                    continue;
+                }
+            };
+
+            match connecting.await {
+                Ok(connection) => {
+                    let remote_addr = connection.remote_address().to_string();
+                    let local_addr = endpoint
+                        .local_addr()
+                        .map(|a| a.to_string())
+                        .unwrap_or_default();
+                    let _ = conn_tx.send(Ok((connection, endpoint, remote_addr, local_addr)));
+                    return;
+                }
+                Err(e) => {
+                    last_err = format!("handshake: {e}");
+                    continue;
+                }
             }
-        };
-        endpoint.set_default_client_config(quinn_config);
-
-        let connecting = match endpoint.connect(addr, &host) {
-            Ok(c) => c,
-            Err(e) => {
-                let _ = conn_tx.send(Err(format!("connect: {e}")));
-                return;
-            }
-        };
-
-        let connection = match connecting.await {
-            Ok(c) => c,
-            Err(e) => {
-                let _ = conn_tx.send(Err(format!("handshake: {e}")));
-                return;
-            }
-        };
-
-        let remote_addr = connection.remote_address().to_string();
-        let local_addr = endpoint
-            .local_addr()
-            .map(|a| a.to_string())
-            .unwrap_or_default();
-        let _ = conn_tx.send(Ok((connection, endpoint, remote_addr, local_addr)));
+        }
+        let _ = conn_tx.send(Err(last_err));
     });
 
     match conn_rx.await {

--- a/crates/cljrs-net/src/quic_config.rs
+++ b/crates/cljrs-net/src/quic_config.rs
@@ -1,0 +1,74 @@
+//! Build quinn client/server configs from Clojure opts maps.
+//!
+//! Delegates TLS layer construction to `tls::build_client_config` /
+//! `tls::build_server_config`, then wraps the resulting rustls configs into
+//! quinn via `QuicClientConfig::try_from` / `QuicServerConfig::try_from`.
+//! Transport parameters (`:max-idle-ms`, `:keep-alive-ms`, `:max-streams`) are
+//! applied to a `quinn::TransportConfig` and attached to the returned config.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+
+use cljrs_value::{Keyword, MapValue, Value, ValueError, ValueResult};
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn opts_u64(opts: &MapValue, key: &str) -> Option<u64> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n > 0 => Some(n as u64),
+        _ => None,
+    }
+}
+
+fn transport_config(opts: &MapValue) -> Arc<quinn::TransportConfig> {
+    let mut transport = quinn::TransportConfig::default();
+
+    if let Some(ms) = opts_u64(opts, "max-idle-ms") {
+        if let Ok(v) = quinn::VarInt::try_from(ms) {
+            transport.max_idle_timeout(Some(quinn::IdleTimeout::from(v)));
+        }
+    }
+
+    if let Some(ms) = opts_u64(opts, "keep-alive-ms") {
+        transport.keep_alive_interval(Some(Duration::from_millis(ms)));
+    }
+
+    if let Some(n) = opts_u64(opts, "max-streams") {
+        if let Ok(v) = quinn::VarInt::try_from(n) {
+            transport.max_concurrent_bidi_streams(v);
+        }
+    }
+
+    Arc::new(transport)
+}
+
+/// Build a `quinn::ClientConfig` from a Clojure opts map.
+///
+/// All TLS options (`:insecure-skip-verify`, `:alpn`, `:roots`) are forwarded
+/// to `tls::build_client_config`. QUIC transport params (`:max-idle-ms`,
+/// `:keep-alive-ms`, `:max-streams`) are applied via `TransportConfig`.
+pub fn client_config(opts: &MapValue) -> ValueResult<quinn::ClientConfig> {
+    let rustls_cfg = crate::tls::build_client_config(opts)?;
+    let quic_cfg = QuicClientConfig::try_from(rustls_cfg)
+        .map_err(|e| ValueError::Other(format!("quinn client config: {e}")))?;
+    let mut config = quinn::ClientConfig::new(Arc::new(quic_cfg));
+    config.transport_config(transport_config(opts));
+    Ok(config)
+}
+
+/// Build a `quinn::ServerConfig` from a Clojure opts map.
+///
+/// Requires `:cert` and `:key` (PEM file paths). All other TLS options are
+/// forwarded to `tls::build_server_config`. QUIC transport params are applied.
+pub fn server_config(opts: &MapValue) -> ValueResult<quinn::ServerConfig> {
+    let rustls_cfg = crate::tls::build_server_config(opts)?;
+    let quic_cfg = QuicServerConfig::try_from(rustls_cfg)
+        .map_err(|e| ValueError::Other(format!("quinn server config: {e}")))?;
+    let mut config = quinn::ServerConfig::with_crypto(Arc::new(quic_cfg));
+    config.transport_config(transport_config(opts));
+    Ok(config)
+}

--- a/crates/cljrs-net/src/quic_config.rs
+++ b/crates/cljrs-net/src/quic_config.rs
@@ -28,18 +28,20 @@ fn transport_config(opts: &MapValue) -> Arc<quinn::TransportConfig> {
     let mut transport = quinn::TransportConfig::default();
 
     if let Some(ms) = opts_u64(opts, "max-idle-ms")
-        && let Ok(v) = quinn::VarInt::try_from(ms) {
-            transport.max_idle_timeout(Some(quinn::IdleTimeout::from(v)));
-        }
+        && let Ok(v) = quinn::VarInt::try_from(ms)
+    {
+        transport.max_idle_timeout(Some(quinn::IdleTimeout::from(v)));
+    }
 
     if let Some(ms) = opts_u64(opts, "keep-alive-ms") {
         transport.keep_alive_interval(Some(Duration::from_millis(ms)));
     }
 
     if let Some(n) = opts_u64(opts, "max-streams")
-        && let Ok(v) = quinn::VarInt::try_from(n) {
-            transport.max_concurrent_bidi_streams(v);
-        }
+        && let Ok(v) = quinn::VarInt::try_from(n)
+    {
+        transport.max_concurrent_bidi_streams(v);
+    }
 
     Arc::new(transport)
 }

--- a/crates/cljrs-net/src/quic_config.rs
+++ b/crates/cljrs-net/src/quic_config.rs
@@ -27,21 +27,19 @@ fn opts_u64(opts: &MapValue, key: &str) -> Option<u64> {
 fn transport_config(opts: &MapValue) -> Arc<quinn::TransportConfig> {
     let mut transport = quinn::TransportConfig::default();
 
-    if let Some(ms) = opts_u64(opts, "max-idle-ms") {
-        if let Ok(v) = quinn::VarInt::try_from(ms) {
+    if let Some(ms) = opts_u64(opts, "max-idle-ms")
+        && let Ok(v) = quinn::VarInt::try_from(ms) {
             transport.max_idle_timeout(Some(quinn::IdleTimeout::from(v)));
         }
-    }
 
     if let Some(ms) = opts_u64(opts, "keep-alive-ms") {
         transport.keep_alive_interval(Some(Duration::from_millis(ms)));
     }
 
-    if let Some(n) = opts_u64(opts, "max-streams") {
-        if let Ok(v) = quinn::VarInt::try_from(n) {
+    if let Some(n) = opts_u64(opts, "max-streams")
+        && let Ok(v) = quinn::VarInt::try_from(n) {
             transport.max_concurrent_bidi_streams(v);
         }
-    }
 
     Arc::new(transport)
 }

--- a/crates/cljrs-net/tests/quic.rs
+++ b/crates/cljrs-net/tests/quic.rs
@@ -116,7 +116,7 @@ fn test_quic_echo_round_trip() {
             cljrs_net::quic_config::client_config(&client_opts).expect("client config");
 
         // Connect.
-        let promise = cljrs_net::quic::connect_to("localhost", port, quinn_config, 8, 8, 8);
+        let promise = cljrs_net::quic::connect_to("127.0.0.1", port, quinn_config, 8, 8, 8);
         let conn_val = chan_take(&as_chan(&promise)).await;
         let conn = match conn_val {
             Value::Map(m) => m,

--- a/crates/cljrs-net/tests/quic.rs
+++ b/crates/cljrs-net/tests/quic.rs
@@ -40,9 +40,8 @@ fn make_server_config() -> (quinn::ServerConfig, rcgen::CertifiedKey) {
         .expect("rcgen cert generation failed");
 
     let cert_der = rustls::pki_types::CertificateDer::from(certified.cert.der().to_vec());
-    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(
-        certified.key_pair.serialize_der().into(),
-    );
+    let key_der =
+        rustls::pki_types::PrivateKeyDer::Pkcs8(certified.key_pair.serialize_der().into());
 
     let rustls_cfg = rustls::ServerConfig::builder_with_provider(Arc::new(
         rustls::crypto::ring::default_provider(),
@@ -63,9 +62,8 @@ fn make_server_config() -> (quinn::ServerConfig, rcgen::CertifiedKey) {
 /// Spawn a simple QUIC echo server on the WorkerPool.
 /// Returns the bound port.
 fn spawn_echo_server(server_config: quinn::ServerConfig) -> u16 {
-    let endpoint =
-        quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap())
-            .expect("server endpoint");
+    let endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap())
+        .expect("server endpoint");
     let port = endpoint.local_addr().unwrap().port();
 
     WorkerPool::global().handle().spawn(async move {
@@ -112,16 +110,13 @@ fn test_quic_echo_round_trip() {
         let port = spawn_echo_server(server_config);
 
         // Build insecure client config (accepts self-signed cert).
-        let client_opts = MapValue::from_pairs(vec![(
-            kw("insecure-skip-verify"),
-            Value::Bool(true),
-        )]);
+        let client_opts =
+            MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
         let quinn_config =
             cljrs_net::quic_config::client_config(&client_opts).expect("client config");
 
         // Connect.
-        let promise =
-            cljrs_net::quic::connect_to("localhost", port, quinn_config, 8, 8, 8);
+        let promise = cljrs_net::quic::connect_to("localhost", port, quinn_config, 8, 8, 8);
         let conn_val = chan_take(&as_chan(&promise)).await;
         let conn = match conn_val {
             Value::Map(m) => m,
@@ -173,13 +168,8 @@ fn test_quic_echo_round_trip() {
             match chan_take(&in_ch).await {
                 Value::Nil => break,
                 Value::ByteArray(arr) => {
-                    let bytes: Vec<u8> = arr
-                        .get()
-                        .lock()
-                        .unwrap()
-                        .iter()
-                        .map(|&b| b as u8)
-                        .collect();
+                    let bytes: Vec<u8> =
+                        arr.get().lock().unwrap().iter().map(|&b| b as u8).collect();
                     response.extend_from_slice(&bytes);
                 }
                 Value::Error(e) => panic!("read error: {}", e.get().message()),
@@ -208,10 +198,8 @@ fn test_quic_connect_failure() {
     local.block_on(&rt, async {
         let _globals = setup_globals();
 
-        let client_opts = MapValue::from_pairs(vec![(
-            kw("insecure-skip-verify"),
-            Value::Bool(true),
-        )]);
+        let client_opts =
+            MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
         let quinn_config =
             cljrs_net::quic_config::client_config(&client_opts).expect("client config");
 

--- a/crates/cljrs-net/tests/quic.rs
+++ b/crates/cljrs-net/tests/quic.rs
@@ -1,0 +1,229 @@
+//! Phase Q1 integration tests: QUIC client transport.
+//!
+//! Done criterion: client connects to a quinn echo server, opens a bidirectional
+//! stream, sends bytes, FINs the write side, drains the echoed response.
+//! Also validates the failure path (connect timeout to a dead UDP port yields
+//! Value::Error).
+
+use std::sync::Arc;
+
+use cljrs_async::channel::{chan_put, chan_ref, chan_take};
+use cljrs_async::worker_pool::WorkerPool;
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn map_get(map: &MapValue, key: &str) -> Value {
+    map.get(&kw(key))
+        .unwrap_or_else(|| panic!("map missing :{key}"))
+}
+
+fn as_chan(v: &Value) -> GcPtr<NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => obj.clone(),
+        other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+    }
+}
+
+/// Build a self-signed rustls ServerConfig + QuicServerConfig using rcgen.
+fn make_server_config() -> (quinn::ServerConfig, rcgen::CertifiedKey) {
+    let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("rcgen cert generation failed");
+
+    let cert_der = rustls::pki_types::CertificateDer::from(certified.cert.der().to_vec());
+    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(
+        certified.key_pair.serialize_der().into(),
+    );
+
+    let rustls_cfg = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("tls versions")
+    .with_no_client_auth()
+    .with_single_cert(vec![cert_der], key_der)
+    .expect("server cert");
+
+    let quic_cfg = quinn::crypto::rustls::QuicServerConfig::try_from(Arc::new(rustls_cfg))
+        .expect("quic server config");
+
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_cfg));
+    (server_config, certified)
+}
+
+/// Spawn a simple QUIC echo server on the WorkerPool.
+/// Returns the bound port.
+fn spawn_echo_server(server_config: quinn::ServerConfig) -> u16 {
+    let endpoint =
+        quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap())
+            .expect("server endpoint");
+    let port = endpoint.local_addr().unwrap().port();
+
+    WorkerPool::global().handle().spawn(async move {
+        use tokio::io::AsyncWriteExt;
+        while let Some(incoming) = endpoint.accept().await {
+            let conn = match incoming.await {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            tokio::spawn(async move {
+                loop {
+                    match conn.accept_bi().await {
+                        Err(_) => break,
+                        Ok((mut send, mut recv)) => {
+                            tokio::spawn(async move {
+                                // quinn's own read_to_end takes a byte limit
+                                let data = recv.read_to_end(1 << 20).await.unwrap_or_default();
+                                send.write_all(&data).await.ok();
+                                send.shutdown().await.ok();
+                            });
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    port
+}
+
+/// Phase Q1 done criterion: QUIC client connects, opens a stream, echoes bytes.
+#[test]
+fn test_quic_echo_round_trip() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let (server_config, _cert) = make_server_config();
+        let port = spawn_echo_server(server_config);
+
+        // Build insecure client config (accepts self-signed cert).
+        let client_opts = MapValue::from_pairs(vec![(
+            kw("insecure-skip-verify"),
+            Value::Bool(true),
+        )]);
+        let quinn_config =
+            cljrs_net::quic_config::client_config(&client_opts).expect("client config");
+
+        // Connect.
+        let promise =
+            cljrs_net::quic::connect_to("localhost", port, quinn_config, 8, 8, 8);
+        let conn_val = chan_take(&as_chan(&promise)).await;
+        let conn = match conn_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("QUIC connect failed: {}", e.get().message()),
+            other => panic!("expected map, got {}", other.type_name()),
+        };
+
+        // Extract connection resource to open a stream.
+        let resource_handle = match map_get(&conn, "resource") {
+            Value::Resource(h) => h,
+            other => panic!("expected resource, got {}", other.type_name()),
+        };
+        let conn_res = resource_handle
+            .downcast::<cljrs_net::quic::QuicConnectionResource>()
+            .expect("QuicConnectionResource downcast");
+        let connection = conn_res.connection.clone();
+
+        // Open a bidirectional stream.
+        let stream_promise = cljrs_net::quic::open_stream_on(connection, 8, 8);
+        let stream_val = chan_take(&as_chan(&stream_promise)).await;
+        let stream = match stream_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("open_stream failed: {}", e.get().message()),
+            other => panic!("expected stream map, got {}", other.type_name()),
+        };
+
+        // Verify stream-id is present and non-negative.
+        match map_get(&stream, "stream-id") {
+            Value::Long(id) => assert!(id >= 0, "stream-id must be non-negative"),
+            other => panic!("expected long :stream-id, got {}", other.type_name()),
+        }
+
+        let out_ch = as_chan(&map_get(&stream, "out"));
+        let in_ch = as_chan(&map_get(&stream, "in"));
+
+        // Send bytes and FIN the write side.
+        let request = b"phase Q1 QUIC echo test";
+        let signed: Vec<i8> = request.iter().map(|&b| b as i8).collect();
+        chan_put(
+            &out_ch,
+            Value::ByteArray(GcPtr::new(std::sync::Mutex::new(signed))),
+        )
+        .await;
+        chan_ref(out_ch.get()).close();
+
+        // Drain :in until stream EOF.
+        let mut response: Vec<u8> = Vec::new();
+        loop {
+            match chan_take(&in_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(arr) => {
+                    let bytes: Vec<u8> = arr
+                        .get()
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .map(|&b| b as u8)
+                        .collect();
+                    response.extend_from_slice(&bytes);
+                }
+                Value::Error(e) => panic!("read error: {}", e.get().message()),
+                other => panic!("unexpected on :in: {}", other.type_name()),
+            }
+        }
+
+        assert_eq!(response, request, "QUIC echo must return the same bytes");
+
+        // Close the connection.
+        if let Value::Resource(handle) = map_get(&conn, "resource") {
+            let _ = handle.close();
+        }
+    });
+}
+
+/// A QUIC connect attempt to a port that is not listening must yield Value::Error.
+#[test]
+fn test_quic_connect_failure() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let client_opts = MapValue::from_pairs(vec![(
+            kw("insecure-skip-verify"),
+            Value::Bool(true),
+        )]);
+        let quinn_config =
+            cljrs_net::quic_config::client_config(&client_opts).expect("client config");
+
+        // Port 1 — privileged, not listening; QUIC will time out or get ICMP
+        // unreachable.
+        let promise = cljrs_net::quic::connect_to("127.0.0.1", 1, quinn_config, 8, 8, 8);
+
+        let result = chan_take(&as_chan(&promise)).await;
+        assert!(
+            matches!(result, Value::Error(_)),
+            "expected Value::Error for unreachable QUIC port, got {}",
+            result.type_name()
+        );
+    });
+}


### PR DESCRIPTION
Adds raw multiplexed QUIC client transport to cljrs-net, exposing the
clojure.rust.net.quic namespace. QUIC streams reuse pool_io.rs unchanged
because quinn::SendStream/RecvStream implement AsyncWrite/AsyncRead.

New files:
- src/quic_config.rs  – build quinn::ClientConfig/ServerConfig from opts
  maps by delegating TLS setup to tls::build_client_config/build_server_config
  and wrapping via QuicClientConfig/QuicServerConfig::try_from; applies
  :max-idle-ms / :keep-alive-ms / :max-streams via TransportConfig
- src/quic.rs         – QuicConnectionResource (holds quinn::Connection +
  Endpoint + abort handles), QuicStreamResource, pool accept/open loops,
  LocalSet bridges, connect_to/open_stream_on, builtins connect/open-stream/
  close/stream-close
- src/clojure_rust_net_quic.cljrs – with-stream / drain-stream sugar
- tests/quic.rs       – echo round-trip against a quinn in-test server;
  connect-failure path

Modified:
- Cargo.toml (workspace) – quinn 0.11 (rustls-ring, no aws-lc-rs)
- crates/cljrs-net/Cargo.toml – add quinn dep
- src/lib.rs  – NS_QUIC constant + idempotent init block
- README.md   – document new source files, public API, resource types
- TODO.md     – add Q1–Q5 phased roadmap under cljrs-net/QUIC+HTTP3

All 31 tests in cljrs-net pass (2 new QUIC + 29 existing).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FvAQ5YVGTE2K7dURj6pX67