### PR TITLE
fix: clojure.string/join renders chars as string value, not reader syntax

### DIFF
--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -20,7 +20,7 @@ use crate::util::numeric_as_i64;
 use bigdecimal::{BigDecimal, RoundingMode};
 use cljrs_env::env::GlobalEnv;
 use cljrs_gc::GcPtr;
-use cljrs_value::value::SetValue;
+use cljrs_value::value::{PrintValue, SetValue};
 use cljrs_value::{
     Arity, Atom, CljxCons, CljxPromise, ExceptionInfo, FutureState, Keyword, LazySeq, MapValue,
     Namespace, NativeFn, ObjectArray, PersistentHashMap, PersistentHashSet, PersistentList,
@@ -6767,16 +6767,20 @@ fn builtin_join(args: &[Value]) -> ValueResult<Value> {
     } else {
         (
             match &args[0] {
+                Value::Nil => String::new(),
                 Value::Str(s) => s.get().to_string(),
-                v => format!("{}", v),
+                Value::Char(c) => c.to_string(),
+                v => format!("{}", PrintValue(v)),
             },
             &args[1],
         )
     };
     let joined: String = ValueIter::new(coll.clone())
         .map(|v| match &v {
+            Value::Nil => String::new(),
             Value::Str(s) => s.get().to_string(),
-            other => format!("{}", other),
+            Value::Char(c) => c.to_string(),
+            other => format!("{}", PrintValue(other)),
         })
         .collect::<Vec<_>>()
         .join(&sep);

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -2408,3 +2408,20 @@ fn test_versioned_bad_commit_fails_at_compile_time() {
         "error should mention the bad commit: {msg}"
     );
 }
+
+// ── Regression: clojure.string/join with char elements (issue #200) ─────────
+
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn test_string_join_char_elements_aot() {
+    assert_output(
+        "string_join_chars",
+        r#"
+(require '[clojure.string :as s])
+(defn -main [& _]
+  (println (s/join [\8 \0]))
+  (println (s/join "-" [\8 \0])))
+"#,
+        "80\n8-0",
+    );
+}

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -311,6 +311,26 @@ mod tests {
     }
 
     #[test]
+    fn test_string_join_char_elements() {
+        let (_, mut env) = make_env();
+        run("(require '[clojure.string :as str])", &mut env).unwrap();
+        // Characters must render as their string value, not reader syntax.
+        assert_eq!(
+            run(r"(str/join [\8 \0])", &mut env).unwrap(),
+            Value::string("80")
+        );
+        assert_eq!(
+            run(r"(str/join \- [\8 \0])", &mut env).unwrap(),
+            Value::string("8-0")
+        );
+        // nil elements are treated as empty string (same as (str nil) = "").
+        assert_eq!(
+            run(r#"(str/join "-" [nil "a" nil])"#, &mut env).unwrap(),
+            Value::string("-a-")
+        );
+    }
+
+    #[test]
     fn test_string_capitalize() {
         let (_, mut env) = make_env();
         run("(require '[clojure.string :as str])", &mut env).unwrap();

--- a/crates/cljrs-stdlib/src/string.rs
+++ b/crates/cljrs-stdlib/src/string.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use cljrs_gc::GcPtr;
+use cljrs_value::value::PrintValue;
 use cljrs_value::{Arity, PersistentVector, Value, ValueError, ValueResult};
 
 use crate::register_fns;
@@ -276,8 +277,10 @@ fn join(args: &[Value]) -> ValueResult<Value> {
     let result = items
         .iter()
         .map(|v| match v {
+            Value::Nil => String::new(),
             Value::Str(s) => s.get().clone(),
-            other => format!("{other}"),
+            Value::Char(c) => c.to_string(),
+            other => format!("{}", PrintValue(other)),
         })
         .collect::<Vec<_>>()
         .join(&sep);

--- a/crates/cljrs/tests/jit_robustness.rs
+++ b/crates/cljrs/tests/jit_robustness.rs
@@ -94,3 +94,39 @@ fn closure_bearing_fn_runs_correctly_without_panicking() {
         run.stderr
     );
 }
+
+#[test]
+fn string_join_char_elements_from_jit() {
+    // `clojure.string/join` is never JIT-compiled (builtin-source namespace),
+    // but a hot user function that calls it must still see correct results.
+    // Characters must render as their string value ("80"), not reader syntax
+    // ("\8\0"). Regression for issue #200.
+    let src = r#"
+        (require '[clojure.string :as s])
+        (defn join-chars [chars sep]
+          (s/join sep chars))
+        (dotimes [_ 100]
+          (join-chars [\8 \0] "")
+          (join-chars [\8 \0] "-"))
+        (println (join-chars [\8 \0] ""))
+        (println (join-chars [\8 \0] "-"))
+    "#;
+
+    let run = run_jit(src);
+
+    assert!(
+        run.stdout.contains("80"),
+        "expected \"80\" in stdout, got:\n{}",
+        run.stdout
+    );
+    assert!(
+        run.stdout.contains("8-0"),
+        "expected \"8-0\" in stdout, got:\n{}",
+        run.stdout
+    );
+    assert!(
+        !run.stdout.contains("\\8"),
+        "join produced reader syntax (\\8) instead of char value; stdout:\n{}",
+        run.stdout
+    );
+}


### PR DESCRIPTION
Characters such as \8 were serialized using the readable pr-str form
(\8) instead of the str form (8) when passed as elements to
clojure.string/join.  The root cause was that the join helpers in
string.rs and builtins.rs fell through to format!("{other}") which
invokes the readable Display impl on Value.

Fix both join implementations to match Clojure's str semantics:
- Value::Nil  → "" (same as (str nil))
- Value::Char → the character itself (same as (str \8) = "8")
- other types → PrintValue non-readable form

Regression tests added for the interpreted, AOT (feature-gated), and
JIT code paths.  All three ultimately call the same native Rust
function, so the single-site fix covers all execution tiers.

Fixes #200.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NDhvxNR9Ywwq2JLAnuBkTb