### PR TITLE
fix: pack variadic rest args before passing to async state machine

### DIFF
--- a/crates/cljrs-async/src/runtime.rs
+++ b/crates/cljrs-async/src/runtime.rs
@@ -3,8 +3,9 @@
 use cljrs_env::async_hook::AsyncRuntime;
 use cljrs_env::env::Env;
 use cljrs_env::error::{EvalError, EvalResult};
+use cljrs_gc::GcPtr;
 use cljrs_interp::apply::select_arity;
-use cljrs_value::{NativeObjectBox, Value};
+use cljrs_value::{NativeObjectBox, PersistentList, Value};
 
 use crate::channel::CljChannel;
 use crate::eval_async::{run_async_fn, spawn_future};
@@ -39,30 +40,40 @@ impl AsyncRuntime for AsyncRuntimeImpl {
             // fallback below; only Copy/cloned data escapes.
             let info = {
                 let fr = f.get();
-                select_arity(fr, args.len())
-                    .ok()
-                    .map(|a| (a.ir_arity_id, fr.defining_ns.clone(), fr.name.clone()))
+                select_arity(fr, args.len()).ok().map(|a| {
+                    (
+                        a.ir_arity_id,
+                        fr.defining_ns.clone(),
+                        fr.name.clone(),
+                        a.params.len(),
+                        a.rest_param.is_some(),
+                    )
+                })
             };
-            if let Some((id, ns, name)) = info {
+            if let Some((id, ns, name, n_fixed, is_variadic)) = info {
                 let ctx = (env.globals.clone(), ns.clone());
+                let orig_argc = args.len();
                 // JIT registry (keyed by runtime ir_arity_id).
                 if let Some((poll_fn, n_slots)) = lookup_poll_fn(id) {
-                    return spawn_state_machine(poll_fn, n_slots, args, Some(ctx));
+                    let packed = pack_for_native(&args, n_fixed, is_variadic);
+                    return spawn_state_machine(poll_fn, n_slots, packed, Some(ctx));
                 }
-                // AOT registry (keyed by ns/name/arity, registered by the harness).
+                // AOT registry (keyed by ns/name/fixed-param-count, registered by the harness).
                 if let Some(nm) = name.as_deref()
-                    && let Some((poll_fn, n_slots)) = lookup_poll_fn_named(&ns, nm, args.len())
+                    && let Some((poll_fn, n_slots)) = lookup_poll_fn_named(&ns, nm, n_fixed)
                 {
-                    return spawn_state_machine(poll_fn, n_slots, args, Some(ctx));
+                    let packed = pack_for_native(&args, n_fixed, is_variadic);
+                    return spawn_state_machine(poll_fn, n_slots, packed, Some(ctx));
                 }
                 // One-shot compile attempt (when the JIT installed a hook).
                 if async_jit_enabled()
                     && mark_compile_attempted(id)
                     && let Some(hook) = cljrs_env::async_hook::async_compile_hook()
                 {
-                    hook(&callee, args.len(), &mut env);
+                    hook(&callee, orig_argc, &mut env);
                     if let Some((poll_fn, n_slots)) = lookup_poll_fn(id) {
-                        return spawn_state_machine(poll_fn, n_slots, args, Some(ctx));
+                        let packed = pack_for_native(&args, n_fixed, is_variadic);
+                        return spawn_state_machine(poll_fn, n_slots, packed, Some(ctx));
                     }
                 }
             }
@@ -86,6 +97,29 @@ impl AsyncRuntime for AsyncRuntimeImpl {
             Err(EvalError::Runtime("chan-put: channel is closed".into()))
         }
     }
+}
+
+/// Pack args for a compiled (native) async state machine.
+///
+/// Fixed arities pass args through unchanged. Variadic arities must have the
+/// trailing args collected into a `Value::List` (or `Value::Nil` for empty
+/// rest) before being handed to the state machine, which expects exactly
+/// `n_fixed + 1` slot values. This mirrors what `bind_fn_params` does on the
+/// tree-walking path and what `call_jit_native` does on the sync JIT path.
+fn pack_for_native(args: &[Value], n_fixed: usize, is_variadic: bool) -> Vec<Value> {
+    if !is_variadic {
+        return args.to_vec();
+    }
+    let split = n_fixed.min(args.len());
+    let mut v = args[..split].to_vec();
+    let rest_items = &args[split..];
+    let rest_val = if rest_items.is_empty() {
+        Value::Nil
+    } else {
+        Value::List(GcPtr::new(PersistentList::from_iter(rest_items.to_vec())))
+    };
+    v.push(rest_val);
+    v
 }
 
 #[allow(clippy::result_large_err)]

--- a/crates/cljrs/tests/run_main.rs
+++ b/crates/cljrs/tests/run_main.rs
@@ -69,3 +69,46 @@ fn run_awaits_async_main() {
         "async -main body did not run to completion; stdout was: {stdout}"
     );
 }
+
+fn run_file_with_args(path: &PathBuf, cli_args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .arg("run")
+        .arg(path)
+        .arg("--")
+        .args(cli_args)
+        .output()
+        .expect("run cljrs binary")
+}
+
+#[test]
+fn async_main_receives_cli_args() {
+    let path = write_fixture(
+        "args",
+        r#"
+(defn ^:async -main [& args]
+  (println "count:" (count args))
+  (println "first:" (first args))
+  (println "second:" (second args)))
+"#,
+    );
+    let out = run_file_with_args(&path, &["hello", "world"]);
+    let _ = std::fs::remove_file(&path);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("count: 2"),
+        "expected count 2 for two CLI args; stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("first: hello"),
+        "expected first arg to be \"hello\"; stdout was: {stdout}"
+    );
+    assert!(
+        stdout.contains("second: world"),
+        "expected second arg to be \"world\"; stdout was: {stdout}"
+    );
+}


### PR DESCRIPTION
When `spawn_async_call` dispatched to a JIT- or AOT-compiled async poll
function for a variadic arity, it passed the raw argument list directly to
`spawn_state_machine`. The compiled state machine expected the trailing args
packed into a `Value::List` (or `Value::Nil` for empty rest) in slot[n_fixed],
matching what `bind_fn_params` does on the tree-walking path and what
`call_jit_native` does on the synchronous JIT path.

Without this packing, `& args` in an `^:async -main` would bind to the raw
first string argument rather than a seq of all CLI arguments, causing
`(count args)` to return the string length and `(first args)` to return nil
(issue #220).

The fix extracts `params.len()` and `rest_param.is_some()` from the selected
arity alongside the existing info, then calls a new `pack_for_native` helper
before every `spawn_state_machine` invocation. The AOT named-registry lookup
is also corrected to key on `n_fixed` (the registered fixed-param count)
rather than the total caller arg count.

Adds a regression test `async_main_receives_cli_args` that drives the CLI
binary with two arguments and asserts their count, first, and second values
are correct through the async dispatch path.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SJEugvndLLg1XEXNo3KJwb