### PR TITLE
compile: AOT-compile required namespaces instead of bundling source

### DIFF
--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -190,7 +190,7 @@ pub fn lower_via_clojure(name: Option<&str>, ns: &str, params: &[Arc<str>], form
 pub enum AotError { Io, Parse, Codegen, Eval, Link, NoGcBlacklist(Vec<BlacklistViolation>) /* no-gc only */ }
 ```
 
-Pipeline: read source → parse → evaluate preamble → macro-expand → pin versioned references → discover required namespaces → ANF lower (Rust, `cljrs_ir::lower`) → optimize (escape analysis + region alloc) → **[no-gc] blacklist check** → Cranelift codegen → **compile `^:async` poll functions** → generate Cargo harness → `cargo build --release` → copy binary.
+Pipeline: read source → parse → evaluate preamble → macro-expand → pin versioned references → discover required namespaces → **compile each required namespace** (`lower_namespace`: preamble/body partition + ANF lower) → ANF lower entry (Rust, `cljrs_ir::lower`) → optimize (escape analysis + region alloc) → **[no-gc] blacklist check** → Cranelift codegen (entry + per-namespace initializers) → **compile `^:async` poll functions** → generate Cargo harness → `cargo build --release` → copy binary.
 
 **Async activation (Phase H):** `compile_async_poll_fns` introspects the
 `^:async` fns the program defined (their `def` forms are evaluated into the
@@ -263,7 +263,24 @@ Detects four classes of no-gc memory-safety violations in IR functions:
 3. **LazySeqEscape** — lazy-producing call result is bound as an intermediate and returned unrealized.
 4. **EscapingClosure** — `AllocClosure` stored in a static container.
 
-Multi-file support: when the source file uses `(ns ... (:require [...]))`, the required namespaces are loaded during compilation. Their source files are discovered from `src_dirs`, bundled into the harness as builtin sources, and made available at runtime so the binary is self-contained.
+Multi-file support: when the source file uses `(ns ... (:require [...]))`, the
+required namespaces are loaded during compilation (discovered from `src_dirs`)
+and **each is AOT-compiled into the same object module** — not bundled as
+source and interpreted at startup. `lower_namespace` parses and macro-expands
+each required namespace, partitions its top-level forms into an interpreted
+preamble (`ns`/`require`, `defmacro`, protocol/multimethod forms) and a
+compilable body, and lowers the body to an `__cljrs_ns_init_<i>` function. The
+harness writes each namespace's preamble to `src/ns_<i>_preamble.cljrs`,
+declares its initializer `extern "C"`, and registers a `CompiledNsLoader`
+(`globals.register_compiled_ns_loader`) so that when `require` resolves the
+namespace at runtime, `cljrs_env::loader::do_load` runs the loader — evaluating
+the preamble, then calling the compiled initializer — instead of tree-walking
+source. Transitive `require`s resolve naturally: a namespace's preamble
+contains its own `ns`/`require` form, which triggers loading of its
+dependencies (each via its own compiled loader) before its initializer runs.
+Pinned *versioned* sources (`mylib@<sha>`) are the exception — they still embed
+as interpreted builtin source, since they resolve through the separate
+versioned loader rather than the plain `require` path.
 
 ---
 

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -467,20 +467,45 @@ pub fn compile_file(
     // failed signature) fails the compile instead of the deployed binary.
     pin_versioned_references(&expanded, &mut env)?;
 
-    // Discover user namespaces loaded during expansion (transitive deps),
-    // plus every pinned source fetched from git (embedded under the
-    // versioned namespace name, e.g. "mylib@abc1234").
-    let mut bundled_sources = discover_bundled_sources(&env.globals, &pre_loaded, src_dirs);
+    // Discover user namespaces loaded during expansion (transitive deps).
+    // Each is AOT-compiled into its own initializer (below) rather than
+    // bundled as source and tree-walked at startup.
+    let discovered = discover_bundled_sources(&env.globals, &pre_loaded, src_dirs);
+
+    // Pinned versioned sources (e.g. "mylib@abc1234") stay interpreted: they
+    // resolve through the separate versioned loader — not the plain `require`
+    // path — so they are bundled as builtin source as before.
+    let mut versioned_bundled: Vec<(Arc<str>, String)> = Vec::new();
     for (ns, src) in env.globals.versioned_sources_snapshot() {
-        bundled_sources.push((ns, src.to_string()));
+        versioned_bundled.push((ns, src.to_string()));
     }
-    if !bundled_sources.is_empty() {
+
+    // Lower each discovered namespace to an interpreted preamble (ns/require,
+    // macros) plus an optional natively compiled initializer.
+    let mut compiled_namespaces: Vec<CompiledNamespace> = Vec::new();
+    let mut dep_irs: Vec<(String, IrFunction)> = Vec::new();
+    for (i, (ns, src)) in discovered.iter().enumerate() {
+        let init_symbol = format!("__cljrs_ns_init_{i}");
+        let (preamble, ir_opt) = lower_namespace(ns, src, &init_symbol, &env.globals)?;
+        let init_symbol = if let Some(ir) = ir_opt {
+            dep_irs.push((init_symbol.clone(), ir));
+            Some(init_symbol)
+        } else {
+            None
+        };
+        compiled_namespaces.push(CompiledNamespace {
+            ns: ns.clone(),
+            init_symbol,
+            preamble,
+        });
+    }
+    if !compiled_namespaces.is_empty() {
         eprintln!(
-            "[aot] bundling {} required namespace(s): {}",
-            bundled_sources.len(),
-            bundled_sources
+            "[aot] compiling {} required namespace(s): {}",
+            compiled_namespaces.len(),
+            compiled_namespaces
                 .iter()
-                .map(|(ns, _)| ns.as_ref())
+                .map(|c| c.ns.as_ref())
                 .collect::<Vec<_>>()
                 .join(", ")
         );
@@ -564,6 +589,16 @@ pub fn compile_file(
     let func_id = compiler.declare_function("__cljrs_main", 0)?;
     compiler.compile_function(&ir_func, func_id)?;
 
+    // Compile each required namespace's initializer into the same module.
+    // Subfunction symbols are globally unique (per `fresh_global_name_id`),
+    // so initializers can share one object module without name collisions.
+    for (init_symbol, ns_ir) in &dep_irs {
+        declare_subfunctions(ns_ir, &mut compiler)?;
+        compile_subfunctions(ns_ir, &mut compiler)?;
+        let id = compiler.declare_function(init_symbol, 0)?;
+        compiler.compile_function(ns_ir, id)?;
+    }
+
     // ── 4b. Async poll functions (Phase H) ──────────────────────────────
     // Regular `defn`s are compiled into `__cljrs_main`; `^:async` ones stay
     // interpreted (their body has `await`) and so were never evaluated into the
@@ -594,7 +629,8 @@ pub fn compile_file(
         out_path,
         &obj_bytes,
         &interpreted_source,
-        &bundled_sources,
+        &compiled_namespaces,
+        &versioned_bundled,
         &async_polls,
         rust_config,
     )?;
@@ -844,6 +880,70 @@ fn find_user_source(rel: &str, src_dirs: &[PathBuf]) -> Option<String> {
     None
 }
 
+/// One required namespace compiled into the AOT object module: its interpreted
+/// preamble (the `ns`/`require` form and any `defmacro`/protocol/multimethod
+/// definitions that must run through the interpreter) and the symbol of its
+/// natively compiled initializer (`None` when the namespace has no compilable
+/// top-level forms — e.g. a namespace consisting only of `defmacro`s).
+struct CompiledNamespace {
+    ns: Arc<str>,
+    init_symbol: Option<String>,
+    preamble: String,
+}
+
+/// Lower one required namespace to an interpreted preamble plus an optional
+/// natively compiled initializer.
+///
+/// `source` is the namespace's Clojure source.  The namespace has already been
+/// loaded into `globals` during the entry file's macro-expansion, so its own
+/// macros and requires are available; here we only macro-expand (never
+/// re-evaluate) in order to partition top-level forms into an interpreted
+/// preamble (ns/require, defmacro, protocols, …) and a compilable body which is
+/// lowered to an `__cljrs_ns_init_*` IR function.  Returns `(preamble, ir)`
+/// where `ir` is `None` if the namespace has no compilable top-level forms.
+fn lower_namespace(
+    ns_name: &str,
+    source: &str,
+    init_symbol: &str,
+    globals: &Arc<cljrs_env::env::GlobalEnv>,
+) -> AotResult<(String, Option<IrFunction>)> {
+    let mut parser = Parser::new(source.to_string(), format!("<{ns_name}>"));
+    let forms = parser.parse_all()?;
+
+    // Macro-expand each form in an env rooted at this namespace so symbol and
+    // alias resolution match how the namespace's own code sees the world.
+    let mut env = cljrs_eval::Env::new(globals.clone(), ns_name);
+    let mut expanded = Vec::with_capacity(forms.len());
+    for form in &forms {
+        match cljrs_interp::macros::macroexpand_all(form, &mut env) {
+            Ok(f) => expanded.push(f),
+            Err(e) => return Err(AotError::Eval(format!("{e:?}"))),
+        }
+    }
+
+    // Partition: interpreted preamble vs compiled body (same rule as the entry
+    // file in `compile_file`).
+    let mut preamble = String::new();
+    let mut compilable = Vec::new();
+    for (i, form) in expanded.iter().enumerate() {
+        if needs_interpreter(&forms[i]) || expanded_needs_interpreter(form) {
+            let span = &forms[i].span;
+            preamble.push_str(&source[span.start..span.end]);
+            preamble.push('\n');
+        } else {
+            compilable.push(form.clone());
+        }
+    }
+
+    if compilable.is_empty() {
+        return Ok((preamble, None));
+    }
+
+    let mut ir = lower_via_rust(Some(init_symbol), ns_name, &[], &compilable, &mut env)?;
+    optimize_direct_calls(&mut ir);
+    Ok((preamble, Some(ir)))
+}
+
 // ── Harness generation ──────────────────────────────────────────────────────
 
 /// Create a temporary Cargo project that links the compiled object code with
@@ -972,7 +1072,8 @@ fn build_harness(
     out_path: &Path,
     obj_bytes: &[u8],
     interpreted_source: &str,
-    bundled_sources: &[(Arc<str>, String)],
+    compiled_namespaces: &[CompiledNamespace],
+    versioned_bundled: &[(Arc<str>, String)],
     async_polls: &[AsyncPollEntry],
     rust_config: Option<&cljrs_deps::RustConfig>,
 ) -> AotResult<(PathBuf, bool)> {
@@ -1044,19 +1145,62 @@ edition = "2024"
         std::fs::write(harness_dir.join("src/preamble.cljrs"), interpreted_source)?;
     }
 
-    // Write bundled dependency sources.
-    for (i, (ns, src)) in bundled_sources.iter().enumerate() {
-        let filename = format!("bundled_{i}.cljrs");
+    // Write pinned versioned dependency sources (still interpreted at startup —
+    // they resolve through the versioned loader, not the plain require path).
+    let mut bundled_registration = String::new();
+    for (i, (ns, src)) in versioned_bundled.iter().enumerate() {
+        let filename = format!("versioned_{i}.cljrs");
         std::fs::write(harness_dir.join("src").join(&filename), src)?;
-        eprintln!("[aot] bundled {ns} → src/{filename}");
+        eprintln!("[aot] bundled (interpreted) {ns} → src/{filename}");
+        bundled_registration.push_str(&format!(
+            "    globals.register_builtin_source({ns:?}, include_str!({filename:?}));\n"
+        ));
     }
 
-    // Generate registration code for bundled sources.
-    let mut bundled_registration = String::new();
-    for (i, (ns, _)) in bundled_sources.iter().enumerate() {
-        bundled_registration.push_str(&format!(
-            "    globals.register_builtin_source(\"{ns}\", \
-             include_str!(\"bundled_{i}.cljrs\"));\n"
+    // Write the interpreted preamble for each AOT-compiled namespace, and build
+    // the extern declarations + loader registrations that wire each required
+    // namespace's compiled initializer into `require`.
+    let mut ns_init_externs = String::new();
+    let mut compiled_ns_registration = String::new();
+    for (i, cns) in compiled_namespaces.iter().enumerate() {
+        let preamble_file = format!("ns_{i}_preamble.cljrs");
+        std::fs::write(harness_dir.join("src").join(&preamble_file), &cns.preamble)?;
+        let ns = cns.ns.as_ref();
+        let ns_label = format!("<{ns}>");
+        eprintln!(
+            "[aot] compiled namespace {ns} → src/{preamble_file} + {}",
+            cns.init_symbol.as_deref().unwrap_or("(preamble only)")
+        );
+
+        let init_call = match &cns.init_symbol {
+            Some(sym) => {
+                ns_init_externs.push_str(&format!("    fn {sym}() -> *const Value;\n"));
+                format!("        unsafe {{ {sym}(); }}\n")
+            }
+            None => String::new(),
+        };
+
+        compiled_ns_registration.push_str(&format!(
+            r#"    globals.register_compiled_ns_loader({ns:?}, std::sync::Arc::new(
+        |globals: &std::sync::Arc<cljrs_env::env::GlobalEnv>| -> cljrs_env::error::EvalResult<()> {{
+        let mut env = cljrs_eval::Env::new(globals.clone(), {ns:?});
+        cljrs_env::callback::push_eval_context(&env);
+        let preamble = include_str!({preamble_file:?});
+        if !preamble.is_empty() {{
+            let mut parser = cljrs_reader::Parser::new(preamble.to_string(), {ns_label:?}.to_string());
+            let forms = parser.parse_all().map_err(cljrs_env::error::EvalError::Read)?;
+            for form in &forms {{
+                cljrs_eval::eval(form, &mut env)?;
+            }}
+        }}
+        // Re-push the eval context with the (possibly updated) namespace before
+        // running the compiled initializer.
+        cljrs_env::callback::pop_eval_context();
+        cljrs_env::callback::push_eval_context(&env);
+{init_call}        cljrs_env::callback::pop_eval_context();
+        Ok(())
+    }}));
+"#,
         ));
     }
 
@@ -1191,7 +1335,7 @@ use cljrs_value::Value;
 
 unsafe extern "C" {{
     fn __cljrs_main() -> *const Value;
-}}
+{ns_init_externs}}}
 
 async fn run() {{
     // Parse environment -X flags.
@@ -1219,7 +1363,10 @@ async fn run() {{
 
     // Register bundled dependency sources so require can find them
     // without needing source files on disk.
-{bundled}{native_init}
+{bundled}
+    // Register AOT-compiled namespace loaders so `require` runs their native
+    // initializers instead of interpreting source.
+{compiled_ns}{native_init}
     let mut env = cljrs_eval::Env::new(globals, "user");
 
     // Push an eval context so rt_call can dispatch through the interpreter.
@@ -1260,6 +1407,8 @@ fn main() {{
 "#,
         preamble = preamble_code,
         bundled = bundled_registration,
+        compiled_ns = compiled_ns_registration,
+        ns_init_externs = ns_init_externs,
         native_init = native_init_code,
         main_call = main_call_code,
         async_polls = async_poll_registration,

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -525,7 +525,7 @@ pub fn compile_file(
             interpreted_source.push_str(src_text);
             interpreted_source.push('\n');
         } else {
-            compilable.push(form.clone());
+            compilable.push(qualify_aliases(form, &env.current_ns, &env.globals));
         }
     }
     if !interpreted_source.is_empty() {
@@ -891,6 +891,58 @@ struct CompiledNamespace {
     preamble: String,
 }
 
+/// Rewrite namespace-alias-qualified symbols (`alias/name`) to their fully
+/// qualified form (`real-ns/name`) using `ns`'s alias table.
+///
+/// Compiled `LoadGlobal` bakes in the namespace part of a symbol at lower time
+/// and resolves it at runtime; for a plain alias (`u/wrap`) that resolution
+/// otherwise depends on the namespace *active when the compiled function runs*,
+/// which is the caller's — not the function's defining namespace.  Resolving the
+/// alias here makes the symbol carry its real namespace (`utils/wrap`), so it
+/// resolves correctly no matter where the compiled function is invoked from.
+///
+/// Only var references are rewritten: in Clojure bare symbols inside collection
+/// literals are evaluated, so they are rewritten too, but `quote`d data is left
+/// untouched.
+fn qualify_aliases(form: &cljrs_reader::Form, ns: &str, globals: &Arc<cljrs_env::env::GlobalEnv>) -> cljrs_reader::Form {
+    use cljrs_reader::form::FormKind;
+    let recur = |f: &cljrs_reader::Form| qualify_aliases(f, ns, globals);
+    let map_vec = |v: &[cljrs_reader::Form]| v.iter().map(&recur).collect::<Vec<_>>();
+    let kind = match &form.kind {
+        FormKind::Symbol(s) => match s.find('/') {
+            Some(slash) if s != "/" => {
+                let (alias, rest) = (&s[..slash], &s[slash + 1..]);
+                if !alias.is_empty()
+                    && !rest.is_empty()
+                    && let Some(real) = globals.resolve_alias(ns, alias)
+                    && real.as_ref() != alias
+                {
+                    FormKind::Symbol(format!("{real}/{rest}"))
+                } else {
+                    return form.clone();
+                }
+            }
+            _ => return form.clone(),
+        },
+        FormKind::List(v) => FormKind::List(map_vec(v)),
+        FormKind::Vector(v) => FormKind::Vector(map_vec(v)),
+        FormKind::Map(v) => FormKind::Map(map_vec(v)),
+        FormKind::Set(v) => FormKind::Set(map_vec(v)),
+        FormKind::AnonFn(v) => FormKind::AnonFn(map_vec(v)),
+        FormKind::SyntaxQuote(f) => FormKind::SyntaxQuote(Box::new(recur(f))),
+        FormKind::Unquote(f) => FormKind::Unquote(Box::new(recur(f))),
+        FormKind::UnquoteSplice(f) => FormKind::UnquoteSplice(Box::new(recur(f))),
+        FormKind::Deref(f) => FormKind::Deref(Box::new(recur(f))),
+        FormKind::Var(f) => FormKind::Var(Box::new(recur(f))),
+        FormKind::Meta(m, f) => FormKind::Meta(Box::new(recur(m)), Box::new(recur(f))),
+        FormKind::TaggedLiteral(t, f) => FormKind::TaggedLiteral(t.clone(), Box::new(recur(f))),
+        // `quote`d data and scalars (and reader conditionals, already resolved
+        // for this platform at parse time) are left untouched.
+        _ => return form.clone(),
+    };
+    cljrs_reader::Form::new(kind, form.span.clone())
+}
+
 /// Lower one required namespace to an interpreted preamble plus an optional
 /// natively compiled initializer.
 ///
@@ -931,7 +983,7 @@ fn lower_namespace(
             preamble.push_str(&source[span.start..span.end]);
             preamble.push('\n');
         } else {
-            compilable.push(form.clone());
+            compilable.push(qualify_aliases(form, ns_name, globals));
         }
     }
 

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -904,7 +904,11 @@ struct CompiledNamespace {
 /// Only var references are rewritten: in Clojure bare symbols inside collection
 /// literals are evaluated, so they are rewritten too, but `quote`d data is left
 /// untouched.
-fn qualify_aliases(form: &cljrs_reader::Form, ns: &str, globals: &Arc<cljrs_env::env::GlobalEnv>) -> cljrs_reader::Form {
+fn qualify_aliases(
+    form: &cljrs_reader::Form,
+    ns: &str,
+    globals: &Arc<cljrs_env::env::GlobalEnv>,
+) -> cljrs_reader::Form {
     use cljrs_reader::form::FormKind;
     let recur = |f: &cljrs_reader::Form| qualify_aliases(f, ns, globals);
     let map_vec = |v: &[cljrs_reader::Form]| v.iter().map(&recur).collect::<Vec<_>>();

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -50,6 +50,18 @@ load registers a `:rust/load :dylib` dep's exports into the **unversioned**
 namespace (built at the dep's pinned `:git/sha`), so a plain
 `(require '[my.native.lib :as l])` of a pure-native package succeeds.
 
+AOT-compiled namespaces: the binary produced by `cljrs compile` registers a
+`CompiledNsLoader` per required namespace via
+`GlobalEnv::register_compiled_ns_loader`.  `loader::do_load` checks
+`GlobalEnv::compiled_ns_loader` **first** — before builtin source, disk, and
+native fallbacks — and, when one is present, runs it instead of interpreting
+Clojure source.  The loader evaluates the namespace's small interpreted
+preamble (its `ns`/`require` form and any `defmacro`/protocol/multimethod
+definitions) and then calls the namespace's natively compiled initializer, so
+the bulk of a required namespace runs as machine code rather than being
+tree-walked at startup.  `*ns*` is saved/restored around the loader so the
+caller's namespace is undisturbed.
+
 ## gc_roots module
 
 The `gc_roots` module manages GC root registration for the interpreter's Rust call stack. Public API includes:

--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -159,7 +159,22 @@ pub struct GlobalEnv {
     /// `(require '[my.native.lib :as lib])` brings the native code in.
     #[allow(clippy::type_complexity)]
     pub native_require_loader: RwLock<Option<NativeRequireLoader>>,
+    /// Loaders for **AOT-compiled namespaces**, installed by the binary
+    /// produced by `cljrs compile`.  Keyed by namespace name.  When a plain
+    /// `require` resolves a namespace that has a registered loader, `load_ns`
+    /// invokes the loader instead of interpreting Clojure source: the loader
+    /// evaluates the namespace's small interpreted preamble (its `ns`/`require`
+    /// and macro definitions) and then calls the namespace's natively compiled
+    /// initializer, so the bulk of the namespace runs as machine code rather
+    /// than being tree-walked at startup.
+    #[allow(clippy::type_complexity)]
+    pub compiled_ns_loaders: RwLock<HashMap<Arc<str>, CompiledNsLoader>>,
 }
+
+/// Loader callback for an AOT-compiled namespace (see
+/// `GlobalEnv::compiled_ns_loaders`).  Given the global env, it loads the
+/// namespace by running its interpreted preamble and its compiled initializer.
+pub type CompiledNsLoader = Arc<dyn Fn(&Arc<GlobalEnv>) -> EvalResult<()> + Send + Sync>;
 
 /// Loader callback for pinned native packages (see
 /// `GlobalEnv::pinned_native_loader`).
@@ -208,6 +223,7 @@ impl GlobalEnv {
             provenance_warned: Mutex::new(HashSet::new()),
             pinned_native_loader: RwLock::new(None),
             native_require_loader: RwLock::new(None),
+            compiled_ns_loaders: RwLock::new(HashMap::new()),
         })
     }
 
@@ -227,6 +243,20 @@ impl GlobalEnv {
     /// Look up an embedded source for a namespace, if one has been registered.
     pub fn builtin_source(&self, ns: &str) -> Option<&'static str> {
         self.builtin_sources.read().unwrap().get(ns).copied()
+    }
+
+    /// Register a loader for an AOT-compiled namespace (called by the harness
+    /// `main` of a binary produced by `cljrs compile`).
+    pub fn register_compiled_ns_loader(&self, ns: &str, loader: CompiledNsLoader) {
+        self.compiled_ns_loaders
+            .write()
+            .unwrap()
+            .insert(Arc::from(ns), loader);
+    }
+
+    /// Look up the loader for an AOT-compiled namespace, if one is registered.
+    pub fn compiled_ns_loader(&self, ns: &str) -> Option<CompiledNsLoader> {
+        self.compiled_ns_loaders.read().unwrap().get(ns).cloned()
     }
 
     /// Mark a namespace as fully loaded from a file.

--- a/crates/cljrs-env/src/loader.rs
+++ b/crates/cljrs-env/src/loader.rs
@@ -103,6 +103,32 @@ pub(crate) fn claim_or_wait(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> Eva
 /// The caller is responsible for claiming/releasing the namespace in the
 /// `loading` map.
 fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
+    // AOT-compiled namespace: a binary produced by `cljrs compile` registers a
+    // loader for each required namespace.  Run it instead of interpreting
+    // source — the loader evaluates a small interpreted preamble (ns/require,
+    // macros) and then calls the namespace's natively compiled initializer.
+    if let Some(loader) = globals.compiled_ns_loader(ns_name) {
+        // Ensure the namespace exists before its compiled `def`s run, then
+        // pre-refer clojure.core so the preamble can use core fns before its
+        // own `(ns ...)` form (mirrors the source-file path below).
+        globals.get_or_create_ns(ns_name);
+        if ns_name.as_ref() != "clojure.core" {
+            globals.refer_all(ns_name, "clojure.core");
+        }
+        // Save and restore *ns* so the caller's namespace is not disturbed by
+        // the `(ns ...)` form in the loaded namespace's preamble.
+        let saved_ns = globals
+            .lookup_var("clojure.core", "*ns*")
+            .and_then(|v| crate::dynamics::deref_var(&v));
+        let result = loader(globals);
+        if let Some(saved) = saved_ns
+            && let Some(var) = globals.lookup_var("clojure.core", "*ns*")
+        {
+            var.get().bind(saved);
+        }
+        return result;
+    }
+
     // Resolve namespace name: check built-in registry first, then disk.
     // Clojure convention: dots → path separators, hyphens → underscores.
     let rel_path = ns_name.replace('.', "/").replace('-', "_");


### PR DESCRIPTION
`cljrs compile` previously embedded each required namespace's source into
the binary and interpreted it at startup via `register_builtin_source`, so
only the entry namespace ran as native code. Now each discovered namespace
is lowered to its own `__cljrs_ns_init_*` initializer in the same object
module and wired into `require` through a new `CompiledNsLoader` registry:
`loader::do_load` runs the loader (interpreted preamble + compiled
initializer) instead of tree-walking source. Transitive requires resolve
naturally because each namespace's preamble carries its own ns/require form.

Pinned versioned sources still embed as interpreted builtin source, since
they resolve through the separate versioned loader rather than plain require.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014nkKDPcbdjE6noGPDZua5e