### PR TITLE
Add HTTP/2 client module to cljrs-net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "cljrs-stdlib",
  "cljrs-types",
  "cljrs-value",
+ "h2",
  "h3",
  "h3-quinn",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ arc-swap     = "1"
 quinn        = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 h3           = "0.0.8"
 h3-quinn     = "0.0.10"
+h2           = "0.4"
 tower-lsp     = "0.20"
 dashmap       = "6"
 

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -23,6 +23,7 @@ rustls-native-certs = "0.8"
 quinn          = { workspace = true }
 h3             = { workspace = true }
 h3-quinn       = { workspace = true }
+h2             = { workspace = true }
 bytes          = "1"
 http           = "1"
 

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: TCP/Unix/TLS/QUIC networking for clojurust — channel-oriented sockets delivered as core.async channels.
 
-**Status**: Phases A–G + A2 + Q1 + Q2 + Q3 implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics, pool-based I/O, QUIC client transport, QUIC server transport, HTTP/3 client).
+**Status**: Phases A–G + A2 + Q1 + Q2 + Q3 + H2 implemented (TCP client + server, framing, UDP datagrams, TLS client/server, Unix-domain stream sockets, lifecycle/timeouts/ergonomics, pool-based I/O, QUIC client transport, QUIC server transport, HTTP/3 client, HTTP/2 client).
 
 **Design**: Follows the aleph/netty-in-core.async model. A connection is a duplex pair of channels — `:in` carries `byte-array` chunks read from the socket, `:out` accepts `byte-array`/string values to write. A server is a channel of connections. Higher-level protocols are higher-order functions over those channels: the `frame` function pipes a raw `:in` channel through a stateful framer spec, emitting complete application messages.
 
@@ -12,7 +12,7 @@
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, `clojure.rust.net.unix`, `clojure.rust.net.quic`, and `clojure.rust.net` |
+| `src/lib.rs` | `init()` entry point; loads `clojure.rust.net.tcp`, `clojure.rust.net.frame`, `clojure.rust.net.udp`, `clojure.rust.net.tls`, `clojure.rust.net.unix`, `clojure.rust.net.quic`, `clojure.rust.net.h3`, `clojure.rust.net.http2`, and `clojure.rust.net` |
 | `src/pool_io.rs` | Shared pool tasks and bridge helpers: `ReadMsg`, `PoolStreamSetup`, `pool_reader`, `pool_writer`, `read_bridge`, `write_bridge`, `bytes_value`, `net_error` |
 | `src/tcp.rs` | `TcpStreamResource` (Vec<AbortHandle>), `TcpListenerResource` (Vec<AbortHandle>), pool-based connect/accept, `connect`/`listen`/`close` builtins |
 | `src/frame.rs` | `FramerSpec` native object, stateful framers (`LinesFramer`, `DelimiterFramer`, `LengthPrefixedFramer`), `frame`/encode builtins |
@@ -22,6 +22,7 @@
 | `src/quic_config.rs` | Build `quinn::ClientConfig`/`ServerConfig` from opts maps; delegates TLS to `tls::build_client_config`/`build_server_config`, wraps via `QuicClientConfig::try_from`; applies QUIC transport params (`:max-idle-ms`, `:keep-alive-ms`, `:max-streams`) |
 | `src/quic.rs` | `QuicConnectionResource` (holds `quinn::Connection` + `Endpoint` + abort handles), `QuicStreamResource` (abort handles for pool reader/writer + LocalSet bridges), `QuicListenerResource` (holds `Endpoint` + abort handles for pool accept loop + LocalSet bridge), pool accept/open loops, LocalSet bridges, `connect_to`/`open_stream_on`/`listen_on`, `connect`/`open-stream`/`close`/`stream-close`/`listen`/`listen-close` builtins |
 | `src/h3.rs` | `H3Resource` (holds `quinn::Connection` + `Endpoint` + abort handles for pool streaming task and LocalSet body-bridge), pool task for QUIC connect + h3 handshake + request send + response header recv + body streaming, LocalSet body bridge (`local_body_bridge`), `get`/`h3_request` public Rust API, `get`/`request`/`close` Clojure builtins |
+| `src/h2.rs` | `H2Resource` (holds abort handles for the h2 connection driver, pool streaming task, and LocalSet body-bridge), pool task for TCP connect + TLS handshake (ALPN `h2`) + h2 handshake + request send + response header recv + body streaming (with flow-control release), LocalSet body bridge (`local_body_bridge`), `get`/`h2_request` public Rust API, `get`/`request`/`close` Clojure builtins |
 | `src/clojure_rust_net_tcp.cljrs` | Clojure source for `clojure.rust.net.tcp`; `start-server` sugar |
 | `src/clojure_rust_net_frame.cljrs` | Clojure source for `clojure.rust.net.frame`; `pipe-map` helper |
 | `src/clojure_rust_net_udp.cljrs` | Clojure source for `clojure.rust.net.udp`; usage examples |
@@ -29,6 +30,7 @@
 | `src/clojure_rust_net_unix.cljrs` | Clojure source for `clojure.rust.net.unix`; `start-server` sugar |
 | `src/clojure_rust_net_quic.cljrs` | Clojure source for `clojure.rust.net.quic`; `with-stream`, `drain-stream`, `start-server` sugar |
 | `src/clojure_rust_net_h3.cljrs` | Clojure source for `clojure.rust.net.h3`; `drain-body`, `get-string` sugar |
+| `src/clojure_rust_net_http2.cljrs` | Clojure source for `clojure.rust.net.http2`; `drain-body`, `get-string` sugar |
 | `src/clojure_rust_net.cljrs` | Clojure source for umbrella `clojure.rust.net`; dispatches on `:transport` (`:tcp`, `:tls`, `:unix`) |
 | `tests/tcp_client.rs` | Phase A integration tests (connect, send, recv, error path) |
 | `tests/tcp_server.rs` | Phase B integration tests (listen, echo round-trip, close) |
@@ -38,6 +40,8 @@
 | `tests/unix.rs` | Phase F integration tests (Unix echo round-trip, listener unlinks path, stale socket removal) |
 | `tests/lifecycle.rs` | Phase G integration tests (split-err, drain-to, with-open, :connect-timeout-ms) |
 | `tests/quic.rs` | Phases Q1+Q2 integration tests (QUIC echo round-trip via quinn in-test server, QUIC server echo via `listen_on`, listener close, connect-failure path) |
+| `tests/h3.rs` | Phase Q3 integration tests (HTTP/3 GET round-trip via h3 in-test server, :body EOF close, close-before-drain) |
+| `tests/http2.rs` | Phase H2 integration tests (HTTP/2 GET round-trip via h2-over-TLS in-test server, :body EOF close, close-before-drain, connect-failure path) |
 
 ## Public API
 
@@ -136,6 +140,37 @@ builds register stub functions that throw "not supported on this platform".
 ;; => server-map — spawns go-loop that calls (handler conn) for each accepted conn
 ```
 
+### `clojure.rust.net.http2` (Phase H2)
+
+HTTP/2 client over TLS. Each request establishes a fresh TLS connection (ALPN
+`"h2"`) and issues one request. The TCP connect, TLS handshake, h2 handshake,
+and all HTTP/2 I/O run on the `WorkerPool`; the response body is streamed to a
+`:body` channel via a LocalSet bridge.
+
+```clojure
+;; Phase H2 — HTTP/2 GET
+(get "https://host/path")
+(get "https://host/path" opts)
+;; => promise-chan — yields {:status long :headers {"k" "v" ...} :body <chan> :resource <H2Resource>}
+;;    or Value::Error on connection/request failure
+;; :body yields byte-array chunks; closed at EOF or on error
+;; Opts: :insecure-skip-verify, :alpn (default ["h2"]), :roots (same as tls/connect)
+;;       :body-buf (channel depth, default 8)
+
+;; General request
+(request {:method "GET" :url "https://host/path" :headers {"accept" "text/plain"}})
+(request req opts)
+;; :method defaults to "GET"; :url required; no request body is sent yet (POST body is future work)
+
+(close resp)  ;; => nil — aborts all tasks (including the connection driver),
+              ;;          dropping the TLS stream / TCP socket; closes :body
+
+;; Clojure sugar:
+(drain-body resp)        ;; => byte-array of all :body data (^:async context)
+(get-string url)         ;; => response body as a UTF-8 string (^:async context)
+(get-string url opts)
+```
+
 ### `clojure.rust.net` (umbrella)
 
 ```clojure
@@ -229,7 +264,13 @@ pub fn quic::open_stream_on(connection: quinn::Connection, in_buf: usize, out_bu
 pub fn quic::listen_on(host: &str, port: u16, server_config: quinn::ServerConfig, conns_buf: usize, streams_buf: usize, in_buf: usize, out_buf: usize) -> ValueResult<Value>
 pub fn quic_config::client_config(opts: &MapValue) -> ValueResult<quinn::ClientConfig>
 pub fn quic_config::server_config(opts: &MapValue) -> ValueResult<quinn::ServerConfig>
-pub const NS_QUIC: &str  // "clojure.rust.net.quic"
+pub fn h3::get(url: &str, opts: &MapValue, body_buf: usize) -> ValueResult<Value>
+pub fn h3::h3_request(url: &str, method: http::Method, extra_headers: Vec<(String, String)>, opts: &MapValue, body_buf: usize) -> ValueResult<Value>
+pub fn h2::get(url: &str, opts: &MapValue, body_buf: usize) -> ValueResult<Value>
+pub fn h2::h2_request(url: &str, method: http::Method, extra_headers: Vec<(String, String)>, opts: &MapValue, body_buf: usize) -> ValueResult<Value>
+pub const NS_QUIC: &str   // "clojure.rust.net.quic"
+pub const NS_H3: &str     // "clojure.rust.net.h3"
+pub const NS_HTTP2: &str  // "clojure.rust.net.http2"
 ```
 
 `init` registers all namespaces including `clojure.rust.net.quic`, calling `cljrs_async::init` internally. Idempotent.
@@ -273,6 +314,10 @@ Implements `cljrs_value::Resource` (Arc-backed). Holds the `quinn::Endpoint` (ke
 ### `UnixListenerResource` (`#[cfg(unix)]`)
 
 Implements `cljrs_value::Resource` (Arc-backed). Holds the `AbortHandle` for the `accept_loop` task and the socket's filesystem `path`. `close()` aborts the task and **unlinks the socket path** via `std::fs::remove_file`, so the next `listen_on` on the same path does not get EADDRINUSE. `listen_on` also pre-unlinks any stale socket file before binding.
+
+### `H2Resource`
+
+Implements `cljrs_value::Resource` (Arc-backed). Holds `Vec<AbortHandle>` for the HTTP/2 connection driver task, the WorkerPool body-streaming task, and the LocalSet body-bridge task. `close()` aborts all tasks; aborting the connection driver drops the TLS stream, which closes the underlying TCP socket. `resource_type` → `"Http2Connection"`. Unlike QUIC/HTTP/3, h2 has no explicit connection object — the connection lives entirely inside the driver task, so dropping that task is what tears the connection down.
 
 ## Connection Model
 

--- a/crates/cljrs-net/src/clojure_rust_net_http2.cljrs
+++ b/crates/cljrs-net/src/clojure_rust_net_http2.cljrs
@@ -1,0 +1,56 @@
+;; clojure.rust.net.http2 — HTTP/2 client.
+;;
+;; Phase H2 (HTTP/2 client over TLS):
+;;   get     — (get url) / (get url opts) => promise-chan -> response-map
+;;   request — (request req) / (request req opts) => promise-chan -> response-map
+;;   close   — (close resp) => nil
+;;
+;; Response map shape:
+;;   {:status  200
+;;    :headers {"content-type" "text/plain" ...}
+;;    :body    <chan>    ; byte-array chunks; closed at EOF or error
+;;    :resource <H2Resource>}
+;;
+;; Opts (same as tls/connect):
+;;   :insecure-skip-verify — skip TLS cert verification (testing only)
+;;   :alpn                 — vector of ALPN strings (default ["h2"])
+;;   :roots                — CA roots (:webpki default, :system, or CA PEM path)
+;;   :body-buf             — :body channel buffer depth (default 8)
+
+(defn drain-body
+  "Drain a response `:body` channel to a byte-array and return it.
+  Must be called in a `go` block (uses `await`).
+
+  Example:
+    (go
+      (let [resp (<! (http2/get \"https://host/\"))
+            body (http2/drain-body resp)]
+        (println (String. body \"UTF-8\"))))"
+  [resp]
+  (let [body-ch (:body resp)]
+    (loop [acc []]
+      (let [v (await (clojure.core.async/take! body-ch))]
+        (if (nil? v)
+          (let [total (reduce + 0 (map count acc))
+                result (byte-array total)]
+            (loop [i 0 chunks acc]
+              (when-let [chunk (first chunks)]
+                (System/arraycopy chunk 0 result i (count chunk))
+                (recur (+ i (count chunk)) (rest chunks))))
+            result)
+          (recur (conj acc v)))))))
+
+(defn get-string
+  "Issue a GET request to `url` and return the response body as a UTF-8 string.
+  Must be called in a `go` block (uses `await`).
+
+  Opts: same as `get`.
+
+  Example:
+    (go (println (<! (http2/get-string \"https://host/hello\"))))"
+  ([url] (get-string url {}))
+  ([url opts]
+   (let [resp (await (clojure.core.async/take!
+                       (clojure.rust.net.http2/get url opts)))]
+     (when (some? resp)
+       (String. (drain-body resp) "UTF-8")))))

--- a/crates/cljrs-net/src/h2.rs
+++ b/crates/cljrs-net/src/h2.rs
@@ -1,0 +1,577 @@
+//! HTTP/2 client for `clojure.rust.net.http2` (Phase H2).
+//!
+//! Wraps the `h2` crate on top of a TLS-over-TCP stream (the same TLS client
+//! config builder used by `clojure.rust.net.tls`). For each request a fresh
+//! TLS connection is established; the TCP connect, TLS handshake, HTTP/2
+//! handshake, and all HTTP/2 I/O run on the `WorkerPool`; the response body is
+//! streamed to a `:body` channel via a `LocalSet` bridge task.
+//!
+//! Response map:
+//! ```clojure
+//! {:status  200
+//!  :headers {"content-type" "text/plain" ...}  ; string keys, string values
+//!  :body    <chan>    ; byte-array chunks; closed at EOF or on error
+//!  :resource <H2Resource>}
+//! ```
+//!
+//! `H2Resource` holds abort handles for the HTTP/2 connection driver, the pool
+//! body-streaming task, and the LocalSet body bridge. Call `(http2/close resp)`
+//! to terminate the connection before the body is fully drained — aborting the
+//! connection driver drops the TLS stream and closes the TCP socket.
+//!
+//! ALPN: HTTP/2 over TLS requires the ALPN token `"h2"`. Pass `:alpn ["h2"]` in
+//! opts (or rely on the default injection done by `h2_client_config`).
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use bytes::Buf;
+use rustls::pki_types::ServerName;
+use tokio::net::TcpStream;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::AbortHandle;
+use tokio_rustls::TlsConnector;
+
+use cljrs_async::channel::{chan_deliver, chan_put, chan_ref, make_chan};
+use cljrs_async::eval_async::spawn_future;
+use cljrs_async::worker_pool::WorkerPool;
+use cljrs_env::env::GlobalEnv;
+use cljrs_env::error::EvalResult;
+use cljrs_gc::GcPtr;
+use cljrs_value::{
+    Arity, Keyword, MapValue, NativeFn, NativeObjectBox, PersistentVector, Resource,
+    ResourceHandle, Value, ValueError, ValueResult,
+};
+
+use crate::pool_io::{bytes_value, net_error};
+
+// ── Public entry point ──────────────────────────────────────────────────────────
+
+type Builtin = fn(&[Value]) -> ValueResult<Value>;
+
+pub fn register(globals: &Arc<GlobalEnv>, ns: &str) {
+    let fns: Vec<(&str, Arity, Builtin)> = vec![
+        ("get", Arity::Variadic { min: 1 }, builtin_get),
+        ("request", Arity::Variadic { min: 1 }, builtin_request),
+        ("close", Arity::Fixed(1), builtin_close),
+    ];
+    for (name, arity, func) in fns {
+        let nf = NativeFn::new(name, arity, func);
+        globals.intern(ns, Arc::from(name), Value::NativeFunction(GcPtr::new(nf)));
+    }
+}
+
+// ── H2Resource ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct H2Inner {
+    closed: bool,
+    abort_handles: Vec<AbortHandle>,
+}
+
+/// `Resource` for an HTTP/2 connection.
+///
+/// Holds abort handles for the HTTP/2 connection driver task, the WorkerPool
+/// body-streaming task, and the LocalSet body-bridge task. `close()` aborts all
+/// tasks; aborting the connection driver drops the TLS stream, which closes the
+/// underlying TCP socket. `resource_type` → `"Http2Connection"`.
+#[derive(Debug)]
+pub struct H2Resource {
+    inner: Arc<Mutex<H2Inner>>,
+}
+
+impl H2Resource {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(H2Inner {
+                closed: false,
+                abort_handles: Vec::new(),
+            })),
+        }
+    }
+}
+
+impl Resource for H2Resource {
+    fn close(&self) -> ValueResult<()> {
+        let mut g = self.inner.lock().unwrap();
+        if g.closed {
+            return Ok(());
+        }
+        g.closed = true;
+        for h in g.abort_handles.drain(..) {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.lock().unwrap().closed
+    }
+
+    fn resource_type(&self) -> &'static str {
+        "Http2Connection"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// ── Internal types ──────────────────────────────────────────────────────────────
+
+/// Partial response from the pool task — delivered as soon as response headers
+/// arrive so the LocalSet can build the `:body` channel and response map before
+/// the body is fully streamed.
+struct H2ResponsePartial {
+    status: u16,
+    headers: Vec<(String, String)>,
+    /// Abort handle for the HTTP/2 connection driver task. Held by the resource
+    /// so `close()` can tear down the connection (and the TLS/TCP socket).
+    driver_abort: AbortHandle,
+}
+
+// ── Value / opts helpers ────────────────────────────────────────────────────────
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn opts_str(opts: &MapValue, key: &str) -> Option<String> {
+    match opts.get(&kw(key))? {
+        Value::Str(s) => Some(s.get().clone()),
+        _ => None,
+    }
+}
+
+fn opts_usize(opts: &MapValue, key: &str) -> Option<usize> {
+    match opts.get(&kw(key))? {
+        Value::Long(n) if n >= 0 => Some((n as usize).max(1)),
+        _ => None,
+    }
+}
+
+/// Return an `Arc<rustls::ClientConfig>` suitable for HTTP/2: identical to the
+/// TLS client config from `tls::build_client_config`, but with `"h2"` injected
+/// into `:alpn` when the caller did not set it.
+fn h2_client_config(opts: &MapValue) -> ValueResult<Arc<rustls::ClientConfig>> {
+    if opts.get(&kw("alpn")).is_some() {
+        return crate::tls::build_client_config(opts);
+    }
+    let alpn_val = Value::Vector(GcPtr::new(PersistentVector::from_iter([Value::string(
+        "h2",
+    )])));
+    let new_opts = opts.assoc(kw("alpn"), alpn_val);
+    crate::tls::build_client_config(&new_opts)
+}
+
+// ── URL / header parsing ────────────────────────────────────────────────────────
+
+fn parse_url(url: &str) -> Result<(String, u16, http::Uri), String> {
+    let uri: http::Uri = url
+        .parse()
+        .map_err(|e| format!("invalid URL '{url}': {e}"))?;
+    let host = uri
+        .host()
+        .ok_or_else(|| format!("URL '{url}' missing host"))?
+        .to_string();
+    let port = uri.port_u16().unwrap_or(443);
+    Ok((host, port, uri))
+}
+
+/// Extract `{:headers {"k" "v" ...}}` from a request map. Returns an empty vec
+/// if the key is absent or not a string→string map.
+fn extract_headers(req_map: &MapValue) -> Vec<(String, String)> {
+    let h_map = match req_map.get(&kw("headers")) {
+        Some(Value::Map(m)) => m.clone(),
+        _ => return vec![],
+    };
+    h_map
+        .iter()
+        .filter_map(|(k, v)| {
+            let ks = match k {
+                Value::Str(s) => s.get().clone(),
+                Value::Keyword(kw) => kw.get().full_name(),
+                _ => return None,
+            };
+            let vs = match v {
+                Value::Str(s) => s.get().clone(),
+                _ => return None,
+            };
+            Some((ks, vs))
+        })
+        .collect()
+}
+
+// ── Pool task ───────────────────────────────────────────────────────────────────
+
+/// Runs entirely on the `WorkerPool`:
+///
+/// 1. TCP connect.
+/// 2. TLS handshake (ALPN `"h2"`), mirroring `tls.rs::do_tls_connect`.
+/// 3. HTTP/2 handshake via `h2::client::handshake`.
+/// 4. Spawn the h2 connection driver task (drives all frame I/O).
+/// 5. Send the HTTP request and receive response headers.
+/// 6. Send `H2ResponsePartial` (status + headers + driver abort handle) via
+///    `response_tx` so the `LocalSet` can build the response map while body
+///    streaming continues.
+/// 7. Stream response body chunks to `body_tx` (dropping it closes `:body`).
+#[allow(clippy::too_many_arguments)]
+async fn pool_h2_request(
+    host: String,
+    port: u16,
+    config: Arc<rustls::ClientConfig>,
+    uri: http::Uri,
+    method: http::Method,
+    extra_headers: Vec<(String, String)>,
+    body_tx: mpsc::Sender<Result<Vec<u8>, String>>,
+    response_tx: oneshot::Sender<Result<H2ResponsePartial, String>>,
+) {
+    macro_rules! fail {
+        ($msg:expr) => {{
+            let _ = response_tx.send(Err($msg));
+            return;
+        }};
+    }
+
+    // ── 1. TCP connect ─────────────────────────────────────────────────────────
+    let addr = format!("{host}:{port}");
+    let tcp_stream = match TcpStream::connect(&addr).await {
+        Ok(s) => s,
+        Err(e) => fail!(format!("connect to {addr}: {e}")),
+    };
+
+    // ── 2. TLS handshake ───────────────────────────────────────────────────────
+    let server_name = match ServerName::try_from(host.as_str()) {
+        Ok(n) => n.to_owned(),
+        Err(e) => fail!(format!("invalid SNI hostname {host}: {e}")),
+    };
+    let connector = TlsConnector::from(config);
+    let tls_stream = match connector.connect(server_name, tcp_stream).await {
+        Ok(s) => s,
+        Err(e) => fail!(format!("TLS handshake: {e}")),
+    };
+
+    // If the server negotiated an ALPN protocol other than h2, the peer is not
+    // speaking HTTP/2 — fail early with a clear message rather than letting the
+    // h2 handshake hang or produce a cryptic frame error.
+    {
+        let (_, conn) = tls_stream.get_ref();
+        if let Some(proto) = conn.alpn_protocol()
+            && proto != b"h2"
+        {
+            fail!(format!(
+                "server did not negotiate HTTP/2 (ALPN = {:?})",
+                String::from_utf8_lossy(proto)
+            ));
+        }
+    }
+
+    // ── 3. HTTP/2 handshake ────────────────────────────────────────────────────
+    let (h2, connection) = match h2::client::handshake(tls_stream).await {
+        Ok(pair) => pair,
+        Err(e) => fail!(format!("h2 handshake: {e}")),
+    };
+
+    // ── 4. Spawn the connection driver (drives all frame I/O) ──────────────────
+    let driver_jh = tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    let driver_abort = driver_jh.abort_handle();
+
+    let mut send_request = match h2.ready().await {
+        Ok(sr) => sr,
+        Err(e) => {
+            driver_abort.abort();
+            fail!(format!("h2 ready: {e}"));
+        }
+    };
+
+    // ── 5. Build and send request ──────────────────────────────────────────────
+    let mut req_builder = http::Request::builder().method(method).uri(uri);
+    for (k, v) in &extra_headers {
+        req_builder = req_builder.header(k.as_str(), v.as_str());
+    }
+    let req = match req_builder.body(()) {
+        Ok(r) => r,
+        Err(e) => {
+            driver_abort.abort();
+            fail!(format!("build request: {e}"));
+        }
+    };
+
+    // `end_of_stream = true`: no request body (GET/HEAD; POST body is future work).
+    let (response_fut, _send_stream) = match send_request.send_request(req, true) {
+        Ok(pair) => pair,
+        Err(e) => {
+            driver_abort.abort();
+            fail!(format!("send request: {e}"));
+        }
+    };
+
+    // ── 6. Receive response headers ────────────────────────────────────────────
+    let response = match response_fut.await {
+        Ok(r) => r,
+        Err(e) => {
+            driver_abort.abort();
+            fail!(format!("recv response: {e}"));
+        }
+    };
+
+    let status = response.status().as_u16();
+    let headers: Vec<(String, String)> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let mut body = response.into_body();
+
+    let partial = H2ResponsePartial {
+        status,
+        headers,
+        driver_abort: driver_abort.clone(),
+    };
+
+    // ── 7. Deliver headers to LocalSet ─────────────────────────────────────────
+    if response_tx.send(Ok(partial)).is_err() {
+        // LocalSet gave up before headers arrived; clean up.
+        driver_abort.abort();
+        return;
+    }
+
+    // ── 8. Stream response body ────────────────────────────────────────────────
+    while let Some(chunk) = body.data().await {
+        match chunk {
+            Ok(bytes) => {
+                let len = bytes.remaining();
+                // Release flow-control capacity so the peer can send more.
+                let _ = body.flow_control().release_capacity(len);
+                if body_tx.send(Ok(bytes.to_vec())).await.is_err() {
+                    break; // body bridge was dropped (LocalSet closed :body)
+                }
+            }
+            Err(e) => {
+                let _ = body_tx.send(Err(format!("body read: {e}"))).await;
+                break;
+            }
+        }
+    }
+    // Dropping body_tx closes the mpsc channel → body bridge closes `:body`.
+    driver_abort.abort();
+}
+
+// ── LocalSet bridge ─────────────────────────────────────────────────────────────
+
+/// Receives body chunks from the pool task and puts `Value::ByteArray` values
+/// on the `:body` channel. Closes the channel at EOF or on error.
+async fn local_body_bridge(
+    mut body_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
+    body_chan: GcPtr<NativeObjectBox>,
+) {
+    while let Some(result) = body_rx.recv().await {
+        match result {
+            Ok(bytes) if bytes.is_empty() => {} // skip empty DATA frames
+            Ok(bytes) => {
+                if !chan_put(&body_chan, bytes_value(&bytes)).await {
+                    break; // consumer closed :body early
+                }
+            }
+            Err(e) => {
+                chan_put(&body_chan, net_error(e)).await;
+                break;
+            }
+        }
+    }
+    chan_ref(body_chan.get()).close();
+}
+
+// ── Public Rust API ─────────────────────────────────────────────────────────────
+
+/// Issue an HTTP/2 `GET` request and return a promise channel.
+///
+/// The promise yields:
+/// ```clojure
+/// {:status 200 :headers {"k" "v" ...} :body <chan> :resource <H2Resource>}
+/// ```
+/// or a `Value::Error` on connection/request failure.
+///
+/// `opts` are the same as `tls/connect` (`:insecure-skip-verify`, `:alpn`,
+/// `:roots`). `:alpn ["h2"]` is injected automatically when absent.
+pub fn get(url: &str, opts: &MapValue, body_buf: usize) -> ValueResult<Value> {
+    h2_request(url, http::Method::GET, vec![], opts, body_buf)
+}
+
+/// Issue an arbitrary HTTP/2 request and return a promise channel.
+///
+/// `method` is an `http::Method` (e.g. `GET`, `POST`). `extra_headers` is a list
+/// of `(name, value)` pairs to add to the request. Currently no request body is
+/// sent (POST body support is deferred to a later phase).
+pub fn h2_request(
+    url: &str,
+    method: http::Method,
+    extra_headers: Vec<(String, String)>,
+    opts: &MapValue,
+    body_buf: usize,
+) -> ValueResult<Value> {
+    let (host, port, uri) = parse_url(url).map_err(ValueError::Other)?;
+    let config = h2_client_config(opts)?;
+
+    let (body_tx, body_rx) = mpsc::channel::<Result<Vec<u8>, String>>(body_buf.max(1));
+    let (response_tx, response_rx) = oneshot::channel::<Result<H2ResponsePartial, String>>();
+
+    let pool_jh = WorkerPool::global().handle().spawn(pool_h2_request(
+        host,
+        port,
+        config,
+        uri,
+        method,
+        extra_headers,
+        body_tx,
+        response_tx,
+    ));
+    let pool_abort = pool_jh.abort_handle();
+
+    let promise = make_chan(1);
+    let promise_val = Value::NativeObject(promise.clone());
+
+    spawn_future(async move {
+        do_h2_response(response_rx, body_rx, body_buf, pool_abort, promise).await
+    });
+
+    Ok(promise_val)
+}
+
+async fn do_h2_response(
+    response_rx: oneshot::Receiver<Result<H2ResponsePartial, String>>,
+    body_rx: mpsc::Receiver<Result<Vec<u8>, String>>,
+    body_buf: usize,
+    pool_abort: AbortHandle,
+    promise: GcPtr<NativeObjectBox>,
+) -> EvalResult {
+    let partial = match response_rx.await {
+        Err(_) => {
+            chan_deliver(&promise, net_error("pool task dropped")).await;
+            return Ok(Value::Nil);
+        }
+        Ok(Err(e)) => {
+            chan_deliver(&promise, net_error(e)).await;
+            return Ok(Value::Nil);
+        }
+        Ok(Ok(p)) => p,
+    };
+
+    // Build :body channel and LocalSet bridge.
+    let body_chan = make_chan(body_buf);
+    let bridge_jh = tokio::task::spawn_local(local_body_bridge(body_rx, body_chan.clone()));
+    let bridge_abort = bridge_jh.abort_handle();
+
+    // Build H2Resource.
+    let resource = H2Resource::new();
+    {
+        let mut g = resource.inner.lock().unwrap();
+        g.abort_handles.push(pool_abort);
+        g.abort_handles.push(partial.driver_abort);
+        g.abort_handles.push(bridge_abort);
+    }
+    let resource_handle = ResourceHandle::new(resource);
+
+    // Build headers map (string keys → string values).
+    let headers_pairs: Vec<(Value, Value)> = partial
+        .headers
+        .iter()
+        .map(|(k, v)| (Value::string(k.clone()), Value::string(v.clone())))
+        .collect();
+    let headers_val = Value::Map(MapValue::from_pairs(headers_pairs));
+
+    // Deliver response map.
+    let resp = Value::Map(MapValue::from_pairs(vec![
+        (kw("status"), Value::Long(partial.status as i64)),
+        (kw("headers"), headers_val),
+        (kw("body"), Value::NativeObject(body_chan)),
+        (kw("resource"), Value::Resource(resource_handle)),
+    ]));
+    chan_deliver(&promise, resp).await;
+
+    Ok(Value::Nil)
+}
+
+// ── Builtins ────────────────────────────────────────────────────────────────────
+
+/// `(get url)` or `(get url opts)` — issue a GET request, return promise chan.
+///
+/// `url` must be a full HTTPS URL, e.g. `"https://host:443/path"`.
+/// Opts: `:insecure-skip-verify`, `:alpn`, `:roots`, `:body-buf` (channel depth,
+/// default 8).
+fn builtin_get(args: &[Value]) -> ValueResult<Value> {
+    let url = match args.first() {
+        Some(Value::Str(s)) => s.get().clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "string URL",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let opts = match args.get(1) {
+        Some(Value::Map(m)) => m.clone(),
+        _ => MapValue::empty(),
+    };
+    let body_buf = opts_usize(&opts, "body-buf").unwrap_or(8);
+    get(&url, &opts, body_buf)
+}
+
+/// `(request {:method m :url u :headers {...}} opts)` — general HTTP/2 request.
+///
+/// `:method` defaults to `"GET"`. `:url` is required. `:headers` is an optional
+/// map of extra request header name→value strings. No request body is sent;
+/// POST/PUT body support is deferred to a later phase.
+fn builtin_request(args: &[Value]) -> ValueResult<Value> {
+    let req_map = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "map {:url str :method str :headers map}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+    let opts = match args.get(1) {
+        Some(Value::Map(m)) => m.clone(),
+        _ => MapValue::empty(),
+    };
+
+    let url = opts_str(&req_map, "url").ok_or_else(|| ValueError::Other(":url required".into()))?;
+    let method_str = opts_str(&req_map, "method").unwrap_or_else(|| "GET".to_string());
+    let method = method_str
+        .parse::<http::Method>()
+        .map_err(|e| ValueError::Other(format!("invalid :method '{method_str}': {e}")))?;
+    let extra_headers = extract_headers(&req_map);
+    let body_buf = opts_usize(&opts, "body-buf").unwrap_or(8);
+
+    h2_request(&url, method, extra_headers, &opts, body_buf)
+}
+
+/// `(close resp)` — close an HTTP/2 response / connection early.
+///
+/// Aborts all background tasks (including the connection driver), which drops
+/// the TLS stream and closes the TCP socket. The `:body` channel will be closed
+/// if it hasn't already been drained.
+fn builtin_close(args: &[Value]) -> ValueResult<Value> {
+    let resp = match args.first() {
+        Some(Value::Map(m)) => m.clone(),
+        other => {
+            return Err(ValueError::WrongType {
+                expected: "http2 response map {:resource <H2Resource>}",
+                got: other.map(|v| v.type_name().to_string()).unwrap_or_default(),
+            });
+        }
+    };
+
+    if let Some(Value::NativeObject(obj)) = resp.get(&kw("body")) {
+        chan_ref(obj.get()).close();
+    }
+    if let Some(Value::Resource(handle)) = resp.get(&kw("resource")) {
+        let _ = handle.close();
+    }
+
+    Ok(Value::Nil)
+}

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use cljrs_async::load_source;
 
 pub mod frame;
+pub mod h2;
 pub mod h3;
 mod pool_io;
 pub mod quic;
@@ -50,6 +51,9 @@ const NET_QUIC_SOURCE: &str = include_str!("clojure_rust_net_quic.cljrs");
 /// Clojure source for `clojure.rust.net.h3`.
 const NET_H3_SOURCE: &str = include_str!("clojure_rust_net_h3.cljrs");
 
+/// Clojure source for `clojure.rust.net.http2`.
+const NET_HTTP2_SOURCE: &str = include_str!("clojure_rust_net_http2.cljrs");
+
 pub const NS_TCP: &str = "clojure.rust.net.tcp";
 pub const NS: &str = "clojure.rust.net";
 pub const NS_FRAME: &str = "clojure.rust.net.frame";
@@ -58,6 +62,7 @@ pub const NS_TLS: &str = "clojure.rust.net.tls";
 pub const NS_UNIX: &str = "clojure.rust.net.unix";
 pub const NS_QUIC: &str = "clojure.rust.net.quic";
 pub const NS_H3: &str = "clojure.rust.net.h3";
+pub const NS_HTTP2: &str = "clojure.rust.net.http2";
 
 /// Register the networking namespaces.
 ///
@@ -120,6 +125,14 @@ pub fn init(globals: &Arc<cljrs_env::env::GlobalEnv>) {
         h3::register(globals, NS_H3);
         load_source(globals, NS_H3, NET_H3_SOURCE);
         globals.mark_loaded(NS_H3);
+    }
+
+    if !globals.is_loaded(NS_HTTP2) {
+        globals.get_or_create_ns(NS_HTTP2);
+        globals.refer_all(NS_HTTP2, "clojure.core");
+        h2::register(globals, NS_HTTP2);
+        load_source(globals, NS_HTTP2, NET_HTTP2_SOURCE);
+        globals.mark_loaded(NS_HTTP2);
     }
 
     if !globals.is_loaded(NS) {

--- a/crates/cljrs-net/tests/http2.rs
+++ b/crates/cljrs-net/tests/http2.rs
@@ -1,0 +1,298 @@
+//! Phase H2 integration tests: HTTP/2 client.
+//!
+//! Done criterion: `h2::get` connects to a TLS-backed h2 server (ALPN "h2"),
+//! receives a 200 response with a body, and drains the `:body` channel.
+//!
+//! The test server is built directly from `h2` + `tokio-rustls` + `rcgen`
+//! (raw, no cljrs-net abstractions) and runs on the `WorkerPool`, mirroring the
+//! pattern used in the `tls.rs` and `h3.rs` tests.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cljrs_async::channel::{chan_ref, chan_take};
+use cljrs_async::worker_pool::WorkerPool;
+use cljrs_gc::GcPtr;
+use cljrs_value::{Keyword, MapValue, NativeObjectBox, Value};
+use tokio_rustls::TlsAcceptor;
+
+fn setup_globals() -> Arc<cljrs_env::env::GlobalEnv> {
+    let globals = cljrs_stdlib::standard_env();
+    cljrs_net::init(&globals);
+    globals
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn map_get(map: &MapValue, key: &str) -> Value {
+    map.get(&kw(key))
+        .unwrap_or_else(|| panic!("map missing :{key}"))
+}
+
+fn as_chan(v: &Value) -> GcPtr<NativeObjectBox> {
+    match v {
+        Value::NativeObject(obj) => obj.clone(),
+        other => panic!("expected NativeObject (channel), got {}", other.type_name()),
+    }
+}
+
+/// Build a self-signed server config with "h2" ALPN.
+fn make_acceptor() -> TlsAcceptor {
+    let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("rcgen cert generation failed");
+
+    let cert_der = rustls::pki_types::CertificateDer::from(certified.cert.der().to_vec());
+    let key_der =
+        rustls::pki_types::PrivateKeyDer::Pkcs8(certified.key_pair.serialize_der().into());
+
+    let mut rustls_cfg = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("tls versions")
+    .with_no_client_auth()
+    .with_single_cert(vec![cert_der], key_der)
+    .expect("server cert");
+
+    // Required: h2 ALPN negotiation must succeed on both sides.
+    rustls_cfg.alpn_protocols = vec![b"h2".to_vec()];
+
+    TlsAcceptor::from(Arc::new(rustls_cfg))
+}
+
+/// Spawn a minimal HTTP/2-over-TLS server on the WorkerPool. Returns the port.
+///
+/// Responds to every request with HTTP 200 and the body `"h2 test body"`.
+fn spawn_h2_server(acceptor: TlsAcceptor) -> u16 {
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind h2 test listener");
+    std_listener.set_nonblocking(true).expect("set_nonblocking");
+    let port = std_listener.local_addr().unwrap().port();
+
+    WorkerPool::global().handle().spawn(async move {
+        let listener = tokio::net::TcpListener::from_std(std_listener).expect("from_std");
+        loop {
+            let (tcp, _) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => break,
+            };
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                let tls = match acceptor.accept(tcp).await {
+                    Ok(s) => s,
+                    Err(_) => return,
+                };
+                let mut connection = match h2::server::handshake(tls).await {
+                    Ok(c) => c,
+                    Err(_) => return,
+                };
+                while let Some(request) = connection.accept().await {
+                    let (_req, mut respond) = match request {
+                        Ok(pair) => pair,
+                        Err(_) => break,
+                    };
+                    let response = http::Response::builder()
+                        .status(200)
+                        .header("content-type", "text/plain")
+                        .body(())
+                        .unwrap();
+                    let mut send = match respond.send_response(response, false) {
+                        Ok(s) => s,
+                        Err(_) => break,
+                    };
+                    let _ = send.send_data(Bytes::from_static(b"h2 test body"), true);
+                }
+            });
+        }
+    });
+
+    port
+}
+
+/// Phase H2 done criterion: HTTP/2 GET returns status 200 and the expected body.
+#[test]
+fn test_h2_get_round_trip() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let acceptor = make_acceptor();
+        let port = spawn_h2_server(acceptor);
+
+        let url = format!("https://localhost:{port}/");
+        let opts = MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
+
+        let promise = cljrs_net::h2::get(&url, &opts, 8).expect("h2::get failed");
+        let resp_val = chan_take(&as_chan(&promise)).await;
+        let resp = match resp_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("HTTP/2 GET failed: {}", e.get().message()),
+            other => panic!("expected response map, got {}", other.type_name()),
+        };
+
+        // Verify :status 200.
+        let status = match map_get(&resp, "status") {
+            Value::Long(n) => n,
+            other => panic!("expected long :status, got {}", other.type_name()),
+        };
+        assert_eq!(status, 200, "expected HTTP 200");
+
+        // :headers must be a map.
+        match map_get(&resp, "headers") {
+            Value::Map(_) => {}
+            other => panic!("expected map :headers, got {}", other.type_name()),
+        }
+
+        // Drain :body until EOF.
+        let body_ch = as_chan(&map_get(&resp, "body"));
+        let mut body: Vec<u8> = Vec::new();
+        loop {
+            match chan_take(&body_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(arr) => {
+                    body.extend(arr.get().lock().unwrap().iter().map(|&b| b as u8));
+                }
+                Value::Error(e) => panic!("body read error: {}", e.get().message()),
+                other => panic!("unexpected body value: {}", other.type_name()),
+            }
+        }
+        assert_eq!(
+            body, b"h2 test body",
+            "response body must match server payload"
+        );
+
+        // Clean up resource.
+        if let Value::Resource(h) = map_get(&resp, "resource") {
+            let _ = h.close();
+        }
+    });
+}
+
+/// Draining the :body channel must yield the full body, then close (yield Nil).
+#[test]
+fn test_h2_body_channel_closes_on_eof() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let acceptor = make_acceptor();
+        let port = spawn_h2_server(acceptor);
+
+        let url = format!("https://localhost:{port}/");
+        let opts = MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
+
+        let promise = cljrs_net::h2::get(&url, &opts, 8).expect("h2::get failed");
+        let resp_val = chan_take(&as_chan(&promise)).await;
+        let resp = match resp_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("HTTP/2 GET failed: {}", e.get().message()),
+            other => panic!("expected map, got {}", other.type_name()),
+        };
+
+        let body_ch = as_chan(&map_get(&resp, "body"));
+
+        // The :body channel must close (yield Nil) after all data is delivered.
+        let mut chunks = 0usize;
+        loop {
+            match chan_take(&body_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(_) => chunks += 1,
+                Value::Error(e) => panic!("body error: {}", e.get().message()),
+                other => panic!("unexpected: {}", other.type_name()),
+            }
+        }
+        assert!(chunks >= 1, ":body must yield at least one chunk");
+
+        // A second take on the closed channel must return Nil immediately.
+        let v = chan_take(&body_ch).await;
+        assert!(
+            matches!(v, Value::Nil),
+            "closed :body must yield Nil, got {}",
+            v.type_name()
+        );
+    });
+}
+
+/// `(close resp)` before draining :body must close the channel.
+#[test]
+fn test_h2_close_before_drain() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        let acceptor = make_acceptor();
+        let port = spawn_h2_server(acceptor);
+
+        let url = format!("https://localhost:{port}/");
+        let opts = MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
+
+        let promise = cljrs_net::h2::get(&url, &opts, 8).expect("h2::get failed");
+        let resp_val = chan_take(&as_chan(&promise)).await;
+        let resp = match resp_val {
+            Value::Map(m) => m,
+            Value::Error(e) => panic!("HTTP/2 GET failed: {}", e.get().message()),
+            other => panic!("expected map, got {}", other.type_name()),
+        };
+
+        let body_ch = as_chan(&map_get(&resp, "body"));
+
+        // Close without draining — resource must close cleanly.
+        if let Value::Resource(h) = map_get(&resp, "resource") {
+            h.close().expect("close failed");
+        }
+        // Close the body channel explicitly (mirrors what builtin_close does).
+        chan_ref(body_ch.get()).close();
+
+        // After close, :body must eventually yield Nil. Body data may already
+        // be buffered in the channel (the bridge task may have run before the
+        // abort took effect), so drain any residual data first.
+        loop {
+            match chan_take(&body_ch).await {
+                Value::Nil => break,
+                Value::ByteArray(_) => {} // drain buffered data
+                other => panic!("unexpected value on closed :body: {}", other.type_name()),
+            }
+        }
+    });
+}
+
+/// A connection attempt to a port that isn't listening must yield Value::Error.
+#[test]
+fn test_h2_connect_failure() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+
+    local.block_on(&rt, async {
+        let _globals = setup_globals();
+
+        // Port 1 is privileged and almost certainly not listening.
+        let opts = MapValue::from_pairs(vec![(kw("insecure-skip-verify"), Value::Bool(true))]);
+        let promise = cljrs_net::h2::get("https://127.0.0.1:1/", &opts, 8).expect("h2::get failed");
+
+        let result = chan_take(&as_chan(&promise)).await;
+        assert!(
+            matches!(result, Value::Error(_)),
+            "expected Value::Error for refused HTTP/2 connection, got {}",
+            result.type_name()
+        );
+    });
+}


### PR DESCRIPTION
Add `clojure.rust.net.http2`, an HTTP/2 client wrapping the `h2` crate over
a TLS-on-TCP transport. Mirrors the existing `clojure.rust.net.h3` design:
the TCP connect, TLS handshake (ALPN "h2"), h2 handshake, request, and body
streaming run on the WorkerPool; the response body is bridged to a `:body`
core.async channel on the LocalSet.

- `src/h2.rs`: H2Resource + pool request task + LocalSet body bridge;
  `get`/`h2_request` Rust API and `get`/`request`/`close` builtins. Defaults
  ALPN to ["h2"] and verifies the negotiated protocol; releases h2 flow-control
  capacity as body chunks arrive.
- `src/clojure_rust_net_http2.cljrs`: `drain-body` / `get-string` sugar.
- Wire the namespace into `init()`; add NS_HTTP2 constant.
- `tests/http2.rs`: GET round-trip over an h2-over-TLS test server, :body EOF
  close, close-before-drain, and connect-failure path.
- Add `h2` workspace dependency; update crate README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014YDjWnsCR7otNZoEZC33ro