### PR TITLE
Fix clojure.string/replace to accept regex pattern as match argument

### DIFF
--- a/clojure-test-suite/test/clojure/string_test/replace.cljc
+++ b/clojure-test-suite/test/clojure/string_test/replace.cljc
@@ -1,0 +1,16 @@
+(ns clojure.string-test.replace
+  (:require [clojure.string :as str]
+            [clojure.test :as t :refer [deftest testing is]]))
+
+(deftest test-replace-string-match
+  (is (= "bbb" (str/replace "aaa" "a" "b")))
+  (is (= "bbc" (str/replace "aac" "a" "b")))
+  (is (= "hello" (str/replace "hello" "x" "y")))
+  (is (= "" (str/replace "aaa" "a" ""))))
+
+(deftest test-replace-pattern-match
+  (is (= "host" (str/replace "--host" #"^--" "")))
+  (is (= "bbb" (str/replace "aaa" #"a" "b")))
+  (is (= "hello world" (str/replace "hello   world" #"\s+" " ")))
+  (is (= "" (str/replace "123" #"\d+" "")))
+  (is (= "123" (str/replace "123" #"[a-z]+" ""))))

--- a/clojure-test-suite/test/clojure/string_test/replace_first.cljc
+++ b/clojure-test-suite/test/clojure/string_test/replace_first.cljc
@@ -1,0 +1,12 @@
+(ns clojure.string-test.replace-first
+  (:require [clojure.string :as str]
+            [clojure.test :as t :refer [deftest testing is]]))
+
+(deftest test-replace-first-string-match
+  (is (= "baa" (str/replace-first "aaa" "a" "b")))
+  (is (= "hello" (str/replace-first "hello" "x" "y"))))
+
+(deftest test-replace-first-pattern-match
+  (is (= "host" (str/replace-first "--host" #"^--" "")))
+  (is (= "baa" (str/replace-first "aaa" #"a" "b")))
+  (is (= "hello world  end" (str/replace-first "hello  world  end" #"\s+" " "))))

--- a/crates/cljrs-stdlib/README.md
+++ b/crates/cljrs-stdlib/README.md
@@ -64,6 +64,10 @@ pub fn standard_env_with_paths(source_paths: Vec<PathBuf>) -> Arc<GlobalEnv>;
 `replace`, `replace-first`, `split`, `split-lines`, `join`,
 `index-of`, `last-index-of`
 
+`replace` and `replace-first` accept either a string or a regex pattern
+(`#"..."`) as the match argument. When the match is a pattern, `replace`
+replaces all occurrences and `replace-first` replaces only the first.
+
 ### clojure.set functions
 
 `union`, `intersection`, `difference`, `subset?`, `superset?`,

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -279,6 +279,23 @@ mod tests {
             run("(str/replace-first \"aabbcc\" \"a\" \"X\")", &mut env).unwrap(),
             Value::string("Xabbcc")
         );
+        // regex match (issue #188)
+        assert_eq!(
+            run("(str/replace \"--host\" #\"^--\" \"\")", &mut env).unwrap(),
+            Value::string("host")
+        );
+        assert_eq!(
+            run("(str/replace \"aaa\" #\"a\" \"b\")", &mut env).unwrap(),
+            Value::string("bbb")
+        );
+        assert_eq!(
+            run("(str/replace-first \"aaa\" #\"a\" \"b\")", &mut env).unwrap(),
+            Value::string("baa")
+        );
+        assert_eq!(
+            run("(str/replace-first \"--host\" #\"^--\" \"\")", &mut env).unwrap(),
+            Value::string("host")
+        );
     }
 
     #[test]

--- a/crates/cljrs-stdlib/src/string.rs
+++ b/crates/cljrs-stdlib/src/string.rs
@@ -176,16 +176,32 @@ fn includes_q(args: &[Value]) -> ValueResult<Value> {
 
 fn replace(args: &[Value]) -> ValueResult<Value> {
     let s = get_str(&args[0])?;
-    let from = get_str(&args[1])?;
     let to = get_str(&args[2])?;
-    Ok(make_str(s.replace(from.as_ref(), to.as_ref())))
+    match &args[1] {
+        Value::Pattern(re) => {
+            let re = re.get();
+            Ok(make_str(re.replace_all(s.as_ref(), to.as_ref()).into_owned()))
+        }
+        _ => {
+            let from = get_str(&args[1])?;
+            Ok(make_str(s.replace(from.as_ref(), to.as_ref())))
+        }
+    }
 }
 
 fn replace_first(args: &[Value]) -> ValueResult<Value> {
     let s = get_str(&args[0])?;
-    let from = get_str(&args[1])?;
     let to = get_str(&args[2])?;
-    Ok(make_str(s.replacen(from.as_ref(), to.as_ref(), 1)))
+    match &args[1] {
+        Value::Pattern(re) => {
+            let re = re.get();
+            Ok(make_str(re.replace(s.as_ref(), to.as_ref()).into_owned()))
+        }
+        _ => {
+            let from = get_str(&args[1])?;
+            Ok(make_str(s.replacen(from.as_ref(), to.as_ref(), 1)))
+        }
+    }
 }
 
 /// `(split s delim)` or `(split s delim limit)`.

--- a/crates/cljrs-stdlib/src/string.rs
+++ b/crates/cljrs-stdlib/src/string.rs
@@ -180,7 +180,9 @@ fn replace(args: &[Value]) -> ValueResult<Value> {
     match &args[1] {
         Value::Pattern(re) => {
             let re = re.get();
-            Ok(make_str(re.replace_all(s.as_ref(), to.as_ref()).into_owned()))
+            Ok(make_str(
+                re.replace_all(s.as_ref(), to.as_ref()).into_owned(),
+            ))
         }
         _ => {
             let from = get_str(&args[1])?;


### PR DESCRIPTION
Previously replace and replace-first only accepted a string for the
match argument, throwing "expected string, got pattern" when given a
regex. Added pattern dispatch (matching the existing split implementation)
so that Value::Pattern uses regex replace_all / replace respectively.

Fixes #188.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S3gsxv7jtAaKxT1M5QPSg4