### PR TITLE
fix: implement TryCatchFinally in IR interpreter instead of delegatin…

### DIFF
--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -1315,7 +1315,8 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
         // ── Dynamic binding / exception handling ────────────────────────
         KnownFn::SetBangVar => builtin_call_native("set!", &args),
         KnownFn::WithBindings => eval_ir_with_bindings(args, env),
-        KnownFn::WithOutStr | KnownFn::TryCatchFinally => {
+        KnownFn::TryCatchFinally => eval_ir_try_catch_finally(args, env),
+        KnownFn::WithOutStr => {
             let fn_name = known_fn_to_name(known_fn);
             let callee = load_builtin(env, fn_name)?;
             apply_value(&callee, args, env)
@@ -1373,6 +1374,38 @@ fn eval_ir_with_bindings(args: Vec<Value>, env: &mut Env) -> EvalResult {
     }
     let _guard = cljrs_env::dynamics::push_frame(frame);
     cljrs_env::apply::apply_value(&body, vec![], env)
+}
+
+/// Handle `KnownFn::TryCatchFinally` emitted by `lower_try`.
+///
+/// Args are `[body-fn, catch-fn-or-nil, finally-fn-or-nil]`.  The body thunk
+/// is called with no arguments.  On a thrown exception the catch thunk (if not
+/// nil) is called with the exception value as its sole argument.  The finally
+/// thunk (if not nil) is always called with no arguments before returning.
+fn eval_ir_try_catch_finally(args: Vec<Value>, env: &mut Env) -> EvalResult {
+    let body = args.first().cloned().unwrap_or(Value::Nil);
+    let catch_fn = args.get(1).cloned().unwrap_or(Value::Nil);
+    let finally_fn = args.get(2).cloned().unwrap_or(Value::Nil);
+
+    let body_result = apply_value(&body, vec![], env);
+
+    let ret = match body_result {
+        Ok(val) => Ok(val),
+        Err(EvalError::Thrown(thrown_val)) => {
+            if matches!(catch_fn, Value::Nil) {
+                Err(EvalError::Thrown(thrown_val))
+            } else {
+                apply_value(&catch_fn, vec![thrown_val], env)
+            }
+        }
+        err => err,
+    };
+
+    if !matches!(finally_fn, Value::Nil) {
+        let _ = apply_value(&finally_fn, vec![], env);
+    }
+
+    ret
 }
 
 /// Call a native builtin by name from the global environment.


### PR DESCRIPTION
…g to stub

KnownFn::TryCatchFinally was routed to load_builtin("try"), which resolved to builtin_stub_nil — a no-op that always returns nil regardless of its arguments.  After IR lowering warms up (~50 calls), this caused any `try` body that called a passed-in closure to return nil instead of the body's actual result.

Add eval_ir_try_catch_finally that directly invokes the body thunk, dispatches the catch thunk on EvalError::Thrown, and always runs the finally thunk — matching the semantics already implemented in rt_try for the JIT path.  Separate the WithOutStr arm so it continues to resolve through the builtin registry.


Claude-Session: https://claude.ai/code/session_012ccANaKNwcqrR4KR2Jd2bV