### PR TITLE
fix(cljrs-interp): bind % to return value in :post conditions

### DIFF
--- a/crates/cljrs-interp/README.md
+++ b/crates/cljrs-interp/README.md
@@ -37,7 +37,9 @@ src/
                    defmulti, defmethod, defrecord, reify, binding, with-out-str.
                    parse_arity peels primitive type hints (`^long x`, `^doubles a`)
                    off params into CljxFnArity::param_hints; let*/loop* binding
-                   hints are stripped via bind_pattern's Meta arm (destructure.rs)
+                   hints are stripped via bind_pattern's Meta arm (destructure.rs);
+                   desugar_pre_post_conditions rewrites {:pre [...] :post [...]} maps
+                   into assertion forms (binds % to return value in :post conditions)
   apply.rs       — eval_call: macro expansion, native-fn dispatch, CljxFn
                    application, recur trampoline; special env-needing handlers
                    (apply, atom, reset!, swap!, volatile!, vreset!, vswap!,

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -1899,10 +1899,7 @@ mod tests {
 
     #[test]
     fn test_pre_and_post_conditions() {
-        let v = eval_str(
-            "(defn g [x] {:pre [(pos? x)] :post [(> % x)]} (inc x)) (g 3)",
-        )
-        .unwrap();
+        let v = eval_str("(defn g [x] {:pre [(pos? x)] :post [(> % x)]} (inc x)) (g 3)").unwrap();
         assert_eq!(v, long(4));
     }
 

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -1868,4 +1868,55 @@ mod tests {
             panic!("expected map");
         }
     }
+
+    // ── :pre/:post conditions ─────────────────────────────────────────────
+
+    #[test]
+    fn test_post_condition_percent_bound() {
+        // % must resolve to the return value inside :post conditions.
+        let v = eval_str("(defn g [x] {:post [(pos? %)]} (inc x)) (g 5)").unwrap();
+        assert_eq!(v, long(6));
+    }
+
+    #[test]
+    fn test_post_condition_violation_throws() {
+        // A failing :post condition must throw.
+        let r = eval_str("(defn g [x] {:post [(neg? %)]} (inc x)) (g 5)");
+        assert!(r.is_err(), "expected error from failing :post condition");
+    }
+
+    #[test]
+    fn test_pre_condition_passes() {
+        let v = eval_str("(defn g [x] {:pre [(pos? x)]} (inc x)) (g 5)").unwrap();
+        assert_eq!(v, long(6));
+    }
+
+    #[test]
+    fn test_pre_condition_violation_throws() {
+        let r = eval_str("(defn g [x] {:pre [(pos? x)]} (inc x)) (g -1)");
+        assert!(r.is_err(), "expected error from failing :pre condition");
+    }
+
+    #[test]
+    fn test_pre_and_post_conditions() {
+        let v = eval_str(
+            "(defn g [x] {:pre [(pos? x)] :post [(> % x)]} (inc x)) (g 3)",
+        )
+        .unwrap();
+        assert_eq!(v, long(4));
+    }
+
+    #[test]
+    fn test_post_condition_no_pre() {
+        // :post only (no :pre).
+        let v = eval_str("(defn h [x] {:post [(number? %)]} (inc x)) (h 2)").unwrap();
+        assert_eq!(v, long(3));
+    }
+
+    #[test]
+    fn test_pre_condition_no_post() {
+        // :pre only (no :post); existing test variant without conditions map.
+        let v = eval_str("(defn h [x] {:pre [(number? x)]} x) (h 42)").unwrap();
+        assert_eq!(v, long(42));
+    }
 }

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -383,8 +383,7 @@ fn desugar_pre_post_conditions(body: &[Form]) -> Vec<Form> {
         let body_expr = if real_body.len() == 1 {
             real_body[0].clone()
         } else {
-            let mut do_forms =
-                vec![Form::new(FormKind::Symbol("do".to_string()), span.clone())];
+            let mut do_forms = vec![Form::new(FormKind::Symbol("do".to_string()), span.clone())];
             do_forms.extend_from_slice(real_body);
             Form::new(FormKind::List(do_forms), span.clone())
         };

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -292,16 +292,132 @@ pub fn parse_arity(params_form: &Form, body: &[Form]) -> EvalResult<CljxFnArity>
         }
     }
 
+    let body = desugar_pre_post_conditions(body);
+
     Ok(CljxFnArity {
         params,
         rest_param,
-        body: body.to_vec(),
+        body,
         destructure_params,
         destructure_rest,
         ir_arity_id: crate::arity::fresh_arity_id(),
         param_hints,
         rest_hint,
     })
+}
+
+/// Desugar a `:pre`/`:post` conditions map at the head of a function body.
+///
+/// Clojure binds `%` to the return value inside `:post` conditions. This
+/// transforms the raw body forms into equivalent assertion code so the
+/// interpreter does not need to handle conditions separately at call time.
+///
+/// Input body (simplified):
+/// ```text
+/// [{:pre [(pos? x)] :post [(pos? %)]} (inc x)]
+/// ```
+/// Output body:
+/// ```text
+/// [(assert (pos? x))
+///  (let* [% (inc x)]
+///    (assert (pos? %))
+///    %)]
+/// ```
+fn desugar_pre_post_conditions(body: &[Form]) -> Vec<Form> {
+    let first = match body.first() {
+        Some(f) => f,
+        None => return body.to_vec(),
+    };
+
+    let entries = match &first.kind {
+        FormKind::Map(entries) => entries,
+        _ => return body.to_vec(),
+    };
+
+    let mut pre_conds: Vec<Form> = Vec::new();
+    let mut post_conds: Vec<Form> = Vec::new();
+    let mut has_conditions = false;
+
+    for chunk in entries.chunks(2) {
+        if chunk.len() < 2 {
+            break;
+        }
+        let (key, val) = (&chunk[0], &chunk[1]);
+        match &key.kind {
+            FormKind::Keyword(k) if k == "pre" => {
+                if let FormKind::Vector(conds) = &val.kind {
+                    pre_conds.extend_from_slice(conds);
+                    has_conditions = true;
+                }
+            }
+            FormKind::Keyword(k) if k == "post" => {
+                if let FormKind::Vector(conds) = &val.kind {
+                    post_conds.extend_from_slice(conds);
+                    has_conditions = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if !has_conditions {
+        return body.to_vec();
+    }
+
+    let real_body = &body[1..]; // strip the conditions map
+    let span = first.span.clone();
+    let mut new_body: Vec<Form> = Vec::new();
+
+    // Emit (assert cond) for each :pre condition.
+    for cond in &pre_conds {
+        new_body.push(make_assert_call(cond, &span));
+    }
+
+    if post_conds.is_empty() {
+        new_body.extend_from_slice(real_body);
+    } else {
+        // Wrap real body in (let* [% <body>] (assert post-cond)... %)
+        // so that % refers to the return value inside :post conditions.
+        let percent = Form::new(FormKind::Symbol("%".to_string()), span.clone());
+
+        let body_expr = if real_body.len() == 1 {
+            real_body[0].clone()
+        } else {
+            let mut do_forms =
+                vec![Form::new(FormKind::Symbol("do".to_string()), span.clone())];
+            do_forms.extend_from_slice(real_body);
+            Form::new(FormKind::List(do_forms), span.clone())
+        };
+
+        let binding_vec = Form::new(
+            FormKind::Vector(vec![percent.clone(), body_expr]),
+            span.clone(),
+        );
+
+        let mut let_forms = vec![
+            Form::new(FormKind::Symbol("let*".to_string()), span.clone()),
+            binding_vec,
+        ];
+        for cond in &post_conds {
+            let_forms.push(make_assert_call(cond, &span));
+        }
+        let_forms.push(percent);
+
+        new_body.push(Form::new(FormKind::List(let_forms), span));
+    }
+
+    new_body
+}
+
+/// Build `(assert <cond>)` as a Form node.
+fn make_assert_call(cond: &Form, span: &cljrs_types::span::Span) -> Form {
+    Form::new(
+        FormKind::List(vec![
+            Form::new(FormKind::Symbol("assert".to_string()), span.clone()),
+            cond.clone(),
+        ]),
+        span.clone(),
+    )
 }
 
 /// Peel a `^hint` wrapper off a parameter form, returning the resolved

--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -42,6 +42,9 @@ src/
                   capture only the enclosing locals their (fully macro-expanded)
                   body references (`collect_symbol_names`, a conservative
                   free-variable over-approximation), not every local in scope.
+                  `desugar_pre_post_conditions` rewrites `{:pre [...] :post [...]}`
+                  maps at the head of a function body into `(assert ...)` forms
+                  (binds `%` to the return value in `:post` conditions).
     context.rs  — LowerCtx builder state used by anf.rs
     escape.rs   — worklist-based escape analysis; inter-procedural via EscapeContext
     inline.rs   — inlining pass: splices small callees into call sites

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -1034,8 +1034,7 @@ fn desugar_pre_post_conditions(body: &[Form]) -> Vec<Form> {
         let body_expr = if real_body.len() == 1 {
             real_body[0].clone()
         } else {
-            let mut do_forms =
-                vec![Form::new(FormKind::Symbol("do".to_string()), span.clone())];
+            let mut do_forms = vec![Form::new(FormKind::Symbol("do".to_string()), span.clone())];
             do_forms.extend_from_slice(real_body);
             Form::new(FormKind::List(do_forms), span.clone())
         };

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -971,6 +971,102 @@ fn lower_defn(ctx: &mut LowerCtx, args: &[Form]) -> R {
     Ok(dst)
 }
 
+// ── :pre/:post condition desugaring ──────────────────────────────────────────
+
+/// Mirror of the interpreter's `desugar_pre_post_conditions`.
+///
+/// If the body begins with a `{:pre [...] :post [...]}` map, rewrite it into
+/// explicit `(assert ...)` forms so the IR lowerer generates the same checks as
+/// the tree-walking interpreter.  `%` is bound to the return value inside
+/// `:post` conditions via `(let* [% <body>] post-asserts... %)`.
+fn desugar_pre_post_conditions(body: &[Form]) -> Vec<Form> {
+    let first = match body.first() {
+        Some(f) => f,
+        None => return body.to_vec(),
+    };
+    let entries = match &first.kind {
+        FormKind::Map(entries) => entries,
+        _ => return body.to_vec(),
+    };
+
+    let mut pre_conds: Vec<Form> = Vec::new();
+    let mut post_conds: Vec<Form> = Vec::new();
+    let mut has_conditions = false;
+
+    for chunk in entries.chunks(2) {
+        if chunk.len() < 2 {
+            break;
+        }
+        let (key, val) = (&chunk[0], &chunk[1]);
+        match &key.kind {
+            FormKind::Keyword(k) if k == "pre" => {
+                if let FormKind::Vector(conds) = &val.kind {
+                    pre_conds.extend_from_slice(conds);
+                    has_conditions = true;
+                }
+            }
+            FormKind::Keyword(k) if k == "post" => {
+                if let FormKind::Vector(conds) = &val.kind {
+                    post_conds.extend_from_slice(conds);
+                    has_conditions = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if !has_conditions {
+        return body.to_vec();
+    }
+
+    let real_body = &body[1..];
+    let span = first.span.clone();
+    let mut new_body: Vec<Form> = Vec::new();
+
+    for cond in &pre_conds {
+        new_body.push(make_assert_call(cond, &span));
+    }
+
+    if post_conds.is_empty() {
+        new_body.extend_from_slice(real_body);
+    } else {
+        let percent = Form::new(FormKind::Symbol("%".to_string()), span.clone());
+        let body_expr = if real_body.len() == 1 {
+            real_body[0].clone()
+        } else {
+            let mut do_forms =
+                vec![Form::new(FormKind::Symbol("do".to_string()), span.clone())];
+            do_forms.extend_from_slice(real_body);
+            Form::new(FormKind::List(do_forms), span.clone())
+        };
+        let binding_vec = Form::new(
+            FormKind::Vector(vec![percent.clone(), body_expr]),
+            span.clone(),
+        );
+        let mut let_forms = vec![
+            Form::new(FormKind::Symbol("let*".to_string()), span.clone()),
+            binding_vec,
+        ];
+        for cond in &post_conds {
+            let_forms.push(make_assert_call(cond, &span));
+        }
+        let_forms.push(percent);
+        new_body.push(Form::new(FormKind::List(let_forms), span));
+    }
+
+    new_body
+}
+
+fn make_assert_call(cond: &Form, span: &cljrs_types::span::Span) -> Form {
+    Form::new(
+        FormKind::List(vec![
+            Form::new(FormKind::Symbol("assert".to_string()), span.clone()),
+            cond.clone(),
+        ]),
+        span.clone(),
+    )
+}
+
 // ── fn / fn* ──────────────────────────────────────────────────────────────────
 
 fn parse_params(params_vec: &[Form]) -> Result<(Vec<Form>, Option<Form>), LowerError> {
@@ -1067,7 +1163,7 @@ fn lower_fn(ctx: &mut LowerCtx, args: &[Form], is_async: bool) -> R {
             vec![AritySpec {
                 fixed,
                 rest,
-                body: rest_args[1..].to_vec(),
+                body: desugar_pre_post_conditions(&rest_args[1..]),
             }]
         } else {
             // Multi arity: each element is a list (params body...)
@@ -1088,7 +1184,7 @@ fn lower_fn(ctx: &mut LowerCtx, args: &[Form], is_async: bool) -> R {
                     Ok(AritySpec {
                         fixed,
                         rest,
-                        body: arity_parts[1..].to_vec(),
+                        body: desugar_pre_post_conditions(&arity_parts[1..]),
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?


### PR DESCRIPTION
Clojure binds `%` to the function's return value inside `:post`
conditions. cljrs was not doing this, causing `Unable to resolve symbol: %`
errors when any `:post` condition referenced `%`.

Add `desugar_pre_post_conditions` in `parse_arity`: when the first body
form is a `{:pre [...] :post [...]}` map, rewrite the body to:
  1. Emit `(assert cond)` for each `:pre` condition.
  2. Wrap the real body in `(let* [% <body-expr>] (assert post-cond)... %)`
     so `%` refers to the return value inside `:post` conditions.

Fixes #186.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LLzEXGebknzNXHJ35JNV6G