### PR TITLE
fix(#210): resolve reader conditionals in catch exception-type position

### DIFF
--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -712,6 +712,43 @@ mod tests {
     }
 
     #[test]
+    fn test_catch_reader_conditional_type() {
+        // Regression for #210: a reader conditional in the catch type position must
+        // be resolved before matching — previously the catch clause was silently
+        // dropped and the exception escaped.
+
+        // Single-branch: #?(:rust Exception)
+        let v =
+            eval_str(r#"(try (throw (ex-info "boom" {})) (catch #?(:rust Exception) e :caught))"#)
+                .unwrap();
+        let kw_caught = Value::keyword(cljrs_value::Keyword::simple("caught"));
+        assert_eq!(v, kw_caught, "single-branch reader cond");
+
+        // Multi-branch: the :rust branch must win over :clj/:cljs/:default ordering
+        let v = eval_str(concat!(
+            "(try (throw (ex-info \"boom\" {})) ",
+            "(catch #?(:clj Throwable :cljs :default :rust Exception) e :caught))",
+        ))
+        .unwrap();
+        assert_eq!(v, kw_caught, "multi-branch reader cond");
+
+        // A reader conditional whose :rust branch resolves to :default is also a
+        // catch-all and must match any exception.
+        let v =
+            eval_str(r#"(try (throw (ex-info "boom" {})) (catch #?(:rust :default) e :caught))"#)
+                .unwrap();
+        assert_eq!(v, kw_caught, "reader cond resolves to :default");
+
+        // A reader conditional with no :rust branch must NOT catch the exception.
+        let result =
+            eval_str(r#"(try (throw (ex-info "boom" {})) (catch #?(:clj Throwable) e :caught))"#);
+        assert!(
+            result.is_err(),
+            "no matching :rust branch must let exception escape"
+        );
+    }
+
+    #[test]
     fn test_nth_negative_index() {
         // Negative index returns the not-found default, or throws without one.
         assert_eq!(

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1005,11 +1005,21 @@ pub fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form])
                 if i < body_end {
                     body_end = i;
                 }
-                // The catch type may be a symbol (`Throwable`, `java.lang.Exception`)
-                // or the ClojureScript `:default` catch-all keyword.
+                // The catch type may be a symbol (`Throwable`, `java.lang.Exception`),
+                // the ClojureScript `:default` catch-all keyword, or a reader
+                // conditional `#?(:rust Exception :clj ...)` whose selected branch
+                // resolves to one of those.
                 let type_sym = match parts.get(1).map(|f| &f.kind) {
                     Some(FormKind::Symbol(s)) => s.as_str(),
                     Some(FormKind::Keyword(s)) => s.as_str(),
+                    Some(FormKind::ReaderCond {
+                        splicing: false,
+                        clauses,
+                    }) => match select_reader_cond(clauses).map(|f| &f.kind) {
+                        Some(FormKind::Symbol(s)) => s.as_str(),
+                        Some(FormKind::Keyword(s)) => s.as_str(),
+                        _ => continue,
+                    },
                     _ => continue,
                 };
                 let binding = match parts.get(2).map(|f| &f.kind) {


### PR DESCRIPTION
`parse_try_args` was matching only `Symbol` and `Keyword` in the
exception-type slot of a `catch` clause and silently dropping any
`ReaderCond` form via `_ => continue`, so

    (catch #?(:rust Exception) e handler)

was never registered as a catch clause and the exception escaped.

Fix: add a `FormKind::ReaderCond { splicing: false, .. }` arm that
calls the already-imported `select_reader_cond` to pick the `:rust`
(or `:default`) branch, then extracts the symbol/keyword from the
resolved form exactly as for a literal type name.  A `ReaderCond`
whose selected branch is absent or non-symbol/keyword (e.g. a `:clj`-
only catch that should not apply under `:rust`) still hits `continue`
and is correctly omitted.

The AOT and JIT paths (`lower_try` in `cljrs-ir`) are unaffected:
the type position is not used for match-filtering there (all
exceptions go to the catch closure unconditionally) and the binding
symbol at `cp[2]` / body at `cp[3..]` are correct regardless.

Adds a regression test covering:
- single-branch `#?(:rust Exception)`
- multi-branch `#?(:clj … :rust Exception)`
- `:rust` branch resolving to the `:default` catch-all keyword
- absent `:rust` branch that must let the exception escape

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sw9g7ug5uDRYaeUdPe2A7i