### PR TITLE
compile: read cljrs.edn for project compilation and -main detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ name = "cljrs-compiler"
 version = "0.1.0"
 dependencies = [
  "cljrs-async",
+ "cljrs-base64",
  "cljrs-builtins",
  "cljrs-charset",
  "cljrs-deps",

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -15,6 +15,7 @@ cljrs-async    = { workspace = true }
 cljrs-io       = { workspace = true }
 cljrs-net      = { workspace = true }
 cljrs-charset  = { workspace = true }
+cljrs-base64   = { workspace = true }
 cljrs-builtins = { workspace = true }
 cljrs-deps     = { workspace = true }
 cljrs-types    = { workspace = true }

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -427,11 +427,12 @@ pub fn compile_file(
     // and the `go`/`alt` macros resolve during macro-expansion. The GC
     // service is silently skipped when there is no LocalSet context.
     cljrs_async::init(&globals);
-    // Register I/O, networking, and charset namespaces so that require forms
-    // in source files resolve correctly during macro expansion.
+    // Register I/O, networking, charset, and base64 namespaces so that require
+    // forms in source files resolve correctly during macro expansion.
     cljrs_io::init(&globals);
     cljrs_net::init(&globals);
     cljrs_charset::init(&globals);
+    cljrs_base64::init(&globals);
     let mut env = cljrs_eval::Env::new(globals, "user");
 
     // Snapshot loaded namespaces before expansion so we can detect
@@ -1210,10 +1211,11 @@ async fn run() {{
     // Register the async runtime (clojure.core.async, ^:async dispatch, await).
     cljrs_async::init(&globals);
 {async_polls}
-    // Register I/O, networking, and charset namespaces.
+    // Register I/O, networking, charset, and base64 namespaces.
     cljrs_io::init(&globals);
     cljrs_net::init(&globals);
     cljrs_charset::init(&globals);
+    cljrs_base64::init(&globals);
 
     // Register bundled dependency sources so require can find them
     // without needing source files on disk.
@@ -1282,6 +1284,7 @@ const HARNESS_RUNTIME_CRATES: &[&str] = &[
     "cljrs-io",
     "cljrs-net",
     "cljrs-charset",
+    "cljrs-base64",
 ];
 
 /// Runtime crates the AOT *test* harness links against.  The test runner

--- a/crates/cljrs-deps/README.md
+++ b/crates/cljrs-deps/README.md
@@ -40,6 +40,7 @@ pub struct DepsConfig {
     pub enforce_native_versions:  bool,  // :enforce-native-versions — pinned-native
                                          // provenance mismatches error instead of warning
     pub rust:                     Option<RustConfig>,
+    pub main_ns:                  Option<Arc<str>>,  // :main — AOT entry-point namespace
 }
 
 /// A trusted commit signer from `:trusted-signers`: an inline public key
@@ -95,6 +96,9 @@ pub struct Alias {
  ;; :crate is the path (relative to cljrs.edn) to the directory holding Cargo.toml.
  ;; :init  is the fully-qualified Rust path to a fn(registry: &mut Registry) called
  ;;        at startup before any Clojure source is loaded.
+ ;; AOT entry-point namespace (used by `cljrs compile` when no file is given).
+ :main my.app.core
+
  :rust {:crate "."
         :init  "my_project::cljrs_init"}
 

--- a/crates/cljrs-deps/src/lib.rs
+++ b/crates/cljrs-deps/src/lib.rs
@@ -149,6 +149,9 @@ pub struct DepsConfig {
     pub enforce_native_versions: bool,
     /// Optional Rust-crate configuration for mixed Rust/Clojure projects.
     pub rust: Option<RustConfig>,
+    /// The namespace containing `-main`, used as the AOT entry point.
+    /// Set via `:main` in `cljrs.edn` or overridden by `--main` on the CLI.
+    pub main_ns: Option<Arc<str>>,
 }
 
 impl DepsConfig {

--- a/crates/cljrs-deps/src/parse.rs
+++ b/crates/cljrs-deps/src/parse.rs
@@ -66,6 +66,15 @@ fn extract_config(form: &Form, config_dir: &Path) -> Result<DepsConfig, String> 
             Some("rust") => {
                 config.rust = Some(extract_rust_config(val, config_dir)?);
             }
+            Some("main") => {
+                let ns = sym_or_kw_name(val)
+                    .or_else(|| match &val.kind {
+                        FormKind::Str(s) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .ok_or_else(|| ":main must be a symbol or string".to_string())?;
+                config.main_ns = Some(Arc::from(ns));
+            }
             _ => {} // ignore unknown keys
         }
     }
@@ -363,5 +372,23 @@ mod tests {
         .unwrap();
         assert_eq!(cfg.paths.len(), 1);
         assert!(cfg.rust.is_some());
+    }
+
+    #[test]
+    fn main_key_symbol() {
+        let cfg = parse(r#"{:main my.app.core}"#).unwrap();
+        assert_eq!(cfg.main_ns.as_deref(), Some("my.app.core"));
+    }
+
+    #[test]
+    fn main_key_string() {
+        let cfg = parse(r#"{:main "my.app.core"}"#).unwrap();
+        assert_eq!(cfg.main_ns.as_deref(), Some("my.app.core"));
+    }
+
+    #[test]
+    fn no_main_key_is_none() {
+        let cfg = parse(r#"{:paths ["src"]}"#).unwrap();
+        assert!(cfg.main_ns.is_none());
     }
 }

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -23,7 +23,7 @@ src/
 |---------------|------------------------------------------------------------------------|
 | `run`         | Interpret a `.cljrs` / `.cljc` source file                             |
 | `repl`        | Start an interactive REPL                                              |
-| `compile`     | AOT-compile a source file (or test directory) to a native binary       |
+| `compile`     | AOT-compile a source file or project (via `cljrs.edn`) to a native binary |
 | `eval`        | Evaluate a single Clojure expression and print the result              |
 | `ir-viz`      | Render the optimized IR + source as a self-contained HTML visualizer   |
 | `test`        | Run `clojure.test` namespaces (named on the CLI or auto-discovered)    |
@@ -64,6 +64,7 @@ run to completion. A synchronous `-main` is awaited as a no-op pass-through.
 
 `compile` additionally accepts:
 - `-o, --out <PATH>` — output binary path (required)
+- `--main <NS>` — namespace containing `-main`; overrides `:main` in `cljrs.edn` and auto-detection
 - `--test` — compile a test harness that runs every test in the given file/directory
 
 `ir-viz` accepts:
@@ -82,12 +83,27 @@ deps are fetched.  `deps status` takes no arguments.
 
 ### `cljrs.edn` auto-discovery
 
-When any command that runs code (`run`, `repl`, `eval`, `test`) starts, it
-walks up the directory tree from the current working directory looking for a
-`cljrs.edn` file.  If found, its `:paths` entries are appended to the source
-search path (after any `--src-path` CLI flags), and the parsed `DepsConfig` is
-stored in `GlobalEnv.deps_config` so that versioned symbol resolution can use
-it without a second parse.
+When any command that runs code (`run`, `repl`, `eval`, `test`, `compile`)
+starts, it walks up the directory tree from the current working directory
+looking for a `cljrs.edn` file.  If found, its `:paths` entries are appended
+to the source search path (after any `--src-path` CLI flags), and the parsed
+`DepsConfig` is stored in `GlobalEnv.deps_config` so that versioned symbol
+resolution can use it without a second parse.
+
+#### `compile` and `cljrs.edn`
+
+`cljrs compile` reads `cljrs.edn` to determine:
+
+1. **Source paths** — `:paths` entries are added to `--src-path` (CLI flags come first).
+2. **Dependency source roots** — each dep's source directories are resolved and appended so `require` resolves correctly during compilation.
+3. **Entry-point namespace** — determined by the following priority:
+   - `--main <NS>` CLI flag (highest priority)
+   - `:main` key in `cljrs.edn` (e.g. `:main my.app.core`)
+   - Auto-detection: scans `:paths` for a unique `-main` function; errors if zero or multiple are found
+
+When `cljrs.edn` is present and the entry-point namespace is known, the
+`file` positional argument may be omitted; the compiler finds the source file
+for the main namespace automatically.
 
 Each declared dependency's own source roots are also appended to the search
 path, so a plain `(require '[dep.ns :as …])` resolves namespaces provided by a
@@ -128,6 +144,8 @@ cljrs repl --src-path src
 
 # AOT compile to a native binary
 cljrs compile app.cljrs -o app
+cljrs compile -o app                       # project mode: reads cljrs.edn
+cljrs compile --main my.app.core -o app   # specify entry namespace explicitly
 cljrs compile tests/ -o run-tests --test --src-path src
 
 # One-shot expression

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -930,12 +930,11 @@ fn find_main_namespaces(src_paths: &[PathBuf]) -> Vec<(String, PathBuf)> {
                         {
                             ns_name = Some(n.clone());
                         }
-                    } else if (s == "defn" || s == "defn-") && parts.len() >= 2 {
-                        if let FormKind::Symbol(n) = &parts[1].kind
-                            && n == "-main"
-                        {
-                            has_main = true;
-                        }
+                    } else if (s == "defn" || s == "defn-") && parts.len() >= 2
+                        && let FormKind::Symbol(n) = &parts[1].kind
+                        && n == "-main"
+                    {
+                        has_main = true;
                     }
                 }
             }
@@ -962,10 +961,10 @@ fn collect_source_files(dir: &Path, out: &mut Vec<PathBuf>) {
         let path = entry.path();
         if path.is_dir() {
             collect_source_files(&path, out);
-        } else if let Some(ext) = path.extension() {
-            if ext == "cljrs" || ext == "cljc" {
-                out.push(path);
-            }
+        } else if let Some(ext) = path.extension()
+            && (ext == "cljrs" || ext == "cljc")
+        {
+            out.push(path);
         }
     }
 }

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -136,16 +136,29 @@ enum Commands {
         #[arg(long)]
         gc_hard_limit_mb: Option<usize>,
     },
-    /// AOT-compile a source file to a native binary.
+    /// AOT-compile a source file or project to a native binary.
+    ///
+    /// When `cljrs.edn` is present in the working directory the compiler reads
+    /// `:paths` (source directories), `:deps` (dependency source roots), and
+    /// `:main` (entry-point namespace) from it automatically.  The `-main`
+    /// function is discovered from `:paths` only (not from dependencies); an
+    /// error is raised if more than one `-main` is found and neither `--main`
+    /// nor `:main` resolves the ambiguity.
     Compile {
-        /// Path to the source file, or directory when --test is used.
-        file: PathBuf,
+        /// Path to the source file.  Optional when `cljrs.edn` is present and
+        /// the entry-point namespace can be determined from `--main`, `:main`
+        /// in `cljrs.edn`, or auto-detection of a unique `-main` function.
+        file: Option<PathBuf>,
         /// Output binary path.
         #[arg(short, long)]
         out: PathBuf,
         /// Source directories to search when resolving `require`.
         #[arg(long = "src-path", value_name = "DIR")]
         src_paths: Vec<PathBuf>,
+        /// Namespace containing the `-main` entry point (e.g. `my.app.core`).
+        /// Overrides `:main` in `cljrs.edn` and auto-detection.
+        #[arg(long = "main", value_name = "NS")]
+        main_ns: Option<String>,
         /// Compile a test harness that runs all tests in the given file/directory.
         #[arg(long)]
         test: bool,
@@ -473,27 +486,100 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
             file,
             out,
             src_paths,
+            main_ns,
             test,
             gc_soft_limit_mb,
             gc_hard_limit_mb,
         } => {
-            // GC config is for the compiled binary, not the compilation process
             let _gc_config = build_gc_config(gc_soft_limit_mb, gc_hard_limit_mb);
-            // Load cljrs.edn :rust config so native init gets wired into the
-            // generated harness main.rs.
-            let rust_config = std::env::current_dir()
+
+            // Load cljrs.edn; silently absent is fine.
+            let deps_config = std::env::current_dir()
                 .ok()
-                .and_then(|cwd| cljrs_deps::load_config(&cwd).ok().flatten())
-                .and_then(|c| c.rust);
+                .and_then(|cwd| cljrs_deps::load_config(&cwd).ok().flatten());
+
+            let rust_config = deps_config.as_ref().and_then(|c| c.rust.clone());
+
+            // Build combined source paths: CLI flags first, then cljrs.edn :paths,
+            // then each dependency's source roots.
+            let mut all_src_paths = src_paths.clone();
+            if let Some(ref config) = deps_config {
+                for p in &config.paths {
+                    if !all_src_paths.contains(p) {
+                        all_src_paths.push(p.clone());
+                    }
+                }
+                for p in collect_dep_src_paths(config) {
+                    if !all_src_paths.contains(&p) {
+                        all_src_paths.push(p);
+                    }
+                }
+            }
+
             if test {
-                // For test mode, the file is a directory containing test files
-                cljrs_compiler::aot::compile_test_harness(&file, &out, &src_paths)
+                let test_dir = file
+                    .as_deref()
+                    .unwrap_or_else(|| std::path::Path::new("."));
+                cljrs_compiler::aot::compile_test_harness(test_dir, &out, &all_src_paths)
                     .map_err(|e| miette::miette!("{e}"))?;
             } else {
+                let entry_file = match file {
+                    Some(f) => f,
+                    None => {
+                        // Project mode: determine the entry namespace and locate its file.
+                        let project_paths: Vec<PathBuf> = deps_config
+                            .as_ref()
+                            .map(|c| c.paths.clone())
+                            .unwrap_or_default();
+
+                        let effective_ns = if let Some(ns) = main_ns {
+                            // --main CLI flag takes top priority.
+                            ns
+                        } else if let Some(ns) =
+                            deps_config.as_ref().and_then(|c| c.main_ns.as_deref())
+                        {
+                            // :main in cljrs.edn is second priority.
+                            ns.to_string()
+                        } else {
+                            // Auto-detect from project :paths only (not dep paths).
+                            if project_paths.is_empty() {
+                                return Err(miette::miette!(
+                                    "no source paths: add :paths to cljrs.edn or use --src-path"
+                                ));
+                            }
+                            let mains = find_main_namespaces(&project_paths);
+                            match mains.len() {
+                                0 => return Err(miette::miette!(
+                                    "no -main function found in source paths; \
+                                     specify --main or add :main to cljrs.edn"
+                                )),
+                                1 => mains.into_iter().next().unwrap().0,
+                                _ => {
+                                    let list = mains
+                                        .iter()
+                                        .map(|(ns, _)| ns.as_str())
+                                        .collect::<Vec<_>>()
+                                        .join(", ");
+                                    return Err(miette::miette!(
+                                        "multiple -main functions found ({list}); \
+                                         specify --main or add :main to cljrs.edn"
+                                    ));
+                                }
+                            }
+                        };
+
+                        ns_to_file(&effective_ns, &all_src_paths).ok_or_else(|| {
+                            miette::miette!(
+                                "could not find source file for namespace {effective_ns}"
+                            )
+                        })?
+                    }
+                };
+
                 cljrs_compiler::aot::compile_file(
-                    &file,
+                    &entry_file,
                     &out,
-                    &src_paths,
+                    &all_src_paths,
                     rust_config.as_ref(),
                     versioning.verify_commit_signatures,
                 )
@@ -763,6 +849,140 @@ fn add_dep_source_paths(globals: &Arc<GlobalEnv>, config: &cljrs_deps::DepsConfi
             }
         }
     }
+}
+
+/// Collect source paths contributed by every declared dependency in `config`.
+///
+/// Git deps are resolved from the local cache (run `cljrs deps fetch` first);
+/// missing deps emit a warning and are skipped.
+fn collect_dep_src_paths(config: &cljrs_deps::DepsConfig) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for (name, dep) in &config.deps {
+        let root = match dep {
+            cljrs_deps::Dependency::Local { root } => {
+                if root.is_dir() {
+                    root.clone()
+                } else {
+                    eprintln!(
+                        "cljrs: warning: local dep {name} not found at {}",
+                        root.display()
+                    );
+                    continue;
+                }
+            }
+            cljrs_deps::Dependency::Git(git) => {
+                match cljrs_vcs::worktree_at_commit(&git.url, &git.sha) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!(
+                            "cljrs: warning: git dep {name} ({}) is not available ({e}); \
+                             run `cljrs deps fetch`",
+                            git.url
+                        );
+                        continue;
+                    }
+                }
+            }
+        };
+        for p in dep_source_paths(&root) {
+            if p.is_dir() && !paths.contains(&p) {
+                paths.push(p);
+            }
+        }
+    }
+    paths
+}
+
+/// Scan `src_paths` for source files that define a top-level `-main` function.
+///
+/// Returns a list of `(namespace_name, file_path)` pairs, one per file that
+/// contains `(defn -main ...)` or `(defn- -main ...)` at the top level.
+/// Only looks at the reader-level form structure (no evaluation).
+fn find_main_namespaces(src_paths: &[PathBuf]) -> Vec<(String, PathBuf)> {
+    use cljrs_reader::form::FormKind;
+
+    let mut results = Vec::new();
+    for dir in src_paths {
+        if !dir.is_dir() {
+            continue;
+        }
+        let mut files = Vec::new();
+        collect_source_files(dir, &mut files);
+        for file in files {
+            let Ok(src) = std::fs::read_to_string(&file) else {
+                continue;
+            };
+            let mut parser =
+                cljrs_reader::Parser::new(src, file.display().to_string());
+            let Ok(forms) = parser.parse_all() else {
+                continue;
+            };
+            let mut ns_name: Option<String> = None;
+            let mut has_main = false;
+            for form in &forms {
+                if let FormKind::List(parts) = &form.kind
+                    && let Some(head) = parts.first()
+                    && let FormKind::Symbol(s) = &head.kind
+                {
+                    if s == "ns" {
+                        if let Some(second) = parts.get(1)
+                            && let FormKind::Symbol(n) = &second.kind
+                        {
+                            ns_name = Some(n.clone());
+                        }
+                    } else if (s == "defn" || s == "defn-") && parts.len() >= 2 {
+                        if let FormKind::Symbol(n) = &parts[1].kind
+                            && n == "-main"
+                        {
+                            has_main = true;
+                        }
+                    }
+                }
+            }
+            if has_main {
+                let ns = ns_name.unwrap_or_else(|| {
+                    // Fall back to file-based namespace name if no (ns ...) form.
+                    file_to_namespace(dir, &file).unwrap_or_default()
+                });
+                results.push((ns, file));
+            }
+        }
+    }
+    results
+}
+
+/// Recursively collect `.cljrs` and `.cljc` files under `dir`.
+fn collect_source_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    entries.sort_by_key(|e| e.file_name());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_source_files(&path, out);
+        } else if let Some(ext) = path.extension() {
+            if ext == "cljrs" || ext == "cljc" {
+                out.push(path);
+            }
+        }
+    }
+}
+
+/// Translate a Clojure namespace name into a source file path by searching
+/// `src_paths` for `<ns/with/slashes>.cljrs` or `.cljc`.
+fn ns_to_file(ns: &str, src_paths: &[PathBuf]) -> Option<PathBuf> {
+    let rel: String = ns.replace('.', "/").replace('-', "_");
+    for dir in src_paths {
+        for ext in &["cljrs", "cljc"] {
+            let path = dir.join(format!("{rel}.{ext}"));
+            if path.exists() {
+                return Some(path);
+            }
+        }
+    }
+    None
 }
 
 /// The source roots a dependency at `root` contributes: its `cljrs.edn`

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -517,9 +517,7 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
             }
 
             if test {
-                let test_dir = file
-                    .as_deref()
-                    .unwrap_or_else(|| std::path::Path::new("."));
+                let test_dir = file.as_deref().unwrap_or_else(|| std::path::Path::new("."));
                 cljrs_compiler::aot::compile_test_harness(test_dir, &out, &all_src_paths)
                     .map_err(|e| miette::miette!("{e}"))?;
             } else {
@@ -549,10 +547,12 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
                             }
                             let mains = find_main_namespaces(&project_paths);
                             match mains.len() {
-                                0 => return Err(miette::miette!(
-                                    "no -main function found in source paths; \
+                                0 => {
+                                    return Err(miette::miette!(
+                                        "no -main function found in source paths; \
                                      specify --main or add :main to cljrs.edn"
-                                )),
+                                    ));
+                                }
                                 1 => mains.into_iter().next().unwrap().0,
                                 _ => {
                                     let list = mains
@@ -912,8 +912,7 @@ fn find_main_namespaces(src_paths: &[PathBuf]) -> Vec<(String, PathBuf)> {
             let Ok(src) = std::fs::read_to_string(&file) else {
                 continue;
             };
-            let mut parser =
-                cljrs_reader::Parser::new(src, file.display().to_string());
+            let mut parser = cljrs_reader::Parser::new(src, file.display().to_string());
             let Ok(forms) = parser.parse_all() else {
                 continue;
             };
@@ -930,7 +929,8 @@ fn find_main_namespaces(src_paths: &[PathBuf]) -> Vec<(String, PathBuf)> {
                         {
                             ns_name = Some(n.clone());
                         }
-                    } else if (s == "defn" || s == "defn-") && parts.len() >= 2
+                    } else if (s == "defn" || s == "defn-")
+                        && parts.len() >= 2
                         && let FormKind::Symbol(n) = &parts[1].kind
                         && n == "-main"
                     {


### PR DESCRIPTION
The `compile` subcommand now behaves as a project-aware compiler when
`cljrs.edn` is present in the working directory:

- Reads `:paths` and adds them to the source search path (after any
  `--src-path` CLI flags), so `require`d namespaces are resolved correctly
  during macro expansion and AOT compilation.
- Resolves and appends each declared dependency's source roots (local
  `:local/root` and git `:git/sha` deps) so dependency namespaces are
  available during compilation without extra `--src-path` flags.
- Supports a new `:main` key in `cljrs.edn` that names the entry-point
  namespace (e.g. `:main my.app.core`); parsed as a symbol or string.
- Adds a `--main <NS>` CLI flag that overrides `:main` from the EDN file.
- When the positional `file` argument is omitted, the compiler determines
  the entry file via: `--main` > `:main` in `cljrs.edn` > auto-detection
  (scans `:paths`-only source files for a unique top-level `-main` function;
  errors if zero or multiple are found).

Implementation details:
- `DepsConfig` gains `main_ns: Option<Arc<str>>`.
- `parse.rs` handles the new `:main` key (accepts symbol or string).
- New helpers in `main.rs`: `find_main_namespaces` (reader-level scan for
  `defn -main`), `ns_to_file` (namespace → source file path),
  `collect_dep_src_paths` (dep root → source paths without GlobalEnv).
- `file` in the `Compile` variant is now `Option<PathBuf>`; `--test` mode
  defaults the directory to `.` when `file` is absent.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LAS9jD1H4cvKyVbjNZ1Ank