### PR TITLE
feat(cljrs-net): implement Phase Q3 — HTTP/3 client (h3/get, h3/request, body streaming)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
 name = "cljrs-net"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "cljrs-async",
  "cljrs-env",
  "cljrs-gc",
@@ -1067,6 +1068,9 @@ dependencies = [
  "cljrs-stdlib",
  "cljrs-types",
  "cljrs-value",
+ "h3",
+ "h3-quinn",
+ "http",
  "quinn",
  "rcgen",
  "rustls",
@@ -3284,6 +3288,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3",
+ "quinn",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,6 +4902,7 @@ checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ rustyline    = "18.0.0"
 libloading   = "0.8"
 arc-swap     = "1"
 quinn        = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
+h3           = "0.0.8"
+h3-quinn     = "0.0.10"
 tower-lsp     = "0.20"
 dashmap       = "6"
 

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -21,6 +21,10 @@ rustls-pemfile = "2"
 webpki-roots   = "0.26"
 rustls-native-certs = "0.8"
 quinn          = { workspace = true }
+h3             = { workspace = true }
+h3-quinn       = { workspace = true }
+bytes          = "1"
+http           = "1"
 
 [dev-dependencies]
 cljrs-stdlib   = { workspace = true }

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: TCP/Unix/TLS/QUIC networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–G + A2 + Q1 + Q2 implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics, pool-based I/O, QUIC client transport, QUIC server transport).
+**Status**: Phases A–G + A2 + Q1 + Q2 + Q3 implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics, pool-based I/O, QUIC client transport, QUIC server transport, HTTP/3 client).
 
 **Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
 
@@ -21,12 +21,14 @@
 | `src/unix.rs` | `UnixStreamResource`, `UnixListenerResource` (`close` unlinks path), reader/writer loops, accept loop, `connect`/`listen`/`close` builtins; `#[cfg(unix)]` with non-Unix stubs |
 | `src/quic_config.rs` | Build `quinn::ClientConfig`/`ServerConfig` from opts maps; delegates TLS to `tls::build_client_config`/`build_server_config`, wraps via `QuicClientConfig::try_from`; applies QUIC transport params (`:max-idle-ms`, `:keep-alive-ms`, `:max-streams`) |
 | `src/quic.rs` | `QuicConnectionResource` (holds `quinn::Connection` + `Endpoint` + abort handles), `QuicStreamResource` (abort handles for pool reader/writer + LocalSet bridges), `QuicListenerResource` (holds `Endpoint` + abort handles for pool accept loop + LocalSet bridge), pool accept/open loops, LocalSet bridges, `connect_to`/`open_stream_on`/`listen_on`, `connect`/`open-stream`/`close`/`stream-close`/`listen`/`listen-close` builtins |
+| `src/h3.rs` | `H3Resource` (holds `quinn::Connection` + `Endpoint` + abort handles for pool streaming task and LocalSet body-bridge), pool task for QUIC connect + h3 handshake + request send + response header recv + body streaming, LocalSet body bridge (`local_body_bridge`), `get`/`h3_request` public Rust API, `get`/`request`/`close` Clojure builtins |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
 | `src/clojure_rust_net_udp.cljrs` | Clojure source for `clojure.rust.net.udp`; usage examples |
 | `src/clojure_rust_net_tls.cljrs` | Clojure source for `clojure.rust.net.tls`; `start-server` sugar |
 | `src/clojure_rust_net_unix.cljrs` | Clojure source for `clojure.rust.net.unix`; `start-server` sugar |
 | `src/clojure_rust_net_quic.cljrs` | Clojure source for `clojure.rust.net.quic`; `with-stream`, `drain-stream`, `start-server` sugar |
+| `src/clojure_rust_net_h3.cljrs` | Clojure source for `clojure.rust.net.h3`; `drain-body`, `get-string` sugar |
 | `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net`; dispatches on `:transport` (`:tcp`, `:tls`, `:unix`) |
 | `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
 | `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |

--- a/crates/cljrs-net/src/clojure_rust_net_h3.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_h3.cljrs
@@ -1,0 +1,58 @@
+;; clojure.rust.net.h3 — HTTP/3 client.
+;;
+;; Phase Q3 (HTTP/3 client):
+;;   get     — (get url) / (get url opts) => promise-chan -> response-map
+;;   request — (request req) / (request req opts) => promise-chan -> response-map
+;;   close   — (close resp) => nil
+;;
+;; Response map shape:
+;;   {:status  200
+;;    :headers {"content-type" "text/plain" ...}
+;;    :body    <chan>    ; byte-array chunks; closed at EOF or error
+;;    :resource <H3Resource>}
+;;
+;; Opts (same as quic/connect):
+;;   :insecure-skip-verify — skip TLS cert verification (testing only)
+;;   :alpn                 — vector of ALPN strings (default ["h3"])
+;;   :roots                — CA roots (:webpki default, :system, or CA PEM path)
+;;   :max-idle-ms          — QUIC idle timeout
+;;   :keep-alive-ms        — QUIC keep-alive interval
+;;   :body-buf             — :body channel buffer depth (default 8)
+
+(defn drain-body
+  "Drain a response `:body` channel to a byte-array and return it.
+  Must be called in a `go` block (uses `await`).
+
+  Example:
+    (go
+      (let [resp (<! (h3/get \"https://host:4433/\"))
+            body (h3/drain-body resp)]
+        (println (String. body \"UTF-8\"))))"
+  [resp]
+  (let [body-ch (:body resp)]
+    (loop [acc []]
+      (let [v (await (clojure.core.async/take! body-ch))]
+        (if (nil? v)
+          (let [total (reduce + 0 (map count acc))
+                result (byte-array total)]
+            (loop [i 0 chunks acc]
+              (when-let [chunk (first chunks)]
+                (System/arraycopy chunk 0 result i (count chunk))
+                (recur (+ i (count chunk)) (rest chunks))))
+            result)
+          (recur (conj acc v)))))))
+
+(defn get-string
+  "Issue a GET request to `url` and return the response body as a UTF-8 string.
+  Must be called in a `go` block (uses `await`).
+
+  Opts: same as `get`.
+
+  Example:
+    (go (println (<! (h3/get-string \"https://host:4433/hello\"))))"
+  ([url] (get-string url {}))
+  ([url opts]
+   (let [resp (await (clojure.core.async/take!
+                       (clojure.rust.net.h3/get url opts)))]
+     (when (some? resp)
+       (String. (drain-body resp) "UTF-8")))))

--- a/crates/cljrs-net/src/h3.rs
+++ b/crates/cljrs-net/src/h3.rs
@@ -34,8 +34,8 @@ use cljrs_env::env::GlobalEnv;
 use cljrs_env::error::EvalResult;
 use cljrs_gc::GcPtr;
 use cljrs_value::{
-    Arity, Keyword, MapValue, NativeFn, NativeObjectBox, PersistentVector, Resource, ResourceHandle,
-    Value, ValueError, ValueResult,
+    Arity, Keyword, MapValue, NativeFn, NativeObjectBox, PersistentVector, Resource,
+    ResourceHandle, Value, ValueError, ValueResult,
 };
 
 use crate::pool_io::{bytes_value, net_error};
@@ -337,12 +337,7 @@ async fn pool_h3_request(
     let headers: Vec<(String, String)> = response
         .headers()
         .iter()
-        .map(|(k, v)| {
-            (
-                k.as_str().to_string(),
-                v.to_str().unwrap_or("").to_string(),
-            )
-        })
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
         .collect();
 
     let partial = H3ResponsePartial {
@@ -419,13 +414,7 @@ async fn local_body_bridge(
 /// `:roots`, `:max-idle-ms`, etc.). `:alpn ["h3"]` is injected automatically
 /// when absent.
 pub fn get(url: &str, opts: &MapValue, body_buf: usize) -> ValueResult<Value> {
-    h3_request(
-        url,
-        http::Method::GET,
-        vec![],
-        opts,
-        body_buf,
-    )
+    h3_request(url, http::Method::GET, vec![], opts, body_buf)
 }
 
 /// Issue an arbitrary HTTP/3 request and return a promise channel.
@@ -440,14 +429,11 @@ pub fn h3_request(
     opts: &MapValue,
     body_buf: usize,
 ) -> ValueResult<Value> {
-    let (host, port, uri) =
-        parse_url(url).map_err(ValueError::Other)?;
+    let (host, port, uri) = parse_url(url).map_err(ValueError::Other)?;
     let quinn_config = h3_client_config(opts)?;
 
-    let (body_tx, body_rx) =
-        mpsc::channel::<Result<Vec<u8>, String>>(body_buf.max(1));
-    let (response_tx, response_rx) =
-        oneshot::channel::<Result<H3ResponsePartial, String>>();
+    let (body_tx, body_rx) = mpsc::channel::<Result<Vec<u8>, String>>(body_buf.max(1));
+    let (response_tx, response_rx) = oneshot::channel::<Result<H3ResponsePartial, String>>();
 
     let pool_jh = WorkerPool::global().handle().spawn(pool_h3_request(
         host,
@@ -492,8 +478,7 @@ async fn do_h3_response(
 
     // Build :body channel and LocalSet bridge.
     let body_chan = make_chan(body_buf);
-    let bridge_jh =
-        tokio::task::spawn_local(local_body_bridge(body_rx, body_chan.clone()));
+    let bridge_jh = tokio::task::spawn_local(local_body_bridge(body_rx, body_chan.clone()));
     let bridge_abort = bridge_jh.abort_handle();
 
     // Build H3Resource.
@@ -570,8 +555,7 @@ fn builtin_request(args: &[Value]) -> ValueResult<Value> {
         _ => MapValue::empty(),
     };
 
-    let url =
-        opts_str(&req_map, "url").ok_or_else(|| ValueError::Other(":url required".into()))?;
+    let url = opts_str(&req_map, "url").ok_or_else(|| ValueError::Other(":url required".into()))?;
     let method_str = opts_str(&req_map, "method").unwrap_or_else(|| "GET".to_string());
     let method = method_str
         .parse::<http::Method>()

--- a/crates/cljrs-net/src/h3.rs
+++ b/crates/cljrs-net/src/h3.rs
@@ -1,0 +1,608 @@
+//! HTTP/3 client for `clojure.rust.net.h3` (Phase Q3).
+//!
+//! Wraps `h3`/`h3-quinn` on top of a quinn QUIC connection. For each request a
+//! fresh QUIC connection is established; the TLS/QUIC handshake and all HTTP/3
+//! I/O run on the `WorkerPool`; the response body is streamed to a `:body`
+//! channel via a `LocalSet` bridge task.
+//!
+//! Response map:
+//! ```clojure
+//! {:status  200
+//!  :headers {"content-type" "text/plain" ...}  ; string keys, string values
+//!  :body    <chan>    ; byte-array chunks; closed at EOF or on error
+//!  :resource <H3Resource>}
+//! ```
+//!
+//! `H3Resource` keeps the QUIC connection alive and holds abort handles for the
+//! pool streaming task and LocalSet bridge. Call `(h3/close resp)` to terminate
+//! the connection before the body is fully drained.
+//!
+//! ALPN: HTTP/3 requires the ALPN token `"h3"`. Pass `:alpn ["h3"]` in opts
+//! (or rely on the default injection done by `h3_client_config`).
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use bytes::Buf;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::AbortHandle;
+
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, make_chan};
+use cljrs_async::eval_async::spawn_future;
+use cljrs_async::worker_pool::WorkerPool;
+use cljrs_env::env::GlobalEnv;
+use cljrs_env::error::EvalResult;
+use cljrs_gc::GcPtr;
+use cljrs_value::{
+    Arity, Keyword, MapValue, NativeFn, NativeObjectBox, PersistentVector, Resource, ResourceHandle,
+    Value, ValueError, ValueResult,
+};
+
+use crate::pool_io::{bytes_value, net_error};
+
+// ── Public entry point ──────────────────────────────────────────────────────────
+
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        ("get", Arity::Variadic { min: 1 }, builtin_get),
+        ("request", Arity::Variadic { min: 1 }, builtin_request),
+        ("close", Arity::Fixed(1), builtin_close),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── H3Resource ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct H3Inner {
+    closed: bool,
+    abort_handles: Vec<AbortHandle>,
+}
+
+/// `Resource` for an HTTP/3 connection.
+///
+/// Holds the underlying `quinn::Connection` and `quinn::Endpoint` (keeping the
+/// QUIC/UDP driver alive) and abort handles for the WorkerPool body-streaming
+/// task and the LocalSet body-bridge task. `close()` aborts all tasks and sends
+/// a QUIC CONNECTION_CLOSE to the server. `resource_type` → `"H3Connection"`.
+#[derive(Debug)]
+pub struct H3Resource {
+    connection: quinn::Connection,
+    _endpoint: quinn::Endpoint,
+    inner: Arc<Mutex<H3Inner>>,
+}
+
+impl H3Resource {
+    fn new(connection: quinn::Connection, endpoint: quinn::Endpoint) -> Self {
+        Self {
+            connection,
+            _endpoint: endpoint,
+            inner: Arc::new(Mutex::new(H3Inner {
+                closed: false,
+                abort_handles: Vec::new(),
+            })),
+        }
+    }
+}
+
+impl Resource for H3Resource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        for h in g.abort_handles.drain(..) {
+            h.abort();
+        }
+        self.connection
+            .close(quinn::VarInt::from_u32(0), b"h3 closed");
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "H3Connection"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Internal types ──────────────────────────────────────────────────────────────
+
+/// Partial response from the pool task — delivered as soon as response headers
+/// arrive so the LocalSet can build the `:body` channel and response map before
+/// the body is fully streamed.
+struct H3ResponsePartial {
+    status: u16,
+    headers: Vec<(String, String)>,
+    connection: quinn::Connection,
+    endpoint: quinn::Endpoint,
+}
+
+// ── Value / opts helpers ────────────────────────────────────────────────────────
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn opts_str(opts: &MapValue, key: &str) -> Option<String> {
+    match opts.get(&kw(key))? {
+        Value::Str(s) => Some(s.get().clone()),
+        _ => None,
+    }
+}
+
+fn opts_usize(opts: &MapValue, key: &str) -> Option<usize> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n >= 0 => Some((n as usize).max(1)),
+        _ => None,
+    }
+}
+
+/// Return a `quinn::ClientConfig` suitable for HTTP/3: identical to the TLS/QUIC
+/// client config from `quic_config`, but with `"h3"` injected into `:alpn` when
+/// the caller did not set it.
+fn h3_client_config(opts: &MapValue) -> ValueResult<quinn::ClientConfig> {
+    if opts.get(&kw("alpn")).is_some() {
+        return crate::quic_config::client_config(opts);
+    }
+    let alpn_val = Value::Vector(GcPtr::new(PersistentVector::from_iter([Value::string(
+        "h3",
+    )])));
+    let new_opts = opts.assoc(kw("alpn"), alpn_val);
+    crate::quic_config::client_config(&new_opts)
+}
+
+// ── URL / header parsing ────────────────────────────────────────────────────────
+
+fn parse_url(url: &str) -> Result<(String, u16, http::Uri), String> {
+    let uri: http::Uri = url
+        .parse()
+        .map_err(|e| format!("invalid URL '{url}': {e}"))?;
+    let host = uri
+        .host()
+        .ok_or_else(|| format!("URL '{url}' missing host"))?
+        .to_string();
+    let port = uri.port_u16().unwrap_or(443);
+    Ok((host, port, uri))
+}
+
+/// Extract `{:headers {"k" "v" ...}}` from a request map. Returns an empty vec
+/// if the key is absent or not a string→string map.
+fn extract_headers(req_map: &MapValue) -> Vec<(String, String)> {
+    let h_map = match req_map.get(&kw("headers")) {
+        Some(Value::Map(m)) => m.clone(),
+        _ => return vec![],
+    };
+    h_map
+        .iter()
+        .filter_map(|(k, v)| {
+            let ks = match k {
+                Value::Str(s) => s.get().clone(),
+                Value::Keyword(kw) => kw.get().full_name(),
+                _ => return None,
+            };
+            let vs = match v {
+                Value::Str(s) => s.get().clone(),
+                _ => return None,
+            };
+            Some((ks, vs))
+        })
+        .collect()
+}
+
+// ── Pool task ───────────────────────────────────────────────────────────────────
+
+/// Runs entirely on the `WorkerPool`:
+///
+/// 1. QUIC connect (mirrors `quic.rs::do_quic_connect`).
+/// 2. HTTP/3 handshake via `h3_quinn::Connection` + `h3::client::new`.
+/// 3. Spawn the h3 connection driver task (needed for control-stream frames).
+/// 4. Send the HTTP request and receive response headers.
+/// 5. Send `H3ResponsePartial` (status + headers + QUIC objects) via `response_tx`
+///    so the `LocalSet` can build the response map while body streaming continues.
+/// 6. Stream response body chunks to `body_tx` (dropping it closes the `:body` chan).
+#[allow(clippy::too_many_arguments)]
+async fn pool_h3_request(
+    host: String,
+    port: u16,
+    quinn_config: quinn::ClientConfig,
+    uri: http::Uri,
+    method: http::Method,
+    extra_headers: Vec<(String, String)>,
+    body_tx: mpsc::Sender<Result<Vec<u8>, String>>,
+    response_tx: oneshot::Sender<Result<H3ResponsePartial, String>>,
+) {
+    macro_rules! fail {
+        ($msg:expr) => {{
+            let _ = response_tx.send(Err($msg));
+            return;
+        }};
+    }
+
+    // ── 1. QUIC connect ────────────────────────────────────────────────────────
+    let addr_str = format!("{host}:{port}");
+    let addrs: Vec<std::net::SocketAddr> = match tokio::net::lookup_host(&addr_str).await {
+        Ok(it) => {
+            let (v4, v6): (Vec<_>, Vec<_>) = it.partition(|a| a.is_ipv4());
+            v4.into_iter().chain(v6).collect()
+        }
+        Err(e) => fail!(format!("lookup {addr_str}: {e}")),
+    };
+    if addrs.is_empty() {
+        fail!(format!("no address for {addr_str}"));
+    }
+
+    let mut last_err = String::new();
+    let mut maybe_conn: Option<(quinn::Connection, quinn::Endpoint)> = None;
+    for addr in &addrs {
+        let bind: std::net::SocketAddr = if addr.is_ipv6() {
+            "[::]:0".parse().unwrap()
+        } else {
+            "0.0.0.0:0".parse().unwrap()
+        };
+        let mut endpoint = match quinn::Endpoint::client(bind) {
+            Ok(e) => e,
+            Err(e) => {
+                last_err = format!("endpoint: {e}");
+                continue;
+            }
+        };
+        endpoint.set_default_client_config(quinn_config.clone());
+        let connecting = match endpoint.connect(*addr, &host) {
+            Ok(c) => c,
+            Err(e) => {
+                last_err = format!("connect: {e}");
+                continue;
+            }
+        };
+        match connecting.await {
+            Ok(connection) => {
+                maybe_conn = Some((connection, endpoint));
+                break;
+            }
+            Err(e) => {
+                last_err = format!("handshake: {e}");
+                continue;
+            }
+        }
+    }
+    let (quinn_connection, endpoint) = match maybe_conn {
+        Some(pair) => pair,
+        None => fail!(last_err),
+    };
+
+    // ── 2. H3 setup ───────────────────────────────────────────────────────────
+    let h3_conn = h3_quinn::Connection::new(quinn_connection.clone());
+    let (mut driver, mut send_request) = match h3::client::new(h3_conn).await {
+        Ok(pair) => pair,
+        Err(e) => fail!(format!("h3 handshake: {e}")),
+    };
+
+    // Spawn the h3 connection driver (processes control-stream frames while
+    // request/response I/O is in flight).
+    let driver_jh = tokio::spawn(async move {
+        let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+    });
+    let driver_abort = driver_jh.abort_handle();
+
+    // ── 3. Build and send request ─────────────────────────────────────────────
+    let mut req_builder = http::Request::builder().method(method).uri(uri);
+    for (k, v) in &extra_headers {
+        req_builder = req_builder.header(k.as_str(), v.as_str());
+    }
+    let req = match req_builder.body(()) {
+        Ok(r) => r,
+        Err(e) => {
+            driver_abort.abort();
+            fail!(format!("build request: {e}"));
+        }
+    };
+
+    let mut stream = match send_request.send_request(req).await {
+        Ok(s) => s,
+        Err(e) => {
+            driver_abort.abort();
+            fail!(format!("send request: {e}"));
+        }
+    };
+
+    // Finish the request (no body for GET / HEAD; POST body is future work).
+    if let Err(e) = stream.finish().await {
+        driver_abort.abort();
+        fail!(format!("finish request: {e}"));
+    }
+
+    // ── 4. Receive response headers ───────────────────────────────────────────
+    let response = match stream.recv_response().await {
+        Ok(r) => r,
+        Err(e) => {
+            driver_abort.abort();
+            fail!(format!("recv response: {e}"));
+        }
+    };
+
+    let status = response.status().as_u16();
+    let headers: Vec<(String, String)> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_str().to_string(),
+                v.to_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+
+    let partial = H3ResponsePartial {
+        status,
+        headers,
+        connection: quinn_connection,
+        endpoint,
+    };
+
+    // ── 5. Deliver headers to LocalSet ────────────────────────────────────────
+    if response_tx.send(Ok(partial)).is_err() {
+        // LocalSet gave up before headers arrived; clean up.
+        driver_abort.abort();
+        return;
+    }
+
+    // ── 6. Stream response body ───────────────────────────────────────────────
+    loop {
+        match stream.recv_data().await {
+            Ok(None) => break,
+            Ok(Some(mut chunk)) => {
+                let n = chunk.remaining();
+                let bytes = chunk.copy_to_bytes(n).to_vec();
+                if body_tx.send(Ok(bytes)).await.is_err() {
+                    break; // body bridge was dropped (LocalSet closed :body)
+                }
+            }
+            Err(e) => {
+                let _ = body_tx.send(Err(format!("body read: {e}"))).await;
+                break;
+            }
+        }
+    }
+    // Dropping body_tx closes the mpsc channel → body bridge closes `:body`.
+    driver_abort.abort();
+}
+
+// ── LocalSet bridge ─────────────────────────────────────────────────────────────
+
+/// Receives body chunks from the pool task and puts `Value::ByteArray` values
+/// on the `:body` channel. Closes the channel at EOF or on error.
+async fn local_body_bridge(
+    mut body_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
+    body_chan: GcPtr<NativeObjectBox>,
+) {
+    while let Some(result) = body_rx.recv().await {
+        match result {
+            Ok(bytes) if bytes.is_empty() => {} // skip empty DATA frames
+            Ok(bytes) => {
+                if !chan_put(&body_chan, bytes_value(&bytes)).await {
+                    break; // consumer closed :body early
+                }
+            }
+            Err(e) => {
+                chan_put(&body_chan, net_error(e)).await;
+                break;
+            }
+        }
+    }
+    chan_ref(body_chan.get()).close();
+}
+
+// ── Public Rust API ─────────────────────────────────────────────────────────────
+
+/// Issue an HTTP/3 `GET` request and return a promise channel.
+///
+/// The promise yields:
+/// ```clojure
+/// {:status 200 :headers {"k" "v" ...} :body <chan> :resource <H3Resource>}
+/// ```
+/// or a `Value::Error` on connection/request failure.
+///
+/// `opts` are the same as `quic/connect` (`:insecure-skip-verify`, `:alpn`,
+/// `:roots`, `:max-idle-ms`, etc.). `:alpn ["h3"]` is injected automatically
+/// when absent.
+pub fn get(url: &str, opts: &MapValue, body_buf: usize) -> ValueResult<Value> {
+    h3_request(
+        url,
+        http::Method::GET,
+        vec![],
+        opts,
+        body_buf,
+    )
+}
+
+/// Issue an arbitrary HTTP/3 request and return a promise channel.
+///
+/// `method` is a string (e.g. `"GET"`, `"POST"`). `extra_headers` is a list of
+/// `(name, value)` pairs to add to the request. Currently no request body is
+/// sent (POST body support is deferred to a later phase).
+pub fn h3_request(
+    url: &str,
+    method: http::Method,
+    extra_headers: Vec<(String, String)>,
+    opts: &MapValue,
+    body_buf: usize,
+) -> ValueResult<Value> {
+    let (host, port, uri) =
+        parse_url(url).map_err(ValueError::Other)?;
+    let quinn_config = h3_client_config(opts)?;
+
+    let (body_tx, body_rx) =
+        mpsc::channel::<Result<Vec<u8>, String>>(body_buf.max(1));
+    let (response_tx, response_rx) =
+        oneshot::channel::<Result<H3ResponsePartial, String>>();
+
+    let pool_jh = WorkerPool::global().handle().spawn(pool_h3_request(
+        host,
+        port,
+        quinn_config,
+        uri,
+        method,
+        extra_headers,
+        body_tx,
+        response_tx,
+    ));
+    let pool_abort = pool_jh.abort_handle();
+
+    let promise = make_chan(1);
+    let promise_val = Value::NativeObject(promise.clone());
+
+    spawn_future(async move {
+        do_h3_response(response_rx, body_rx, body_buf, pool_abort, promise).await
+    });
+
+    Ok(promise_val)
+}
+
+async fn do_h3_response(
+    response_rx: oneshot::Receiver<Result<H3ResponsePartial, String>>,
+    body_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
+    body_buf: usize,
+    pool_abort: AbortHandle,
+    promise: GcPtr<NativeObjectBox>,
+) -> EvalResult {
+    let partial = match response_rx.await {
+        Err(_) => {
+            chan_deliver(&promise, net_error("pool task dropped")).await;
+            return Ok(Value::Nil);
+        }
+        Ok(Err(e)) => {
+            chan_deliver(&promise, net_error(e)).await;
+            return Ok(Value::Nil);
+        }
+        Ok(Ok(p)) => p,
+    };
+
+    // Build :body channel and LocalSet bridge.
+    let body_chan = make_chan(body_buf);
+    let bridge_jh =
+        tokio::task::spawn_local(local_body_bridge(body_rx, body_chan.clone()));
+    let bridge_abort = bridge_jh.abort_handle();
+
+    // Build H3Resource.
+    let resource = H3Resource::new(partial.connection, partial.endpoint);
+    {
+        let mut g = resource.inner.lock().unwrap();
+        g.abort_handles.push(pool_abort);
+        g.abort_handles.push(bridge_abort);
+    }
+    let resource_handle = ResourceHandle::new(resource);
+
+    // Build headers map (string keys → string values).
+    let headers_pairs: Vec<(Value, Value)> = partial
+        .headers
+        .iter()
+        .map(|(k, v)| (Value::string(k.clone()), Value::string(v.clone())))
+        .collect();
+    let headers_val = Value::Map(MapValue::from_pairs(headers_pairs));
+
+    // Deliver response map.
+    let resp = Value::Map(MapValue::from_pairs(vec![
+        (kw("status"), Value::Long(partial.status as i64)),
+        (kw("headers"), headers_val),
+        (kw("body"), Value::NativeObject(body_chan)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]));
+    chan_deliver(&promise, resp).await;
+
+    Ok(Value::Nil)
+}
+
+// ── Builtins ────────────────────────────────────────────────────────────────────
+
+/// `(get url)` or `(get url opts)` — issue a GET request, return promise chan.
+///
+/// `url` must be a full HTTPS URL, e.g. `"https://host:4433/path"`.
+/// Opts: `:insecure-skip-verify`, `:alpn`, `:roots`, `:max-idle-ms`,
+/// `:keep-alive-ms`, `:max-streams`, `:body-buf` (channel depth, default 8).
+fn builtin_get(args: &[Value]) -> ValueResult<Value> {
+    let url = match args.first() {
+        Some(Value::Str(s)) => s.get().clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "string URL",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let opts = match args.get(1) {
+        Some(Value::Map(m)) => m.clone(),
+        _ => MapValue::empty(),
+    };
+    let body_buf = opts_usize(&opts, "body-buf").unwrap_or(8);
+    get(&url, &opts, body_buf)
+}
+
+/// `(request {:method m :url u :headers {...}} opts)` — general HTTP/3 request.
+///
+/// `:method` defaults to `"GET"`. `:url` is required. `:headers` is an optional
+/// map of extra request header name→value strings. No request body is sent;
+/// POST/PUT body support is deferred to a later phase.
+fn builtin_request(args: &[Value]) -> ValueResult<Value> {
+    let req_map = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:url str :method str :headers map}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let opts = match args.get(1) {
+        Some(Value::Map(m)) => m.clone(),
+        _ => MapValue::empty(),
+    };
+
+    let url =
+        opts_str(&req_map, "url").ok_or_else(|| ValueError::Other(":url required".into()))?;
+    let method_str = opts_str(&req_map, "method").unwrap_or_else(|| "GET".to_string());
+    let method = method_str
+        .parse::<http::Method>()
+        .map_err(|e| ValueError::Other(format!("invalid :method '{method_str}': {e}")))?;
+    let extra_headers = extract_headers(&req_map);
+    let body_buf = opts_usize(&opts, "body-buf").unwrap_or(8);
+
+    h3_request(&url, method, extra_headers, &opts, body_buf)
+}
+
+/// `(close resp)` — close an H3 response / connection early.
+///
+/// Aborts all background tasks and sends a QUIC CONNECTION_CLOSE to the server.
+/// The `:body` channel will be closed if it hasn't already been drained.
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let resp = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "h3 response map {:resource <H3Resource>}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::NativeObject(obj)) = resp.get(&kw("body")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::Resource(handle)) = resp.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use cljrs_async::load_source;
 
 pub mod frame;
+pub mod h3;
 mod pool_io;
 pub mod quic;
 pub mod quic_config;
@@ -46,6 +47,9 @@ const NET_UNIX_SOURCE: &str = include_str!("clojure_rust_net_unix.cljrs");
 /// Clojure source for `clojure.rust.net.quic`.
 const NET_QUIC_SOURCE: &str = include_str!("clojure_rust_net_quic.cljrs");
 
+/// Clojure source for `clojure.rust.net.h3`.
+const NET_H3_SOURCE: &str = include_str!("clojure_rust_net_h3.cljrs");
+
 pub const NS_TCP: &str = "clojure.rust.net.tcp";
 pub const NS: &str = "clojure.rust.net";
 pub const NS_FRAME: &str = "clojure.rust.net.frame";
@@ -53,6 +57,7 @@ pub const NS_UDP: &str = "clojure.rust.net.udp";
 pub const NS_TLS: &str = "clojure.rust.net.tls";
 pub const NS_UNIX: &str = "clojure.rust.net.unix";
 pub const NS_QUIC: &str = "clojure.rust.net.quic";
+pub const NS_H3: &str = "clojure.rust.net.h3";
 
 /// Register the networking namespaces.
 ///
@@ -107,6 +112,14 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         quic::register(globals, NS_QUIC);
         load_source(globals, NS_QUIC, NET_QUIC_SOURCE);
         globals.mark_loaded(NS_QUIC);
+    }
+
+    if !globals.is_loaded(NS_H3) {
+        globals.get_or_create_ns(NS_H3);
+        globals.refer_all(NS_H3, "clojure.core");
+        h3::register(globals, NS_H3);
+        load_source(globals, NS_H3, NET_H3_SOURCE);
+        globals.mark_loaded(NS_H3);
     }
 
     if !globals.is_loaded(NS) {

--- a/crates/cljrs-net/tests/h3.rs
+++ b/crates/cljrs-net/tests/h3.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 use bytes::Bytes;
 use cljrs_async::channel::{chan_ref, chan_take};
 use cljrs_async::worker_pool::WorkerPool;
-use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
 use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
 
 fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
     let globals = cljrs_stdlib::standard_env();
@@ -42,11 +42,9 @@ fn make_server_config() -> quinn::ServerConfig {
     let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
         .expect("rcgen cert generation failed");
 
-    let cert_der =
-        rustls::pki_types::CertificateDer::from(certified.cert.der().to_vec());
-    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(
-        certified.key_pair.serialize_der().into(),
-    );
+    let cert_der = rustls::pki_types::CertificateDer::from(certified.cert.der().to_vec());
+    let key_der =
+        rustls::pki_types::PrivateKeyDer::Pkcs8(certified.key_pair.serialize_der().into());
 
     let mut rustls_cfg = rustls::ServerConfig::builder_with_provider(Arc::new(
         rustls::crypto::ring::default_provider(),
@@ -70,9 +68,8 @@ fn make_server_config() -> quinn::ServerConfig {
 ///
 /// Responds to every request with HTTP 200 and the body `"h3 Q3 test body"`.
 fn spawn_h3_server(server_config: quinn::ServerConfig) -> u16 {
-    let endpoint =
-        quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap())
-            .expect("server endpoint");
+    let endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap())
+        .expect("server endpoint");
     let port = endpoint.local_addr().unwrap().port();
 
     WorkerPool::global().handle().spawn(async move {
@@ -182,8 +179,7 @@ fn test_h3_get_round_trip() {
             }
         }
         assert_eq!(
-            body,
-            b"h3 Q3 test body",
+            body, b"h3 Q3 test body",
             "response body must match server payload"
         );
 
@@ -286,10 +282,7 @@ fn test_h3_close_before_drain() {
             match chan_take(&body_ch).await {
                 Value::Nil => break,
                 Value::ByteArray(_) => {} // drain buffered data
-                other => panic!(
-                    "unexpected value on closed :body: {}",
-                    other.type_name()
-                ),
+                other => panic!("unexpected value on closed :body: {}", other.type_name()),
             }
         }
     });

--- a/crates/cljrs-net/tests/h3.rs
+++ b/crates/cljrs-net/tests/h3.rs
@@ -1,0 +1,296 @@
+//! Phase Q3 integration tests: HTTP/3 client.
+//!
+//! Done criterion: `h3::get` connects to a quinn-backed h3 echo server,
+//! receives a 200 response with a body, and drains the `:body` channel.
+//!
+//! The test server is built directly from `h3` + `h3-quinn` + `quinn` (raw,
+//! no cljrs-net abstractions) and runs on the `WorkerPool`, mirroring the
+//! pattern used in `quic.rs` tests.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cljrs_async::channel::{chan_ref, chan_take};
+use cljrs_async::worker_pool::WorkerPool;
+use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
+use cljrs_gc::GcPtr;
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn map_get(map: &MapValue, key: &str) -> Value {
+    map.get(&kw(key))
+        .unwrap_or_else(|| panic!("map missing :{key}"))
+}
+
+fn as_chan(v: &Value) -> GcPtr<NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => obj.clone(),
+        other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+    }
+}
+
+/// Build a self-signed server config with "h3" ALPN.
+fn make_server_config() -> quinn::ServerConfig {
+    let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("rcgen cert generation failed");
+
+    let cert_der =
+        rustls::pki_types::CertificateDer::from(certified.cert.der().to_vec());
+    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(
+        certified.key_pair.serialize_der().into(),
+    );
+
+    let mut rustls_cfg = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("tls versions")
+    .with_no_client_auth()
+    .with_single_cert(vec![cert_der], key_der)
+    .expect("server cert");
+
+    // Required: h3 ALPN negotiation must succeed on both sides.
+    rustls_cfg.alpn_protocols = vec![b"h3".to_vec()];
+
+    let quic_cfg = quinn::crypto::rustls::QuicServerConfig::try_from(Arc::new(rustls_cfg))
+        .expect("quic server config");
+
+    quinn::ServerConfig::with_crypto(Arc::new(quic_cfg))
+}
+
+/// Spawn a minimal H3 server on the WorkerPool. Returns the bound port.
+///
+/// Responds to every request with HTTP 200 and the body `"h3 Q3 test body"`.
+fn spawn_h3_server(server_config: quinn::ServerConfig) -> u16 {
+    let endpoint =
+        quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap())
+            .expect("server endpoint");
+    let port = endpoint.local_addr().unwrap().port();
+
+    WorkerPool::global().handle().spawn(async move {
+        while let Some(incoming) = endpoint.accept().await {
+            let conn = match incoming.await {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            tokio::spawn(async move {
+                let h3_conn = h3_quinn::Connection::new(conn);
+                let mut h3_server: h3::server::Connection<h3_quinn::Connection, Bytes> =
+                    match h3::server::Connection::new(h3_conn).await {
+                        Ok(s) => s,
+                        Err(_) => return,
+                    };
+
+                loop {
+                    // h3 0.0.8: accept() returns Option<RequestResolver>;
+                    // call resolve_request().await to get (Request, RequestStream).
+                    let resolver = match h3_server.accept().await {
+                        Ok(None) => break,
+                        Err(_) => break,
+                        Ok(Some(r)) => r,
+                    };
+                    let (_, mut stream) = match resolver.resolve_request().await {
+                        Ok(pair) => pair,
+                        Err(_) => break,
+                    };
+                    let resp = http::Response::builder()
+                        .status(200)
+                        .header("content-type", "text/plain")
+                        .body(())
+                        .unwrap();
+                    if stream.send_response(resp).await.is_err() {
+                        break;
+                    }
+                    if stream
+                        .send_data(Bytes::from_static(b"h3 Q3 test body"))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                    let _ = stream.finish().await;
+                }
+            });
+        }
+    });
+
+    port
+}
+
+/// Phase Q3 done criterion: HTTP/3 GET returns status 200 and the expected body.
+#[test]
+fn test_h3_get_round_trip() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let server_config = make_server_config();
+        let port = spawn_h3_server(server_config);
+
+        let url = format!("https://localhost:{port}/");
+        let opts = MapValue::from_pairs(vec![
+            (kw("insecure-skip-verify"), Value::Bool(true)),
+            // ALPN is injected automatically by h3_client_config when absent,
+            // but the server above accepts any (or no) ALPN.
+        ]);
+
+        let promise = cljrs_net::h3::get(&url, &opts, 8).expect("h3::get failed");
+        let resp_val = chan_take(&as_chan(&promise)).await;
+        let resp = match resp_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("H3 GET failed: {}", e.get().message()),
+            other => panic!("expected response map, got {}", other.type_name()),
+        };
+
+        // Verify :status 200.
+        let status = match map_get(&resp, "status") {
+            Value::Long(n) => n,
+            other => panic!("expected long :status, got {}", other.type_name()),
+        };
+        assert_eq!(status, 200, "expected HTTP 200");
+
+        // :headers must be a map.
+        match map_get(&resp, "headers") {
+            Value::Map(_) => {}
+            other => panic!("expected map :headers, got {}", other.type_name()),
+        }
+
+        // Drain :body until EOF.
+        let body_ch = as_chan(&map_get(&resp, "body"));
+        let mut body: Vec<u8> = Vec::new();
+        loop {
+            match chan_take(&body_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(arr) => {
+                    body.extend(arr.get().lock().unwrap().iter().map(|&b| b as u8));
+                }
+                Value::Error(e) => panic!("body read error: {}", e.get().message()),
+                other => panic!("unexpected body value: {}", other.type_name()),
+            }
+        }
+        assert_eq!(
+            body,
+            b"h3 Q3 test body",
+            "response body must match server payload"
+        );
+
+        // Clean up resource.
+        if let Value::Resource(h) = map_get(&resp, "resource") {
+            let _ = h.close();
+        }
+    });
+}
+
+/// Draining the :body channel before calling close must yield the full body.
+#[test]
+fn test_h3_body_channel_closes_on_eof() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let server_config = make_server_config();
+        let port = spawn_h3_server(server_config);
+
+        let url = format!("https://localhost:{port}/");
+        let opts = MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
+
+        let promise = cljrs_net::h3::get(&url, &opts, 8).expect("h3::get failed");
+        let resp_val = chan_take(&as_chan(&promise)).await;
+        let resp = match resp_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("H3 GET failed: {}", e.get().message()),
+            other => panic!("expected map, got {}", other.type_name()),
+        };
+
+        let body_ch = as_chan(&map_get(&resp, "body"));
+
+        // The :body channel must close (yield Nil) after all data is delivered.
+        let mut chunks = 0usize;
+        loop {
+            match chan_take(&body_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(_) => chunks += 1,
+                Value::Error(e) => panic!("body error: {}", e.get().message()),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        assert!(chunks >= 1, ":body must yield at least one chunk");
+
+        // A second take on the closed channel must return Nil immediately.
+        let v = chan_take(&body_ch).await;
+        assert!(
+            matches!(v, Value::Nil),
+            "closed :body must yield Nil, got {}",
+            v.type_name()
+        );
+    });
+}
+
+/// `(close resp)` before draining :body must close the channel.
+#[test]
+fn test_h3_close_before_drain() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let server_config = make_server_config();
+        let port = spawn_h3_server(server_config);
+
+        let url = format!("https://localhost:{port}/");
+        let opts = MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
+
+        let promise = cljrs_net::h3::get(&url, &opts, 8).expect("h3::get failed");
+        let resp_val = chan_take(&as_chan(&promise)).await;
+        let resp = match resp_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("H3 GET failed: {}", e.get().message()),
+            other => panic!("expected map, got {}", other.type_name()),
+        };
+
+        let body_ch = as_chan(&map_get(&resp, "body"));
+
+        // Close without draining — resource must close cleanly.
+        if let Value::Resource(h) = map_get(&resp, "resource") {
+            h.close().expect("close failed");
+        }
+        // Close the body channel explicitly (mirrors what builtin_close does).
+        chan_ref(body_ch.get()).close();
+
+        // After close, :body must eventually yield Nil. Body data may already
+        // be buffered in the channel (the bridge task may have run before the
+        // abort took effect), so drain any residual data first.
+        loop {
+            match chan_take(&body_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(_) => {} // drain buffered data
+                other => panic!(
+                    "unexpected value on closed :body: {}",
+                    other.type_name()
+                ),
+            }
+        }
+    });
+}


### PR DESCRIPTION
Add h3.rs with `get` and `request` builtins that connect via QUIC,
perform an HTTP/3 handshake using the h3 + h3-quinn crates, and deliver
the response as a map with :status, :headers, :body channel, and
:resource handle. Body chunks stream via an mpsc bridge between the
WorkerPool and LocalSet. Clojure helpers drain-body and get-string are
provided in clojure_rust_net_h3.cljrs. Three integration tests verify
round-trip GET, body-channel EOF close, and close-before-drain.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D9NPP7JtYDEJLrpnVT7Zeb