### PR TITLE
fix(#211): sequential destructuring must not throw on short collections

### DIFF
--- a/crates/cljrs-compiler/src/codegen.rs
+++ b/crates/cljrs-compiler/src/codegen.rs
@@ -2142,7 +2142,9 @@ impl<'a, 'b, M: Module> FunctionTranslator<'a, 'b, M> {
             KnownFn::TryCatchFinally => self.rt.rt_try,
             KnownFn::Dissoc => self.rt.rt_dissoc,
             KnownFn::Disj => self.rt.rt_disj,
-            KnownFn::Nth => self.rt.rt_nth,
+            // `rt_nth` already returns nil on out-of-bounds, which is exactly
+            // the lenient destructuring semantics — so both share the bridge.
+            KnownFn::Nth | KnownFn::NthLenient => self.rt.rt_nth,
             KnownFn::Contains => self.rt.rt_contains,
             KnownFn::Cons => self.rt.rt_alloc_cons,
             KnownFn::Seq => self.rt.rt_seq,

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -1168,6 +1168,13 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
             Ok(result)
         }
         KnownFn::Nth => builtin_call_native("nth", &args),
+        KnownFn::NthLenient => {
+            // Destructuring nth: out-of-bounds yields nil, never throws.  The
+            // 3-arg `nth` returns its default (nil here) for a short collection.
+            let mut args = args;
+            args.push(Value::Nil);
+            builtin_call_native("nth", &args)
+        }
         KnownFn::Aget => builtin_call_native("aget", &args),
         KnownFn::Aset => builtin_call_native("aset", &args),
         KnownFn::Alength => builtin_call_native("alength", &args),

--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -161,6 +161,13 @@ operand (`Repr::LongArray`/`DoubleArray`) with an unboxed index, codegen loads/
 stores unboxed `i64`/`f64` elements; otherwise it uses a boxed bridge.  All
 paths bounds-check and throw on out-of-range access.
 
+`Nth` and `NthLenient` differ only in out-of-bounds behaviour: `Nth` is
+user-level `(nth coll idx)` and throws, while `NthLenient` is the
+sequential-destructuring nth (`(nth coll idx nil)`) emitted by the lowerer
+for `[a b c]` patterns — a short collection binds the missing positions to
+`nil` rather than throwing.  Both compile to the `rt_nth` bridge (already
+nil-on-OOB); the IR interpreter appends the nil default for `NthLenient`.
+
 Some `KnownFn` variants exist purely for analysis precision — the
 codegen and IR interpreter dispatch them through the dynamic builtin
 lookup like a regular `Call`, but the analyzer can use them to tighten

--- a/crates/cljrs-ir/src/lib.rs
+++ b/crates/cljrs-ir/src/lib.rs
@@ -122,6 +122,11 @@ pub enum KnownFn {
     Disj,
     Get,
     Nth,
+    /// `nth` with Clojure sequential-destructuring semantics: an out-of-bounds
+    /// index yields `nil` instead of throwing (i.e. `(nth coll idx nil)`).
+    /// Emitted only by destructuring lowering; user-level `(nth v i)` stays
+    /// [`KnownFn::Nth`], which throws on out-of-bounds.
+    NthLenient,
     Count,
     Contains,
 
@@ -993,6 +998,7 @@ impl KnownFn {
             // Pure functions — no side effects, no allocation (result is scalar or reuses input)
             KnownFn::Get
             | KnownFn::Nth
+            | KnownFn::NthLenient
             | KnownFn::Count
             | KnownFn::Contains
             | KnownFn::First

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -578,7 +578,15 @@ fn lower_destructure_sequential(
 fn lower_emit_nth(ctx: &mut LowerCtx, val: VarId, idx: i64) -> VarId {
     let idx_var = ctx.emit_const(Const::Long(idx));
     let dst = ctx.fresh_var();
-    ctx.emit(Inst::CallKnown(dst, KnownFn::Nth, vec![val, idx_var]));
+    // Sequential destructuring binds missing positions to nil — `(nth coll idx
+    // nil)` — so it must never throw on a short collection.  Use the lenient
+    // nth, not `KnownFn::Nth` (which throws out-of-bounds, matching user-level
+    // `(nth v i)`).
+    ctx.emit(Inst::CallKnown(
+        dst,
+        KnownFn::NthLenient,
+        vec![val, idx_var],
+    ));
     dst
 }
 

--- a/crates/cljrs-ir/src/lower/escape.rs
+++ b/crates/cljrs-ir/src/lower/escape.rs
@@ -65,10 +65,10 @@ pub(crate) fn known_fn_arg_escapes(func: &KnownFn, arg_index: usize) -> bool {
     use KnownFn::*;
     match func {
         // Non-escaping: predicates, arithmetic, I/O, lookups that return elements
-        Get | Nth | Count | CountFilter | Contains | First | Add | Sub | Mul | Div | Rem | Eq
-        | Lt | Gt | Lte | Gte | IsNil | IsSeq | IsVector | IsMap | IsEmpty | Peek | Identical
-        | IsNumber | IsString | IsKeyword | IsSymbol | IsBool | IsInt | Str | Deref | AtomDeref
-        | Println | Pr | Prn | Print => false,
+        Get | Nth | NthLenient | Count | CountFilter | Contains | First | Add | Sub | Mul | Div
+        | Rem | Eq | Lt | Gt | Lte | Gte | IsNil | IsSeq | IsVector | IsMap | IsEmpty | Peek
+        | Identical | IsNumber | IsString | IsKeyword | IsSymbol | IsBool | IsInt | Str | Deref
+        | AtomDeref | Println | Pr | Prn | Print => false,
 
         // These return a modified copy of arg 0 → arg 0 escapes; others don't
         Dissoc | Disj => arg_index == 0,

--- a/crates/cljrs-ir/src/lower/regionalize.rs
+++ b/crates/cljrs-ir/src/lower/regionalize.rs
@@ -259,7 +259,11 @@ fn call_result_safe_for_deep(
                     // Element extractors return an inner pointer by reference.
                     if matches!(
                         kf,
-                        KnownFn::First | KnownFn::Nth | KnownFn::Get | KnownFn::Peek
+                        KnownFn::First
+                            | KnownFn::Nth
+                            | KnownFn::NthLenient
+                            | KnownFn::Get
+                            | KnownFn::Peek
                     ) {
                         return false;
                     }

--- a/crates/cljrs/tests/background_lowering.rs
+++ b/crates/cljrs/tests/background_lowering.rs
@@ -152,6 +152,41 @@ fn background_lowering_works_without_jit() {
     );
 }
 
+/// Regression for #211: sequential destructuring of a collection shorter than
+/// its pattern must bind the missing positions to `nil`, not throw — at every
+/// tier.  Once `parse`'s reduce closure crossed the warm threshold it was
+/// IR-lowered, and its inner `[opt-type opt optarg]` destructure of a
+/// two-element token threw "index out of bounds: 2 >= 2" (the lowerer emitted a
+/// strict `nth`; Clojure destructuring is `(nth coll idx nil)`).  Mirrors
+/// `clojure.tools.cli/parse-option-tokens`: a `reduce` returning a three-element
+/// vector whose step destructures short tokens.
+#[test]
+fn short_destructure_in_warm_reduce_yields_nil_not_oob() {
+    let src = r#"
+        (defn parse [tokens]
+          (reduce
+            (fn [[m errors args] [opt-type opt optarg]]
+              (if (= opt-type :short)
+                [(assoc m opt 1) errors args]
+                [m errors (conj args opt)]))
+            [{} [] []]
+            tokens))
+        (loop [i 0]
+          (when (< i 200)
+            (let [[opts errors args] (parse [[:short "-v"]])]
+              (when (or (not= opts {"-v" 1}) (not= errors []) (not= args []))
+                (println "WRONG at" i opts errors args)))
+            (recur (+ i 1))))
+        (println "ok")
+    "#;
+    let (stdout, stderr) = run_warm(src, &["--jit-threshold", "50"], &[]);
+    assert!(
+        !stdout.contains("WRONG"),
+        "short destructure miscompiled after warm-up:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("ok"), "program did not complete:\n{stdout}");
+}
+
 /// `--ir-threshold 0` disables background lowering: no publish may appear.
 #[test]
 fn ir_threshold_zero_disables_background_lowering() {


### PR DESCRIPTION
Once a function crossed the background IR-lowering threshold, sequential
destructuring of a collection shorter than its pattern threw "index out of
bounds" instead of binding the missing positions to nil. The reproduction in
the issue — `clojure.tools.cli/parse-option-tokens`, a `reduce` returning a
three-element vector whose step destructures short `[opt-type opt optarg]`
tokens — failed at exactly the threshold call and every call thereafter.

Root cause: the ANF lowerer emitted a strict two-arg `KnownFn::Nth` for each
destructure position. That op throws on out-of-bounds (correct for user-level
`(nth v i)`), but Clojure sequential destructuring is defined as
`(nth coll idx nil)` and must yield nil for missing positions. The JIT's
`rt_nth` bridge already returns nil on out-of-bounds, so compiled code was
lenient; only the Tier-1 IR interpreter (which dispatches to the strict 2-arg
`nth` builtin) threw — which is why the bug appeared only after the IR
threshold, and not under eager lowering (where the outer caller's nested calls
fall back to the tree-walker).

Fix: introduce a dedicated `KnownFn::NthLenient` that destructuring lowering
emits instead of `Nth`. It carries the same escape/region/effect semantics as
`Nth` (a non-escaping element extractor) but returns nil on out-of-bounds:
codegen reuses the already-lenient `rt_nth` bridge, and the IR interpreter
appends a nil default to the `nth` builtin call. User-level `(nth v i)` keeps
its strict throwing behaviour, untouched.

Adds a background-lowering regression test mirroring the issue's reduce; the
fix is verified across the tree-walk, IR-interpreter, JIT, and AOT tiers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N2xfRixZxdXamQFwQS4XTG