### PR TITLE
fix: format handles width/flag specifiers like %-5s (issue #199)

### DIFF
--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -5718,7 +5718,14 @@ fn fmt_signed(negative: bool, abs: &str, plus: bool, space: bool, paren: bool) -
 
 /// Format `f` as scientific notation matching Java's `%e` / `%E`.
 /// Exponent always has a sign and at least two digits: `1.234568e+02`.
-fn fmt_scientific(f: f64, prec: usize, upper: bool, plus: bool, space: bool, paren: bool) -> String {
+fn fmt_scientific(
+    f: f64,
+    prec: usize,
+    upper: bool,
+    plus: bool,
+    space: bool,
+    paren: bool,
+) -> String {
     if f.is_nan() {
         return "NaN".to_string();
     }
@@ -5897,11 +5904,7 @@ fn builtin_format(args: &[Value]) -> ValueResult<Value> {
                 i += 1;
             }
             if i > prec_start {
-                chars[prec_start..i]
-                    .iter()
-                    .collect::<String>()
-                    .parse()
-                    .ok()
+                chars[prec_start..i].iter().collect::<String>().parse().ok()
             } else {
                 Some(0)
             }
@@ -6002,9 +6005,7 @@ fn builtin_format(args: &[Value]) -> ValueResult<Value> {
                     None => 0.0,
                 };
                 let prec = precision.unwrap_or(6);
-                let s = fmt_scientific(
-                    f, prec, conv == 'E', flag_plus, flag_space, flag_paren,
-                );
+                let s = fmt_scientific(f, prec, conv == 'E', flag_plus, flag_space, flag_paren);
                 fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
             }
 
@@ -6021,9 +6022,7 @@ fn builtin_format(args: &[Value]) -> ValueResult<Value> {
                     Some(0) | None => 6,
                     Some(p) => p,
                 };
-                let s = fmt_general(
-                    f, prec, conv == 'G', flag_plus, flag_space, flag_paren,
-                );
+                let s = fmt_general(f, prec, conv == 'G', flag_plus, flag_space, flag_paren);
                 fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
             }
 

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -5624,8 +5624,183 @@ fn builtin_byte(args: &[Value]) -> ValueResult<Value> {
     }
 }
 
+// ── format helpers ────────────────────────────────────────────────────────────
+
+/// Pad `s` to at least `width` characters, space-padding only (for strings /
+/// non-numeric values).
+fn fmt_pad(out: &mut String, s: &str, width: Option<usize>, left: bool) {
+    let slen = s.chars().count();
+    match width {
+        Some(w) if w > slen => {
+            let n = w - slen;
+            if left {
+                out.push_str(s);
+                for _ in 0..n {
+                    out.push(' ');
+                }
+            } else {
+                for _ in 0..n {
+                    out.push(' ');
+                }
+                out.push_str(s);
+            }
+        }
+        _ => out.push_str(s),
+    }
+}
+
+/// Pad a numeric string to `width`.  When zero-padding the sign character (if
+/// any) is emitted before the zeros.
+fn fmt_pad_num(out: &mut String, s: &str, width: Option<usize>, left: bool, zero: bool) {
+    let slen = s.chars().count();
+    match width {
+        Some(w) if w > slen => {
+            let n = w - slen;
+            if left {
+                out.push_str(s);
+                for _ in 0..n {
+                    out.push(' ');
+                }
+            } else if zero {
+                let first = s.chars().next().unwrap_or(' ');
+                if matches!(first, '-' | '+' | ' ') {
+                    out.push(first);
+                    for _ in 0..n {
+                        out.push('0');
+                    }
+                    out.push_str(&s[first.len_utf8()..]);
+                } else {
+                    for _ in 0..n {
+                        out.push('0');
+                    }
+                    out.push_str(s);
+                }
+            } else {
+                for _ in 0..n {
+                    out.push(' ');
+                }
+                out.push_str(s);
+            }
+        }
+        _ => out.push_str(s),
+    }
+}
+
+/// Format `n` with comma thousands-separators.
+fn fmt_grouped(n: u64) -> String {
+    let s = n.to_string();
+    let mut buf = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            buf.push(',');
+        }
+        buf.push(c);
+    }
+    buf.chars().rev().collect()
+}
+
+/// Prepend the appropriate sign to an absolute-value digit string.
+fn fmt_signed(negative: bool, abs: &str, plus: bool, space: bool, paren: bool) -> String {
+    if negative {
+        if paren {
+            format!("({})", abs)
+        } else {
+            format!("-{}", abs)
+        }
+    } else if plus {
+        format!("+{}", abs)
+    } else if space {
+        format!(" {}", abs)
+    } else {
+        abs.to_string()
+    }
+}
+
+/// Format `f` as scientific notation matching Java's `%e` / `%E`.
+/// Exponent always has a sign and at least two digits: `1.234568e+02`.
+fn fmt_scientific(f: f64, prec: usize, upper: bool, plus: bool, space: bool, paren: bool) -> String {
+    if f.is_nan() {
+        return "NaN".to_string();
+    }
+    if f.is_infinite() {
+        let s = if f > 0.0 { "Infinity" } else { "-Infinity" };
+        return s.to_string();
+    }
+    let negative = f.is_sign_negative();
+    let f_abs = f.abs();
+    let e_char = if upper { 'E' } else { 'e' };
+
+    let (mantissa_str, exp) = if f_abs == 0.0 {
+        let frac = if prec > 0 {
+            format!(".{}", "0".repeat(prec))
+        } else {
+            String::new()
+        };
+        (format!("0{}", frac), 0i32)
+    } else {
+        let exp = f_abs.log10().floor() as i32;
+        let mantissa = f_abs / 10f64.powi(exp);
+        let ms = format!("{:.prec$}", mantissa);
+        // Rounding can push mantissa to 10.0
+        if ms.starts_with("10") {
+            (format!("{:.prec$}", mantissa / 10.0), exp + 1)
+        } else {
+            (ms, exp)
+        }
+    };
+
+    let exp_sign = if exp >= 0 { '+' } else { '-' };
+    let exp_abs = exp.unsigned_abs();
+    let abs_str = format!("{}{}{}{:02}", mantissa_str, e_char, exp_sign, exp_abs);
+    fmt_signed(negative, &abs_str, plus, space, paren)
+}
+
+/// Format `f` using `%g` / `%G` semantics (shortest of fixed / scientific,
+/// trailing zeros stripped).
+fn fmt_general(f: f64, prec: usize, upper: bool, plus: bool, space: bool, paren: bool) -> String {
+    if f.is_nan() {
+        return "NaN".to_string();
+    }
+    if f.is_infinite() {
+        let s = if f > 0.0 { "Infinity" } else { "-Infinity" };
+        return s.to_string();
+    }
+    let negative = f.is_sign_negative();
+    let f_abs = f.abs();
+    let exp = if f_abs == 0.0 {
+        0i32
+    } else {
+        f_abs.log10().floor() as i32
+    };
+    let e_char = if upper { 'E' } else { 'e' };
+
+    let abs_str = if exp < -4 || exp >= prec as i32 {
+        let sci_prec = prec.saturating_sub(1);
+        let mantissa = if f_abs == 0.0 {
+            0.0
+        } else {
+            f_abs / 10f64.powi(exp)
+        };
+        let ms = format!("{:.prec$}", mantissa, prec = sci_prec);
+        let ms = ms.trim_end_matches('0');
+        let ms = ms.trim_end_matches('.');
+        let exp_sign = if exp >= 0 { '+' } else { '-' };
+        format!("{}{}{}{:02}", ms, e_char, exp_sign, exp.unsigned_abs())
+    } else {
+        let decimal_places = ((prec as i32) - 1 - exp).max(0) as usize;
+        let s = format!("{:.prec$}", f_abs, prec = decimal_places);
+        if s.contains('.') {
+            s.trim_end_matches('0').trim_end_matches('.').to_string()
+        } else {
+            s
+        }
+    };
+    fmt_signed(negative, &abs_str, plus, space, paren)
+}
+
+// ── builtin_format ────────────────────────────────────────────────────────────
+
 fn builtin_format(args: &[Value]) -> ValueResult<Value> {
-    // Minimal format: just use str for now.
     let fmt = match &args[0] {
         Value::Str(s) => s.get().clone(),
         v => {
@@ -5635,40 +5810,330 @@ fn builtin_format(args: &[Value]) -> ValueResult<Value> {
             });
         }
     };
-    // Simple %s substitution.
-    let result = fmt;
-    let mut arg_idx = 1;
+
+    let chars: Vec<char> = fmt.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    let mut arg_idx = 1usize;
     let mut out = String::new();
-    let mut chars = result.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '%' {
-            match chars.next() {
-                Some('s') => {
-                    if let Some(v) = args.get(arg_idx) {
-                        match v {
-                            Value::Str(s) => out.push_str(s.get()),
-                            other => out.push_str(&format!("{}", other)),
-                        }
-                        arg_idx += 1;
-                    }
+
+    while i < len {
+        if chars[i] != '%' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        i += 1; // consume '%'
+        if i >= len {
+            out.push('%');
+            break;
+        }
+
+        // ── Parse flags ───────────────────────────────────────────────────────
+        let mut flag_left = false;
+        let mut flag_plus = false;
+        let mut flag_space = false;
+        let mut flag_zero = false;
+        let mut flag_paren = false;
+        let mut flag_comma = false;
+        let mut flag_alt = false;
+
+        loop {
+            match chars.get(i).copied() {
+                Some('-') => {
+                    flag_left = true;
+                    i += 1;
                 }
-                Some('d') => {
-                    if let Some(v) = args.get(arg_idx) {
-                        out.push_str(&format!("{}", numeric_as_i64(v).unwrap_or(0)));
-                        arg_idx += 1;
-                    }
+                Some('+') => {
+                    flag_plus = true;
+                    i += 1;
                 }
-                Some('%') => out.push('%'),
-                Some(c2) => {
-                    out.push('%');
-                    out.push(c2);
+                Some(' ') => {
+                    flag_space = true;
+                    i += 1;
                 }
-                None => out.push('%'),
+                // '0' is the zero-pad flag only before width digits; consumed
+                // at most once — subsequent '0's become part of the width.
+                Some('0') if !flag_zero => {
+                    flag_zero = true;
+                    i += 1;
+                }
+                Some('(') => {
+                    flag_paren = true;
+                    i += 1;
+                }
+                Some(',') => {
+                    flag_comma = true;
+                    i += 1;
+                }
+                Some('#') => {
+                    flag_alt = true;
+                    i += 1;
+                }
+                _ => break,
+            }
+        }
+
+        // ── Parse width ───────────────────────────────────────────────────────
+        let width_start = i;
+        while i < len && chars[i].is_ascii_digit() {
+            i += 1;
+        }
+        let width: Option<usize> = if i > width_start {
+            chars[width_start..i]
+                .iter()
+                .collect::<String>()
+                .parse()
+                .ok()
+        } else {
+            None
+        };
+
+        // ── Parse precision ───────────────────────────────────────────────────
+        let precision: Option<usize> = if i < len && chars[i] == '.' {
+            i += 1;
+            let prec_start = i;
+            while i < len && chars[i].is_ascii_digit() {
+                i += 1;
+            }
+            if i > prec_start {
+                chars[prec_start..i]
+                    .iter()
+                    .collect::<String>()
+                    .parse()
+                    .ok()
+            } else {
+                Some(0)
             }
         } else {
-            out.push(c);
+            None
+        };
+
+        if i >= len {
+            out.push('%');
+            break;
+        }
+
+        let conv = chars[i];
+        i += 1;
+
+        match conv {
+            // ── Literal % / newline ───────────────────────────────────────────
+            '%' => out.push('%'),
+            'n' => out.push('\n'),
+
+            // ── String ───────────────────────────────────────────────────────
+            's' | 'S' => {
+                let s = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        let raw = match v {
+                            Value::Nil => "null".to_string(),
+                            Value::Str(s) => s.get().clone(),
+                            other => format!("{}", other),
+                        };
+                        match precision {
+                            Some(p) => raw.chars().take(p).collect(),
+                            None => raw,
+                        }
+                    }
+                    None => String::new(),
+                };
+                let s = if conv == 'S' { s.to_uppercase() } else { s };
+                fmt_pad(&mut out, &s, width, flag_left);
+            }
+
+            // ── Decimal integer ───────────────────────────────────────────────
+            'd' => {
+                let n = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        numeric_as_i64(v).unwrap_or(0)
+                    }
+                    None => 0,
+                };
+                let abs_digits = if flag_comma {
+                    fmt_grouped(n.unsigned_abs())
+                } else {
+                    n.unsigned_abs().to_string()
+                };
+                let s = fmt_signed(n < 0, &abs_digits, flag_plus, flag_space, flag_paren);
+                fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
+            }
+
+            // ── Fixed-point float ─────────────────────────────────────────────
+            'f' => {
+                let f = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        numeric_as_f64(v).unwrap_or(0.0)
+                    }
+                    None => 0.0,
+                };
+                let prec = precision.unwrap_or(6);
+                let negative = f.is_sign_negative();
+                let f_abs = f.abs();
+                let abs_str = if flag_comma {
+                    let s = format!("{:.prec$}", f_abs);
+                    match s.find('.') {
+                        Some(idx) => {
+                            let int_n: u64 = s[..idx].parse().unwrap_or(0);
+                            format!("{}{}", fmt_grouped(int_n), &s[idx..])
+                        }
+                        None => {
+                            let int_n: u64 = s.parse().unwrap_or(0);
+                            fmt_grouped(int_n)
+                        }
+                    }
+                } else {
+                    format!("{:.prec$}", f_abs)
+                };
+                let s = fmt_signed(negative, &abs_str, flag_plus, flag_space, flag_paren);
+                fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
+            }
+
+            // ── Scientific notation ───────────────────────────────────────────
+            'e' | 'E' => {
+                let f = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        numeric_as_f64(v).unwrap_or(0.0)
+                    }
+                    None => 0.0,
+                };
+                let prec = precision.unwrap_or(6);
+                let s = fmt_scientific(
+                    f, prec, conv == 'E', flag_plus, flag_space, flag_paren,
+                );
+                fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
+            }
+
+            // ── General float ─────────────────────────────────────────────────
+            'g' | 'G' => {
+                let f = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        numeric_as_f64(v).unwrap_or(0.0)
+                    }
+                    None => 0.0,
+                };
+                let prec = match precision {
+                    Some(0) | None => 6,
+                    Some(p) => p,
+                };
+                let s = fmt_general(
+                    f, prec, conv == 'G', flag_plus, flag_space, flag_paren,
+                );
+                fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
+            }
+
+            // ── Hex integer ───────────────────────────────────────────────────
+            'x' | 'X' => {
+                let n = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        numeric_as_i64(v).unwrap_or(0) as u64
+                    }
+                    None => 0,
+                };
+                let digits = if conv == 'X' {
+                    format!("{:X}", n)
+                } else {
+                    format!("{:x}", n)
+                };
+                let s = if flag_alt {
+                    let prefix = if conv == 'X' { "0X" } else { "0x" };
+                    format!("{}{}", prefix, digits)
+                } else {
+                    digits
+                };
+                fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
+            }
+
+            // ── Octal integer ─────────────────────────────────────────────────
+            'o' => {
+                let n = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        numeric_as_i64(v).unwrap_or(0) as u64
+                    }
+                    None => 0,
+                };
+                let s = format!("{:o}", n);
+                fmt_pad_num(&mut out, &s, width, flag_left, flag_zero && !flag_left);
+            }
+
+            // ── Boolean ───────────────────────────────────────────────────────
+            'b' | 'B' => {
+                let s = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        match v {
+                            Value::Nil | Value::Bool(false) => "false".to_string(),
+                            _ => "true".to_string(),
+                        }
+                    }
+                    None => "false".to_string(),
+                };
+                let s = if conv == 'B' { s.to_uppercase() } else { s };
+                fmt_pad(&mut out, &s, width, flag_left);
+            }
+
+            // ── Character ─────────────────────────────────────────────────────
+            'c' | 'C' => {
+                let s = match args.get(arg_idx) {
+                    Some(v) => {
+                        arg_idx += 1;
+                        match v {
+                            Value::Char(c) => c.to_string(),
+                            Value::Long(n) => char::from_u32(*n as u32)
+                                .map(|c| c.to_string())
+                                .unwrap_or_default(),
+                            _ => String::new(),
+                        }
+                    }
+                    None => String::new(),
+                };
+                let s = if conv == 'C' { s.to_uppercase() } else { s };
+                fmt_pad(&mut out, &s, width, flag_left);
+            }
+
+            // ── Unknown conversion — emit literally ───────────────────────────
+            other => {
+                out.push('%');
+                if flag_left {
+                    out.push('-');
+                }
+                if flag_plus {
+                    out.push('+');
+                }
+                if flag_space {
+                    out.push(' ');
+                }
+                if flag_zero {
+                    out.push('0');
+                }
+                if flag_paren {
+                    out.push('(');
+                }
+                if flag_comma {
+                    out.push(',');
+                }
+                if flag_alt {
+                    out.push('#');
+                }
+                if let Some(w) = width {
+                    out.push_str(&w.to_string());
+                }
+                if let Some(p) = precision {
+                    out.push('.');
+                    out.push_str(&p.to_string());
+                }
+                out.push(other);
+            }
         }
     }
+
     Ok(Value::string(out))
 }
 

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -2330,6 +2330,29 @@ fn test_versioned_snapshot_is_self_contained() {
     );
 }
 
+// ── Regression: issue #199 — format ignores width/flag specifiers ─────────────
+
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn test_format_width_flags() {
+    assert_output(
+        "format_width_flags",
+        r#"
+(println (format "%-5s" "ab"))
+(println (format "%-5s|" "ab"))
+(println (format "%-15s%s" "a" "b"))
+(println (format "%s %s" "a" "b"))
+(println (format "%d" 5))
+(println (format "%5d" 42))
+(println (format "%-5d" 42))
+(println (format "%05d" 42))
+(println (format "%+d" 42))
+(println (format "%5s" "ab"))
+"#,
+        "ab   \nab   |\na              b\na b\n5\n   42\n42   \n00042\n+42\n   ab",
+    );
+}
+
 // ── Regression: issue #198 — into rejects lazy-seq / cons as target ──────────
 
 #[test]

--- a/crates/cljrs/tests/format_width.rs
+++ b/crates/cljrs/tests/format_width.rs
@@ -85,7 +85,11 @@ const FMT_SCRIPT: &str = r#"
 
 fn check_output(out: &str, label: &str) {
     let lines: Vec<&str> = out.lines().collect();
-    assert_eq!(lines.len(), 10, "{label}: expected 10 output lines, got:\n{out}");
+    assert_eq!(
+        lines.len(),
+        10,
+        "{label}: expected 10 output lines, got:\n{out}"
+    );
 
     // (format "%-5s" "ab")  → "ab   "
     assert_eq!(lines[0], "ab   ", "{label}: %-5s wrong");

--- a/crates/cljrs/tests/format_width.rs
+++ b/crates/cljrs/tests/format_width.rs
@@ -1,0 +1,164 @@
+//! Regression tests for issue #199: `format` width/flag specifiers like `%-5s`.
+//!
+//! `builtin_format` is a native function shared by all execution tiers (interpreter,
+//! JIT, AOT).  The old code fell through to a literal-emit branch for any specifier
+//! that contained flags or a width component, so `%-5s` was emitted as the literal
+//! string `%-5s` instead of a padded value, and argument consumption was thrown off.
+//!
+//! Three test groups verify the fix across each execution path.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn unique_path(prefix: &str) -> std::path::PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "cljrs_fmt_{}_{nanos}_{seq}_{}.cljrs",
+        prefix,
+        std::process::id()
+    ))
+}
+
+/// Run `src` through the interpreter (`cljrs run`, no JIT promotion).
+fn run_interp(src: &str) -> String {
+    let path = unique_path("interp");
+    std::fs::write(&path, src).expect("write script");
+    let output = Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .args(["run"])
+        .arg(&path)
+        .output()
+        .expect("spawn cljrs");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "cljrs exited {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("utf8 stdout")
+}
+
+/// Run `src` under JIT with a very low threshold so hot functions get compiled.
+fn run_jit(src: &str) -> String {
+    let path = unique_path("jit");
+    std::fs::write(&path, src).expect("write script");
+    let output = Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .args(["--jit-threshold", "50", "run"])
+        .arg(&path)
+        .env("CLJRS_EAGER_LOWER", "1")
+        .output()
+        .expect("spawn cljrs");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "cljrs (jit) exited {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("utf8 stdout")
+}
+
+// ── Clojure format script ─────────────────────────────────────────────────────
+
+/// A script that exercises format specifiers from the issue and prints each
+/// result on its own line, prefixed by `result:` so assertions are clear.
+const FMT_SCRIPT: &str = r#"
+(println (format "%-5s" "ab"))
+(println (format "%-5s|" "ab"))
+(println (format "%-15s%s" "a" "b"))
+(println (format "%s %s" "a" "b"))
+(println (format "%d" 5))
+(println (format "%5d" 42))
+(println (format "%-5d" 42))
+(println (format "%05d" 42))
+(println (format "%+d" 42))
+(println (format "%5s" "ab"))
+"#;
+
+fn check_output(out: &str, label: &str) {
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 10, "{label}: expected 10 output lines, got:\n{out}");
+
+    // (format "%-5s" "ab")  → "ab   "
+    assert_eq!(lines[0], "ab   ", "{label}: %-5s wrong");
+    // (format "%-5s|" "ab") → "ab   |"
+    assert_eq!(lines[1], "ab   |", "{label}: %-5s| wrong");
+    // (format "%-15s%s" "a" "b") → "a              b"
+    assert_eq!(
+        lines[2], "a              b",
+        "{label}: %-15s%s wrong — got {:?}",
+        lines[2]
+    );
+    // bare %s still works
+    assert_eq!(lines[3], "a b", "{label}: %s %s wrong");
+    // bare %d still works
+    assert_eq!(lines[4], "5", "{label}: %d wrong");
+    // right-justify integer
+    assert_eq!(lines[5], "   42", "{label}: %5d wrong");
+    // left-justify integer
+    assert_eq!(lines[6], "42   ", "{label}: %-5d wrong");
+    // zero-pad integer
+    assert_eq!(lines[7], "00042", "{label}: %05d wrong");
+    // plus flag
+    assert_eq!(lines[8], "+42", "{label}: %+d wrong");
+    // right-justify string
+    assert_eq!(lines[9], "   ab", "{label}: %5s wrong");
+}
+
+// ── Interpreter tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn format_width_flags_interpreter() {
+    let out = run_interp(FMT_SCRIPT);
+    check_output(&out, "interpreter");
+}
+
+// ── JIT tests ─────────────────────────────────────────────────────────────────
+
+/// Call format from inside a hot loop so the JIT compiles the surrounding
+/// function and exercises the builtin call seam under native code.
+#[test]
+fn format_width_flags_jit() {
+    // Run the same checks once (confirming builtins work from JIT context),
+    // then run the hot loop to confirm promotion doesn't break anything.
+    let src = r#"
+(defn check-format [i]
+  (let [r1 (format "%-5s" "ab")
+        r2 (format "%-5s|" "ab")
+        r3 (format "%-15s%s" "a" "b")
+        r4 (format "%05d" 42)
+        r5 (format "%5s" "ab")]
+    (when (or (not= r1 "ab   ")
+              (not= r2 "ab   |")
+              (not= r3 "a              b")
+              (not= r4 "00042")
+              (not= r5 "   ab"))
+      (println "FAIL at i=" i
+               "r1=" r1 "r2=" r2 "r3=" r3 "r4=" r4 "r5=" r5))))
+
+(dotimes [i 10000]
+  (check-format i))
+(println "done")
+"#;
+    let out = run_jit(src);
+    assert!(
+        !out.contains("FAIL"),
+        "format width/flags produced wrong results under JIT:\n{out}"
+    );
+    assert!(
+        out.trim_end().ends_with("done"),
+        "expected 'done' at end of JIT output:\n{out}"
+    );
+}
+
+// AOT path: the same `builtin_format` native function is embedded in AOT
+// binaries.  An equivalent test lives in
+// `crates/cljrs-compiler/tests/aot_e2e.rs` behind the `aot_full_test` feature.


### PR DESCRIPTION
The old `builtin_format` only recognised bare `%s` and `%d`; any specifier
with flags (`-`, `+`, `0`, ` `, `(`, `,`) or a width/precision component fell
through to the literal-emit branch, so `%-5s` was emitted verbatim and
argument consumption was thrown off.

Replace the minimal hand-rolled parser with a full Java-Formatter-compatible
implementation that correctly parses:
- flags:  - (left-justify), + (sign), space, 0 (zero-pad), ( (paren), , (grouping), # (alt)
- width:  minimum field width
- precision: max chars for %s, decimal places for %f/%e/%g
- conversions: s S d f e E g G x X o b B c C n %

Key design:
- The '0' flag is consumed greedily only once (before width digits), so
  %05d → flag_zero=true, width=5, matching C/Java behaviour.
- Zero-padding for signed numbers places the sign before the zeros.
- left-justify (-) takes precedence over zero-pad (0).

Helper functions added: fmt_pad, fmt_pad_num, fmt_grouped, fmt_signed,
fmt_scientific, fmt_general.

Tests added:
- crates/cljrs/tests/format_width.rs — interpreter + JIT paths (always run)
- crates/cljrs-compiler/tests/aot_e2e.rs — AOT path (aot_full_test feature)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GL9WWgz554WwYviL4ietT6