### PR TITLE
Fix #'alias/sym var-quote not resolving namespace aliases

### DIFF
--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -2432,6 +2432,12 @@ pub unsafe extern "C" fn rt_load_var(
         if let Some(var) = globals.lookup_var_in_ns(ns, name) {
             return box_val(Value::Var(var));
         }
+        // Try resolving ns as an alias in the current namespace.
+        if let Some(resolved_ns) = globals.resolve_alias(&current_ns, ns)
+            && let Some(var) = globals.lookup_var_in_ns(&resolved_ns, name)
+        {
+            return box_val(Value::Var(var));
+        }
         // If ns is the current namespace, also check refers via current ns.
         if ns == current_ns.as_ref()
             && let Some(var) = globals.lookup_var_in_ns(&current_ns, name)

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -106,9 +106,15 @@ pub fn eval(form: &Form, env: &mut Env) -> EvalResult {
         FormKind::Var(inner) => {
             if let FormKind::Symbol(s) = &inner.kind {
                 let parsed = Symbol::parse(s);
-                let ns = parsed.namespace.as_deref().unwrap_or(&env.current_ns);
+                let ns: Arc<str> = match parsed.namespace.as_deref() {
+                    Some(ns_part) => env
+                        .globals
+                        .resolve_alias(&env.current_ns, ns_part)
+                        .unwrap_or_else(|| Arc::from(ns_part)),
+                    None => env.current_ns.clone(),
+                };
                 env.globals
-                    .lookup_var_in_ns(ns, &parsed.name)
+                    .lookup_var_in_ns(&ns, &parsed.name)
                     .map(Value::Var)
                     .ok_or_else(|| EvalError::UnboundSymbol(s.clone()))
             } else {
@@ -1434,6 +1440,38 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result.to_string(), "\"Hi Alice\"");
+    }
+
+    #[test]
+    fn test_var_quote_alias_resolution() {
+        // #'alias/sym must resolve the alias to the full namespace, just like
+        // a regular function call does (issue #187).
+        let dir = temp_ns_dir("var_quote_alias");
+        // lib.core maps to lib/core.cljrs on the source path.
+        std::fs::create_dir_all(dir.join("lib")).unwrap();
+        std::fs::write(
+            dir.join("lib/core.cljrs"),
+            "(ns lib.core) (defn public [x] (* x 2))",
+        )
+        .unwrap();
+        let (_, mut env) = make_env_with_paths(vec![dir]);
+        // Regular call via alias must work first.
+        let call_result = eval_src(
+            "(require '[lib.core :as l]) (l/public 21)",
+            &mut env,
+        )
+        .unwrap();
+        assert_eq!(call_result, Value::Long(42));
+        // #'alias/sym reader form.
+        let var_result = eval_src("#'l/public", &mut env).unwrap();
+        assert!(
+            matches!(var_result, Value::Var(_)),
+            "expected Var, got {var_result:?}"
+        );
+        assert_eq!(var_result.to_string(), "#'lib.core/public");
+        // (var alias/sym) special form must also resolve the alias.
+        let var_special = eval_src("(var l/public)", &mut env).unwrap();
+        assert_eq!(var_special.to_string(), "#'lib.core/public");
     }
 
     #[test]

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -1456,11 +1456,7 @@ mod tests {
         .unwrap();
         let (_, mut env) = make_env_with_paths(vec![dir]);
         // Regular call via alias must work first.
-        let call_result = eval_src(
-            "(require '[lib.core :as l]) (l/public 21)",
-            &mut env,
-        )
-        .unwrap();
+        let call_result = eval_src("(require '[lib.core :as l]) (l/public 21)", &mut env).unwrap();
         assert_eq!(call_result, Value::Long(42));
         // #'alias/sym reader form.
         let var_result = eval_src("#'l/public", &mut env).unwrap();

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -826,10 +826,16 @@ fn eval_var(args: &[Form], env: &mut Env) -> EvalResult {
         _ => return Err(EvalError::Runtime("var requires a symbol".into())),
     };
     let parsed = cljrs_value::Symbol::parse(&sym);
-    let ns = parsed.namespace.as_deref().unwrap_or(&env.current_ns);
+    let ns: Arc<str> = match parsed.namespace.as_deref() {
+        Some(ns_part) => env
+            .globals
+            .resolve_alias(&env.current_ns, ns_part)
+            .unwrap_or_else(|| Arc::from(ns_part)),
+        None => env.current_ns.clone(),
+    };
     let name = parsed.name.as_ref();
     env.globals
-        .lookup_var_in_ns(ns, name)
+        .lookup_var_in_ns(&ns, name)
         .map(Value::Var)
         .ok_or_else(|| EvalError::UnboundSymbol(sym))
 }


### PR DESCRIPTION
Both the #'alias/sym reader form (FormKind::Var in eval.rs) and the
(var alias/sym) special form (special.rs) were passing the alias
directly to lookup_var_in_ns without first calling resolve_alias,
unlike regular symbol evaluation which already does so. This caused
UnboundSymbol errors whenever a :require :as alias was used in a
var-quote.

Fixes #187.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QdyjQZN1BrW8LSGe1B14o8