### PR TITLE
fix: resolve ::keyword to call-site namespace through macro expansion and JIT

### DIFF
--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -4387,7 +4387,7 @@ fn intern_keyword(name: &str) -> *const Value {
     if let Some(v) = table.get(name) {
         return v.0.get() as *const Value;
     }
-    let ptr = GcPtr::new(Value::Keyword(GcPtr::new(Keyword::simple(name))));
+    let ptr = GcPtr::new(Value::Keyword(GcPtr::new(Keyword::parse(name))));
     let raw = ptr.get() as *const Value;
     table.insert(name.to_string(), SharedVal(ptr));
     raw

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -2445,3 +2445,39 @@ fn test_string_join_char_elements_aot() {
         "80\n8-0",
     );
 }
+
+// ── Issue #209: ::keyword resolution through macros (AOT path) ────────────────
+
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn test_auto_kw_through_if_not_aot() {
+    // ::kw must resolve to the call-site namespace in AOT-compiled code, not
+    // the macro definition namespace.
+    assert_output(
+        "auto_kw_if_not",
+        r#"
+(ns my.app)
+(defn check [v]
+  (if-not (= v ::error) :WRONG :right))
+(defn -main [& _]
+  (println (check ::error))
+  (println (check ::other)))
+"#,
+        ":right\n:WRONG",
+    );
+}
+
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn test_auto_kw_qualified_keyword_aot() {
+    // Verify the keyword is fully namespace-qualified in the output.
+    assert_output(
+        "auto_kw_qualified",
+        r#"
+(ns acme.core)
+(defn -main [& _]
+  (println ::status))
+"#,
+        ":acme.core/status",
+    );
+}

--- a/crates/cljrs-eval/src/lower.rs
+++ b/crates/cljrs-eval/src/lower.rs
@@ -172,7 +172,11 @@ fn lower_arity_inner(
     do_optimize: bool,
     is_async: bool,
 ) -> Result<(IrFunction, Vec<(Arc<str>, Arc<str>)>), LowerError> {
+    // Temporarily set current_ns to the function's defining namespace so that
+    // ::kw resolution in macroexpand_body uses the correct namespace.
+    let prev_ns = std::mem::replace(&mut env.current_ns, ns.clone());
     let expanded_body = macroexpand_body(body, env);
+    env.current_ns = prev_ns;
     lower_expanded_arity(
         name,
         params,

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -687,10 +687,20 @@ fn macro_apply(
     arg_forms: &[Form],
     env: &mut Env,
 ) -> EvalResult<Form> {
+    // Resolve ::kw forms using the caller's namespace before the macro sees them.
+    // In Clojure, ::kw is resolved at read time; we approximate that here so a
+    // macro splicing its arguments into a new form cannot re-resolve them against
+    // the macro's own namespace.
+    let ns = env.current_ns.clone();
+    let resolved_args: Vec<Form> = arg_forms
+        .iter()
+        .map(|f| crate::macros::resolve_auto_kws(f, &ns))
+        .collect();
+
     // &form: the whole call expression as a list value.
     let form_val = {
         let mut items = vec![form_to_value(func_form)];
-        for f in arg_forms {
+        for f in &resolved_args {
             items.push(form_to_value(f));
         }
         Value::List(GcPtr::new(PersistentList::from_iter(items)))
@@ -708,7 +718,7 @@ fn macro_apply(
 
     // Prepend &form and &env, then pass remaining arg forms as unevaluated values.
     let mut args = vec![form_val, env_val];
-    args.extend(arg_forms.iter().map(form_to_value));
+    args.extend(resolved_args.iter().map(form_to_value));
 
     let expanded_val = call_cljrs_fn(mfn, args.as_ref(), env)?;
     let dummy_span = cljrs_types::span::Span::new(Arc::new("<macro>".to_string()), 0, 0, 1, 1);

--- a/crates/cljrs-interp/src/macros.rs
+++ b/crates/cljrs-interp/src/macros.rs
@@ -17,8 +17,19 @@ pub fn macroexpand_1(form: &Form, env: &mut Env) -> EvalResult<Form> {
         && let Some(FormKind::Symbol(s)) = parts.first().map(|f| &f.kind)
         && let Some(macro_fn) = resolve_macro(s, env)
     {
+        // Resolve ::keywords using the caller's namespace before the macro sees
+        // them.  In Clojure, ::kw is resolved at READ time; since cljrs keeps
+        // AutoKeyword forms in the AST until eval, we resolve them here — the
+        // last point at which env.current_ns reflects the call site.
+        let resolved = resolve_auto_kws(form, &env.current_ns);
+        let parts = if let FormKind::List(p) = &resolved.kind {
+            p
+        } else {
+            unreachable!()
+        };
+
         // Build &form value (the whole call as a list).
-        let form_val = form_to_value(form);
+        let form_val = form_to_value(&resolved);
         // Build &env value (local bindings as a map — empty at top level).
         let env_val = {
             let (names, vals) = env.all_local_bindings();
@@ -35,6 +46,41 @@ pub fn macroexpand_1(form: &Form, env: &mut Env) -> EvalResult<Form> {
         return value_to_form(&expanded, dummy);
     }
     Ok(form.clone())
+}
+
+/// Walk a form tree and replace every `AutoKeyword(s)` with `Keyword("{ns}/{s}")`.
+///
+/// `::kw` must be resolved using the namespace at the call site (not the
+/// macro's definition namespace).  Clojure resolves it at read time; we do it
+/// here, just before the form is handed to the macro, so the macro always
+/// receives fully-qualified keywords.
+pub(crate) fn resolve_auto_kws(form: &Form, ns: &str) -> Form {
+    let kind = match &form.kind {
+        FormKind::AutoKeyword(s) => FormKind::Keyword(format!("{ns}/{s}")),
+        FormKind::List(items) => {
+            FormKind::List(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
+        }
+        FormKind::Vector(items) => {
+            FormKind::Vector(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
+        }
+        FormKind::Map(items) => {
+            FormKind::Map(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
+        }
+        FormKind::Set(items) => {
+            FormKind::Set(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
+        }
+        // ::kw is resolved at read time in Clojure, so resolve inside quote too.
+        FormKind::Quote(inner) => FormKind::Quote(Box::new(resolve_auto_kws(inner, ns))),
+        FormKind::SyntaxQuote(inner) => {
+            FormKind::SyntaxQuote(Box::new(resolve_auto_kws(inner, ns)))
+        }
+        FormKind::Unquote(inner) => FormKind::Unquote(Box::new(resolve_auto_kws(inner, ns))),
+        FormKind::UnquoteSplice(inner) => {
+            FormKind::UnquoteSplice(Box::new(resolve_auto_kws(inner, ns)))
+        }
+        _ => return form.clone(),
+    };
+    Form::new(kind, form.span.clone())
 }
 
 /// Fully expand a form until the head is no longer a macro.

--- a/crates/cljrs-interp/tests/auto_keyword_macro.rs
+++ b/crates/cljrs-interp/tests/auto_keyword_macro.rs
@@ -1,0 +1,121 @@
+//! Regression tests for issue #209: `::keyword` must resolve to the caller's
+//! namespace at the point of macroexpansion, not the macro's definition
+//! namespace.
+//!
+//! In Clojure, `::kw` is resolved at READ time.  cljrs keeps `AutoKeyword`
+//! nodes in the AST and resolves them lazily; before this fix, macros received
+//! the unresolved `AutoKeyword` and re-resolved it against the macro's own
+//! namespace (`clojure.core`) rather than the caller's.
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::{Keyword, Value};
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+/// Evaluate `src` in namespace `ns` (via `(ns ...)` switch) and return the
+/// last value.  The env starts in `user` so clojure.core is available.
+fn eval_in_ns(ns: &str, src: &str) -> Value {
+    let (_, mut env) = make_env();
+    // Switch to the target namespace so ::kw resolves against it.
+    let ns_switch = format!("(ns {ns})");
+    let mut parser = Parser::new(ns_switch, "<setup>".to_string());
+    for form in parser.parse_all().expect("parse ns") {
+        cljrs_interp::eval::eval(&form, &mut env).expect("eval ns");
+    }
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, &mut env).expect("eval error");
+    }
+    result
+}
+
+fn kw(ns: &str, name: &str) -> Value {
+    Value::keyword(Keyword::qualified(ns, name))
+}
+
+// ── Core regression: issue #209 ──────────────────────────────────────────────
+
+#[test]
+fn auto_kw_resolves_to_caller_ns_through_if_not() {
+    // The original failing case from the issue report.
+    let result = eval_in_ns(
+        "my.app",
+        r#"(let [v ::error] (if-not (= v ::error) :WRONG :right))"#,
+    );
+    assert_eq!(
+        result,
+        Value::keyword(Keyword::simple("right")),
+        "if-not must not re-resolve ::error against clojure.core"
+    );
+}
+
+#[test]
+fn auto_kw_bound_value_is_namespace_qualified() {
+    // Binding ::error in let produces :my.app/error, not :error.
+    let result = eval_in_ns("my.app", r#"(let [v ::error] v)"#);
+    assert_eq!(result, kw("my.app", "error"));
+}
+
+#[test]
+fn auto_kw_equality_holds_through_if_not() {
+    // Both sides of the comparison must resolve to the same qualified keyword.
+    let result = eval_in_ns(
+        "acme.core",
+        r#"(let [v ::status] (if-not (= v ::status) false true))"#,
+    );
+    assert_eq!(result, Value::Bool(true));
+}
+
+#[test]
+fn plain_if_auto_kw_still_works() {
+    // Plain `if` was already correct; ensure we haven't regressed it.
+    let result = eval_in_ns(
+        "my.app",
+        r#"(let [v ::error] (if (= v ::error) :right :WRONG))"#,
+    );
+    assert_eq!(result, Value::keyword(Keyword::simple("right")));
+}
+
+#[test]
+fn explicit_qualified_kw_works_through_if_not() {
+    // Explicit :my.app/error must also be fine (was already working).
+    let result = eval_in_ns(
+        "my.app",
+        r#"(let [v ::error] (if-not (= v :my.app/error) :WRONG :right))"#,
+    );
+    assert_eq!(result, Value::keyword(Keyword::simple("right")));
+}
+
+#[test]
+fn auto_kw_through_when_not() {
+    // when-not is also built on if-not; exercise that path.
+    let result = eval_in_ns("my.app", r#"(let [v ::ok] (when-not (= v ::ok) :WRONG))"#);
+    // (when-not <truthy-cond>) → nil
+    assert_eq!(result, Value::Nil);
+}
+
+#[test]
+fn auto_kw_different_namespaces_are_not_equal() {
+    // ::error in ns1 != ::error in ns2.
+    let r1 = eval_in_ns("ns1", r#"(let [v ::error] v)"#);
+    let r2 = eval_in_ns("ns2", r#"(let [v ::error] v)"#);
+    assert_eq!(r1, kw("ns1", "error"));
+    assert_eq!(r2, kw("ns2", "error"));
+    assert_ne!(r1, r2);
+}
+
+#[test]
+fn auto_kw_equality_with_direct_let() {
+    // Sanity check: even without a macro, both sides of = resolve identically.
+    let result = eval_in_ns("my.app", r#"(= ::error ::error)"#);
+    assert_eq!(result, Value::Bool(true));
+}

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -248,12 +248,13 @@ fn lower_form(ctx: &mut LowerCtx, form: &Form) -> R {
         FormKind::Str(s) => Ok(ctx.emit_const(Const::Str(Arc::from(s.as_str())))),
         FormKind::Regex(s) => Ok(ctx.emit_const(Const::Str(Arc::from(s.as_str())))),
         FormKind::Symbolic(f) => Ok(ctx.emit_const(Const::Double(*f))),
-        FormKind::Keyword(s) => {
-            // Strip namespace prefix for keyword constants (mirrors `(name kw)`).
-            let local_name = kw_local_name(s);
-            Ok(ctx.emit_const(Const::Keyword(Arc::from(local_name))))
+        FormKind::Keyword(s) => Ok(ctx.emit_const(Const::Keyword(Arc::from(s.as_str())))),
+        FormKind::AutoKeyword(s) => {
+            // ::kw must resolve to the current namespace at the call site, just as
+            // the interpreter's eval.rs does at runtime.
+            let full = format!("{}/{s}", ctx.ns());
+            Ok(ctx.emit_const(Const::Keyword(Arc::from(full.as_str()))))
         }
-        FormKind::AutoKeyword(s) => Ok(ctx.emit_const(Const::Keyword(Arc::from(s.as_str())))),
         FormKind::Symbol(s) => lower_symbol(ctx, s),
         FormKind::Vector(elems) => {
             let vars: Result<Vec<VarId>, _> = elems.iter().map(|e| lower_form(ctx, e)).collect();
@@ -352,8 +353,7 @@ fn lower_list(ctx: &mut LowerCtx, parts: &[Form]) -> R {
         return match args.len() {
             1 => {
                 let m = lower_form(ctx, &args[0])?;
-                let local = kw_local_name(s);
-                let k = ctx.emit_const(Const::Keyword(Arc::from(local)));
+                let k = ctx.emit_const(Const::Keyword(Arc::from(s.as_str())));
                 let dst = ctx.fresh_var();
                 ctx.emit(Inst::CallKnown(dst, KnownFn::Get, vec![m, k]));
                 Ok(dst)
@@ -2539,7 +2539,7 @@ fn lower_quote(ctx: &mut LowerCtx, form: &Form) -> R {
         FormKind::Float(f) => Ok(ctx.emit_const(Const::Double(*f))),
         FormKind::Str(s) => Ok(ctx.emit_const(Const::Str(Arc::from(s.as_str())))),
         FormKind::Char(c) => Ok(ctx.emit_const(Const::Char(*c))),
-        FormKind::Keyword(s) => Ok(ctx.emit_const(Const::Keyword(Arc::from(kw_local_name(s))))),
+        FormKind::Keyword(s) => Ok(ctx.emit_const(Const::Keyword(Arc::from(s.as_str())))),
         FormKind::Symbol(s) => Ok(ctx.emit_const(Const::Symbol(Arc::from(s.as_str())))),
         FormKind::Vector(elems) => {
             let vars: Result<Vec<VarId>, _> = elems.iter().map(|e| lower_quote(ctx, e)).collect();
@@ -2633,15 +2633,6 @@ fn versioned_ns_base(ns: &str) -> Option<&str> {
         Some(&ns[..pos])
     } else {
         None
-    }
-}
-
-/// Extract the local (non-namespace) part of a keyword string.
-/// `"ns/foo"` → `"foo"`, `"foo"` → `"foo"`.
-fn kw_local_name(s: &str) -> &str {
-    match s.rfind('/') {
-        Some(pos) => &s[pos + 1..],
-        None => s,
     }
 }
 

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -294,6 +294,7 @@ fn main() -> miette::Result<()> {
 
     let cli = Cli::parse();
     let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_max_level(if cli.trace {
             tracing::Level::TRACE
         } else if cli.debug {

--- a/crates/cljrs/tests/auto_keyword_macro_jit.rs
+++ b/crates/cljrs/tests/auto_keyword_macro_jit.rs
@@ -1,0 +1,122 @@
+//! JIT-path regression tests for issue #209.
+//!
+//! `::keyword` must resolve to the namespace where the code was written
+//! (the call site), not the macro's definition namespace, even after the
+//! JIT promotes a hot function to native code.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn run_jit(src: &str) -> String {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "cljrs_auto_kw_jit_{}_{nanos}_{seq}.cljrs",
+        std::process::id()
+    ));
+    std::fs::write(&path, src).expect("write script");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .args(["--jit-threshold", "50", "run"])
+        .arg(&path)
+        .env("CLJRS_EAGER_LOWER", "1")
+        .output()
+        .expect("spawn cljrs");
+
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "cljrs exited with {:?}\nstderr:\n{}\nstdout:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+    String::from_utf8(output.stdout).expect("utf8 stdout")
+}
+
+// ── Regression: issue #209 ────────────────────────────────────────────────────
+
+#[test]
+fn auto_kw_if_not_correct_through_jit() {
+    // Verify that ::kw resolves to the call-site namespace even after the
+    // function is promoted to native code.  Runs 10 000 iterations so the
+    // JIT threshold (50) is crossed and native code executes per-iteration.
+    let src = r#"
+(ns my.app)
+
+(defn check [v]
+  (if-not (= v ::error) :WRONG :right))
+
+(def results
+  (loop [i 0 acc []]
+    (if (= i 10000)
+      acc
+      (recur (inc i) (conj acc (check ::error))))))
+
+(println (every? #(= % :right) results))
+"#;
+    let out = run_jit(src);
+    assert_eq!(
+        out.trim(),
+        "true",
+        "every iteration must return :right through if-not after JIT"
+    );
+}
+
+#[test]
+fn auto_kw_when_not_correct_through_jit() {
+    let src = r#"
+(ns my.app)
+
+(defn sentinel? [v]
+  (when-not (= v ::sentinel) :not-sentinel))
+
+(def results
+  (loop [i 0 acc []]
+    (if (= i 10000)
+      acc
+      (recur (inc i) (conj acc (sentinel? ::sentinel))))))
+
+(println (every? nil? results))
+"#;
+    let out = run_jit(src);
+    assert_eq!(
+        out.trim(),
+        "true",
+        "::kw through when-not must return nil (every? nil?) after JIT"
+    );
+}
+
+#[test]
+fn auto_kw_resolves_to_correct_ns_through_jit() {
+    let src = r#"
+(ns acme.core)
+
+(defn validate [x]
+  (let [sentinel ::missing]
+    (if-not (= x sentinel) :found :missing)))
+
+(def r1s
+  (loop [i 0 acc []]
+    (if (= i 10000)
+      acc
+      (recur (inc i) (conj acc (validate ::missing))))))
+
+(def r2s
+  (loop [i 0 acc []]
+    (if (= i 10000)
+      acc
+      (recur (inc i) (conj acc (validate ::other))))))
+
+(println (and (every? #(= % :missing) r1s)
+              (every? #(= % :found) r2s)))
+"#;
+    let out = run_jit(src);
+    assert_eq!(out.trim(), "true");
+}


### PR DESCRIPTION
Issue #209: AutoKeyword forms were resolving to the wrong namespace when
passed through macros like if-not, and when compiled by the JIT.

Three bugs fixed:

1. macros.rs: macroexpand_1 and macro_apply now pre-resolve AutoKeyword
   forms to the caller's namespace before handing them to form_to_value,
   so macros always receive fully-qualified keyword values.

2. anf.rs: FormKind::AutoKeyword uses ctx.ns() (the function's defining
   namespace) for qualification; FormKind::Keyword and quoted keyword paths
   no longer strip the namespace via the now-removed kw_local_name helper.

3. rt_abi.rs: intern_keyword uses Keyword::parse instead of Keyword::simple,
   so "my.app/error" is interned as Keyword{ns:Some("my.app"),name:"error"}
   rather than Keyword{ns:None,name:"my.app/error"}, matching how the
   interpreter and IR interpreter construct the same keyword.

Also: lower.rs temporarily sets env.current_ns to the function's defining
namespace during background macroexpansion so ::kw resolves against the
defn's namespace, not the caller's.

Logging is now directed to stderr in the cljrs binary so program stdout
stays clean (the tracing subscriber was defaulting to stdout, which
polluted test output with Cranelift JIT IR dumps).

Regression tests: 8 interpreter tests (cljrs-interp) and 3 JIT tests
(cljrs) covering if-not, when-not, let, and cross-namespace comparisons.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KoRzum91tD6Ti7uedQ43fV