### PR TITLE
Add distinct? predicate and fix reader conditionals in vectors/let*

### DIFF
--- a/crates/cljrs-builtins/src/bootstrap.cljrs
+++ b/crates/cljrs-builtins/src/bootstrap.cljrs
@@ -297,6 +297,10 @@
 (defmacro when-not [test & body]
   (list 'if test nil (cons 'do body)))
 
+(defmacro if-not
+  ([test then] (list 'if test nil then))
+  ([test then else] (list 'if test else then)))
+
 (defmacro if-let
   ([bindings then] (list 'if-let bindings then nil))
   ([bindings then else]
@@ -1049,4 +1053,4 @@
 (defn re-seq
   [re s]
   (let [matcher (re-matcher re s)]
-    (take-while identity (repeatedly #(re-find matcher)))))
+    (seq (take-while identity (repeatedly #(re-find matcher))))))

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -344,6 +344,7 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         ),
         ("flatten", Arity::Fixed(1), builtin_flatten),
         ("distinct", Arity::Fixed(1), builtin_distinct),
+        ("distinct?", Arity::Variadic { min: 1 }, builtin_distinct_q),
         ("frequencies", Arity::Fixed(1), builtin_frequencies),
         ("interleave", Arity::Variadic { min: 0 }, builtin_interleave),
         ("interpose", Arity::Fixed(2), builtin_interpose),
@@ -4581,6 +4582,18 @@ fn builtin_distinct(args: &[Value]) -> ValueResult<Value> {
         }
     }
     Ok(Value::List(GcPtr::new(PersistentList::from_iter(out))))
+}
+
+fn builtin_distinct_q(args: &[Value]) -> ValueResult<Value> {
+    use cljrs_value::ClojureHash;
+    let mut seen = std::collections::HashSet::new();
+    for v in args {
+        let h = v.clojure_hash();
+        if !seen.insert(h) {
+            return Ok(Value::Bool(false));
+        }
+    }
+    Ok(Value::Bool(true))
 }
 
 fn builtin_frequencies(args: &[Value]) -> ValueResult<Value> {

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -52,6 +52,16 @@ pub fn eval(form: &Form, env: &mut Env) -> EvalResult {
         // ── Collections ───────────────────────────────────────────────────
         FormKind::List(forms) => eval_list(forms, env),
         FormKind::Vector(forms) => {
+            let expanded_forms;
+            let forms: &[Form] = if forms
+                .iter()
+                .any(|f| matches!(f.kind, FormKind::ReaderCond { .. }))
+            {
+                expanded_forms = expand_reader_conds(forms);
+                &expanded_forms
+            } else {
+                forms
+            };
             let mut vals: Vec<Value> = Vec::with_capacity(forms.len());
             for f in forms {
                 let _root = cljrs_env::gc_roots::root_values(&vals);

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -487,9 +487,17 @@ fn eval_if(args: &[Form], env: &mut Env) -> EvalResult {
 // ── let* ──────────────────────────────────────────────────────────────────────
 
 fn eval_let(args: &[Form], env: &mut Env) -> EvalResult {
-    let bindings = match args.first().map(|f| &f.kind) {
+    let raw_bindings = match args.first().map(|f| &f.kind) {
         Some(FormKind::Vector(v)) => v.clone(),
         _ => return Err(EvalError::Runtime("let* requires a binding vector".into())),
+    };
+    let bindings = if raw_bindings
+        .iter()
+        .any(|f| matches!(f.kind, FormKind::ReaderCond { .. }))
+    {
+        expand_reader_conds(&raw_bindings)
+    } else {
+        raw_bindings
     };
 
     if bindings.len() % 2 != 0 {


### PR DESCRIPTION
## Summary
This PR adds the `distinct?` predicate function and fixes reader conditional expansion in vector and `let*` binding contexts.

## Key Changes

- **New builtin `distinct?`**: Implements a variadic predicate that returns `true` if all arguments are distinct (no duplicates), `false` otherwise. Uses Clojure hashing for equality comparison.

- **Reader conditional expansion in vectors**: Vector literals now properly expand reader conditionals (`#?`) before evaluation, ensuring platform-specific code in vectors is correctly filtered for the `:rust` platform.

- **Reader conditional expansion in `let*` bindings**: The `let*` special form now expands reader conditionals in binding vectors before processing, allowing platform-specific bindings to work correctly.

- **New `if-not` macro**: Added a convenience macro that inverts the condition of `if` (equivalent to `(if (not test) then else)`), with both 2-arity and 3-arity variants.

- **Fix `re-seq` return type**: Wrapped the result of `re-seq` in `seq` to ensure it returns a proper sequence rather than a lazy sequence object, improving consistency with Clojure semantics.

## Implementation Details

The `distinct?` function uses a `HashSet` to track seen values by their Clojure hash, returning `false` as soon as a duplicate is encountered for efficiency.

Reader conditional expansion in vectors and `let*` follows the existing pattern: check if any form in the collection is a reader conditional, and if so, expand all of them before proceeding with evaluation/binding.

https://claude.ai/code/session_01WqUqzwkQ35kar8TSMMi3ct