### PR TITLE
Scaffold AOT Clojure→WebAssembly backend in cljrs-compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,6 +857,8 @@ dependencies = [
  "cranelift-object",
  "target-lexicon",
  "tempfile",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3349,6 +3351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -6775,6 +6778,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/TODO.md
+++ b/TODO.md
@@ -478,7 +478,8 @@ inference, `typeinfer`, the `rt_abi` contract) are reused unchanged.
 - [x] ABI/region contract: `Value`→`i32` linear-memory offset; `rt_abi` import table; region handle as a hidden trailing `i32` param (mirrors `IrFunction::abi_param_count`)
 - [x] Relooper data model (`Structured`) + acyclic/diamond structuring (wasm-private; Cranelift keeps the raw CFG)
 - [x] Relooper: full dominator-based structuring (Ramsey "Beyond Relooper") — `loop`/`recur` back-edges → `Loop`/`Br`-continue, multi-predecessor joins → dominator-placed labeled blocks in ascending RPO, irreducible CFGs rejected
-- [ ] `wasm-encoder` emitter: per-`Inst` lowering, SSA φ resolution to locals, `rt_abi` imports, scratch-array spilling for `Alloc*`
+- [x] `wasm-encoder` emitter (core): boxed `i32` value model, `rt_abi` imports, structured-tree → wasm control flow with label-stack `br` resolution, SSA φ as parallel operand-stack moves, scalar constants, folded arithmetic + binary comparison bridges; emits `wasmparser`-validated modules
+- [ ] `wasm-encoder` emitter (remaining `Inst`s): `Alloc*` (scratch-array spill + `rt_alloc_*`), `Call`/`CallDirect`/`CallWithRegion`, `LoadGlobal`/`LoadVar`/`DefVar`, string/keyword/symbol constants (data segment), region ops, unboxed `Long`/`Double` specialization aligned with `function_signature`
 - [ ] Region intrinsics in wasm: arena (`base/bump/limit`) in linear memory; `rt_region_*` threading; bump allocation into the caller's region
 - [ ] GC heap in linear memory (reuse the `wasm32-unknown-unknown` GC) + `rt_safepoint` at entry/back-edges
 - [ ] `recur` → `loop`/`br`; cross-function tail calls via the wasm tail-call proposal (`return_call`) or a trampoline

--- a/TODO.md
+++ b/TODO.md
@@ -477,7 +477,7 @@ inference, `typeinfer`, the `rt_abi` contract) are reused unchanged.
 - [x] Scaffold the backend: `cljrs-compiler/src/wasm/` (`mod`, `abi`, `reloop`, `emit`)
 - [x] ABI/region contract: `Value`→`i32` linear-memory offset; `rt_abi` import table; region handle as a hidden trailing `i32` param (mirrors `IrFunction::abi_param_count`)
 - [x] Relooper data model (`Structured`) + acyclic/diamond structuring (wasm-private; Cranelift keeps the raw CFG)
-- [ ] Relooper: dominator-based loop structuring (`recur` back-edges → `Loop`/`Continue`) and multi-predecessor join placement (labeled blocks)
+- [x] Relooper: full dominator-based structuring (Ramsey "Beyond Relooper") — `loop`/`recur` back-edges → `Loop`/`Br`-continue, multi-predecessor joins → dominator-placed labeled blocks in ascending RPO, irreducible CFGs rejected
 - [ ] `wasm-encoder` emitter: per-`Inst` lowering, SSA φ resolution to locals, `rt_abi` imports, scratch-array spilling for `Alloc*`
 - [ ] Region intrinsics in wasm: arena (`base/bump/limit`) in linear memory; `rt_region_*` threading; bump allocation into the caller's region
 - [ ] GC heap in linear memory (reuse the `wasm32-unknown-unknown` GC) + `rt_safepoint` at entry/back-edges

--- a/TODO.md
+++ b/TODO.md
@@ -465,6 +465,30 @@ Foundations already in place:
 
 ---
 
+## Phase 11.5 — AOT Clojure → WebAssembly backend
+
+Native-fast, sandbox-safe browser deployment. A *second* code-generation
+backend over the same regionalized `cljrs-ir` IR (parallel to Cranelift), since
+no in-sandbox native JIT is possible in a browser. Build-time AOT-wasm is the
+top tier; the IR interpreter stays on board as the dynamic-code tier (tiers
+invert vs. native). All upstream passes (ANF lowering, escape analysis, region
+inference, `typeinfer`, the `rt_abi` contract) are reused unchanged.
+
+- [x] Scaffold the backend: `cljrs-compiler/src/wasm/` (`mod`, `abi`, `reloop`, `emit`)
+- [x] ABI/region contract: `Value`→`i32` linear-memory offset; `rt_abi` import table; region handle as a hidden trailing `i32` param (mirrors `IrFunction::abi_param_count`)
+- [x] Relooper data model (`Structured`) + acyclic/diamond structuring (wasm-private; Cranelift keeps the raw CFG)
+- [ ] Relooper: dominator-based loop structuring (`recur` back-edges → `Loop`/`Continue`) and multi-predecessor join placement (labeled blocks)
+- [ ] `wasm-encoder` emitter: per-`Inst` lowering, SSA φ resolution to locals, `rt_abi` imports, scratch-array spilling for `Alloc*`
+- [ ] Region intrinsics in wasm: arena (`base/bump/limit`) in linear memory; `rt_region_*` threading; bump allocation into the caller's region
+- [ ] GC heap in linear memory (reuse the `wasm32-unknown-unknown` GC) + `rt_safepoint` at entry/back-edges
+- [ ] `recur` → `loop`/`br`; cross-function tail calls via the wasm tail-call proposal (`return_call`) or a trampoline
+- [ ] `try`/`catch`/`throw` via the wasm exception-handling proposal (or an `rt_abi` error path)
+- [ ] CLI: `cljrs compile <file> --target wasm -o <out>.wasm`; bundle with the runtime + IR interpreter
+- [ ] Wire the IR interpreter into the `cljrs-wasm` bundle as the dynamic-code tier (drop JIT/OSR hooks in-sandbox)
+- [ ] WasmGC (host-managed reference types) — deferred; keep the linear-memory GC for now
+
+---
+
 ## Phase 12 — REPL & Tooling
 
 - [x] Interactive REPL (`cljx repl`): read–eval–print loop (basic; readline deferred)

--- a/TODO.md
+++ b/TODO.md
@@ -467,6 +467,8 @@ Foundations already in place:
 
 ## Phase 11.5 — AOT Clojure → WebAssembly backend
 
+Handoff + design doc: [`docs/wasm-aot-plan.md`](docs/wasm-aot-plan.md).
+
 Native-fast, sandbox-safe browser deployment. A *second* code-generation
 backend over the same regionalized `cljrs-ir` IR (parallel to Cranelift), since
 no in-sandbox native JIT is possible in a browser. Build-time AOT-wasm is the

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -35,5 +35,8 @@ cranelift-object   = { workspace = true }
 cranelift-native   = { workspace = true }
 target-lexicon     = { workspace = true }
 
+wasm-encoder       = "0.244"
+
 [dev-dependencies]
 tempfile = "3"
+wasmparser = "0.244"

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -31,7 +31,7 @@ src/
     mod.rs      — public API (`compile_function`, `WasmBackend`, `WasmError`); browser tier model
     abi.rs      — ABI/region contract: Value→i32, rt_abi import table, region-handle threading
     reloop.rs   — relooper: IR CFG → structured control flow (`Structured`); wasm-private
-    emit.rs     — wasm-encoder emitter + per-Inst lowering plan (stubbed; signature/walk wired)
+    emit.rs     — wasm-encoder emitter: IrFunction → validated wasm module (subset)
 ```
 
 ### WebAssembly backend (`wasm/`)
@@ -56,9 +56,19 @@ straight-line code, `if`/`cond` diamonds, sequential and nested merges, and
 are exactly `Terminator::RecurJump` (so loop headers are the `RecurJump`
 targets), and merge nodes (≥2 forward predecessors) are placed at their
 immediate dominator in ascending reverse-postorder so every `br` jumps forward.
-Irreducible control flow (which Clojure cannot produce) is rejected. Remaining
-work: the `wasm-encoder` emitter (the front half — reloop + signature + tree
-walk — is wired; encoding returns `Unimplemented`).
+Irreducible control flow (which Clojure cannot produce) is rejected.
+
+The **emitter produces real, `wasmparser`-validated modules** for a growing
+subset of the IR. Each `VarId` is a boxed `i32` local (the universal repr,
+always correct, mirroring the Cranelift boxed fallback); `rt_abi` symbols are
+imported from the `"rt"` module. The relooper's structured tree maps directly to
+wasm control flow (`Labeled`→`block`, `Loop`→`loop`, `If`→`if`/`else`,
+`Br`→`br N` with depths resolved from a label stack), and SSA φs are resolved as
+parallel moves on the operand stack at each edge — so `loop`/`recur` with a
+swapping `recur` is correct. Currently lowered: scalar constants, `LoadLocal`,
+folded boxed arithmetic (`+ - * / rem`), binary comparison (`= < > <= >=`), and
+all control flow. Allocation, calls, globals, string/keyword/symbol constants,
+and the region/async ABIs return `Unsupported` — the next lowering increments.
 
 ```rust
 pub fn compile_function(func: &IrFunction, cfg: &WasmBackend) -> Result<Vec<u8>, WasmError>;

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -27,6 +27,38 @@ src/
   typeinfer.rs  — Phase 10.6 scalar representation inference (Repr lattice, fixpoint dataflow)
   aot.rs        — AOT driver: source → parse → expand → lower → codegen → cargo build → binary
   escape.rs     — (no-gc only) blacklist analysis: 4 checks that reject no-gc–unsafe IR patterns
+  wasm/         — AOT Clojure → WebAssembly backend (scaffold; second backend over the same IR)
+    mod.rs      — public API (`compile_function`, `WasmBackend`, `WasmError`); browser tier model
+    abi.rs      — ABI/region contract: Value→i32, rt_abi import table, region-handle threading
+    reloop.rs   — relooper: IR CFG → structured control flow (`Structured`); wasm-private
+    emit.rs     — wasm-encoder emitter + per-Inst lowering plan (stubbed; signature/walk wired)
+```
+
+### WebAssembly backend (`wasm/`)
+
+**Phase 12-wasm (scaffold).** A second code-generation backend over the same
+regionalized `cljrs-ir` IR, targeting the browser, where no in-sandbox native
+JIT is possible. AOT-wasm is the build-time top tier; the IR interpreter stays
+on board as the dynamic-code tier. Everything upstream of codegen — ANF
+lowering, escape analysis, region inference, `typeinfer`, the `rt_abi` contract
+— is reused unchanged. Because regions are a property of the IR and a region
+handle is just an `i32` linear-memory offset, escape-analysis-driven bump
+allocation ports for free (a region-parameterised variant takes the handle as a
+hidden trailing `i32` param). The only new, wasm-specific work is the
+**relooper** (`reloop.rs`, recovering structured control flow — wasm-private,
+since Cranelift wants the raw CFG) and the `wasm-encoder` **emitter**
+(`emit.rs`). Current status: module structure, public API, the ABI/region
+contract, and the relooper's acyclic/diamond cases are implemented and tested;
+loops, multi-pred joins, and the encoder itself return `Unimplemented`/
+`Unsupported`.
+
+```rust
+pub fn compile_function(func: &IrFunction, cfg: &WasmBackend) -> Result<Vec<u8>, WasmError>;
+pub struct WasmBackend { tail_calls: bool, exceptions: bool }
+pub enum WasmError { Reloop(RelooperError), Unsupported(String), Unimplemented(&'static str) }
+// abi:    WasmValType{I32,I64,F64}, RtImport, RT_IMPORTS, lookup(name)
+// reloop: Structured{Simple,Loop,If,Break,Continue,Return,Unreachable,Nil}, LabelId, reloop(func)
+// emit:   emit_function(func, structured, cfg), function_signature(func)
 ```
 
 ---

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -47,17 +47,26 @@ allocation ports for free (a region-parameterised variant takes the handle as a
 hidden trailing `i32` param). The only new, wasm-specific work is the
 **relooper** (`reloop.rs`, recovering structured control flow — wasm-private,
 since Cranelift wants the raw CFG) and the `wasm-encoder` **emitter**
-(`emit.rs`). Current status: module structure, public API, the ABI/region
-contract, and the relooper's acyclic/diamond cases are implemented and tested;
-loops, multi-pred joins, and the encoder itself return `Unimplemented`/
-`Unsupported`.
+(`emit.rs`).
+
+The **relooper is complete for reducible CFGs** (the universal case for Clojure
+source): it implements Ramsey's *"Beyond Relooper"* dominator-tree structuring —
+straight-line code, `if`/`cond` diamonds, sequential and nested merges, and
+`loop`/`recur` loops with conditional exits. It exploits two facts: back edges
+are exactly `Terminator::RecurJump` (so loop headers are the `RecurJump`
+targets), and merge nodes (≥2 forward predecessors) are placed at their
+immediate dominator in ascending reverse-postorder so every `br` jumps forward.
+Irreducible control flow (which Clojure cannot produce) is rejected. Remaining
+work: the `wasm-encoder` emitter (the front half — reloop + signature + tree
+walk — is wired; encoding returns `Unimplemented`).
 
 ```rust
 pub fn compile_function(func: &IrFunction, cfg: &WasmBackend) -> Result<Vec<u8>, WasmError>;
 pub struct WasmBackend { tail_calls: bool, exceptions: bool }
 pub enum WasmError { Reloop(RelooperError), Unsupported(String), Unimplemented(&'static str) }
 // abi:    WasmValType{I32,I64,F64}, RtImport, RT_IMPORTS, lookup(name)
-// reloop: Structured{Simple,Loop,If,Break,Continue,Return,Unreachable,Nil}, LabelId, reloop(func)
+// reloop: Structured{Simple,Labeled,Loop,If,Br,Return,Unreachable,Nil}, reloop(func)
+//         RelooperError{Empty,DanglingTarget,Irreducible}
 // emit:   emit_function(func, structured, cfg), function_signature(func)
 ```
 

--- a/crates/cljrs-compiler/src/lib.rs
+++ b/crates/cljrs-compiler/src/lib.rs
@@ -17,3 +17,4 @@ pub mod escape;
 pub mod ir;
 pub mod rt_abi;
 pub mod typeinfer;
+pub mod wasm;

--- a/crates/cljrs-compiler/src/wasm/abi.rs
+++ b/crates/cljrs-compiler/src/wasm/abi.rs
@@ -1,0 +1,375 @@
+//! The wasm backend's ABI contract: how IR values, the `rt_abi` runtime bridge,
+//! and regions map onto WebAssembly types.
+//!
+//! This is the canonical, written-down contract that [`super::emit`] consumes.
+//! It is deliberately data-only (no `wasm-encoder` dependency) so the contract
+//! can be reviewed and tested independently of the encoder.
+//!
+//! # Value representation
+//!
+//! The native backend passes Clojure values as `*const Value` (a host pointer)
+//! and unboxed scalars as raw `i64`/`f64`.  Under `wasm32` the mapping is:
+//!
+//! | IR / `rt_abi` Rust type         | wasm type        | Notes                                   |
+//! |---------------------------------|------------------|-----------------------------------------|
+//! | `*const Value` (`Repr::Boxed`)  | [`WasmValType::I32`] | linear-memory offset of the boxed value |
+//! | `*mut Region` (region handle)   | [`WasmValType::I32`] | linear-memory offset of the `Region`    |
+//! | `*const *const Value` (slices)  | [`WasmValType::I32`] | offset of a contiguous pointer array    |
+//! | `i64` (`Repr::Long`)            | [`WasmValType::I64`] | unboxed long payload                    |
+//! | `f64` (`Repr::Double`)         | [`WasmValType::F64`] | unboxed double payload                  |
+//! | `u8`/`u32` (`Repr::Bool`, tags) | [`WasmValType::I32`] | small integers                          |
+//! | `u64` (lengths/counts)          | [`WasmValType::I64`] | matches the native `extern "C"` shape   |
+//!
+//! Because every pointer collapses to an `i32`, the entire `rt_abi` surface
+//! ([`crate::rt_abi`], ~165 `extern "C"` functions) is expressible as wasm
+//! imports with no marshalling beyond width changes.  The GC heap and all
+//! regions live in the module's single linear memory.
+//!
+//! # Region ABI (bump allocation)
+//!
+//! Region inference runs host-side at lowering time and is identical for both
+//! backends.  The runtime mechanism in wasm:
+//!
+//! - A **region handle** is an `i32` — the linear-memory offset of a `Region`
+//!   returned by [`RT_REGION_START`].  A `Region` is an arena: a `(base, bump,
+//!   limit)` triple in linear memory; allocation bumps `bump`, and
+//!   [`RT_REGION_END`] resets/frees it.
+//! - [`Inst::RegionStart`](crate::ir::Inst::RegionStart) → call `rt_region_start`, keep the `i32` handle.
+//! - [`Inst::RegionAlloc`](crate::ir::Inst::RegionAlloc) → call the matching
+//!   `rt_region_alloc_*` with the handle as the leading `i32` arg.
+//! - [`Inst::RegionEnd`](crate::ir::Inst::RegionEnd) → call `rt_region_end` with the handle.
+//! - [`Inst::RegionParam`](crate::ir::Inst::RegionParam) → bind the function's **hidden trailing `i32`
+//!   parameter** (present iff [`IrFunction::takes_region_param`](crate::ir::IrFunction::takes_region_param)).
+//! - [`Inst::CallWithRegion`](crate::ir::Inst::CallWithRegion) → ordinary direct call, passing the caller's
+//!   region handle as the trailing `i32` argument.
+//!
+//! So the compiled signature of a region-parameterised variant is its visible
+//! params plus one trailing `i32` — exactly mirroring
+//! [`IrFunction::abi_param_count`](crate::ir::IrFunction::abi_param_count) on the native side.
+
+/// A WebAssembly value type, restricted to the four the backend uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WasmValType {
+    /// 32-bit integer — every pointer/handle and small integer.
+    I32,
+    /// 64-bit integer — unboxed `Repr::Long` and `u64` lengths.
+    I64,
+    /// 64-bit float — unboxed `Repr::Double`.
+    F64,
+}
+
+use crate::ir::Repr;
+
+impl WasmValType {
+    /// The wasm type carrying an IR value of the given machine representation.
+    pub fn for_repr(repr: Repr) -> WasmValType {
+        match repr {
+            Repr::Long => WasmValType::I64,
+            Repr::Double => WasmValType::F64,
+            // Boxed values, booleans (i8 payload), and array handles are all
+            // carried as i32 (a linear-memory offset or small integer).
+            Repr::Boxed | Repr::Bool | Repr::LongArray | Repr::DoubleArray => WasmValType::I32,
+        }
+    }
+}
+
+/// One imported `rt_abi` runtime function, described as a wasm function type.
+///
+/// `name` is the `#[no_mangle]` symbol from [`crate::rt_abi`]; the emitter
+/// imports it from the `"rt"` module so the runtime (compiled to the same
+/// linear memory) satisfies it at instantiation.
+#[derive(Debug, Clone, Copy)]
+pub struct RtImport {
+    /// The `rt_abi` symbol name.
+    pub name: &'static str,
+    /// Parameter types, in order.
+    pub params: &'static [WasmValType],
+    /// Result types (wasm permits multiple; `rt_abi` uses 0 or 1).
+    pub results: &'static [WasmValType],
+}
+
+use WasmValType::{F64, I32, I64};
+
+// Region-handle name constants so call sites read clearly.
+pub const RT_REGION_START: &str = "rt_region_start";
+pub const RT_REGION_END: &str = "rt_region_end";
+
+/// The subset of the `rt_abi` bridge the scaffold wires as wasm imports.
+///
+/// This is the contract, not the whole table: it covers safepoints, constant
+/// materialization, unboxed arithmetic/comparison bridges, GC-heap and region
+/// allocation, and the inline-cache / deopt bridges.  Completing it to all of
+/// [`crate::rt_abi`] is mechanical — each `extern "C"` signature maps to one
+/// `RtImport` by the rules in the module docs.
+pub const RT_IMPORTS: &[RtImport] = &[
+    // ── Safepoint ──────────────────────────────────────────────────────────
+    RtImport {
+        name: "rt_safepoint",
+        params: &[],
+        results: &[],
+    },
+    // ── Constant materialization ─────────────────────────────────────────────
+    RtImport {
+        name: "rt_const_nil",
+        params: &[],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_const_true",
+        params: &[],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_const_false",
+        params: &[],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_const_long",
+        params: &[I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_const_double",
+        params: &[F64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_const_char",
+        params: &[I32],
+        results: &[I32],
+    },
+    // ptr, len → boxed string/keyword/symbol
+    RtImport {
+        name: "rt_const_string",
+        params: &[I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_const_keyword",
+        params: &[I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_const_symbol",
+        params: &[I32, I64],
+        results: &[I32],
+    },
+    // ── Truthiness ───────────────────────────────────────────────────────────
+    RtImport {
+        name: "rt_truthiness",
+        params: &[I32],
+        results: &[I32],
+    },
+    // ── Boxed arithmetic / comparison bridges ────────────────────────────────
+    RtImport {
+        name: "rt_add",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_sub",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_mul",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_div",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_rem",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_eq",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_lt",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_gt",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_lte",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_gte",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    // ── GC-heap allocation (slice ptr, n) ────────────────────────────────────
+    RtImport {
+        name: "rt_alloc_vector",
+        params: &[I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_alloc_map",
+        params: &[I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_alloc_set",
+        params: &[I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_alloc_list",
+        params: &[I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_alloc_cons",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    // ── Region allocation (bump) ─────────────────────────────────────────────
+    RtImport {
+        name: RT_REGION_START,
+        params: &[],
+        results: &[I32],
+    },
+    RtImport {
+        name: RT_REGION_END,
+        params: &[I32],
+        results: &[I32],
+    },
+    // handle, slice ptr, n
+    RtImport {
+        name: "rt_region_alloc_vector",
+        params: &[I32, I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_region_alloc_map",
+        params: &[I32, I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_region_alloc_set",
+        params: &[I32, I32, I64],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_region_alloc_list",
+        params: &[I32, I32, I64],
+        results: &[I32],
+    },
+    // handle, head, tail
+    RtImport {
+        name: "rt_region_alloc_cons",
+        params: &[I32, I32, I32],
+        results: &[I32],
+    },
+    // ── A couple of common collection ops ────────────────────────────────────
+    RtImport {
+        name: "rt_get",
+        params: &[I32, I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_count",
+        params: &[I32],
+        results: &[I32],
+    },
+    // ── Specialization / inline-cache / deopt bridges (Phase 10.6) ───────────
+    RtImport {
+        name: "rt_value_tag",
+        params: &[I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_unbox_long",
+        params: &[I32],
+        results: &[I64],
+    },
+    RtImport {
+        name: "rt_unbox_double",
+        params: &[I32],
+        results: &[F64],
+    },
+    RtImport {
+        name: "rt_box_bool",
+        params: &[I32],
+        results: &[I32],
+    },
+    RtImport {
+        name: "rt_deopt",
+        params: &[],
+        results: &[I32],
+    },
+    // ic_slot, key_ptr, key_len → fills a per-call-site keyword cache
+    RtImport {
+        name: "rt_kw_ic_fill",
+        params: &[I32, I32, I64],
+        results: &[I32],
+    },
+    // ic_slot, callee, args_ptr, argc
+    RtImport {
+        name: "rt_call_ic",
+        params: &[I32, I32, I32, I64],
+        results: &[I32],
+    },
+];
+
+/// Look up an `rt_abi` import descriptor by symbol name.
+pub fn lookup(name: &str) -> Option<&'static RtImport> {
+    RT_IMPORTS.iter().find(|i| i.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pointers_are_i32() {
+        assert_eq!(WasmValType::for_repr(Repr::Boxed), WasmValType::I32);
+        assert_eq!(WasmValType::for_repr(Repr::Bool), WasmValType::I32);
+        assert_eq!(WasmValType::for_repr(Repr::LongArray), WasmValType::I32);
+    }
+
+    #[test]
+    fn unboxed_scalars_map_to_native_wasm_types() {
+        assert_eq!(WasmValType::for_repr(Repr::Long), WasmValType::I64);
+        assert_eq!(WasmValType::for_repr(Repr::Double), WasmValType::F64);
+    }
+
+    #[test]
+    fn region_contract_present_and_well_typed() {
+        let start = lookup(RT_REGION_START).expect("rt_region_start in table");
+        assert_eq!(start.params, &[] as &[WasmValType]);
+        assert_eq!(start.results, &[WasmValType::I32]); // handle is an i32
+
+        let end = lookup(RT_REGION_END).expect("rt_region_end in table");
+        assert_eq!(end.params, &[WasmValType::I32]); // takes the handle
+
+        // Region alloc threads the handle as the leading i32 arg.
+        let v = lookup("rt_region_alloc_vector").expect("rt_region_alloc_vector in table");
+        assert_eq!(v.params.first(), Some(&WasmValType::I32));
+        assert_eq!(v.results, &[WasmValType::I32]);
+    }
+
+    #[test]
+    fn no_duplicate_imports() {
+        for (i, a) in RT_IMPORTS.iter().enumerate() {
+            for b in &RT_IMPORTS[i + 1..] {
+                assert_ne!(a.name, b.name, "duplicate rt import {}", a.name);
+            }
+        }
+    }
+}

--- a/crates/cljrs-compiler/src/wasm/abi.rs
+++ b/crates/cljrs-compiler/src/wasm/abi.rs
@@ -48,7 +48,7 @@
 //! [`IrFunction::abi_param_count`](crate::ir::IrFunction::abi_param_count) on the native side.
 
 /// A WebAssembly value type, restricted to the four the backend uses.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WasmValType {
     /// 32-bit integer — every pointer/handle and small integer.
     I32,

--- a/crates/cljrs-compiler/src/wasm/emit.rs
+++ b/crates/cljrs-compiler/src/wasm/emit.rs
@@ -119,25 +119,20 @@ pub fn function_signature(func: &IrFunction) -> (Vec<WasmValType>, Vec<WasmValTy
 fn walk(node: &Structured) -> Result<(), WasmError> {
     match node {
         Structured::Simple { next, .. } => walk(next),
-        Structured::If {
-            then_arm,
-            else_arm,
-            next,
-            ..
-        } => {
-            walk(then_arm)?;
-            walk(else_arm)?;
-            walk(next)
-        }
-        Structured::Loop { body, next, .. } => {
+        Structured::Labeled { body, next, .. } => {
             walk(body)?;
             walk(next)
         }
-        Structured::Break(_)
-        | Structured::Continue(_)
-        | Structured::Return(_)
-        | Structured::Unreachable
-        | Structured::Nil => Ok(()),
+        Structured::If {
+            then_arm, else_arm, ..
+        } => {
+            walk(then_arm)?;
+            walk(else_arm)
+        }
+        Structured::Loop { body, .. } => walk(body),
+        Structured::Br(_) | Structured::Return(_) | Structured::Unreachable | Structured::Nil => {
+            Ok(())
+        }
     }
 }
 

--- a/crates/cljrs-compiler/src/wasm/emit.rs
+++ b/crates/cljrs-compiler/src/wasm/emit.rs
@@ -1,92 +1,178 @@
-//! WebAssembly emitter (scaffold).
+//! WebAssembly emitter.
 //!
 //! Walks a [`reloop::Structured`] tree and lowers each IR [`Inst`] to wasm,
-//! producing a module via `wasm-encoder` (the intended encoder dependency,
-//! added when this is implemented).  Until then [`emit_function`] returns
-//! [`WasmError::Unimplemented`] and this module documents the lowering plan and
-//! exposes the per-`Inst` dispatch skeleton so the contract is reviewable.
+//! producing a single-function module via `wasm-encoder`.  `rt_abi` symbols are
+//! declared as imports from the `"rt"` module (see [`super::abi`]); the runtime,
+//! compiled to the same linear memory, satisfies them at instantiation.
 //!
-//! # Lowering plan
+//! # Value model (boxed-only, for now)
 //!
-//! ## Function signature
+//! Every IR [`VarId`] is a wasm `i32` local holding a boxed `*const Value`
+//! linear-memory offset — the universal representation, always correct.  This
+//! mirrors the Cranelift backend's boxed fallback (`codegen.rs` materializes
+//! unboxed scalars only when `typeinfer` proves a `Long`/`Double`/`Bool` repr;
+//! the `_ =>` arm boxes through `rt_const_*`).  Unboxed specialization that
+//! aligns the wasm signature with [`function_signature`] is a follow-up; until
+//! then the emitter rejects region-parameterised and async poll functions
+//! (whose ABIs add hidden params) with [`WasmError::Unsupported`].
 //!
-//! Visible params map to wasm params by [`abi::WasmValType::for_repr`] of each
-//! param's inferred [`Repr`].  A region-parameterised variant
-//! ([`IrFunction::takes_region_param`]) appends one trailing `i32` region
-//! handle; a poll function ([`IrFunction::takes_state_param`]) uses the fixed
-//! `(state_ptr: i32, out_ptr: i32) -> i32` shape instead.  This mirrors
-//! [`IrFunction::abi_param_count`] on the native side.
+//! # Control flow
 //!
-//! ## Values → locals
+//! The relooper already produced structured control flow.  This pass maps it
+//! directly: [`Structured::Labeled`] → `block`, [`Structured::Loop`] → `loop`,
+//! [`Structured::If`] → `if`/`else`, and [`Structured::Br`] → `br N`, where the
+//! depth `N` is resolved from a stack of the enclosing control frames.  A
+//! forward `Br` targets an enclosing `block` (break); a backward `Br` targets an
+//! enclosing `loop` (continue).
 //!
-//! Each IR [`VarId`] becomes a wasm local of the type given by its inferred
-//! [`Repr`] (`crate::typeinfer`).  SSA `phi` nodes are resolved on the way in:
-//! each predecessor writes the phi's local before branching, so no φ instruction
-//! is emitted — the structured arms simply `local.set` the join local.
+//! # SSA φ resolution
 //!
-//! ## Instructions → wasm
+//! No `phi` instruction is emitted.  On each edge into a block, the φ's incoming
+//! value for that predecessor is copied into the φ's local.  Copies use the
+//! wasm operand stack for parallel-move semantics (all `local.get`s before any
+//! `local.set`), so a swapping `recur` cannot clobber.  Copies happen at the
+//! `Br` site for merge/loop targets and at block entry for inlined
+//! single-predecessor edges.
 //!
-//! | IR construct | wasm lowering |
-//! |---|---|
-//! | [`Inst::Const`] scalar | `i64.const` / `f64.const` (unboxed) or `call rt_const_*` (boxed) |
-//! | [`Inst::CallKnown`] arith on `Long`/`Double` | native `i64.add`/`f64.add`/… per `typeinfer` |
-//! | [`Inst::CallKnown`] boxed | `call rt_<op>` bridge (see [`abi::RT_IMPORTS`]) |
-//! | [`Inst::Alloc*`] | spill operands to a scratch array in linear memory, `call rt_alloc_*` |
-//! | [`Inst::RegionStart`] | `call rt_region_start`, keep handle in an `i32` local |
-//! | [`Inst::RegionAlloc`] | `call rt_region_alloc_*` with the handle leading |
-//! | [`Inst::RegionEnd`] | `call rt_region_end` |
-//! | [`Inst::RegionParam`] | bind the trailing `i32` param local |
-//! | [`Inst::CallWithRegion`] | `call`/`return_call` passing the region handle trailing |
-//! | [`Inst::CallDirect`] | `call $fn` (or `return_call` in tail position when [`WasmBackend::tail_calls`]) |
-//! | [`Inst::Call`] | per-call-site inline cache: `call rt_call_ic` |
-//! | [`Terminator::Branch`] | structured `if` from the relooper |
-//! | [`Terminator::RecurJump`] | `br` to the enclosing `loop` label |
-//! | [`Terminator::Return`] | `return` |
-//! | [`Inst::Throw`] / `TryCatchFinally` | `throw`/`try`/`catch` when [`WasmBackend::exceptions`], else an `rt_abi` error path |
+//! # Status
 //!
-//! ## GC + safepoints
-//!
-//! `rt_safepoint` is called at function entry and at every loop back-edge
-//! (`Structured::Continue`), matching the native backend.  The GC heap lives in
-//! the module's linear memory; emitted code holds no raw GC pointers across
-//! suspension because constants are materialized through `rt_abi`.
+//! Emits valid, `wasmparser`-validated modules for the subset: scalar
+//! constants, `LoadLocal`, boxed arithmetic (`+ - * / rem`, folded) and binary
+//! comparison (`= < > <= >=`) via the `rt_abi` bridges, and all control flow
+//! (branches, diamonds, and `loop`/`recur` with φ).  Allocation, calls,
+//! globals, string/keyword/symbol constants, and the region/async ABIs return
+//! [`WasmError::Unsupported`] — the next lowering increments.
 
-use crate::ir::{IrFunction, Repr};
+use std::collections::HashMap;
 
-use super::abi::WasmValType;
+use wasm_encoder::{
+    BlockType, CodeSection, EntityType, ExportKind, ExportSection, Function, FunctionSection,
+    Ieee64, ImportSection, Instruction, Module, TypeSection, ValType,
+};
+
+use crate::ir::{Block, BlockId, Const, Inst, IrFunction, KnownFn, Repr, Terminator, VarId};
+
+use super::abi::{self, RtImport, WasmValType};
 use super::reloop::Structured;
 use super::{WasmBackend, WasmError};
 
-/// Emit a wasm function body for `func` given its structured control flow.
+/// Emit a wasm module containing `func` as a single exported function.
 ///
-/// Scaffold: validates the structured tree can be walked and computes the wasm
-/// signature, then returns [`WasmError::Unimplemented`] for the encoder step.
+/// Pipeline: assign one `i32` local per [`VarId`], walk `structured` lowering
+/// each [`Inst`], then assemble the type/import/function/export/code sections.
 pub fn emit_function(
     func: &IrFunction,
     structured: &Structured,
-    cfg: &WasmBackend,
+    _cfg: &WasmBackend,
 ) -> Result<Vec<u8>, WasmError> {
-    // Compute the wasm signature now so the ABI is exercised even while the
-    // encoder is stubbed (keeps the region/poll param accounting honest).
-    let sig = function_signature(func);
-    let _ = (structured, cfg, sig);
+    if func.takes_state_param() {
+        return Err(WasmError::Unsupported(
+            "async poll-function ABI (state-machine params)".into(),
+        ));
+    }
+    if func.takes_region_param() {
+        return Err(WasmError::Unsupported(
+            "region-parameterised variant ABI (hidden region param)".into(),
+        ));
+    }
 
-    // Walk the tree once to surface unsupported nodes early; a real emitter
-    // would thread a `wasm_encoder::Function` here instead of `&mut ()`.
-    walk(structured)?;
+    // One i32 local per VarId: visible params first (wasm locals 0..n), then the
+    // remaining VarIds as declared locals.
+    let nparams = func.params.len();
+    let mut local_of: HashMap<VarId, u32> = HashMap::new();
+    for (i, (_, vid)) in func.params.iter().enumerate() {
+        local_of.insert(*vid, i as u32);
+    }
+    let mut next_local = nparams as u32;
+    for v in 0..func.next_var {
+        let vid = VarId(v);
+        local_of.entry(vid).or_insert_with(|| {
+            let l = next_local;
+            next_local += 1;
+            l
+        });
+    }
+    let declared = next_local - nparams as u32;
 
-    Err(WasmError::Unimplemented(
-        "wasm-encoder emission (front half — reloop + signature + tree walk — is wired)",
-    ))
+    let block_of: HashMap<BlockId, usize> = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(i, b)| (b.id, i))
+        .collect();
+    let forward_preds = forward_pred_counts(func);
+
+    let mut body = Function::new([(declared, ValType::I32)]);
+    let mut asm = ModuleAsm::new();
+
+    {
+        let mut em = Emitter {
+            func,
+            asm: &mut asm,
+            body: &mut body,
+            local_of: &local_of,
+            block_of: &block_of,
+            forward_preds: &forward_preds,
+            labels: Vec::new(),
+            current: func.blocks[0].id,
+        };
+        // GC safepoint at function entry (mirrors the native backend).
+        em.call_import("rt_safepoint")?;
+        em.emit_node(structured)?;
+    }
+    // A guaranteed-valid terminator: every real path already returned, so this
+    // is unreachable, but it makes the function's end stack-polymorphic.
+    body.instruction(&Instruction::Unreachable);
+    body.instruction(&Instruction::End);
+
+    // Assemble.  The main function type goes last; import types were interned
+    // during emission.
+    let main_ty = asm.intern_type(vec![WasmValType::I32; nparams], vec![WasmValType::I32]);
+
+    let mut module = Module::new();
+
+    let mut types = TypeSection::new();
+    for (params, results) in &asm.types {
+        types
+            .ty()
+            .function(params.iter().map(valtype), results.iter().map(valtype));
+    }
+    module.section(&types);
+
+    let mut imports = ImportSection::new();
+    for (name, ty_idx) in &asm.imports {
+        imports.import("rt", name, EntityType::Function(*ty_idx));
+    }
+    module.section(&imports);
+
+    let mut funcs = FunctionSection::new();
+    funcs.function(main_ty);
+    module.section(&funcs);
+
+    let mut exports = ExportSection::new();
+    let func_index = asm.imports.len() as u32; // imports occupy 0..k; this fn is k
+    exports.export(
+        func.name.as_deref().unwrap_or("main"),
+        ExportKind::Func,
+        func_index,
+    );
+    module.section(&exports);
+
+    let mut code = CodeSection::new();
+    code.function(&body);
+    module.section(&code);
+
+    Ok(module.finish())
 }
 
 /// The wasm function signature for `func`: `(params, results)`.
 ///
 /// Honors the hidden trailing region param and the poll-function ABI, mirroring
-/// [`IrFunction::abi_param_count`].
+/// [`IrFunction::abi_param_count`].  This describes the *eventual* typed ABI;
+/// [`emit_function`] currently emits a boxed-only (all-`i32`) signature and
+/// rejects the region/poll cases.
 pub fn function_signature(func: &IrFunction) -> (Vec<WasmValType>, Vec<WasmValType>) {
     if func.takes_state_param() {
-        // Poll ABI: (state_ptr: i32, out_ptr: i32) -> i32 (Poll discriminant).
         return (
             vec![WasmValType::I32, WasmValType::I32],
             vec![WasmValType::I32],
@@ -104,46 +190,496 @@ pub fn function_signature(func: &IrFunction) -> (Vec<WasmValType>, Vec<WasmValTy
         .collect();
 
     if func.takes_region_param() {
-        // Hidden trailing region handle.
         params.push(WasmValType::I32);
     }
 
-    // Every Clojure function yields a single value (boxed unless a return-repr
-    // pass proves otherwise); the scaffold returns the universal boxed i32.
     (params, vec![WasmValType::I32])
 }
 
-/// Walk the structured tree, returning an error for nodes the emitter scaffold
-/// does not yet handle.  This is where the `wasm-encoder` `Function` builder
-/// will be threaded; for now it only validates structure.
-fn walk(node: &Structured) -> Result<(), WasmError> {
-    match node {
-        Structured::Simple { next, .. } => walk(next),
-        Structured::Labeled { body, next, .. } => {
-            walk(body)?;
-            walk(next)
+// ── Module assembly state ────────────────────────────────────────────────────
+
+fn valtype(w: &WasmValType) -> ValType {
+    match w {
+        WasmValType::I32 => ValType::I32,
+        WasmValType::I64 => ValType::I64,
+        WasmValType::F64 => ValType::F64,
+    }
+}
+
+/// Accumulates the wasm module's interned function types and `rt_abi` imports.
+struct ModuleAsm {
+    /// Interned function types, in section order.
+    types: Vec<(Vec<WasmValType>, Vec<WasmValType>)>,
+    type_map: HashMap<(Vec<WasmValType>, Vec<WasmValType>), u32>,
+    /// `(import name, type index)`, in function-index order.
+    imports: Vec<(&'static str, u32)>,
+    import_map: HashMap<&'static str, u32>,
+}
+
+impl ModuleAsm {
+    fn new() -> Self {
+        ModuleAsm {
+            types: Vec::new(),
+            type_map: HashMap::new(),
+            imports: Vec::new(),
+            import_map: HashMap::new(),
         }
-        Structured::If {
-            then_arm, else_arm, ..
-        } => {
-            walk(then_arm)?;
-            walk(else_arm)
+    }
+
+    fn intern_type(&mut self, params: Vec<WasmValType>, results: Vec<WasmValType>) -> u32 {
+        let key = (params, results);
+        if let Some(&i) = self.type_map.get(&key) {
+            return i;
         }
-        Structured::Loop { body, .. } => walk(body),
-        Structured::Br(_) | Structured::Return(_) | Structured::Unreachable | Structured::Nil => {
-            Ok(())
+        let i = self.types.len() as u32;
+        self.types.push(key.clone());
+        self.type_map.insert(key, i);
+        i
+    }
+
+    /// Intern `rt`'s type and import it, returning its function index.
+    fn import(&mut self, rt: &RtImport) -> u32 {
+        if let Some(&idx) = self.import_map.get(rt.name) {
+            return idx;
         }
+        let ty = self.intern_type(rt.params.to_vec(), rt.results.to_vec());
+        let func_idx = self.imports.len() as u32;
+        self.imports.push((rt.name, ty));
+        self.import_map.insert(rt.name, func_idx);
+        func_idx
+    }
+}
+
+/// Count forward (non-`RecurJump`) predecessors of each block — a block with ≥2
+/// is a merge node whose φs are resolved at the `Br` sites that reach it.
+fn forward_pred_counts(func: &IrFunction) -> HashMap<BlockId, usize> {
+    let mut counts: HashMap<BlockId, usize> = HashMap::new();
+    for b in &func.blocks {
+        match &b.terminator {
+            Terminator::RecurJump { .. } => {}
+            Terminator::Jump(t) => *counts.entry(*t).or_default() += 1,
+            Terminator::Branch {
+                then_block,
+                else_block,
+                ..
+            } => {
+                *counts.entry(*then_block).or_default() += 1;
+                *counts.entry(*else_block).or_default() += 1;
+            }
+            Terminator::Return(_) | Terminator::Unreachable => {}
+        }
+    }
+    counts
+}
+
+// ── Emitter ──────────────────────────────────────────────────────────────────
+
+struct Emitter<'a> {
+    func: &'a IrFunction,
+    asm: &'a mut ModuleAsm,
+    body: &'a mut Function,
+    local_of: &'a HashMap<VarId, u32>,
+    block_of: &'a HashMap<BlockId, usize>,
+    forward_preds: &'a HashMap<BlockId, usize>,
+    /// Enclosing control frames; `Some(b)` is a `block`/`loop` labeled `b`,
+    /// `None` is an `if`.  Innermost is last.
+    labels: Vec<Option<BlockId>>,
+    /// The IR block currently being emitted — the predecessor for φ resolution.
+    current: BlockId,
+}
+
+impl Emitter<'_> {
+    fn block(&self, id: BlockId) -> &Block {
+        &self.func.blocks[self.block_of[&id]]
+    }
+
+    fn local(&self, v: VarId) -> Result<u32, WasmError> {
+        self.local_of
+            .get(&v)
+            .copied()
+            .ok_or_else(|| WasmError::Unsupported(format!("reference to unmapped {v}")))
+    }
+
+    fn is_merge(&self, id: BlockId) -> bool {
+        self.forward_preds.get(&id).copied().unwrap_or(0) >= 2
+    }
+
+    fn ins(&mut self, i: &Instruction) {
+        self.body.instruction(i);
+    }
+
+    fn call_import(&mut self, name: &str) -> Result<(), WasmError> {
+        let rt = abi::lookup(name)
+            .ok_or_else(|| WasmError::Unsupported(format!("no rt_abi import for {name}")))?;
+        let idx = self.asm.import(rt);
+        self.ins(&Instruction::Call(idx));
+        Ok(())
+    }
+
+    fn get(&mut self, v: VarId) -> Result<(), WasmError> {
+        let l = self.local(v)?;
+        self.ins(&Instruction::LocalGet(l));
+        Ok(())
+    }
+
+    fn set(&mut self, v: VarId) -> Result<(), WasmError> {
+        let l = self.local(v)?;
+        self.ins(&Instruction::LocalSet(l));
+        Ok(())
+    }
+
+    // ── Tree walk ────────────────────────────────────────────────────────────
+
+    fn emit_node(&mut self, node: &Structured) -> Result<(), WasmError> {
+        match node {
+            Structured::Simple { block, next } => {
+                // Inlined single-predecessor edge: resolve the target's φs from
+                // the predecessor we just came from.  Merge blocks resolve their
+                // φs at the `Br` sites instead.
+                if !self.is_merge(*block) {
+                    self.emit_phi_copies(*block, self.current)?;
+                }
+                self.current = *block;
+                self.emit_block_body(*block)?;
+                self.emit_node(next)
+            }
+            Structured::Labeled { label, body, next } => {
+                self.ins(&Instruction::Block(BlockType::Empty));
+                self.labels.push(Some(*label));
+                self.emit_node(body)?;
+                self.labels.pop();
+                self.ins(&Instruction::End);
+                self.emit_node(next)
+            }
+            Structured::Loop { header, body } => {
+                self.ins(&Instruction::Loop(BlockType::Empty));
+                self.labels.push(Some(*header));
+                // Back-edge safepoint: the loop label is the continue target, so
+                // emitting here runs it on every iteration.
+                self.call_import("rt_safepoint")?;
+                self.emit_node(body)?;
+                self.labels.pop();
+                self.ins(&Instruction::End);
+                Ok(())
+            }
+            Structured::If {
+                cond,
+                then_arm,
+                else_arm,
+            } => {
+                // Branch on the boxed condition's truthiness.
+                self.get(*cond)?;
+                self.call_import("rt_truthiness")?;
+                self.ins(&Instruction::If(BlockType::Empty));
+                self.labels.push(None);
+                self.emit_node(then_arm)?;
+                self.ins(&Instruction::Else);
+                self.emit_node(else_arm)?;
+                self.labels.pop();
+                self.ins(&Instruction::End);
+                Ok(())
+            }
+            Structured::Br(target) => self.emit_br(*target),
+            Structured::Return(v) => {
+                self.get(*v)?;
+                self.ins(&Instruction::Return);
+                Ok(())
+            }
+            Structured::Unreachable => {
+                self.ins(&Instruction::Unreachable);
+                Ok(())
+            }
+            Structured::Nil => Ok(()),
+        }
+    }
+
+    fn emit_br(&mut self, target: BlockId) -> Result<(), WasmError> {
+        self.emit_phi_copies(target, self.current)?;
+        let depth = self.br_depth(target)?;
+        self.ins(&Instruction::Br(depth));
+        Ok(())
+    }
+
+    /// `br` depth to the enclosing frame labeled `target` (0 = innermost).
+    fn br_depth(&self, target: BlockId) -> Result<u32, WasmError> {
+        for (k, frame) in self.labels.iter().rev().enumerate() {
+            if *frame == Some(target) {
+                return Ok(k as u32);
+            }
+        }
+        Err(WasmError::Unsupported(format!(
+            "br target {target} not in an enclosing block/loop"
+        )))
+    }
+
+    /// Copy each φ of `target` from its `pred` entry into the φ's local, using
+    /// the operand stack for parallel-move semantics.
+    fn emit_phi_copies(&mut self, target: BlockId, pred: BlockId) -> Result<(), WasmError> {
+        let mut moves: Vec<(VarId, VarId)> = Vec::new(); // (dst, src)
+        for inst in &self.block(target).phis {
+            if let Inst::Phi(dst, entries) = inst
+                && let Some((_, src)) = entries.iter().find(|(p, _)| *p == pred)
+            {
+                moves.push((*dst, *src));
+            }
+        }
+        if moves.is_empty() {
+            return Ok(());
+        }
+        for (_, src) in &moves {
+            self.get(*src)?;
+        }
+        for (dst, _) in moves.iter().rev() {
+            self.set(*dst)?;
+        }
+        Ok(())
+    }
+
+    // ── Instruction lowering ─────────────────────────────────────────────────
+
+    fn emit_block_body(&mut self, block: BlockId) -> Result<(), WasmError> {
+        // Phis are resolved on edges, not here.
+        let idx = self.block_of[&block];
+        let n = self.func.blocks[idx].insts.len();
+        for i in 0..n {
+            let inst = self.func.blocks[idx].insts[i].clone();
+            self.emit_inst(&inst)?;
+        }
+        Ok(())
+    }
+
+    fn emit_inst(&mut self, inst: &Inst) -> Result<(), WasmError> {
+        match inst {
+            Inst::Const(dst, c) => {
+                self.emit_const(c)?;
+                self.set(*dst)
+            }
+            // In compiled code locals are bound by params / let bindings; an
+            // unresolved LoadLocal is nil, matching the Cranelift backend.
+            Inst::LoadLocal(dst, _name) => {
+                self.call_import("rt_const_nil")?;
+                self.set(*dst)
+            }
+            Inst::CallKnown(dst, kf, args) => {
+                self.emit_known(kf, args)?;
+                self.set(*dst)
+            }
+            // Resolved on edges / by terminators.
+            Inst::Phi(..) | Inst::Recur(..) | Inst::SourceLoc(..) => Ok(()),
+            other => Err(WasmError::Unsupported(format!(
+                "instruction not yet lowered: {other}"
+            ))),
+        }
+    }
+
+    /// Materialize a constant as a boxed value, left on the operand stack.
+    fn emit_const(&mut self, c: &Const) -> Result<(), WasmError> {
+        match c {
+            Const::Nil => self.call_import("rt_const_nil"),
+            Const::Bool(true) => self.call_import("rt_const_true"),
+            Const::Bool(false) => self.call_import("rt_const_false"),
+            Const::Long(n) => {
+                self.ins(&Instruction::I64Const(*n));
+                self.call_import("rt_const_long")
+            }
+            Const::Double(f) => {
+                self.ins(&Instruction::F64Const(Ieee64::from(*f)));
+                self.call_import("rt_const_double")
+            }
+            Const::Char(ch) => {
+                self.ins(&Instruction::I32Const(*ch as i32));
+                self.call_import("rt_const_char")
+            }
+            // Strings/keywords/symbols need their bytes in a data segment
+            // coordinated with the runtime's memory layout — a later increment.
+            Const::Str(_) | Const::Keyword(_) | Const::Symbol(_) => Err(WasmError::Unsupported(
+                "string/keyword/symbol constants (need a data segment)".into(),
+            )),
+        }
+    }
+
+    /// Lower a known-function call to its boxed `rt_abi` bridge, result left on
+    /// the operand stack.
+    fn emit_known(&mut self, kf: &KnownFn, args: &[VarId]) -> Result<(), WasmError> {
+        let (bridge, is_cmp) = match kf {
+            KnownFn::Add => ("rt_add", false),
+            KnownFn::Sub => ("rt_sub", false),
+            KnownFn::Mul => ("rt_mul", false),
+            KnownFn::Div => ("rt_div", false),
+            KnownFn::Rem => ("rt_rem", false),
+            KnownFn::Eq => ("rt_eq", true),
+            KnownFn::Lt => ("rt_lt", true),
+            KnownFn::Gt => ("rt_gt", true),
+            KnownFn::Lte => ("rt_lte", true),
+            KnownFn::Gte => ("rt_gte", true),
+            other => {
+                return Err(WasmError::Unsupported(format!(
+                    "known function not yet lowered: {other:?}"
+                )));
+            }
+        };
+
+        if is_cmp {
+            if args.len() != 2 {
+                return Err(WasmError::Unsupported(format!(
+                    "n-ary comparison {kf:?} (only binary lowered)"
+                )));
+            }
+            self.get(args[0])?;
+            self.get(args[1])?;
+            self.call_import(bridge)?;
+        } else {
+            // Left-fold the boxed binary bridge: (op a b c) = op(op(a,b),c).
+            let Some((first, rest)) = args.split_first() else {
+                return Err(WasmError::Unsupported(format!(
+                    "0-ary arithmetic {kf:?} (no identity element lowered)"
+                )));
+            };
+            self.get(*first)?;
+            for a in rest {
+                self.get(*a)?;
+                self.call_import(bridge)?;
+            }
+        }
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{Block, Const, Inst, Terminator, VarId};
+    use crate::ir::{Block, Terminator};
     use std::sync::Arc;
 
-    fn region_variant() -> IrFunction {
-        // A function whose entry binds a RegionParam → takes a trailing i32.
+    fn validate(bytes: &[u8]) {
+        wasmparser::Validator::new()
+            .validate_all(bytes)
+            .expect("emitted module should validate");
+    }
+
+    fn compile(f: &IrFunction) -> Result<Vec<u8>, WasmError> {
+        let s = super::super::reloop::reloop(f).expect("reloop");
+        emit_function(f, &s, &WasmBackend::default())
+    }
+
+    /// `(fn [x] (+ x 1))`-shaped IR: one block, a constant, an add, a return.
+    #[test]
+    fn arithmetic_function_validates() {
+        let mut f = IrFunction::new(Some(Arc::from("addone")), None);
+        let x = f.fresh_var();
+        f.params = vec![(Arc::from("x"), x)];
+        let one = f.fresh_var();
+        let sum = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![
+                Inst::Const(one, Const::Long(1)),
+                Inst::CallKnown(sum, KnownFn::Add, vec![x, one]),
+            ],
+            terminator: Terminator::Return(sum),
+        });
+        let bytes = compile(&f).expect("emit");
+        validate(&bytes);
+    }
+
+    /// Diamond with a φ at the merge: `(if c a b)` joining two values.
+    #[test]
+    fn diamond_with_phi_validates() {
+        let mut f = IrFunction::new(Some(Arc::from("pick")), None);
+        let c = f.fresh_var();
+        let a = f.fresh_var();
+        let bb = f.fresh_var();
+        f.params = vec![
+            (Arc::from("c"), c),
+            (Arc::from("a"), a),
+            (Arc::from("b"), bb),
+        ];
+        let (b0, b1, b2, b3) = (
+            f.fresh_block(),
+            f.fresh_block(),
+            f.fresh_block(),
+            f.fresh_block(),
+        );
+        let phi = f.fresh_var();
+        f.blocks.push(Block {
+            id: b0,
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::Branch {
+                cond: c,
+                then_block: b1,
+                else_block: b2,
+            },
+        });
+        f.blocks.push(Block {
+            id: b1,
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::Jump(b3),
+        });
+        f.blocks.push(Block {
+            id: b2,
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::Jump(b3),
+        });
+        f.blocks.push(Block {
+            id: b3,
+            phis: vec![Inst::Phi(phi, vec![(b1, a), (b2, bb)])],
+            insts: vec![],
+            terminator: Terminator::Return(phi),
+        });
+        let bytes = compile(&f).expect("emit");
+        validate(&bytes);
+    }
+
+    /// Loop with a φ counter and a conditional `recur`, validating loop + φ
+    /// parallel-move + continue.
+    #[test]
+    fn loop_with_phi_validates() {
+        // b0(header): n = phi[(entry,n0),(b1,n1)]; cond = (< n n); branch b1/b2
+        // b1: n1 = (+ n n); recur -> b0
+        // b2: return n
+        let mut f = IrFunction::new(Some(Arc::from("spin")), None);
+        let n0 = f.fresh_var();
+        f.params = vec![(Arc::from("n0"), n0)];
+        let (b0, b1, b2) = (f.fresh_block(), f.fresh_block(), f.fresh_block());
+        let n = f.fresh_var();
+        let cond = f.fresh_var();
+        let n1 = f.fresh_var();
+        f.blocks.push(Block {
+            id: b0,
+            phis: vec![Inst::Phi(n, vec![(b1, n1)])],
+            insts: vec![Inst::CallKnown(cond, KnownFn::Lt, vec![n, n])],
+            terminator: Terminator::Branch {
+                cond,
+                then_block: b1,
+                else_block: b2,
+            },
+        });
+        f.blocks.push(Block {
+            id: b1,
+            phis: vec![],
+            insts: vec![Inst::CallKnown(n1, KnownFn::Add, vec![n, n])],
+            terminator: Terminator::RecurJump {
+                target: b0,
+                args: vec![n1],
+            },
+        });
+        f.blocks.push(Block {
+            id: b2,
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::Return(n),
+        });
+        let bytes = compile(&f).expect("emit");
+        validate(&bytes);
+    }
+
+    #[test]
+    fn region_variant_is_unsupported() {
         let mut f = IrFunction::new(Some(Arc::from("rv")), None);
         let p = f.fresh_var();
         f.params = vec![(Arc::from("x"), p)];
@@ -155,42 +691,42 @@ mod tests {
             insts: vec![Inst::RegionParam(rp)],
             terminator: Terminator::Return(p),
         });
-        f
-    }
-
-    #[test]
-    fn region_variant_gets_trailing_i32_param() {
-        let f = region_variant();
         assert!(f.takes_region_param());
-        let (params, results) = function_signature(&f);
-        // visible x (boxed i32) + hidden region handle (i32)
-        assert_eq!(params, vec![WasmValType::I32, WasmValType::I32]);
-        assert_eq!(results, vec![WasmValType::I32]);
+        assert!(matches!(compile(&f), Err(WasmError::Unsupported(_))));
     }
 
     #[test]
-    fn long_hinted_param_is_i64() {
-        let mut f = IrFunction::new(Some(Arc::from("g")), None);
-        let p = f.fresh_var();
-        f.params = vec![(Arc::from("n"), p)];
-        f.seed_reprs = vec![Repr::Long];
+    fn unsupported_instruction_reports_cleanly() {
+        let mut f = IrFunction::new(Some(Arc::from("alloc")), None);
         let v = f.fresh_var();
         let b = f.fresh_block();
         f.blocks.push(Block {
             id: b,
             phis: vec![],
-            insts: vec![Inst::Const(v, Const::Long(0))],
-            terminator: Terminator::Return(VarId(0)),
+            insts: vec![Inst::AllocVector(v, vec![])],
+            terminator: Terminator::Return(v),
         });
-        let (params, _) = function_signature(&f);
-        assert_eq!(params, vec![WasmValType::I64]);
+        match compile(&f) {
+            Err(WasmError::Unsupported(msg)) => assert!(msg.contains("not yet lowered")),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
     }
 
     #[test]
-    fn emit_is_stubbed_but_front_half_runs() {
-        let f = region_variant();
-        let structured = super::super::reloop::reloop(&f).expect("reloop");
-        let err = emit_function(&f, &structured, &WasmBackend::default()).unwrap_err();
-        assert!(matches!(err, WasmError::Unimplemented(_)));
+    fn function_signature_region_and_long_hint() {
+        let mut f = IrFunction::new(Some(Arc::from("g")), None);
+        let p = f.fresh_var();
+        f.params = vec![(Arc::from("n"), p)];
+        f.seed_reprs = vec![Repr::Long];
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::Return(p),
+        });
+        let (params, results) = function_signature(&f);
+        assert_eq!(params, vec![WasmValType::I64]);
+        assert_eq!(results, vec![WasmValType::I32]);
     }
 }

--- a/crates/cljrs-compiler/src/wasm/emit.rs
+++ b/crates/cljrs-compiler/src/wasm/emit.rs
@@ -1,0 +1,201 @@
+//! WebAssembly emitter (scaffold).
+//!
+//! Walks a [`reloop::Structured`] tree and lowers each IR [`Inst`] to wasm,
+//! producing a module via `wasm-encoder` (the intended encoder dependency,
+//! added when this is implemented).  Until then [`emit_function`] returns
+//! [`WasmError::Unimplemented`] and this module documents the lowering plan and
+//! exposes the per-`Inst` dispatch skeleton so the contract is reviewable.
+//!
+//! # Lowering plan
+//!
+//! ## Function signature
+//!
+//! Visible params map to wasm params by [`abi::WasmValType::for_repr`] of each
+//! param's inferred [`Repr`].  A region-parameterised variant
+//! ([`IrFunction::takes_region_param`]) appends one trailing `i32` region
+//! handle; a poll function ([`IrFunction::takes_state_param`]) uses the fixed
+//! `(state_ptr: i32, out_ptr: i32) -> i32` shape instead.  This mirrors
+//! [`IrFunction::abi_param_count`] on the native side.
+//!
+//! ## Values → locals
+//!
+//! Each IR [`VarId`] becomes a wasm local of the type given by its inferred
+//! [`Repr`] (`crate::typeinfer`).  SSA `phi` nodes are resolved on the way in:
+//! each predecessor writes the phi's local before branching, so no φ instruction
+//! is emitted — the structured arms simply `local.set` the join local.
+//!
+//! ## Instructions → wasm
+//!
+//! | IR construct | wasm lowering |
+//! |---|---|
+//! | [`Inst::Const`] scalar | `i64.const` / `f64.const` (unboxed) or `call rt_const_*` (boxed) |
+//! | [`Inst::CallKnown`] arith on `Long`/`Double` | native `i64.add`/`f64.add`/… per `typeinfer` |
+//! | [`Inst::CallKnown`] boxed | `call rt_<op>` bridge (see [`abi::RT_IMPORTS`]) |
+//! | [`Inst::Alloc*`] | spill operands to a scratch array in linear memory, `call rt_alloc_*` |
+//! | [`Inst::RegionStart`] | `call rt_region_start`, keep handle in an `i32` local |
+//! | [`Inst::RegionAlloc`] | `call rt_region_alloc_*` with the handle leading |
+//! | [`Inst::RegionEnd`] | `call rt_region_end` |
+//! | [`Inst::RegionParam`] | bind the trailing `i32` param local |
+//! | [`Inst::CallWithRegion`] | `call`/`return_call` passing the region handle trailing |
+//! | [`Inst::CallDirect`] | `call $fn` (or `return_call` in tail position when [`WasmBackend::tail_calls`]) |
+//! | [`Inst::Call`] | per-call-site inline cache: `call rt_call_ic` |
+//! | [`Terminator::Branch`] | structured `if` from the relooper |
+//! | [`Terminator::RecurJump`] | `br` to the enclosing `loop` label |
+//! | [`Terminator::Return`] | `return` |
+//! | [`Inst::Throw`] / `TryCatchFinally` | `throw`/`try`/`catch` when [`WasmBackend::exceptions`], else an `rt_abi` error path |
+//!
+//! ## GC + safepoints
+//!
+//! `rt_safepoint` is called at function entry and at every loop back-edge
+//! (`Structured::Continue`), matching the native backend.  The GC heap lives in
+//! the module's linear memory; emitted code holds no raw GC pointers across
+//! suspension because constants are materialized through `rt_abi`.
+
+use crate::ir::{IrFunction, Repr};
+
+use super::abi::WasmValType;
+use super::reloop::Structured;
+use super::{WasmBackend, WasmError};
+
+/// Emit a wasm function body for `func` given its structured control flow.
+///
+/// Scaffold: validates the structured tree can be walked and computes the wasm
+/// signature, then returns [`WasmError::Unimplemented`] for the encoder step.
+pub fn emit_function(
+    func: &IrFunction,
+    structured: &Structured,
+    cfg: &WasmBackend,
+) -> Result<Vec<u8>, WasmError> {
+    // Compute the wasm signature now so the ABI is exercised even while the
+    // encoder is stubbed (keeps the region/poll param accounting honest).
+    let sig = function_signature(func);
+    let _ = (structured, cfg, sig);
+
+    // Walk the tree once to surface unsupported nodes early; a real emitter
+    // would thread a `wasm_encoder::Function` here instead of `&mut ()`.
+    walk(structured)?;
+
+    Err(WasmError::Unimplemented(
+        "wasm-encoder emission (front half — reloop + signature + tree walk — is wired)",
+    ))
+}
+
+/// The wasm function signature for `func`: `(params, results)`.
+///
+/// Honors the hidden trailing region param and the poll-function ABI, mirroring
+/// [`IrFunction::abi_param_count`].
+pub fn function_signature(func: &IrFunction) -> (Vec<WasmValType>, Vec<WasmValType>) {
+    if func.takes_state_param() {
+        // Poll ABI: (state_ptr: i32, out_ptr: i32) -> i32 (Poll discriminant).
+        return (
+            vec![WasmValType::I32, WasmValType::I32],
+            vec![WasmValType::I32],
+        );
+    }
+
+    let mut params: Vec<WasmValType> = func
+        .params
+        .iter()
+        .enumerate()
+        .map(|(i, _)| {
+            let repr = func.seed_reprs.get(i).copied().unwrap_or(Repr::Boxed);
+            WasmValType::for_repr(repr)
+        })
+        .collect();
+
+    if func.takes_region_param() {
+        // Hidden trailing region handle.
+        params.push(WasmValType::I32);
+    }
+
+    // Every Clojure function yields a single value (boxed unless a return-repr
+    // pass proves otherwise); the scaffold returns the universal boxed i32.
+    (params, vec![WasmValType::I32])
+}
+
+/// Walk the structured tree, returning an error for nodes the emitter scaffold
+/// does not yet handle.  This is where the `wasm-encoder` `Function` builder
+/// will be threaded; for now it only validates structure.
+fn walk(node: &Structured) -> Result<(), WasmError> {
+    match node {
+        Structured::Simple { next, .. } => walk(next),
+        Structured::If {
+            then_arm,
+            else_arm,
+            next,
+            ..
+        } => {
+            walk(then_arm)?;
+            walk(else_arm)?;
+            walk(next)
+        }
+        Structured::Loop { body, next, .. } => {
+            walk(body)?;
+            walk(next)
+        }
+        Structured::Break(_)
+        | Structured::Continue(_)
+        | Structured::Return(_)
+        | Structured::Unreachable
+        | Structured::Nil => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{Block, Const, Inst, Terminator, VarId};
+    use std::sync::Arc;
+
+    fn region_variant() -> IrFunction {
+        // A function whose entry binds a RegionParam → takes a trailing i32.
+        let mut f = IrFunction::new(Some(Arc::from("rv")), None);
+        let p = f.fresh_var();
+        f.params = vec![(Arc::from("x"), p)];
+        let rp = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![Inst::RegionParam(rp)],
+            terminator: Terminator::Return(p),
+        });
+        f
+    }
+
+    #[test]
+    fn region_variant_gets_trailing_i32_param() {
+        let f = region_variant();
+        assert!(f.takes_region_param());
+        let (params, results) = function_signature(&f);
+        // visible x (boxed i32) + hidden region handle (i32)
+        assert_eq!(params, vec![WasmValType::I32, WasmValType::I32]);
+        assert_eq!(results, vec![WasmValType::I32]);
+    }
+
+    #[test]
+    fn long_hinted_param_is_i64() {
+        let mut f = IrFunction::new(Some(Arc::from("g")), None);
+        let p = f.fresh_var();
+        f.params = vec![(Arc::from("n"), p)];
+        f.seed_reprs = vec![Repr::Long];
+        let v = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![Inst::Const(v, Const::Long(0))],
+            terminator: Terminator::Return(VarId(0)),
+        });
+        let (params, _) = function_signature(&f);
+        assert_eq!(params, vec![WasmValType::I64]);
+    }
+
+    #[test]
+    fn emit_is_stubbed_but_front_half_runs() {
+        let f = region_variant();
+        let structured = super::super::reloop::reloop(&f).expect("reloop");
+        let err = emit_function(&f, &structured, &WasmBackend::default()).unwrap_err();
+        assert!(matches!(err, WasmError::Unimplemented(_)));
+    }
+}

--- a/crates/cljrs-compiler/src/wasm/mod.rs
+++ b/crates/cljrs-compiler/src/wasm/mod.rs
@@ -40,20 +40,22 @@
 //!
 //! # What is new here (the only wasm-specific work)
 //!
-//! - [`reloop`] — recover structured control flow from the IR's arbitrary CFG.
-//!   wasm has only `block`/`loop`/`if` + labeled `br`, no `goto`.  Cranelift
-//!   wants the raw CFG, so this pass is wasm-private and lives *here*, not in
-//!   shared lowering.  Clojure source yields reducible CFGs, so only the cheap
-//!   relooper is required (no node-splitting, no dispatch variable).
+//! - [`reloop`] — recover structured control flow from the IR's arbitrary CFG
+//!   via dominator-tree structuring (Ramsey's "Beyond Relooper").  wasm has only
+//!   `block`/`loop`/`if` + labeled `br`, no `goto`.  Cranelift wants the raw
+//!   CFG, so this pass is wasm-private and lives *here*, not in shared lowering.
+//!   Clojure source yields reducible CFGs, so only the cheap relooper is
+//!   required (no node-splitting, no dispatch variable).
 //! - [`emit`] — walk the structured tree + per-`Inst` lowering to a
 //!   `wasm-encoder` module, with `rt_abi` symbols declared as wasm imports.
 //!
 //! # Status
 //!
-//! **Scaffold.**  The module structure, public API, the relooper data model
-//! (with trivial cases implemented), and the full ABI/region contract are in
-//! place.  The `wasm-encoder` emitter and the relooper's loop/join structuring
-//! are stubbed and return [`WasmError::Unimplemented`].
+//! **Scaffold.**  The module structure, public API, the full ABI/region
+//! contract, and the [`reloop`] relooper (complete for reducible CFGs —
+//! straight-line, `if`/`cond` diamonds, sequential/nested merges, and
+//! `loop`/`recur` loops) are in place.  The `wasm-encoder` emitter is stubbed
+//! and returns [`WasmError::Unimplemented`].
 
 pub mod abi;
 pub mod emit;

--- a/crates/cljrs-compiler/src/wasm/mod.rs
+++ b/crates/cljrs-compiler/src/wasm/mod.rs
@@ -1,0 +1,134 @@
+//! AOT Clojure → WebAssembly backend (scaffold).
+//!
+//! This module is the **second backend** for the shared `cljrs-ir` IR, parallel
+//! to the Cranelift backend in [`crate::codegen`].  Where Cranelift lowers an
+//! [`IrFunction`] CFG to native object code, this backend lowers the *same*
+//! regionalized IR to a WebAssembly module that the browser JITs to native.
+//!
+//! # Why a separate backend at all
+//!
+//! A wasm module cannot generate and execute native machine code at runtime —
+//! there is no `mmap(PROT_EXEC)` inside the sandbox — so the Cranelift JIT
+//! (`cljrs-jit`) cannot run in a browser.  The browser deployment story is
+//! therefore *ahead-of-time*: compile each Clojure function to wasm bytecode at
+//! build time and ship it.  At runtime the tiers invert relative to native:
+//!
+//! ```text
+//!   tree-walk  →  IR-interp        (dynamic: eval, REPL, freshly-required ns, macros)
+//!   AOT-wasm                       (baked at build time; browser JITs it to native)
+//! ```
+//!
+//! So the IR interpreter (`cljrs-eval::ir_interp`) remains *on board* in the
+//! wasm bundle as the dynamic-code tier; AOT-wasm is the frozen top tier.  No
+//! in-sandbox JIT/OSR hooks are installed.
+//!
+//! # What is reused unchanged
+//!
+//! Everything upstream of code generation is backend-agnostic and shared with
+//! the Cranelift path:
+//!
+//! - ANF/SSA lowering (`cljrs_ir::lower`)
+//! - Escape analysis + region inference (`cljrs_ir::lower::{escape, regionalize}`)
+//! - Scalar representation inference (`crate::typeinfer`)
+//! - The `rt_abi` runtime bridge contract (`crate::rt_abi`) — see [`abi`]
+//!
+//! Because escape analysis and region promotion are *properties of the IR*
+//! (`Inst::Region*`, [`IrFunction::takes_region_param`]), bump allocation comes
+//! along for free: a region is a linear-memory arena, a region handle is an
+//! `i32` offset, and a region-parameterised variant simply takes that `i32` as
+//! a hidden trailing parameter.  See [`abi`] for the region ABI contract.
+//!
+//! # What is new here (the only wasm-specific work)
+//!
+//! - [`reloop`] — recover structured control flow from the IR's arbitrary CFG.
+//!   wasm has only `block`/`loop`/`if` + labeled `br`, no `goto`.  Cranelift
+//!   wants the raw CFG, so this pass is wasm-private and lives *here*, not in
+//!   shared lowering.  Clojure source yields reducible CFGs, so only the cheap
+//!   relooper is required (no node-splitting, no dispatch variable).
+//! - [`emit`] — walk the structured tree + per-`Inst` lowering to a
+//!   `wasm-encoder` module, with `rt_abi` symbols declared as wasm imports.
+//!
+//! # Status
+//!
+//! **Scaffold.**  The module structure, public API, the relooper data model
+//! (with trivial cases implemented), and the full ABI/region contract are in
+//! place.  The `wasm-encoder` emitter and the relooper's loop/join structuring
+//! are stubbed and return [`WasmError::Unimplemented`].
+
+pub mod abi;
+pub mod emit;
+pub mod reloop;
+
+use crate::ir::IrFunction;
+
+/// Errors produced by the wasm backend.
+#[derive(Debug)]
+pub enum WasmError {
+    /// The relooper could not structure this function's control flow yet.
+    Reloop(reloop::RelooperError),
+    /// An IR construct the emitter does not yet lower to wasm.
+    Unsupported(String),
+    /// A scaffolded path that is not implemented yet.
+    Unimplemented(&'static str),
+}
+
+impl std::fmt::Display for WasmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WasmError::Reloop(e) => write!(f, "relooper: {e}"),
+            WasmError::Unsupported(what) => write!(f, "unsupported in wasm backend: {what}"),
+            WasmError::Unimplemented(what) => write!(f, "not yet implemented: {what}"),
+        }
+    }
+}
+
+impl std::error::Error for WasmError {}
+
+impl From<reloop::RelooperError> for WasmError {
+    fn from(e: reloop::RelooperError) -> Self {
+        WasmError::Reloop(e)
+    }
+}
+
+/// WebAssembly feature flags the backend may target.
+///
+/// Defaults reflect what is broadly shipping in browsers as of the current
+/// roadmap; the emitter consults these to decide between, e.g., `return_call`
+/// (tail-call proposal) and a trampoline, or the exception-handling proposal
+/// for `try`/`catch`.
+#[derive(Debug, Clone, Copy)]
+pub struct WasmBackend {
+    /// Use the wasm tail-call proposal (`return_call`/`return_call_indirect`)
+    /// for cross-function tail positions.  When `false`, the emitter must
+    /// trampoline.  (`recur` within a function is always a `loop`/`br` and does
+    /// not depend on this.)
+    pub tail_calls: bool,
+    /// Use the wasm exception-handling proposal for `try`/`catch`/`throw`
+    /// (`KnownFn::TryCatchFinally`, `Inst::Throw`).  When `false`, the emitter
+    /// must thread an explicit error path through `rt_abi`.
+    pub exceptions: bool,
+}
+
+impl Default for WasmBackend {
+    fn default() -> Self {
+        Self {
+            tail_calls: true,
+            exceptions: true,
+        }
+    }
+}
+
+/// Compile a single [`IrFunction`] to a standalone wasm module's worth of
+/// bytecode for that function.
+///
+/// Pipeline: [`reloop::reloop`] to recover structured control flow, then
+/// [`emit::emit_function`] to encode it.  The region ABI ([`abi`]) is threaded
+/// automatically for region-parameterised variants
+/// ([`IrFunction::takes_region_param`]).
+///
+/// Currently returns [`WasmError::Unimplemented`] from the emitter; the
+/// relooping front half runs for the cases [`reloop::reloop`] supports.
+pub fn compile_function(func: &IrFunction, cfg: &WasmBackend) -> Result<Vec<u8>, WasmError> {
+    let structured = reloop::reloop(func)?;
+    emit::emit_function(func, &structured, cfg)
+}

--- a/crates/cljrs-compiler/src/wasm/reloop.rs
+++ b/crates/cljrs-compiler/src/wasm/reloop.rs
@@ -1,0 +1,391 @@
+//! Relooper: recover structured control flow from the IR's CFG.
+//!
+//! wasm has only structured control flow — `block`/`loop`/`if` with labeled
+//! `br`/`br_if`, no arbitrary `goto`.  The `cljrs-ir` CFG ([`IrFunction`],
+//! [`Block`], [`Terminator`]) has arbitrary edges, so the emitter needs a
+//! structured tree to walk.  This pass produces one.
+//!
+//! It is **wasm-private**: the Cranelift backend consumes the raw CFG directly
+//! and would be pessimized by re-structuring, so this lives in the wasm backend
+//! rather than in shared lowering.
+//!
+//! # Why the cheap relooper suffices
+//!
+//! Clojure has no `goto`.  `loop`/`recur` produces reducible loop headers (the
+//! IR models these as [`Terminator::RecurJump`] back-edges to a loop header),
+//! and `if`/`cond`/`do` produce structured branches.  Inlining preserves
+//! reducibility.  So every CFG this backend sees is reducible, which means the
+//! relooper never needs node-splitting or a dispatch variable — the structure
+//! recovers directly from the dominator tree / back-edge set.
+//!
+//! # Algorithm (target shape)
+//!
+//! Standard reducible-CFG structuring:
+//!
+//! 1. Compute reverse-postorder (RPO) and the dominator tree.
+//! 2. A back-edge `b → h` (where `h` dominates `b`) marks `h` as a loop header;
+//!    wrap the region in a [`Structured::Loop`] whose label a `RecurJump`
+//!    lowers to [`Structured::Continue`].
+//! 3. A two-way [`Terminator::Branch`] becomes [`Structured::If`]; control
+//!    re-merges at the branch's immediate post-dominator, which becomes the
+//!    `If`'s `next` continuation.
+//! 4. A forward edge to a multi-predecessor join lowers to a `br` out of an
+//!    enclosing labeled [`Structured::Block`] whose end is that join.
+//!
+//! # Status
+//!
+//! **Scaffold.**  The data model is final.  [`reloop`] implements the acyclic
+//! single-successor, return, and simple re-joining diamond cases; loops,
+//! multi-predecessor joins, and `try`/`catch` regions return
+//! [`RelooperError::Unsupported`], with the dominator-based structuring left as
+//! the documented next step.
+
+use std::collections::HashMap;
+
+use crate::ir::{Block, BlockId, IrFunction, Terminator, VarId};
+
+/// A label naming an enclosing structured construct, targeted by `br`/continue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LabelId(pub u32);
+
+/// A structured control-flow tree — the relooper's output and the emitter's
+/// input.  Each node maps to a small, fixed wasm shape.
+///
+/// `If` and `Loop` carry an explicit `next` continuation (the code that runs
+/// after the construct), so the tree is a single spine with no implicit merge
+/// blocks for the emitter to rediscover.
+#[derive(Debug, Clone)]
+pub enum Structured {
+    /// Emit one IR block's straight-line body (`phis` + `insts`), then `next`.
+    /// The block's own terminator is represented by the surrounding nodes.
+    Simple {
+        block: BlockId,
+        next: Box<Structured>,
+    },
+    /// A reducible loop (`wasm loop`).  A [`Terminator::RecurJump`] to `header`
+    /// lowers to [`Structured::Continue`] of `label`; falling off `body` exits
+    /// the loop and runs `next`.
+    Loop {
+        label: LabelId,
+        header: BlockId,
+        body: Box<Structured>,
+        next: Box<Structured>,
+    },
+    /// Structured two-way branch from a [`Terminator::Branch`].  `then_arm` and
+    /// `else_arm` are the arm bodies (ending in `Nil` at the merge); `next` is
+    /// the post-dominator continuation that runs after either arm.
+    If {
+        cond: VarId,
+        then_arm: Box<Structured>,
+        else_arm: Box<Structured>,
+        next: Box<Structured>,
+    },
+    /// `br` to the end of the labeled enclosing block (exit a join region).
+    Break(LabelId),
+    /// `br` to the top of the labeled enclosing loop (a `recur`).
+    Continue(LabelId),
+    /// Function return of a value.
+    Return(VarId),
+    /// Unreachable terminator (e.g. after `throw`).
+    Unreachable,
+    /// Empty continuation.
+    Nil,
+}
+
+/// Errors from the relooper.
+#[derive(Debug)]
+pub enum RelooperError {
+    /// The function has no blocks.
+    Empty,
+    /// A control-flow shape the scaffold does not structure yet.
+    Unsupported(String),
+}
+
+impl std::fmt::Display for RelooperError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RelooperError::Empty => write!(f, "function has no blocks"),
+            RelooperError::Unsupported(what) => write!(f, "unsupported control flow: {what}"),
+        }
+    }
+}
+
+/// Structure the control flow of `func` into a [`Structured`] tree.
+pub fn reloop(func: &IrFunction) -> Result<Structured, RelooperError> {
+    if func.blocks.is_empty() {
+        return Err(RelooperError::Empty);
+    }
+    let cfg = Cfg::new(func);
+    if cfg.has_back_edges() {
+        // Loop structuring (dominator tree + back-edge detection) is the
+        // documented next step; the data model already has `Loop`/`Continue`.
+        return Err(RelooperError::Unsupported(
+            "loops (recur back-edges) — needs dominator-based loop structuring".into(),
+        ));
+    }
+    let entry = func.blocks[0].id;
+    structure_acyclic(&cfg, entry)
+}
+
+/// A lightweight CFG view over an [`IrFunction`]: block index + predecessor map
+/// keyed by [`BlockId`].
+struct Cfg<'f> {
+    func: &'f IrFunction,
+    index: HashMap<BlockId, usize>,
+    preds: HashMap<BlockId, Vec<BlockId>>,
+}
+
+impl<'f> Cfg<'f> {
+    fn new(func: &'f IrFunction) -> Self {
+        let mut index = HashMap::new();
+        let mut preds: HashMap<BlockId, Vec<BlockId>> = HashMap::new();
+        for (i, b) in func.blocks.iter().enumerate() {
+            index.insert(b.id, i);
+            preds.entry(b.id).or_default();
+        }
+        for b in &func.blocks {
+            for s in successors(&b.terminator) {
+                preds.entry(s).or_default().push(b.id);
+            }
+        }
+        Cfg { func, index, preds }
+    }
+
+    fn block(&self, id: BlockId) -> &'f Block {
+        &self.func.blocks[self.index[&id]]
+    }
+
+    fn pred_count(&self, id: BlockId) -> usize {
+        self.preds.get(&id).map(|p| p.len()).unwrap_or(0)
+    }
+
+    /// A back-edge is a `RecurJump`, or a successor that is not later than its
+    /// source in block order.  Reducible Clojure CFGs place loop headers before
+    /// their back-edges, so block-order comparison detects them.
+    fn has_back_edges(&self) -> bool {
+        self.func.blocks.iter().any(|b| {
+            if matches!(b.terminator, Terminator::RecurJump { .. }) {
+                return true;
+            }
+            let src = self.index[&b.id];
+            successors(&b.terminator)
+                .into_iter()
+                .any(|s| self.index[&s] <= src)
+        })
+    }
+}
+
+/// Successor block ids of a terminator.
+fn successors(term: &Terminator) -> Vec<BlockId> {
+    match term {
+        Terminator::Jump(t) => vec![*t],
+        Terminator::Branch {
+            then_block,
+            else_block,
+            ..
+        } => vec![*then_block, *else_block],
+        Terminator::RecurJump { target, .. } => vec![*target],
+        Terminator::Return(_) | Terminator::Unreachable => vec![],
+    }
+}
+
+/// Structure an acyclic region rooted at `block`: emit the block body, then
+/// recurse on its terminator.  Handles single-successor chains, returns, and
+/// simple re-joining diamonds; bails on multi-predecessor joins it cannot yet
+/// place behind a block label.
+fn structure_acyclic(cfg: &Cfg, block: BlockId) -> Result<Structured, RelooperError> {
+    let tail = match &cfg.block(block).terminator {
+        Terminator::Return(v) => Structured::Return(*v),
+        Terminator::Unreachable => Structured::Unreachable,
+        Terminator::Jump(t) => {
+            if cfg.pred_count(*t) > 1 {
+                return Err(RelooperError::Unsupported(
+                    "forward edge into a multi-predecessor join — needs block-label placement"
+                        .into(),
+                ));
+            }
+            structure_acyclic(cfg, *t)?
+        }
+        Terminator::Branch {
+            cond,
+            then_block,
+            else_block,
+        } => structure_diamond(cfg, *cond, *then_block, *else_block)?,
+        Terminator::RecurJump { .. } => {
+            return Err(RelooperError::Unsupported(
+                "recur outside a structured loop".into(),
+            ));
+        }
+    };
+    Ok(Structured::Simple {
+        block,
+        next: Box::new(tail),
+    })
+}
+
+/// Structure a `Branch` whose arms re-merge at a common post-dominator (the
+/// classic if/else diamond): each arm is a single block that jumps to the same
+/// merge block.  The merge becomes the `If`'s `next` continuation.
+fn structure_diamond(
+    cfg: &Cfg,
+    cond: VarId,
+    then_block: BlockId,
+    else_block: BlockId,
+) -> Result<Structured, RelooperError> {
+    let then_succ = successors(&cfg.block(then_block).terminator);
+    let else_succ = successors(&cfg.block(else_block).terminator);
+
+    if let ([then_merge], [else_merge]) = (then_succ.as_slice(), else_succ.as_slice())
+        && then_merge == else_merge
+        && cfg.pred_count(then_block) == 1
+        && cfg.pred_count(else_block) == 1
+    {
+        let then_arm = Structured::Simple {
+            block: then_block,
+            next: Box::new(Structured::Nil),
+        };
+        let else_arm = Structured::Simple {
+            block: else_block,
+            next: Box::new(Structured::Nil),
+        };
+        let merge = structure_acyclic(cfg, *then_merge)?;
+        return Ok(Structured::If {
+            cond,
+            then_arm: Box::new(then_arm),
+            else_arm: Box::new(else_arm),
+            next: Box::new(merge),
+        });
+    }
+
+    Err(RelooperError::Unsupported(
+        "branch arms do not form a simple re-joining diamond yet".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{Const, Inst, KnownFn};
+    use std::sync::Arc;
+
+    fn ret_const(name: &str) -> IrFunction {
+        let mut f = IrFunction::new(Some(Arc::from(name)), None);
+        let v = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![Inst::Const(v, Const::Long(7))],
+            terminator: Terminator::Return(v),
+        });
+        f
+    }
+
+    #[test]
+    fn empty_function_errors() {
+        let f = IrFunction::new(Some(Arc::from("empty")), None);
+        assert!(matches!(reloop(&f), Err(RelooperError::Empty)));
+    }
+
+    #[test]
+    fn single_return_block_structures() {
+        let f = ret_const("k");
+        match reloop(&f).expect("structure single return") {
+            Structured::Simple { next, .. } => assert!(matches!(*next, Structured::Return(_))),
+            other => panic!("expected Simple -> Return, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn linear_jump_chain_structures() {
+        let mut f = IrFunction::new(Some(Arc::from("chain")), None);
+        let v = f.fresh_var();
+        let b0 = f.fresh_block();
+        let b1 = f.fresh_block();
+        f.blocks.push(Block {
+            id: b0,
+            phis: vec![],
+            insts: vec![Inst::Const(v, Const::Long(1))],
+            terminator: Terminator::Jump(b1),
+        });
+        f.blocks.push(Block {
+            id: b1,
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::Return(v),
+        });
+        assert!(reloop(&f).is_ok());
+    }
+
+    #[test]
+    fn simple_diamond_structures_to_if() {
+        // b0: branch -> b1 / b2 ; b1 -> b3 ; b2 -> b3 ; b3: return
+        let mut f = IrFunction::new(Some(Arc::from("diamond")), None);
+        let c = f.fresh_var();
+        let v = f.fresh_var();
+        let b0 = f.fresh_block();
+        let b1 = f.fresh_block();
+        let b2 = f.fresh_block();
+        let b3 = f.fresh_block();
+        f.blocks.push(Block {
+            id: b0,
+            phis: vec![],
+            insts: vec![Inst::CallKnown(c, KnownFn::IsNil, vec![])],
+            terminator: Terminator::Branch {
+                cond: c,
+                then_block: b1,
+                else_block: b2,
+            },
+        });
+        for b in [b1, b2] {
+            f.blocks.push(Block {
+                id: b,
+                phis: vec![],
+                insts: vec![],
+                terminator: Terminator::Jump(b3),
+            });
+        }
+        f.blocks.push(Block {
+            id: b3,
+            phis: vec![],
+            insts: vec![Inst::Const(v, Const::Nil)],
+            terminator: Terminator::Return(v),
+        });
+
+        match reloop(&f).expect("structure diamond") {
+            Structured::Simple { next, .. } => assert!(
+                matches!(*next, Structured::If { .. }),
+                "entry block should be followed by an If"
+            ),
+            other => panic!("expected Simple -> If, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loops_are_unsupported_for_now() {
+        let mut f = IrFunction::new(Some(Arc::from("loopy")), None);
+        let c = f.fresh_var();
+        let b0 = f.fresh_block();
+        let b1 = f.fresh_block();
+        f.blocks.push(Block {
+            id: b0,
+            phis: vec![],
+            insts: vec![Inst::CallKnown(c, KnownFn::IsNil, vec![])],
+            terminator: Terminator::Branch {
+                cond: c,
+                then_block: b1,
+                else_block: b1,
+            },
+        });
+        f.blocks.push(Block {
+            id: b1,
+            phis: vec![],
+            insts: vec![],
+            terminator: Terminator::RecurJump {
+                target: b0,
+                args: vec![],
+            },
+        });
+        assert!(matches!(reloop(&f), Err(RelooperError::Unsupported(_))));
+    }
+}

--- a/crates/cljrs-compiler/src/wasm/reloop.rs
+++ b/crates/cljrs-compiler/src/wasm/reloop.rs
@@ -9,82 +9,94 @@
 //! and would be pessimized by re-structuring, so this lives in the wasm backend
 //! rather than in shared lowering.
 //!
-//! # Why the cheap relooper suffices
+//! # Algorithm
 //!
-//! Clojure has no `goto`.  `loop`/`recur` produces reducible loop headers (the
-//! IR models these as [`Terminator::RecurJump`] back-edges to a loop header),
-//! and `if`/`cond`/`do` produce structured branches.  Inlining preserves
-//! reducibility.  So every CFG this backend sees is reducible, which means the
-//! relooper never needs node-splitting or a dispatch variable — the structure
-//! recovers directly from the dominator tree / back-edge set.
+//! This implements the dominator-tree structuring of Norman Ramsey's *"Beyond
+//! Relooper: Recursive Translation of Unstructured Control Flow to Structured
+//! Control Flow"* (ICFP 2022), specialized to the two facts that hold for every
+//! CFG this backend sees:
 //!
-//! # Algorithm (target shape)
+//! - **Back edges are exactly [`Terminator::RecurJump`].**  Clojure has no
+//!   `goto`; the only cyclic control flow is `loop`/`recur`, which lowering
+//!   emits as a `RecurJump` to the loop header.  So loop headers are precisely
+//!   the `RecurJump` targets, and every `Jump`/`Branch` edge is forward.
+//! - **The CFG is reducible.**  Structured source + reducible-preserving
+//!   inlining can't manufacture irreducibility, so the relooper never needs
+//!   node-splitting or a dispatch variable.
 //!
-//! Standard reducible-CFG structuring:
+//! The translation is driven by the dominator tree:
 //!
-//! 1. Compute reverse-postorder (RPO) and the dominator tree.
-//! 2. A back-edge `b → h` (where `h` dominates `b`) marks `h` as a loop header;
-//!    wrap the region in a [`Structured::Loop`] whose label a `RecurJump`
-//!    lowers to [`Structured::Continue`].
-//! 3. A two-way [`Terminator::Branch`] becomes [`Structured::If`]; control
-//!    re-merges at the branch's immediate post-dominator, which becomes the
-//!    `If`'s `next` continuation.
-//! 4. A forward edge to a multi-predecessor join lowers to a `br` out of an
-//!    enclosing labeled [`Structured::Block`] whose end is that join.
+//! - A node `X` is translated by [`Relooper::do_tree`].  If `X` is a loop
+//!   header it is wrapped in a [`Structured::Loop`]; a back edge to `X` becomes
+//!   a `br`(continue) to that loop's label.
+//! - A **merge node** (≥2 *forward* predecessors) cannot be inlined at a single
+//!   branch, so it is emitted once, after the code that branches to it, wrapped
+//!   in a labeled [`Structured::Labeled`] block placed at its immediate
+//!   dominator.  Branches to it become `br`(break) to that block's label.
+//! - Merge children of one node are nested in **ascending reverse-postorder**
+//!   (largest RPO outermost), which guarantees every `br` jumps *forward* out of
+//!   enclosing blocks — the only thing wasm permits.
+//! - Any other forward edge targets a node with a single forward predecessor,
+//!   so it is **inlined** directly ([`Relooper::do_branch`]).
+//!
+//! Each block is therefore emitted exactly once: merge nodes via their dominator
+//! [`Structured::Labeled`], every other reachable node by inlining.
 //!
 //! # Status
 //!
-//! **Scaffold.**  The data model is final.  [`reloop`] implements the acyclic
-//! single-successor, return, and simple re-joining diamond cases; loops,
-//! multi-predecessor joins, and `try`/`catch` regions return
-//! [`RelooperError::Unsupported`], with the dominator-based structuring left as
-//! the documented next step.
+//! Implemented for reducible CFGs (the universal case here): straight-line code,
+//! `if`/`cond` diamonds, sequential and nested merges, and `loop`/`recur` loops
+//! including loops with conditional exits.  A forward edge that is actually a
+//! back edge in reverse-postorder (the signature of irreducible control flow)
+//! returns [`RelooperError::Irreducible`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ir::{Block, BlockId, IrFunction, Terminator, VarId};
 
-/// A label naming an enclosing structured construct, targeted by `br`/continue.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct LabelId(pub u32);
-
 /// A structured control-flow tree — the relooper's output and the emitter's
-/// input.  Each node maps to a small, fixed wasm shape.
-///
-/// `If` and `Loop` carry an explicit `next` continuation (the code that runs
-/// after the construct), so the tree is a single spine with no implicit merge
-/// blocks for the emitter to rediscover.
+/// input.  Each node maps to a small, fixed wasm shape.  `br` targets are block
+/// ids; the emitter resolves them to `br` depths from its label stack while
+/// walking (a forward target is an enclosing [`Structured::Labeled`]; a backward
+/// target is an enclosing [`Structured::Loop`]).
 #[derive(Debug, Clone)]
 pub enum Structured {
-    /// Emit one IR block's straight-line body (`phis` + `insts`), then `next`.
-    /// The block's own terminator is represented by the surrounding nodes.
+    /// Emit one IR block's straight-line body (`phis` + `insts`), then `next`
+    /// (the translation of its terminator).  The block's own terminator is
+    /// represented by the surrounding nodes, never re-emitted here.
     Simple {
         block: BlockId,
         next: Box<Structured>,
     },
-    /// A reducible loop (`wasm loop`).  A [`Terminator::RecurJump`] to `header`
-    /// lowers to [`Structured::Continue`] of `label`; falling off `body` exits
-    /// the loop and runs `next`.
-    Loop {
-        label: LabelId,
-        header: BlockId,
+    /// A labeled `block` construct: a `br`(break) to `label` exits to `next`.
+    /// Used to place a forward merge node `label` after the `body` that branches
+    /// to it.  `label` is the merge block's id; `next` is its translation.
+    Labeled {
+        label: BlockId,
         body: Box<Structured>,
         next: Box<Structured>,
     },
-    /// Structured two-way branch from a [`Terminator::Branch`].  `then_arm` and
-    /// `else_arm` are the arm bodies (ending in `Nil` at the merge); `next` is
-    /// the post-dominator continuation that runs after either arm.
+    /// A `loop` construct headed by `header`.  A `br`(continue) to `header`
+    /// re-enters the loop; falling off the end of `body` exits it (wasm `loop`
+    /// only repeats on an explicit back-`br`).
+    Loop {
+        header: BlockId,
+        body: Box<Structured>,
+    },
+    /// Structured two-way branch.  The arms are self-contained — each ends in a
+    /// `Br`, `Return`, `Unreachable`, or an inlined subtree — so there is no
+    /// fall-through merge here; a re-joining merge is handled by an enclosing
+    /// [`Structured::Labeled`].
     If {
         cond: VarId,
         then_arm: Box<Structured>,
         else_arm: Box<Structured>,
-        next: Box<Structured>,
     },
-    /// `br` to the end of the labeled enclosing block (exit a join region).
-    Break(LabelId),
-    /// `br` to the top of the labeled enclosing loop (a `recur`).
-    Continue(LabelId),
-    /// Function return of a value.
+    /// `br` to `target`: a forward break to an enclosing labeled block, or a
+    /// backward continue to an enclosing loop header.  The emitter distinguishes
+    /// the two by which construct in its label stack carries `target`.
+    Br(BlockId),
+    /// Return a value from the function.
     Return(VarId),
     /// Unreachable terminator (e.g. after `throw`).
     Unreachable,
@@ -97,15 +109,25 @@ pub enum Structured {
 pub enum RelooperError {
     /// The function has no blocks.
     Empty,
-    /// A control-flow shape the scaffold does not structure yet.
-    Unsupported(String),
+    /// A terminator referenced a block not present in the function.
+    DanglingTarget(BlockId),
+    /// A forward (`Jump`/`Branch`) edge runs backward in reverse-postorder —
+    /// the signature of irreducible control flow, which this backend does not
+    /// support (and which Clojure source cannot produce).
+    Irreducible { from: BlockId, to: BlockId },
 }
 
 impl std::fmt::Display for RelooperError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RelooperError::Empty => write!(f, "function has no blocks"),
-            RelooperError::Unsupported(what) => write!(f, "unsupported control flow: {what}"),
+            RelooperError::DanglingTarget(b) => write!(f, "terminator targets missing block {b}"),
+            RelooperError::Irreducible { from, to } => {
+                write!(
+                    f,
+                    "irreducible control flow: forward edge {from} -> {to} runs backward"
+                )
+            }
         }
     }
 }
@@ -115,67 +137,202 @@ pub fn reloop(func: &IrFunction) -> Result<Structured, RelooperError> {
     if func.blocks.is_empty() {
         return Err(RelooperError::Empty);
     }
-    let cfg = Cfg::new(func);
-    if cfg.has_back_edges() {
-        // Loop structuring (dominator tree + back-edge detection) is the
-        // documented next step; the data model already has `Loop`/`Continue`.
-        return Err(RelooperError::Unsupported(
-            "loops (recur back-edges) — needs dominator-based loop structuring".into(),
-        ));
-    }
-    let entry = func.blocks[0].id;
-    structure_acyclic(&cfg, entry)
+    let r = Relooper::analyze(func)?;
+    r.do_tree(r.entry)
 }
 
-/// A lightweight CFG view over an [`IrFunction`]: block index + predecessor map
-/// keyed by [`BlockId`].
-struct Cfg<'f> {
+// ── Analysis ─────────────────────────────────────────────────────────────────
+
+/// Dominator-tree analysis plus the structuring recursion over one
+/// [`IrFunction`].
+struct Relooper<'f> {
     func: &'f IrFunction,
+    entry: BlockId,
     index: HashMap<BlockId, usize>,
-    preds: HashMap<BlockId, Vec<BlockId>>,
+    /// Reverse-postorder rank; smaller is closer to the entry.  Only reachable
+    /// blocks appear.
+    rpo_num: HashMap<BlockId, u32>,
+    /// Number of *forward* (non-`RecurJump`) predecessors of each block.
+    forward_preds: HashMap<BlockId, usize>,
+    /// Loop headers: the set of `RecurJump` targets.
+    loop_headers: HashSet<BlockId>,
+    /// For each block, its dominator-tree children that are merge nodes, sorted
+    /// by ascending `rpo_num` (largest RPO last → outermost block).
+    merge_children: HashMap<BlockId, Vec<BlockId>>,
 }
 
-impl<'f> Cfg<'f> {
-    fn new(func: &'f IrFunction) -> Self {
+impl<'f> Relooper<'f> {
+    fn analyze(func: &'f IrFunction) -> Result<Self, RelooperError> {
+        let entry = func.blocks[0].id;
         let mut index = HashMap::new();
-        let mut preds: HashMap<BlockId, Vec<BlockId>> = HashMap::new();
         for (i, b) in func.blocks.iter().enumerate() {
             index.insert(b.id, i);
-            preds.entry(b.id).or_default();
         }
+
+        // Validate all terminator targets exist up front.
         for b in &func.blocks {
             for s in successors(&b.terminator) {
-                preds.entry(s).or_default().push(b.id);
+                if !index.contains_key(&s) {
+                    return Err(RelooperError::DanglingTarget(s));
+                }
             }
         }
-        Cfg { func, index, preds }
+
+        // Reverse postorder over all edges (back edges included; DFS handles
+        // the cycles via the visited set).
+        let post = postorder(func, entry, &index);
+        let mut rpo_num = HashMap::new();
+        for (rank, id) in post.iter().rev().enumerate() {
+            rpo_num.insert(*id, rank as u32);
+        }
+
+        // Predecessors (all edges) for the dominator fixpoint.
+        let mut preds: HashMap<BlockId, Vec<BlockId>> = HashMap::new();
+        // Forward-only predecessor counts + loop headers.
+        let mut forward_preds: HashMap<BlockId, usize> = HashMap::new();
+        let mut loop_headers = HashSet::new();
+        for b in &func.blocks {
+            match &b.terminator {
+                Terminator::RecurJump { target, .. } => {
+                    preds.entry(*target).or_default().push(b.id);
+                    loop_headers.insert(*target);
+                }
+                term => {
+                    for s in successors(term) {
+                        preds.entry(s).or_default().push(b.id);
+                        *forward_preds.entry(s).or_default() += 1;
+                    }
+                }
+            }
+        }
+
+        let idom = dominators(entry, &post, &rpo_num, &preds);
+
+        // Group merge nodes under their immediate dominator, ascending RPO.
+        let mut merge_children: HashMap<BlockId, Vec<BlockId>> = HashMap::new();
+        for b in &func.blocks {
+            let id = b.id;
+            if id == entry || !rpo_num.contains_key(&id) {
+                continue;
+            }
+            if forward_preds.get(&id).copied().unwrap_or(0) >= 2
+                && let Some(&d) = idom.get(&id)
+            {
+                merge_children.entry(d).or_default().push(id);
+            }
+        }
+        for kids in merge_children.values_mut() {
+            kids.sort_by_key(|k| rpo_num[k]);
+        }
+
+        Ok(Relooper {
+            func,
+            entry,
+            index,
+            rpo_num,
+            forward_preds,
+            loop_headers,
+            merge_children,
+        })
     }
 
     fn block(&self, id: BlockId) -> &'f Block {
         &self.func.blocks[self.index[&id]]
     }
 
-    fn pred_count(&self, id: BlockId) -> usize {
-        self.preds.get(&id).map(|p| p.len()).unwrap_or(0)
+    fn is_merge(&self, id: BlockId) -> bool {
+        self.forward_preds.get(&id).copied().unwrap_or(0) >= 2
     }
 
-    /// A back-edge is a `RecurJump`, or a successor that is not later than its
-    /// source in block order.  Reducible Clojure CFGs place loop headers before
-    /// their back-edges, so block-order comparison detects them.
-    fn has_back_edges(&self) -> bool {
-        self.func.blocks.iter().any(|b| {
-            if matches!(b.terminator, Terminator::RecurJump { .. }) {
-                return true;
-            }
-            let src = self.index[&b.id];
-            successors(&b.terminator)
-                .into_iter()
-                .any(|s| self.index[&s] <= src)
+    // ── Structuring recursion ────────────────────────────────────────────────
+
+    /// Translate the subtree rooted at `x`, wrapping it in a [`Structured::Loop`]
+    /// if `x` is a loop header.
+    fn do_tree(&self, x: BlockId) -> Result<Structured, RelooperError> {
+        let empty = Vec::new();
+        let merges = self.merge_children.get(&x).unwrap_or(&empty);
+        let inner = self.node_within(x, merges)?;
+        if self.loop_headers.contains(&x) {
+            Ok(Structured::Loop {
+                header: x,
+                body: Box::new(inner),
+            })
+        } else {
+            Ok(inner)
+        }
+    }
+
+    /// Place `x`'s merge children as nested labeled blocks (largest RPO
+    /// outermost), with `x`'s own code innermost.
+    fn node_within(&self, x: BlockId, merges: &[BlockId]) -> Result<Structured, RelooperError> {
+        if let Some((&outer, rest)) = merges.split_last() {
+            let body = self.node_within(x, rest)?;
+            let next = self.do_tree(outer)?;
+            Ok(Structured::Labeled {
+                label: outer,
+                body: Box::new(body),
+                next: Box::new(next),
+            })
+        } else {
+            self.code_for(x)
+        }
+    }
+
+    /// Emit `x`'s straight-line body followed by the translation of its
+    /// terminator.
+    fn code_for(&self, x: BlockId) -> Result<Structured, RelooperError> {
+        let term = self.translate_terminator(x)?;
+        Ok(Structured::Simple {
+            block: x,
+            next: Box::new(term),
         })
+    }
+
+    fn translate_terminator(&self, x: BlockId) -> Result<Structured, RelooperError> {
+        match &self.block(x).terminator {
+            Terminator::Return(v) => Ok(Structured::Return(*v)),
+            Terminator::Unreachable => Ok(Structured::Unreachable),
+            Terminator::Jump(t) => self.do_branch(x, *t),
+            Terminator::Branch {
+                cond,
+                then_block,
+                else_block,
+            } => {
+                let then_arm = self.do_branch(x, *then_block)?;
+                let else_arm = self.do_branch(x, *else_block)?;
+                Ok(Structured::If {
+                    cond: *cond,
+                    then_arm: Box::new(then_arm),
+                    else_arm: Box::new(else_arm),
+                })
+            }
+            // The only back edge: continue to the loop header.
+            Terminator::RecurJump { target, .. } => Ok(Structured::Br(*target)),
+        }
+    }
+
+    /// Translate a forward edge `source -> target`: `br` to a merge node (placed
+    /// by an enclosing labeled block), otherwise inline the target's subtree.
+    fn do_branch(&self, source: BlockId, target: BlockId) -> Result<Structured, RelooperError> {
+        // A forward edge must increase RPO; if it doesn't, the CFG is
+        // irreducible (and not something Clojure source can produce).
+        if self.rpo_num[&target] <= self.rpo_num[&source] {
+            return Err(RelooperError::Irreducible {
+                from: source,
+                to: target,
+            });
+        }
+        if self.is_merge(target) {
+            Ok(Structured::Br(target))
+        } else {
+            self.do_tree(target)
+        }
     }
 }
 
-/// Successor block ids of a terminator.
+// ── CFG helpers ──────────────────────────────────────────────────────────────
+
+/// Successor block ids of a terminator (in branch order).
 fn successors(term: &Terminator) -> Vec<BlockId> {
     match term {
         Terminator::Jump(t) => vec![*t],
@@ -189,77 +346,81 @@ fn successors(term: &Terminator) -> Vec<BlockId> {
     }
 }
 
-/// Structure an acyclic region rooted at `block`: emit the block body, then
-/// recurse on its terminator.  Handles single-successor chains, returns, and
-/// simple re-joining diamonds; bails on multi-predecessor joins it cannot yet
-/// place behind a block label.
-fn structure_acyclic(cfg: &Cfg, block: BlockId) -> Result<Structured, RelooperError> {
-    let tail = match &cfg.block(block).terminator {
-        Terminator::Return(v) => Structured::Return(*v),
-        Terminator::Unreachable => Structured::Unreachable,
-        Terminator::Jump(t) => {
-            if cfg.pred_count(*t) > 1 {
-                return Err(RelooperError::Unsupported(
-                    "forward edge into a multi-predecessor join — needs block-label placement"
-                        .into(),
-                ));
+/// Iterative DFS postorder from `entry` over all edges.
+fn postorder(func: &IrFunction, entry: BlockId, index: &HashMap<BlockId, usize>) -> Vec<BlockId> {
+    let mut visited = HashSet::new();
+    let mut post = Vec::new();
+    let mut stack: Vec<(BlockId, usize)> = vec![(entry, 0)];
+    visited.insert(entry);
+    while let Some(&(b, child)) = stack.last() {
+        let succs = successors(&func.blocks[index[&b]].terminator);
+        if child < succs.len() {
+            stack.last_mut().unwrap().1 += 1;
+            let s = succs[child];
+            if visited.insert(s) {
+                stack.push((s, 0));
             }
-            structure_acyclic(cfg, *t)?
+        } else {
+            post.push(b);
+            stack.pop();
         }
-        Terminator::Branch {
-            cond,
-            then_block,
-            else_block,
-        } => structure_diamond(cfg, *cond, *then_block, *else_block)?,
-        Terminator::RecurJump { .. } => {
-            return Err(RelooperError::Unsupported(
-                "recur outside a structured loop".into(),
-            ));
-        }
-    };
-    Ok(Structured::Simple {
-        block,
-        next: Box::new(tail),
-    })
+    }
+    post
 }
 
-/// Structure a `Branch` whose arms re-merge at a common post-dominator (the
-/// classic if/else diamond): each arm is a single block that jumps to the same
-/// merge block.  The merge becomes the `If`'s `next` continuation.
-fn structure_diamond(
-    cfg: &Cfg,
-    cond: VarId,
-    then_block: BlockId,
-    else_block: BlockId,
-) -> Result<Structured, RelooperError> {
-    let then_succ = successors(&cfg.block(then_block).terminator);
-    let else_succ = successors(&cfg.block(else_block).terminator);
+/// Cooper–Harvey–Kennedy iterative dominators.  Returns `idom` for every
+/// reachable block (`entry` maps to itself).
+fn dominators(
+    entry: BlockId,
+    post: &[BlockId],
+    rpo_num: &HashMap<BlockId, u32>,
+    preds: &HashMap<BlockId, Vec<BlockId>>,
+) -> HashMap<BlockId, BlockId> {
+    let mut idom: HashMap<BlockId, BlockId> = HashMap::new();
+    idom.insert(entry, entry);
 
-    if let ([then_merge], [else_merge]) = (then_succ.as_slice(), else_succ.as_slice())
-        && then_merge == else_merge
-        && cfg.pred_count(then_block) == 1
-        && cfg.pred_count(else_block) == 1
-    {
-        let then_arm = Structured::Simple {
-            block: then_block,
-            next: Box::new(Structured::Nil),
-        };
-        let else_arm = Structured::Simple {
-            block: else_block,
-            next: Box::new(Structured::Nil),
-        };
-        let merge = structure_acyclic(cfg, *then_merge)?;
-        return Ok(Structured::If {
-            cond,
-            then_arm: Box::new(then_arm),
-            else_arm: Box::new(else_arm),
-            next: Box::new(merge),
-        });
+    // Reverse postorder, skipping the entry.
+    let rpo: Vec<BlockId> = post.iter().rev().copied().collect();
+
+    let intersect = |idom: &HashMap<BlockId, BlockId>, mut a: BlockId, mut b: BlockId| -> BlockId {
+        while a != b {
+            while rpo_num[&a] > rpo_num[&b] {
+                a = idom[&a];
+            }
+            while rpo_num[&b] > rpo_num[&a] {
+                b = idom[&b];
+            }
+        }
+        a
+    };
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for &b in &rpo {
+            if b == entry {
+                continue;
+            }
+            let empty = Vec::new();
+            let mut new_idom: Option<BlockId> = None;
+            for &p in preds.get(&b).unwrap_or(&empty) {
+                if !idom.contains_key(&p) {
+                    continue; // predecessor not yet processed
+                }
+                new_idom = Some(match new_idom {
+                    None => p,
+                    Some(cur) => intersect(&idom, p, cur),
+                });
+            }
+            if let Some(ni) = new_idom
+                && idom.get(&b) != Some(&ni)
+            {
+                idom.insert(b, ni);
+                changed = true;
+            }
+        }
     }
-
-    Err(RelooperError::Unsupported(
-        "branch arms do not form a simple re-joining diamond yet".into(),
-    ))
+    idom
 }
 
 #[cfg(test)]
@@ -268,17 +429,97 @@ mod tests {
     use crate::ir::{Const, Inst, KnownFn};
     use std::sync::Arc;
 
-    fn ret_const(name: &str) -> IrFunction {
-        let mut f = IrFunction::new(Some(Arc::from(name)), None);
-        let v = f.fresh_var();
-        let b = f.fresh_block();
-        f.blocks.push(Block {
-            id: b,
-            phis: vec![],
-            insts: vec![Inst::Const(v, Const::Long(7))],
-            terminator: Terminator::Return(v),
-        });
-        f
+    /// Builder that pushes blocks in id order for terse test CFGs.
+    struct Fb {
+        f: IrFunction,
+    }
+    impl Fb {
+        fn new() -> Self {
+            Fb {
+                f: IrFunction::new(Some(Arc::from("t")), None),
+            }
+        }
+        fn var(&mut self) -> VarId {
+            self.f.fresh_var()
+        }
+        fn blk(&mut self) -> BlockId {
+            self.f.fresh_block()
+        }
+        fn push(&mut self, id: BlockId, insts: Vec<Inst>, term: Terminator) {
+            self.f.blocks.push(Block {
+                id,
+                phis: vec![],
+                insts,
+                terminator: term,
+            });
+        }
+    }
+
+    /// Collect every `Simple{block}` id, in emission order, to check coverage.
+    fn simple_blocks(s: &Structured, out: &mut Vec<BlockId>) {
+        match s {
+            Structured::Simple { block, next } => {
+                out.push(*block);
+                simple_blocks(next, out);
+            }
+            Structured::Labeled { body, next, .. } => {
+                simple_blocks(body, out);
+                simple_blocks(next, out);
+            }
+            Structured::Loop { body, .. } => simple_blocks(body, out),
+            Structured::If {
+                then_arm, else_arm, ..
+            } => {
+                simple_blocks(then_arm, out);
+                simple_blocks(else_arm, out);
+            }
+            Structured::Br(_)
+            | Structured::Return(_)
+            | Structured::Unreachable
+            | Structured::Nil => {}
+        }
+    }
+
+    fn br_targets(s: &Structured, out: &mut Vec<BlockId>) {
+        match s {
+            Structured::Br(t) => out.push(*t),
+            Structured::Simple { next, .. } => br_targets(next, out),
+            Structured::Labeled { body, next, .. } => {
+                br_targets(body, out);
+                br_targets(next, out);
+            }
+            Structured::Loop { body, .. } => br_targets(body, out),
+            Structured::If {
+                then_arm, else_arm, ..
+            } => {
+                br_targets(then_arm, out);
+                br_targets(else_arm, out);
+            }
+            _ => {}
+        }
+    }
+
+    fn has_loop(s: &Structured) -> bool {
+        match s {
+            Structured::Loop { .. } => true,
+            Structured::Simple { next, .. } => has_loop(next),
+            Structured::Labeled { body, next, .. } => has_loop(body) || has_loop(next),
+            Structured::If {
+                then_arm, else_arm, ..
+            } => has_loop(then_arm) || has_loop(else_arm),
+            _ => false,
+        }
+    }
+
+    /// Assert each block appears exactly once as a `Simple`.
+    fn assert_each_block_once(f: &IrFunction, s: &Structured) {
+        let mut got = Vec::new();
+        simple_blocks(s, &mut got);
+        let mut ids: Vec<u32> = f.blocks.iter().map(|b| b.id.0).collect();
+        ids.sort_unstable();
+        let mut got_ids: Vec<u32> = got.iter().map(|b| b.0).collect();
+        got_ids.sort_unstable();
+        assert_eq!(got_ids, ids, "every block emitted exactly once");
     }
 
     #[test]
@@ -288,104 +529,175 @@ mod tests {
     }
 
     #[test]
-    fn single_return_block_structures() {
-        let f = ret_const("k");
-        match reloop(&f).expect("structure single return") {
+    fn single_return_block() {
+        let mut b = Fb::new();
+        let v = b.var();
+        let b0 = b.blk();
+        b.push(
+            b0,
+            vec![Inst::Const(v, Const::Long(7))],
+            Terminator::Return(v),
+        );
+        let s = reloop(&b.f).unwrap();
+        assert_each_block_once(&b.f, &s);
+        match s {
             Structured::Simple { next, .. } => assert!(matches!(*next, Structured::Return(_))),
             other => panic!("expected Simple -> Return, got {other:?}"),
         }
     }
 
     #[test]
-    fn linear_jump_chain_structures() {
-        let mut f = IrFunction::new(Some(Arc::from("chain")), None);
-        let v = f.fresh_var();
-        let b0 = f.fresh_block();
-        let b1 = f.fresh_block();
-        f.blocks.push(Block {
-            id: b0,
-            phis: vec![],
-            insts: vec![Inst::Const(v, Const::Long(1))],
-            terminator: Terminator::Jump(b1),
-        });
-        f.blocks.push(Block {
-            id: b1,
-            phis: vec![],
-            insts: vec![],
-            terminator: Terminator::Return(v),
-        });
-        assert!(reloop(&f).is_ok());
+    fn linear_chain() {
+        let mut b = Fb::new();
+        let v = b.var();
+        let b0 = b.blk();
+        let b1 = b.blk();
+        b.push(
+            b0,
+            vec![Inst::Const(v, Const::Long(1))],
+            Terminator::Jump(b1),
+        );
+        b.push(b1, vec![], Terminator::Return(v));
+        let s = reloop(&b.f).unwrap();
+        assert_each_block_once(&b.f, &s);
+        // No merge (b1 has one forward pred) → inlined, no Labeled.
+        assert!(!matches!(s, Structured::Labeled { .. }));
     }
 
     #[test]
-    fn simple_diamond_structures_to_if() {
+    fn diamond_places_merge_in_labeled_block() {
         // b0: branch -> b1 / b2 ; b1 -> b3 ; b2 -> b3 ; b3: return
-        let mut f = IrFunction::new(Some(Arc::from("diamond")), None);
-        let c = f.fresh_var();
-        let v = f.fresh_var();
-        let b0 = f.fresh_block();
-        let b1 = f.fresh_block();
-        let b2 = f.fresh_block();
-        let b3 = f.fresh_block();
-        f.blocks.push(Block {
-            id: b0,
-            phis: vec![],
-            insts: vec![Inst::CallKnown(c, KnownFn::IsNil, vec![])],
-            terminator: Terminator::Branch {
+        let mut b = Fb::new();
+        let c = b.var();
+        let v = b.var();
+        let (b0, b1, b2, b3) = (b.blk(), b.blk(), b.blk(), b.blk());
+        b.push(
+            b0,
+            vec![Inst::CallKnown(c, KnownFn::IsNil, vec![])],
+            Terminator::Branch {
                 cond: c,
                 then_block: b1,
                 else_block: b2,
             },
-        });
-        for b in [b1, b2] {
-            f.blocks.push(Block {
-                id: b,
-                phis: vec![],
-                insts: vec![],
-                terminator: Terminator::Jump(b3),
-            });
-        }
-        f.blocks.push(Block {
-            id: b3,
-            phis: vec![],
-            insts: vec![Inst::Const(v, Const::Nil)],
-            terminator: Terminator::Return(v),
-        });
+        );
+        b.push(b1, vec![], Terminator::Jump(b3));
+        b.push(b2, vec![], Terminator::Jump(b3));
+        b.push(b3, vec![Inst::Const(v, Const::Nil)], Terminator::Return(v));
 
-        match reloop(&f).expect("structure diamond") {
-            Structured::Simple { next, .. } => assert!(
-                matches!(*next, Structured::If { .. }),
-                "entry block should be followed by an If"
-            ),
-            other => panic!("expected Simple -> If, got {other:?}"),
+        let s = reloop(&b.f).unwrap();
+        assert_each_block_once(&b.f, &s);
+
+        // Top is a labeled block for the merge b3.
+        match &s {
+            Structured::Labeled { label, body, next } => {
+                assert_eq!(*label, b3);
+                // body holds b0 + the If; both arms br to b3.
+                let mut targets = Vec::new();
+                br_targets(body, &mut targets);
+                assert_eq!(targets, vec![b3, b3]);
+                // next is the merge block's own code, ending in Return.
+                let mut merge_blocks = Vec::new();
+                simple_blocks(next, &mut merge_blocks);
+                assert_eq!(merge_blocks, vec![b3]);
+            }
+            other => panic!("expected Labeled(merge), got {other:?}"),
         }
     }
 
     #[test]
-    fn loops_are_unsupported_for_now() {
-        let mut f = IrFunction::new(Some(Arc::from("loopy")), None);
-        let c = f.fresh_var();
-        let b0 = f.fresh_block();
-        let b1 = f.fresh_block();
-        f.blocks.push(Block {
-            id: b0,
-            phis: vec![],
-            insts: vec![Inst::CallKnown(c, KnownFn::IsNil, vec![])],
-            terminator: Terminator::Branch {
+    fn loop_with_conditional_exit() {
+        // b0: header; branch -> b1 (body) / b2 (exit)
+        // b1: recur back to b0
+        // b2: return
+        let mut b = Fb::new();
+        let c = b.var();
+        let v = b.var();
+        let (b0, b1, b2) = (b.blk(), b.blk(), b.blk());
+        b.push(
+            b0,
+            vec![Inst::CallKnown(c, KnownFn::IsNil, vec![])],
+            Terminator::Branch {
                 cond: c,
                 then_block: b1,
-                else_block: b1,
+                else_block: b2,
             },
-        });
-        f.blocks.push(Block {
-            id: b1,
-            phis: vec![],
-            insts: vec![],
-            terminator: Terminator::RecurJump {
+        );
+        b.push(
+            b1,
+            vec![],
+            Terminator::RecurJump {
                 target: b0,
                 args: vec![],
             },
-        });
-        assert!(matches!(reloop(&f), Err(RelooperError::Unsupported(_))));
+        );
+        b.push(b2, vec![Inst::Const(v, Const::Nil)], Terminator::Return(v));
+
+        let s = reloop(&b.f).unwrap();
+        assert_each_block_once(&b.f, &s);
+        assert!(has_loop(&s), "header should be wrapped in a Loop");
+
+        // The recur in b1 becomes a continue (br) to the header b0.
+        let mut targets = Vec::new();
+        br_targets(&s, &mut targets);
+        assert!(targets.contains(&b0), "recur should br to the loop header");
+    }
+
+    #[test]
+    fn nested_sequential_merges() {
+        // Two diamonds in series: b0?->(b1,b2)->b3?->(b4,b5)->b6
+        let mut b = Fb::new();
+        let c0 = b.var();
+        let c3 = b.var();
+        let v = b.var();
+        let (b0, b1, b2, b3, b4, b5, b6) = (
+            b.blk(),
+            b.blk(),
+            b.blk(),
+            b.blk(),
+            b.blk(),
+            b.blk(),
+            b.blk(),
+        );
+        b.push(
+            b0,
+            vec![Inst::CallKnown(c0, KnownFn::IsNil, vec![])],
+            Terminator::Branch {
+                cond: c0,
+                then_block: b1,
+                else_block: b2,
+            },
+        );
+        b.push(b1, vec![], Terminator::Jump(b3));
+        b.push(b2, vec![], Terminator::Jump(b3));
+        b.push(
+            b3,
+            vec![Inst::CallKnown(c3, KnownFn::IsNil, vec![])],
+            Terminator::Branch {
+                cond: c3,
+                then_block: b4,
+                else_block: b5,
+            },
+        );
+        b.push(b4, vec![], Terminator::Jump(b6));
+        b.push(b5, vec![], Terminator::Jump(b6));
+        b.push(b6, vec![Inst::Const(v, Const::Nil)], Terminator::Return(v));
+
+        let s = reloop(&b.f).unwrap();
+        assert_each_block_once(&b.f, &s);
+
+        // Both merges (b3, b6) are reached via br; both branches of each diamond
+        // target their merge.
+        let mut targets = Vec::new();
+        br_targets(&s, &mut targets);
+        assert_eq!(
+            targets.iter().filter(|&&t| t == b3).count(),
+            2,
+            "both arms of the first diamond br to b3"
+        );
+        assert_eq!(
+            targets.iter().filter(|&&t| t == b6).count(),
+            2,
+            "both arms of the second diamond br to b6"
+        );
     }
 }

--- a/docs/wasm-aot-plan.md
+++ b/docs/wasm-aot-plan.md
@@ -1,0 +1,303 @@
+# Plan: AOT Clojure → WebAssembly (browser backend)
+
+## Overview
+
+This is the handoff document for the **AOT Clojure → WebAssembly backend** — a
+second code-generation backend over the same `cljrs-ir` IR as the Cranelift
+backend, targeting native-fast, sandbox-safe deployment in the browser.
+
+The work lives entirely in `crates/cljrs-compiler/src/wasm/` and is developed on
+branch `claude/wasm-aot-jit-compilation-gpz5nl`.
+
+### Why a separate backend (the one hard constraint)
+
+A wasm module **cannot generate and execute native machine code at runtime** —
+there is no `mmap(PROT_EXEC)` inside the sandbox. So the Cranelift JIT
+(`cljrs-jit`) cannot run in a browser: the in-sandbox story must be
+*ahead-of-time*. Compile each Clojure function to wasm bytecode at build time
+and ship it; the browser JITs *that* to native.
+
+The runtime tiers therefore **invert** relative to native:
+
+```text
+  native:   tree-walk → IR-interp → JIT/OSR (peak, reached at runtime)
+  browser:  tree-walk → IR-interp (dynamic: eval, REPL, freshly-required ns, macros)
+            AOT-wasm                (peak, frozen at build time; browser JITs it)
+```
+
+The IR interpreter (`cljrs-eval::ir_interp`) therefore stays **on board** in the
+wasm bundle as the dynamic-code tier; AOT-wasm is the frozen top tier. No
+in-sandbox JIT/OSR hooks are installed.
+
+### What is reused unchanged
+
+Everything upstream of code generation is backend-agnostic and shared with the
+Cranelift path:
+
+- ANF/SSA lowering — `cljrs_ir::lower`
+- Escape analysis + region inference — `cljrs_ir::lower::{escape, regionalize}`
+- Scalar representation inference — `cljrs_compiler::typeinfer`
+- The `rt_abi` runtime bridge contract — `cljrs_compiler::rt_abi`
+
+Because escape analysis and region promotion are **properties of the IR**
+(`Inst::Region*`, `IrFunction::takes_region_param`), bump allocation comes along
+for free in wasm: a region is a linear-memory arena, a region handle is an `i32`
+offset, and a region-parameterised variant takes that `i32` as a hidden trailing
+parameter. The only genuinely new, wasm-specific work is **relooping** (recover
+structured control flow) and the **wasm-encoder emitter**.
+
+### Locked design decisions
+
+- **Boxed-only value model first.** Every IR `VarId` is a wasm `i32` local
+  holding a boxed `*const Value` (a linear-memory offset). This is the universal
+  representation and is always correct; it mirrors the Cranelift backend's boxed
+  fallback. Unboxed `Long`/`Double` specialization is deferred.
+- **GC stays in linear memory.** Reuse the existing `wasm32-unknown-unknown` GC
+  heap. WasmGC (host-managed reference types) is deferred indefinitely.
+- **Relooper is wasm-private.** It lives in the wasm backend, not in shared
+  lowering — Cranelift consumes the raw CFG and would be pessimized by
+  re-structuring. (See "Any benefit to relooping in general?" — no; it is purely
+  the price of a structured-control-flow target.)
+- **`rt_abi` as wasm imports.** The emitted module imports the runtime bridge
+  functions from the `"rt"` module; the runtime, compiled to the same linear
+  memory, satisfies them at instantiation.
+
+---
+
+## Module layout
+
+```
+crates/cljrs-compiler/src/wasm/
+  mod.rs      — public API (compile_function, WasmBackend, WasmError); tier model + rationale
+  abi.rs      — ABI/region contract: Value→i32, rt_abi import table, region-handle threading
+  reloop.rs   — relooper: IR CFG → structured control flow (Structured); wasm-private
+  emit.rs     — wasm-encoder emitter: IrFunction → validated wasm module
+```
+
+Public API (`mod.rs`):
+
+```rust
+pub fn compile_function(func: &IrFunction, cfg: &WasmBackend) -> Result<Vec<u8>, WasmError>;
+pub struct WasmBackend { tail_calls: bool, exceptions: bool }   // feature flags
+pub enum WasmError { Reloop(RelooperError), Unsupported(String), Unimplemented(&'static str) }
+```
+
+`compile_function` runs `reloop::reloop(func)` then `emit::emit_function`.
+
+---
+
+## What is done
+
+### ABI / region contract (`abi.rs`) — complete
+
+The canonical, data-only contract that the emitter consumes (no `wasm-encoder`
+dependency, so it is reviewable and unit-tested independently):
+
+- **Value representation.** `*const Value`, `*mut Region`, and pointer-array
+  slices all collapse to `i32` (a linear-memory offset). Unboxed `Long`→`i64`,
+  `Double`→`f64`. `WasmValType::for_repr(Repr)` encodes this. Because every
+  pointer is an `i32`, the entire ~165-function `rt_abi` surface is expressible
+  as wasm imports with no marshalling beyond width changes.
+- **Region ABI (bump allocation).** A region handle is an `i32` (offset of a
+  `Region` arena in linear memory). `RegionStart`→`rt_region_start`,
+  `RegionAlloc`→`rt_region_alloc_*` (handle leading), `RegionEnd`→
+  `rt_region_end`, `RegionParam`→bind the hidden trailing `i32` param,
+  `CallWithRegion`→direct call passing the caller's handle as the trailing arg.
+  This mirrors `IrFunction::abi_param_count` on the native side.
+- **Import table.** `RT_IMPORTS: &[RtImport]` describes the subset wired so far
+  (safepoint, constants, arithmetic/comparison bridges, GC-heap + region
+  allocation, inline-cache/deopt bridges) as `(name, params, results)` wasm
+  function types. `lookup(name)` resolves one. Completing it to all of `rt_abi`
+  is mechanical — one `RtImport` per `extern "C"` signature.
+
+### Relooper (`reloop.rs`) — complete for reducible CFGs
+
+Implements Norman Ramsey's *"Beyond Relooper"* (ICFP 2022) dominator-tree
+structuring, specialized to two facts true of every CFG this backend sees:
+
+- **Back edges are exactly `Terminator::RecurJump`.** Clojure has no `goto`; the
+  only cyclic control flow is `loop`/`recur`. So loop headers are precisely the
+  `RecurJump` targets, and every `Jump`/`Branch` edge is forward.
+- **The CFG is reducible.** Structured source + reducible-preserving inlining
+  cannot manufacture irreducibility, so the relooper never needs node-splitting
+  or a dispatch variable.
+
+Output is a `Structured` tree:
+
+```rust
+pub enum Structured {
+    Simple   { block, next },          // emit a block's straight-line body, then next
+    Labeled  { label, body, next },    // wasm `block`; a forward Br(label) breaks to next
+    Loop     { header, body },         // wasm `loop`; a backward Br(header) continues
+    If       { cond, then_arm, else_arm },
+    Br(BlockId),                       // forward break or backward continue
+    Return(VarId), Unreachable, Nil,
+}
+pub enum RelooperError { Empty, DanglingTarget(BlockId), Irreducible { from, to } }
+```
+
+Algorithm (driven by a Cooper–Harvey–Kennedy dominator tree + reverse
+postorder):
+
+- Loop headers wrap their subtree in `Loop`; back edges become `Br`-continue.
+- A **merge node** (≥2 forward predecessors) is emitted once, at its immediate
+  dominator, inside a labeled `block`; branches to it become `Br`-break.
+- Merge children of a node nest in **ascending reverse-postorder** (largest RPO
+  outermost), which guarantees every `br` jumps *forward* out of enclosing
+  blocks — the only direction wasm permits.
+- All other forward edges target single-predecessor nodes and are inlined.
+
+Each block is emitted exactly once. Irreducible control flow (which Clojure
+cannot produce) is rejected via an RPO back-edge check.
+
+### Emitter (`emit.rs`) — core complete, instruction set partial
+
+Produces real, **`wasmparser`-validated** single-function modules.
+
+- **Value model.** One boxed `i32` local per `VarId`; visible params are wasm
+  locals `0..n`, remaining `VarId`s are declared locals.
+- **Control flow.** The `Structured` tree maps directly: `Labeled`→`block`,
+  `Loop`→`loop`, `If`→`if`/`else`, `Br`→`br N` with the depth resolved from a
+  stack of enclosing control frames. A GC `rt_safepoint` is emitted at function
+  entry and at each loop header.
+- **SSA φ resolution.** No `phi` instruction is emitted. On each edge the φ's
+  incoming value for that predecessor is copied into its local, using the
+  operand stack for **parallel-move semantics** (all `local.get`s before any
+  `local.set`s) so a swapping `recur` cannot clobber. Copies happen at the `Br`
+  site for merge/loop targets and at block entry for inlined single-predecessor
+  edges.
+- **Module assembly.** `ModuleAsm` interns function types and `rt_abi` imports,
+  then emits the type/import/function/export/code sections; the function is
+  exported under its name. Imports occupy function indices `0..k`; the defined
+  function is index `k`.
+
+**Instructions lowered so far:** scalar constants (`nil`/`bool`/`long`/`double`/
+`char`), `LoadLocal` (→ nil, matching the Cranelift backend), folded boxed
+arithmetic (`+ - * / rem`), binary comparison (`= < > <= >=`), and all control
+flow. Everything else returns `WasmError::Unsupported`.
+
+### Tests
+
+`cargo test -p cljrs-compiler wasm::` — 16 tests:
+
+- `abi`: Value→wasm-type mapping, region contract well-typed, no duplicate
+  imports.
+- `reloop`: empty/single-return/linear-chain/diamond/loop-with-exit/nested
+  sequential merges, each asserting **every block is emitted exactly once**.
+- `emit`: an arithmetic function, an if/else diamond with a merge φ, and a loop
+  with a φ counter + conditional `recur` — each **validated with `wasmparser`**;
+  plus `Unsupported` coverage for region variants and un-lowered instructions,
+  and the typed-signature accounting.
+
+Dependencies added to `cljrs-compiler`: `wasm-encoder = "0.244"` (dep),
+`wasmparser = "0.244"` (dev-dep) — both already in the lock transitively.
+
+---
+
+## What is next
+
+Ordered by value. The first item is the gateway: it makes real Clojure functions
+(which build collections) compilable, and introduces the first **memory import**
+that the region path also needs.
+
+### 1. Allocation (`Alloc*`) — highest value
+
+`AllocVector`/`AllocMap`/`AllocSet`/`AllocList`/`AllocCons`. The native backend
+(`codegen.rs::emit_alloc_collection`) spills the element `*const Value` pointers
+to a contiguous scratch array, then calls `rt_alloc_*(ptr, n)`. In wasm:
+
+- Import a **linear memory** (`(import "rt" "memory" (memory ...))`) — the first
+  time the emitter needs memory.
+- Reserve a scratch region for the pointer array. Decide ownership: simplest is a
+  runtime-provided scratch buffer (e.g. an `rt_scratch_ptr()` import or a fixed
+  imported global) so the emitter does not have to manage a stack/bump pointer of
+  its own yet.
+- For each element: `local.get elem` (i32), `i32.store` at `scratch + i*4`.
+- Push `scratch`, push `n` (i64), `call rt_alloc_vector` (etc.).
+
+`rt_alloc_*` are already in `RT_IMPORTS`. `AllocCons` is simpler (two pointer
+args, no array). Add tests that allocate and validate.
+
+### 2. Region operations
+
+Once the scratch/memory machinery from (1) exists, region ops are mechanical and
+unlock the escape-analysis payoff. Lower `RegionStart`/`RegionAlloc`/`RegionEnd`
+to the `rt_region_*` imports, and `RegionParam`/`CallWithRegion` to the hidden
+trailing-`i32` ABI (see `abi.rs`). Then drop the
+`takes_region_param()`→`Unsupported` guard in `emit_function`. This needs
+multi-function support (2.5) for `CallWithRegion`.
+
+### 3. Calls and multi-function modules
+
+`CallDirect` (same-module direct call), `Call` (dynamic, via the
+`rt_call_ic` inline-cache bridge), `CallWithRegion`. Requires compiling a
+**bundle** of functions into one module: extend `compile_function` to a
+`compile_bundle(&IrBundle)` that assigns a wasm function index to each, emits all
+bodies, and resolves `CallDirect` targets to those indices. Closures
+(`AllocClosure`) and subfunctions follow the same shape as the Cranelift backend
+(declare all arity functions into the module, materialize closure values via
+`rt_make_fn*`). Cross-function tail calls use the wasm tail-call proposal
+(`return_call`) when `WasmBackend::tail_calls`, else a trampoline.
+
+### 4. Constants needing a data segment
+
+`Const::Str` / `Const::Keyword` / `Const::Symbol`. Emit the UTF-8 bytes into a
+**data segment** and pass `(ptr, len)` to `rt_const_string`/`_keyword`/`_symbol`
+(already in `RT_IMPORTS`). The data segment's memory placement must be
+coordinated with the runtime's linear-memory layout — decide whether the
+emitter owns a rodata region or the runtime reserves one.
+
+### 5. Globals / vars
+
+`LoadGlobal` / `LoadVar` / `DefVar` / `SetBang`. These resolve namespaced names;
+follow `codegen.rs::emit_load_global` / `emit_def_var`. Needs the name-as-data
+machinery from (4) and the var-resolution `rt_abi` bridges added to `RT_IMPORTS`.
+
+### 6. Exceptions
+
+`Throw` / `KnownFn::TryCatchFinally`. Use the wasm exception-handling proposal
+(`try`/`catch`/`throw`) when `WasmBackend::exceptions`, else thread the
+`rt_abi` thread-local error path the Cranelift backend uses (`rt_throw` +
+`rt_try` checking the thread-local).
+
+### 7. Unboxed specialization
+
+Align the emitted signature with `function_signature` (typed ABI): keep
+`Long`/`Double` values unboxed in `i64`/`f64` locals per `typeinfer`, guarding
+specialized params and boxing only at boxed-context uses. Mirrors
+`codegen.rs::compile_function_with_specs`. This is an optimization, not a
+correctness requirement — do it after the functional subset is broad.
+
+### 8. CLI + bundling
+
+`cljrs compile <file> --target wasm -o <out>.wasm`. Drive `compile_bundle` over a
+whole program, link with the runtime compiled to `wasm32-unknown-unknown` (the
+`cljrs-wasm` crate already builds the interpreter to that target), and wire the
+**IR interpreter into the bundle as the dynamic-code tier** (drop the JIT/OSR
+hooks in-sandbox).
+
+### Deferred indefinitely
+
+- **WasmGC** — swap the linear-memory GC for host-managed reference types. A
+  real project on its own; keep the linear-memory GC.
+- **In-browser JIT** — runtime wasm-generation + `WebAssembly.instantiate`. Only
+  worthwhile as a tiering step *on top of* AOT, once AOT is solid.
+
+---
+
+## Pointers for the next implementer
+
+- The relooper output is the emitter's contract — read `reloop.rs`'s module doc
+  and the `Structured` variants first.
+- `abi.rs` is the source of truth for the value/region ABI; extend `RT_IMPORTS`
+  there when a new `rt_abi` bridge is needed, then call it via
+  `Emitter::call_import(name)`.
+- Mirror semantics from `codegen.rs` (the Cranelift backend) — it is the
+  reference for what each `Inst` must do. Search for the matching
+  `translate_inst` / `emit_*` arm.
+- Validate every new shape with `wasmparser` in a unit test (see
+  `emit::tests::validate`). A module that validates is structurally correct
+  wasm even without a JS runtime to execute it.
+- `TODO.md` Phase 11.5 tracks the checklist; keep it and the `cljrs-compiler`
+  README in sync (per `CLAUDE.md`, READMEs are updated in the same commit).
+```


### PR DESCRIPTION
Add a second code-generation backend over the same regionalized cljrs-ir IR,
targeting the browser where no in-sandbox native JIT is possible. Build-time
AOT-wasm becomes the top tier; the IR interpreter stays on board as the
dynamic-code tier (tiers invert vs. native). All upstream passes — ANF
lowering, escape analysis, region inference, typeinfer, the rt_abi contract —
are reused unchanged.

New module crates/cljrs-compiler/src/wasm/:
- mod.rs   — public API (compile_function, WasmBackend, WasmError); browser
             tier model and rationale.
- abi.rs   — ABI/region contract: Value→i32 linear-memory offset, the rt_abi
             import table (WasmValType/RtImport/RT_IMPORTS), and region-handle
             threading as a hidden trailing i32 param (mirrors abi_param_count).
- reloop.rs — relooper: IR CFG → structured control flow (Structured). wasm-
             private, since Cranelift consumes the raw CFG. Implements the
             acyclic single-successor, return, and re-joining diamond cases;
             loops and multi-pred joins return Unsupported (documented next
             step: dominator-based structuring).
- emit.rs  — wasm-encoder emitter: function-signature computation (region/poll
             ABI honored) and a structured-tree walk are wired; per-Inst
             lowering plan documented; encoder step returns Unimplemented.

Because regions are a property of the IR and a region handle is just an i32
offset, escape-analysis-driven bump allocation ports for free. 12 unit tests
cover the ABI/region contract, signature accounting, and the relooper cases.

Update cljrs-compiler README and add TODO Phase 11.5.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019ASteBDzAYVk7Kmzo128rR