### PR TITLE
fix(#194): named anonymous functions return pointer-equal self-reference

### DIFF
--- a/crates/cljrs-eval/src/apply.rs
+++ b/crates/cljrs-eval/src/apply.rs
@@ -142,9 +142,23 @@ fn maybe_request_lowering(f: &CljxFn, arity_id: u64, caller_env: &mut Env) {
     //   would mis-resolve as a global), same restriction as eager lowering.
     // - Bootstrap-era fns (defined before the compiler was ready): never
     //   lowered under eager lowering either; they stay at tree-walk.
+    // Named anonymous functions (`(fn g [] g)`) rely on self_ptr for pointer
+    // identity.  Background lowering would resolve the self-name via
+    // LoadGlobal which fails when no global var exists for that name.  Only
+    // allow lowering if the function either has no name or its name is
+    // already a top-level var in the defining namespace (i.e. it came from
+    // `defn`).
+    let named_without_global = f.name.as_deref().is_some_and(|n| {
+        caller_env
+            .globals
+            .lookup_var_in_ns(&f.defining_ns, n)
+            .is_none()
+    });
+
     if IR_LOWERING_ACTIVE.get()
         || f.is_async
         || !f.closed_over_names.is_empty()
+        || named_without_global
         || crate::jit_state::is_bootstrap_arity(arity_id)
         || no_ir()
         || !caller_env
@@ -239,9 +253,14 @@ fn execute_ir(
     env.push_frame();
     cljrs_interp::apply::bind_fn_params(arity, args, &mut env)?;
 
-    // Self-reference for named functions.
+    // Self-reference for named functions: use self_ptr when available so
+    // the binding is pointer-equal to the outer Value::Fn holding this fn.
     if let Some(ref name) = f.name {
-        let self_val = Value::Fn(GcPtr::new(f.clone()));
+        let self_val = if let Some(ref p) = f.self_ptr {
+            Value::Fn(p.clone())
+        } else {
+            Value::Fn(GcPtr::new(f.clone()))
+        };
         env.bind(name.clone(), self_val);
     }
 

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -515,9 +515,14 @@ pub fn call_cljrs_fn(f: &CljxFn, args: &[Value], caller_env: &mut Env) -> EvalRe
         // Bind params.
         bind_fn_params(arity, &current_args, &mut env)?;
 
-        // Self-reference for named functions.
+        // Self-reference for named functions: use self_ptr when available so
+        // the binding is pointer-equal to the outer Value::Fn holding this fn.
         if let Some(ref name) = f.name {
-            let self_val = Value::Fn(GcPtr::new(f.clone()));
+            let self_val = if let Some(ref p) = f.self_ptr {
+                Value::Fn(p.clone())
+            } else {
+                Value::Fn(GcPtr::new(f.clone()))
+            };
             env.bind(name.clone(), self_val);
         }
 

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -225,7 +225,15 @@ fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
     // Eagerly lower each arity to IR if the compiler is ready.
     //eager_lower_fn(&cljrs_fn, env);
 
-    Ok(Value::Fn(GcPtr::new(cljrs_fn)))
+    let mut ptr = GcPtr::new(cljrs_fn);
+    // For named anonymous functions (fn g ...), store a back-pointer so that
+    // the self-reference returned from the body is pointer-equal to the outer
+    // binding — required for `(= f (f))` to be `true`.
+    if ptr.get().name.is_some() {
+        let self_clone = ptr.clone();
+        ptr.get_mut().self_ptr = Some(self_clone);
+    }
+    Ok(Value::Fn(ptr))
 }
 
 /// Parse one arity: params-form and body forms.

--- a/crates/cljrs-interp/tests/named_fn_identity.rs
+++ b/crates/cljrs-interp/tests/named_fn_identity.rs
@@ -1,0 +1,72 @@
+//! Regression tests for issue #194: named anonymous functions' self-reference
+//! should be pointer-equal to the function value itself.
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_in(src: &str, env: &mut Env) -> Value {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, env).expect("eval error");
+    }
+    result
+}
+
+fn eval_str(src: &str) -> Value {
+    let (_, mut env) = make_env();
+    eval_in(src, &mut env)
+}
+
+// ── Self-reference identity ───────────────────────────────────────────────────
+
+#[test]
+fn named_fn_self_ref_is_identical() {
+    // (fn g [] g) should return itself: (= f (f)) => true
+    let result = eval_str("(let [f (fn g [] g)] (= f (f)))");
+    assert_eq!(result, Value::Bool(true), "(= f (f)) should be true");
+}
+
+#[test]
+fn named_fn_self_ref_recursive_countdown() {
+    // A recursive named fn should still work correctly.
+    let result = eval_str(
+        "(let [count-down (fn countdown [n] (if (= n 0) :done (countdown (- n 1))))]
+           (count-down 5))",
+    );
+    assert!(
+        matches!(&result, Value::Keyword(p) if p.get().name.as_ref() == "done"),
+        "expected :done, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn named_fn_self_ref_multi_call() {
+    // Repeated calls to (f) each return the same f.
+    let result = eval_str(
+        "(let [f (fn g [] g)]
+           (and (= f (f)) (= f ((f))) (= (f) ((f)))))",
+    );
+    assert_eq!(result, Value::Bool(true));
+}
+
+#[test]
+fn defn_self_ref_identity() {
+    // Top-level defn: the function returned from the body should also
+    // be identical to the global binding.
+    let (_, mut env) = make_env();
+    eval_in("(defn self-ref [] self-ref)", &mut env);
+    let result = eval_in("(= self-ref (self-ref))", &mut env);
+    assert_eq!(result, Value::Bool(true));
+}

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -1234,6 +1234,7 @@ fn lower_fn(ctx: &mut LowerCtx, args: &[Form], is_async: bool) -> R {
             arity.rest.as_ref(),
             &arity.body,
             is_async,
+            fn_name.as_deref(),
         )?;
         ctx.add_subfunction(subfn);
 
@@ -1269,6 +1270,7 @@ fn lower_fn_arity(
     rest_param: Option<&Form>,
     body_forms: &[Form],
     is_async: bool,
+    self_name: Option<&str>,
 ) -> Result<IrFunction, LowerError> {
     // Compute raw parameter info (gensym for destructuring patterns).
     struct ParamInfo {
@@ -1345,6 +1347,19 @@ fn lower_fn_arity(
         let id = sub.fresh_var();
         sub.bind_local(pname.clone(), id);
         bound_params.push((pname.clone(), id));
+    }
+
+    // If the arity belongs to a named fn (e.g. `(fn g [] g)`), the self-name
+    // capture arrives as a `Value::Var` cell (filled in by the outer SetBang).
+    // Emit a Deref so that references to the name inside the body resolve to
+    // the actual function value, giving pointer-equal identity on return.
+    if let Some(sname) = self_name
+        && let Some(cap_idx) = capture_names.iter().position(|n| n.as_ref() == sname)
+    {
+        let cap_var = bound_params[cap_idx].1;
+        let deref_id = sub.fresh_var();
+        sub.emit(Inst::Deref(deref_id, cap_var));
+        sub.bind_local(Arc::from(sname), deref_id);
     }
 
     // User params (excluding captures) are the recur targets.
@@ -1514,6 +1529,7 @@ fn lower_try(ctx: &mut LowerCtx, args: &[Form]) -> R {
         None,
         &body_forms,
         false,
+        None,
     )?;
     ctx.add_subfunction(body_fn_ir);
     let body_closure = ctx.fresh_var();
@@ -1561,6 +1577,7 @@ fn lower_try(ctx: &mut LowerCtx, args: &[Form]) -> R {
                 None,
                 &catch_body,
                 false,
+                None,
             )?;
             ctx.add_subfunction(catch_fn_ir);
             let dst = ctx.fresh_var();
@@ -1598,6 +1615,7 @@ fn lower_try(ctx: &mut LowerCtx, args: &[Form]) -> R {
                 None,
                 &fin_body,
                 false,
+                None,
             )?;
             ctx.add_subfunction(fin_fn_ir);
             let dst = ctx.fresh_var();
@@ -1694,6 +1712,7 @@ fn lower_binding(ctx: &mut LowerCtx, args: &[Form]) -> R {
         None,
         &args[1..],
         false,
+        None,
     )?;
     ctx.add_subfunction(body_fn_ir);
     let body_closure = ctx.fresh_var();
@@ -1842,6 +1861,7 @@ fn lower_with_out_str(ctx: &mut LowerCtx, body_forms: &[Form]) -> R {
         None,
         body_forms,
         false,
+        None,
     )?;
     ctx.add_subfunction(body_fn_ir);
 

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -282,14 +282,20 @@ pub struct CljxFn {
     pub closed_over_names: Vec<Arc<str>>,
     pub closed_over_vals: Vec<Value>,
     pub is_macro: bool,
-    pub is_async: bool, // ^:async — dispatched via the async runtime when one is registered
+    pub is_async: bool,       // ^:async — dispatched via the async runtime when one is registered
     pub defining_ns: Arc<str>,
+    pub self_ptr: Option<GcPtr<CljxFn>>, // back-pointer for named-fn pointer identity (issue #194)
 }
 ```
 
 `is_async` is set by the interpreter when a `fn`/`defn` carries `^:async` (or an
 `{:async true}` attr-map). `CljxFn::new` defaults it to `false`; `cljrs-env`'s
 `dispatch_if_async` checks it at call time.
+
+`self_ptr` is set immediately after `GcPtr::new(cljrs_fn)` in `eval_fn` (for
+named anonymous functions) so that the self-reference returned from the function
+body is the *same* `GcPtr` as the outer binding, preserving pointer-equality
+semantics (`(= f (f))` → `true`).  `CljxFn::new` defaults it to `None`.
 
 ### Var-rebind hooks (`jit_hooks`, Phases 10.2/10.5)
 

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -690,6 +690,11 @@ pub struct CljxFn {
     pub is_async: bool,
     /// Namespace in which this function was defined (for macro hygiene).
     pub defining_ns: Arc<str>,
+    /// Back-pointer to the `GcPtr` that owns this `CljxFn`, set immediately
+    /// after allocation so that a named anonymous function's self-reference
+    /// (e.g. `(fn g [] g)`) returns the *identical* pointer to the caller,
+    /// preserving pointer-equality semantics (`(= f (f))` → `true`).
+    pub self_ptr: Option<GcPtr<CljxFn>>,
 }
 
 impl CljxFn {
@@ -709,14 +714,19 @@ impl CljxFn {
             is_macro,
             is_async: false,
             defining_ns,
+            self_ptr: None,
         }
     }
 }
 
 impl cljrs_gc::Trace for CljxFn {
     fn trace(&self, visitor: &mut cljrs_gc::MarkVisitor) {
+        use cljrs_gc::GcVisitor as _;
         for v in &self.closed_over_vals {
             v.trace(visitor);
+        }
+        if let Some(ref p) = self.self_ptr {
+            visitor.visit(p);
         }
     }
 


### PR DESCRIPTION
Three execution paths all created a fresh GcPtr/NativeFunction when
binding the self-name inside a named fn body, so `(= f (f))` was always
false.

Tree-walker (Fix 1):
- Add `self_ptr: Option<GcPtr<CljxFn>>` to `CljxFn`.
- `eval_fn` sets `self_ptr` to a clone of the owning GcPtr for named fns.
- `call_cljrs_fn` (interp) and `execute_ir` (eval) now clone `self_ptr`
  instead of allocating via `GcPtr::new(f.clone())`, so the bound name
  is pointer-equal to the outer `Value::Fn`.

IR/AOT path (Fix 2):
- `lower_fn_arity` gains a `self_name: Option<&str>` parameter.
- When the self-name appears in the capture list the arity emits
  `Inst::Deref` on that capture's VarId, yielding the actual
  `NativeFunction` value rather than the `Value::Var` cell.  The
  deref'd VarId shadows the raw capture so all body references to the
  name see the function itself.
- `lower_fn` passes `fn_name.as_deref()`; all other `lower_fn_arity`
  call sites pass `None`.

Background lowering guard (Fix 3):
- `maybe_request_lowering` now skips named anonymous functions whose
  name is not interned as a global var.  Without this guard the
  background lowering worker would emit `LoadGlobal` for the self-name
  and fail at runtime.  Functions defined with `defn` (whose name IS
  a global) are still eligible for background lowering.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JieBFoU6b8PuopZf158bFK