### PR TITLE
feat(cljrs-base64): integrate into cljrs binary as a built-in module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "cljrs-async",
+ "cljrs-base64",
  "cljrs-charset",
  "cljrs-compiler",
  "cljrs-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
 cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0" }
 cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.0" }
 cljrs-nrepl        = { path = "crates/cljrs-nrepl",        version = "0.1.0" }
+cljrs-base64       = { path = "crates/cljrs-base64",       version = "0.1.0" }
 cljrs-jit          = { path = "crates/cljrs-jit",          version = "0.1.0" }
 cljrs-dylib        = { path = "crates/cljrs-dylib",        version = "0.1.0" }
 

--- a/crates/cljrs-base64/Cargo.toml
+++ b/crates/cljrs-base64/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+cljrs-env     = { workspace = true }
 cljrs-interop = { workspace = true }
 cljrs-gc      = { workspace = true }
 cljrs-value   = { workspace = true }

--- a/crates/cljrs-base64/README.md
+++ b/crates/cljrs-base64/README.md
@@ -1,0 +1,45 @@
+# cljrs-base64
+
+Base64 encoding and decoding for Clojurust, wrapping the [`base64`](https://crates.io/crates/base64) crate.
+
+## Purpose
+
+Exposes standard and URL-safe Base64 encode/decode functions to Clojure code under the `cljrs.base64` namespace.
+
+## Status
+
+Phase 1 — implemented. Linked statically into the `cljrs` binary via the `base64` feature (enabled by default) and also loadable as a dynamic plugin via the `cljrs_init` FFI entry point.
+
+## File layout
+
+| File | Description |
+|---|---|
+| `src/lib.rs` | All implementation: byte-conversion helpers, `init`, `register`, and the `cljrs_init` FFI entry point |
+
+## Public API
+
+```rust
+/// Clojure namespace registered by this crate.
+pub const NS: &str = "cljrs.base64";
+
+/// Register `cljrs.base64` into `globals`. Idempotent.
+pub fn init(globals: &Arc<GlobalEnv>);
+
+/// Register all functions via an existing `Registry` (used by the FFI path).
+pub fn register(registry: &mut Registry);
+
+/// C-ABI entry point for dynamic plugin loading.
+#[no_mangle]
+pub unsafe extern "C" fn cljrs_init(registry: *mut Registry);
+```
+
+### Clojure functions
+
+| Symbol | Signature | Description |
+|---|---|---|
+| `cljrs.base64/encode` | `(encode data)` | Base64-encode `data` (string or byte vector) using standard alphabet with padding; returns a `String` |
+| `cljrs.base64/decode` | `(decode data)` | Decode a standard Base64 string or byte vector; returns a `ByteArray` |
+| `cljrs.base64/encode-url` | `(encode-url data)` | URL-safe Base64 encode without padding; returns a `String` |
+| `cljrs.base64/decode-url` | `(decode-url data)` | URL-safe Base64 decode (no padding); returns a `ByteArray` |
+
+`data` may be a `String`, a `Vector` of integers in `[0, 255]`, a `ByteArray`, or a `ByteBlob`.

--- a/crates/cljrs-base64/src/lib.rs
+++ b/crates/cljrs-base64/src/lib.rs
@@ -1,10 +1,27 @@
+use std::sync::{Arc, Mutex};
+
 use base64::Engine;
 use base64::alphabet::{STANDARD, URL_SAFE};
 use base64::engine::general_purpose::{NO_PAD, PAD};
+use cljrs_env::env::GlobalEnv;
 use cljrs_gc::GcPtr;
 use cljrs_interop::{Registry, wrap_fn1};
 use cljrs_value::Value;
-use std::sync::Mutex;
+
+pub const NS: &str = "cljrs.base64";
+
+/// Register the `cljrs.base64` namespace into `globals`.
+///
+/// Idempotent: the namespace is built only on the first call.
+pub fn init(globals: &Arc<GlobalEnv>) {
+    if globals.is_loaded(NS) {
+        return;
+    }
+    globals.get_or_create_ns(NS);
+    globals.refer_all(NS, "clojure.core");
+    let mut registry = Registry::for_require(globals.clone());
+    register(&mut registry);
+}
 
 fn to_bytes(value: Value) -> Result<Vec<u8>, String> {
     match value {

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["async", "net", "charset"]
+default = ["async", "net", "charset", "base64"]
 # Propagate no-gc to all direct dependencies; transitive deps pick it up through their own feature chains.
 no-gc = [
     "cljrs-gc/no-gc",
@@ -19,9 +19,10 @@ no-gc = [
     "cljrs-jit/no-gc",
 ]
 enable-rustyline = ["rustyline"]
-async = ["dep:cljrs-async", "dep:cljrs-io", "dep:tokio"]
+async   = ["dep:cljrs-async", "dep:cljrs-io", "dep:tokio"]
 net     = ["dep:cljrs-net", "async"]
 charset = ["dep:cljrs-charset"]
+base64  = ["dep:cljrs-base64"]
 
 [[bin]]
 name = "cljrs"
@@ -51,10 +52,11 @@ tracing-subscriber = "0.3.23"
 tracing = "0.1.44"
 rustyline   = { workspace = true, optional = true }
 libloading  = { workspace = true }
-cljrs-async = { workspace = true, optional = true }
-cljrs-io    = { workspace = true, optional = true }
-cljrs-net     = { workspace = true, optional = true }
+cljrs-async  = { workspace = true, optional = true }
+cljrs-io     = { workspace = true, optional = true }
+cljrs-net    = { workspace = true, optional = true }
 cljrs-charset = { workspace = true, optional = true }
+cljrs-base64  = { workspace = true, optional = true }
 tokio         = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -669,6 +669,8 @@ fn setup_globals(
             None => init(&globals),
         }
     });
+    #[cfg(feature = "base64")]
+    cljrs_base64::init(&globals);
     globals
 }
 


### PR DESCRIPTION
Add `init(globals: &Arc<GlobalEnv>)` to cljrs-base64 following the same
pattern as cljrs-io, cljrs-net, cljrs-async, and cljrs-charset. Expose
a `base64` feature in the cljrs binary (on by default) that calls
`cljrs_base64::init` at startup, making `cljrs.base64/encode`,
`cljrs.base64/decode`, `cljrs.base64/encode-url`, and
`cljrs.base64/decode-url` available without dynamic-library loading.

- Add cljrs-base64 to workspace.dependencies
- Add cljrs-env dep to cljrs-base64 (needed for GlobalEnv in init)
- Add NS constant and idempotent init() to cljrs-base64/src/lib.rs
- Add `base64` feature + optional dep to cljrs/Cargo.toml (default on)
- Call cljrs_base64::init after async/io/net/charset init in main.rs
- Create cljrs-base64/README.md per CLAUDE.md crate-doc requirements

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0178pfJA2zWv3EpeLASkDdgN