### PR TITLE
fix: contains? on vector with non-integer key returns false instead of throwing

### DIFF
--- a/clojure-test-suite/test/clojure/core_test/contains_qmark.cljc
+++ b/clojure-test-suite/test/clojure/core_test/contains_qmark.cljc
@@ -15,6 +15,9 @@
       ;; find by index
       (is (= true (contains? ["a" "b" "c"] 0)))
       (is (= false (contains? ["a" "b" "c"] 3)))
+      ;; non-integer key on vector returns false, not an error
+      (is (= false (contains? [1 2 3] :a)))
+      (is (= false (contains? [1 2 3] "x")))
       (is (= true (contains? "abc" 0)))
       (is (= true (contains? "abc" 2)))
       (is (= false (contains? "abc" 3)))

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -3547,13 +3547,8 @@ fn builtin_contains_q(args: &[Value]) -> ValueResult<Value> {
         Value::Vector(v) => {
             if let Value::Long(idx) = &args[1] {
                 *idx >= 0 && (*idx as usize) < v.get().count()
-            } else if let Value::Nil = &args[1] {
-                false
             } else {
-                return Err(ValueError::WrongType {
-                    expected: "int",
-                    got: args[1].type_name().to_string(),
-                });
+                false
             }
         }
         Value::Str(s) => {

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -623,6 +623,17 @@ mod tests {
         assert!(matches!(v, Value::Set(_)));
     }
 
+    #[test]
+    fn test_contains_q_vector_non_integer_key_returns_false() {
+        // Regression for #206: non-integer key on a vector must return false,
+        // not throw a WrongType error.
+        assert_eq!(eval_str("(contains? [1 2 3] :a)").unwrap(), bool_v(false));
+        assert_eq!(eval_str("(contains? [1 2 3] \"x\")").unwrap(), bool_v(false));
+        // Integer keys still work correctly.
+        assert_eq!(eval_str("(contains? [1 2 3] 0)").unwrap(), bool_v(true));
+        assert_eq!(eval_str("(contains? [1 2 3] 9)").unwrap(), bool_v(false));
+    }
+
     // ── set! ──────────────────────────────────────────────────────────────
 
     #[test]

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -628,7 +628,10 @@ mod tests {
         // Regression for #206: non-integer key on a vector must return false,
         // not throw a WrongType error.
         assert_eq!(eval_str("(contains? [1 2 3] :a)").unwrap(), bool_v(false));
-        assert_eq!(eval_str("(contains? [1 2 3] \"x\")").unwrap(), bool_v(false));
+        assert_eq!(
+            eval_str("(contains? [1 2 3] \"x\")").unwrap(),
+            bool_v(false)
+        );
         // Integer keys still work correctly.
         assert_eq!(eval_str("(contains? [1 2 3] 0)").unwrap(), bool_v(true));
         assert_eq!(eval_str("(contains? [1 2 3] 9)").unwrap(), bool_v(false));

--- a/crates/cljrs/tests/jit_robustness.rs
+++ b/crates/cljrs/tests/jit_robustness.rs
@@ -130,3 +130,27 @@ fn string_join_char_elements_from_jit() {
         run.stdout
     );
 }
+
+#[test]
+fn contains_q_vector_non_integer_key_returns_false_under_jit() {
+    // Regression for #206: `(contains? [1 2 3] :a)` must return false, not
+    // throw, even when the call is JIT-compiled.
+    let src = r#"
+        (defn check [v k] (contains? v k))
+        (dotimes [_ 100]
+          (check [1 2 3] :a)
+          (check [1 2 3] "x")
+          (check [1 2 3] 0))
+        (println (check [1 2 3] :a))
+        (println (check [1 2 3] "x"))
+        (println (check [1 2 3] 0))
+    "#;
+
+    let run = run_jit(src);
+
+    assert!(
+        run.stdout.contains("false\nfalse\ntrue"),
+        "unexpected output; stdout:\n{}",
+        run.stdout
+    );
+}


### PR DESCRIPTION
For indexed collections (Vector), `(contains? v k)` must return false when
`k` is not an integer, not throw a WrongType error. The interpreter branch
(`builtin_contains_q`) was the only path with the wrong behavior — the AOT
runtime (`rt_contains`) already returned false for non-integer keys.

Fixes #206.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JwQcDAcS4JHKVYH1PHGJX7