### PR TITLE
wasm: lower collection allocation (Alloc*) in the AOT backend

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -481,7 +481,8 @@ inference, `typeinfer`, the `rt_abi` contract) are reused unchanged.
 - [x] Relooper data model (`Structured`) + acyclic/diamond structuring (wasm-private; Cranelift keeps the raw CFG)
 - [x] Relooper: full dominator-based structuring (Ramsey "Beyond Relooper") — `loop`/`recur` back-edges → `Loop`/`Br`-continue, multi-predecessor joins → dominator-placed labeled blocks in ascending RPO, irreducible CFGs rejected
 - [x] `wasm-encoder` emitter (core): boxed `i32` value model, `rt_abi` imports, structured-tree → wasm control flow with label-stack `br` resolution, SSA φ as parallel operand-stack moves, scalar constants, folded arithmetic + binary comparison bridges; emits `wasmparser`-validated modules
-- [ ] `wasm-encoder` emitter (remaining `Inst`s): `Alloc*` (scratch-array spill + `rt_alloc_*`), `Call`/`CallDirect`/`CallWithRegion`, `LoadGlobal`/`LoadVar`/`DefVar`, string/keyword/symbol constants (data segment), region ops, unboxed `Long`/`Double` specialization aligned with `function_signature`
+- [x] `wasm-encoder` emitter — `Alloc*` (`AllocVector`/`AllocMap`/`AllocSet`/`AllocList`/`AllocCons`): element-pointer arrays marshalled through an imported `"rt" "memory"` + the `rt_scratch_ptr` buffer, then the slice-taking `rt_alloc_*` bridge (map count = pair count, empty = null/0, cons = two pointer args)
+- [ ] `wasm-encoder` emitter (remaining `Inst`s): `Call`/`CallDirect`/`CallWithRegion`, `LoadGlobal`/`LoadVar`/`DefVar`, string/keyword/symbol constants (data segment), region ops, unboxed `Long`/`Double` specialization aligned with `function_signature`
 - [ ] Region intrinsics in wasm: arena (`base/bump/limit`) in linear memory; `rt_region_*` threading; bump allocation into the caller's region
 - [ ] GC heap in linear memory (reuse the `wasm32-unknown-unknown` GC) + `rt_safepoint` at entry/back-edges
 - [ ] `recur` → `loop`/`br`; cross-function tail calls via the wasm tail-call proposal (`return_call`) or a trampoline

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -66,9 +66,12 @@ wasm control flow (`Labeled`→`block`, `Loop`→`loop`, `If`→`if`/`else`,
 `Br`→`br N` with depths resolved from a label stack), and SSA φs are resolved as
 parallel moves on the operand stack at each edge — so `loop`/`recur` with a
 swapping `recur` is correct. Currently lowered: scalar constants, `LoadLocal`,
-folded boxed arithmetic (`+ - * / rem`), binary comparison (`= < > <= >=`), and
-all control flow. Allocation, calls, globals, string/keyword/symbol constants,
-and the region/async ABIs return `Unsupported` — the next lowering increments.
+folded boxed arithmetic (`+ - * / rem`), binary comparison (`= < > <= >=`),
+collection allocation (`AllocVector`/`AllocMap`/`AllocSet`/`AllocList`/
+`AllocCons` — element arrays marshalled through an imported linear memory and the
+`rt_scratch_ptr` buffer), and all control flow. Calls, globals, string/keyword/
+symbol constants, and the region/async ABIs return `Unsupported` — the next
+lowering increments.
 
 ```rust
 pub fn compile_function(func: &IrFunction, cfg: &WasmBackend) -> Result<Vec<u8>, WasmError>;
@@ -106,6 +109,7 @@ All functions are `#[unsafe(no_mangle)] pub extern "C"` — called by symbol nam
 - **Comparison:** `rt_eq`, `rt_case_eq` (type-strict equality for `case` dispatch — `Long`/`BigInt` interchangeable, mixed numerics never equal), `rt_lt`, `rt_gt`, `rt_lte`, `rt_gte`
 - **Primitive arrays:** `rt_alength(arr) -> i64`, `rt_aget_long(arr, i) -> i64`, `rt_aget_double(arr, i) -> f64` (unboxed element loads), `rt_aset_long`/`rt_aset_double` (unboxed stores), `rt_aget`/`rt_aset` (boxed fallback for unknown element types) — all bounds-checked, throwing on out-of-range / type mismatch
 - **Collections:** `rt_alloc_vector`, `rt_alloc_map`, `rt_alloc_set`, `rt_alloc_list`, `rt_alloc_cons`, `rt_get`, `rt_count`, `rt_first`, `rt_rest`, `rt_assoc`, `rt_conj`
+- **Scratch:** `rt_scratch_ptr(n_bytes: u32) -> *mut u8` — a thread-local, monotonically growing scratch buffer the wasm backend uses to marshal element-pointer arrays before the slice-taking `rt_alloc_*` bridges (the native backend uses an on-stack slot instead)
 - **Region alloc:** `rt_region_start() -> *mut Region` (returns the real region pointer; also pushes it onto the thread-local stack for opportunistic allocation and GC root tracing), `rt_region_end(*mut Region)`, `rt_region_alloc_vector/map/set/list/cons(*mut Region, ...)` — these bump directly into the passed region (the handle threaded through `RegionStart`/`RegionParam`/`CallWithRegion`; a null handle falls back to the thread-local lookup). Region closes route through `cljrs_gc::region::close_region`, honouring the Phase 10.5 poison/retire protocol; `rt_try` saves/unwinds the rt-side and gc-side region-stack depths independently
 - **Dispatch:** `rt_call(callee, args, nargs)`, `rt_deref(v)`, `rt_load_global(ns, ns_len, name, name_len)`
 

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -1067,6 +1067,33 @@ fn unwind_regions_to(gc_depth: usize, rt_depth: usize) {
     cljrs_gc::region::unwind_region_stack_to(gc_depth);
 }
 
+// ── Scratch buffer ──────────────────────────────────────────────────────────
+
+thread_local! {
+    /// A reusable, monotonically growing scratch buffer.  The wasm AOT backend
+    /// marshals a contiguous array of element `*const Value` pointers here
+    /// before calling the slice-taking `rt_alloc_*` / `rt_region_alloc_*`
+    /// bridges (the native backend uses an on-stack slot instead).
+    static RT_SCRATCH: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Return a pointer to a thread-local scratch buffer at least `n_bytes` wide.
+///
+/// The buffer is reused across calls and grows monotonically; the returned
+/// pointer is valid only until the next `rt_scratch_ptr` call on the same
+/// thread.  Only the wasm backend uses this; the native backend marshals
+/// element arrays in an explicit stack slot.
+#[unsafe(no_mangle)]
+pub extern "C" fn rt_scratch_ptr(n_bytes: u32) -> *mut u8 {
+    RT_SCRATCH.with(|s| {
+        let mut buf = s.borrow_mut();
+        if buf.len() < n_bytes as usize {
+            buf.resize(n_bytes as usize, 0);
+        }
+        buf.as_mut_ptr()
+    })
+}
+
 // ── Collection construction ─────────────────────────────────────────────────
 
 /// Allocate a vector from `n` element pointers.

--- a/crates/cljrs-compiler/src/wasm/abi.rs
+++ b/crates/cljrs-compiler/src/wasm/abi.rs
@@ -212,6 +212,17 @@ pub const RT_IMPORTS: &[RtImport] = &[
         params: &[I32, I32],
         results: &[I32],
     },
+    // ── Scratch buffer (marshalling arrays for alloc bridges) ────────────────
+    // n_bytes → linear-memory offset of a thread-local scratch buffer at least
+    // `n_bytes` wide.  The wasm backend stores a contiguous array of element
+    // `*const Value` pointers here before calling the slice-taking `rt_alloc_*`
+    // / `rt_region_alloc_*` bridges (the wasm analogue of the native backend's
+    // explicit stack slot).
+    RtImport {
+        name: "rt_scratch_ptr",
+        params: &[I32],
+        results: &[I32],
+    },
     // ── GC-heap allocation (slice ptr, n) ────────────────────────────────────
     RtImport {
         name: "rt_alloc_vector",

--- a/crates/cljrs-compiler/src/wasm/emit.rs
+++ b/crates/cljrs-compiler/src/wasm/emit.rs
@@ -38,16 +38,18 @@
 //!
 //! Emits valid, `wasmparser`-validated modules for the subset: scalar
 //! constants, `LoadLocal`, boxed arithmetic (`+ - * / rem`, folded) and binary
-//! comparison (`= < > <= >=`) via the `rt_abi` bridges, and all control flow
-//! (branches, diamonds, and `loop`/`recur` with φ).  Allocation, calls,
-//! globals, string/keyword/symbol constants, and the region/async ABIs return
-//! [`WasmError::Unsupported`] — the next lowering increments.
+//! comparison (`= < > <= >=`) via the `rt_abi` bridges, collection allocation
+//! (`AllocVector`/`AllocMap`/`AllocSet`/`AllocList`/`AllocCons` — element arrays
+//! marshalled through an imported linear memory and the `rt_scratch_ptr`
+//! buffer), and all control flow (branches, diamonds, and `loop`/`recur` with
+//! φ).  Calls, globals, string/keyword/symbol constants, and the region/async
+//! ABIs return [`WasmError::Unsupported`] — the next lowering increments.
 
 use std::collections::HashMap;
 
 use wasm_encoder::{
     BlockType, CodeSection, EntityType, ExportKind, ExportSection, Function, FunctionSection,
-    Ieee64, ImportSection, Instruction, Module, TypeSection, ValType,
+    Ieee64, ImportSection, Instruction, MemArg, MemoryType, Module, TypeSection, ValType,
 };
 
 use crate::ir::{Block, BlockId, Const, Inst, IrFunction, KnownFn, Repr, Terminator, VarId};
@@ -92,7 +94,10 @@ pub fn emit_function(
             l
         });
     }
-    let declared = next_local - nparams as u32;
+    // One extra i32 local, past all VarId locals, holds the scratch-buffer
+    // pointer transiently while marshalling an allocation's element array.
+    let scratch_local = next_local;
+    let declared = next_local + 1 - nparams as u32;
 
     let block_of: HashMap<BlockId, usize> = func
         .blocks
@@ -113,6 +118,7 @@ pub fn emit_function(
             local_of: &local_of,
             block_of: &block_of,
             forward_preds: &forward_preds,
+            scratch_local,
             labels: Vec::new(),
             current: func.blocks[0].id,
         };
@@ -142,6 +148,21 @@ pub fn emit_function(
     let mut imports = ImportSection::new();
     for (name, ty_idx) in &asm.imports {
         imports.import("rt", name, EntityType::Function(*ty_idx));
+    }
+    if asm.needs_memory {
+        // The runtime owns linear memory; the module imports it.  Memory lives
+        // in its own index space, so this does not shift function indices.
+        imports.import(
+            "rt",
+            "memory",
+            EntityType::Memory(MemoryType {
+                minimum: 1,
+                maximum: None,
+                memory64: false,
+                shared: false,
+                page_size_log2: None,
+            }),
+        );
     }
     module.section(&imports);
 
@@ -214,6 +235,11 @@ struct ModuleAsm {
     /// `(import name, type index)`, in function-index order.
     imports: Vec<(&'static str, u32)>,
     import_map: HashMap<&'static str, u32>,
+    /// Whether the function uses linear memory (e.g. marshalling alloc element
+    /// arrays into the scratch buffer).  When set, the module imports `"rt"
+    /// "memory"`.  Memory imports occupy a separate index space from function
+    /// imports, so this does not affect function indices.
+    needs_memory: bool,
 }
 
 impl ModuleAsm {
@@ -223,6 +249,7 @@ impl ModuleAsm {
             type_map: HashMap::new(),
             imports: Vec::new(),
             import_map: HashMap::new(),
+            needs_memory: false,
         }
     }
 
@@ -281,6 +308,9 @@ struct Emitter<'a> {
     local_of: &'a HashMap<VarId, u32>,
     block_of: &'a HashMap<BlockId, usize>,
     forward_preds: &'a HashMap<BlockId, usize>,
+    /// An i32 local (past all VarId locals) that transiently holds the
+    /// scratch-buffer pointer while marshalling an allocation's element array.
+    scratch_local: u32,
     /// Enclosing control frames; `Some(b)` is a `block`/`loop` labeled `b`,
     /// `None` is an `if`.  Innermost is last.
     labels: Vec<Option<BlockId>>,
@@ -464,6 +494,32 @@ impl Emitter<'_> {
                 self.emit_known(kf, args)?;
                 self.set(*dst)
             }
+            Inst::AllocVector(dst, elems) => {
+                self.emit_alloc("rt_alloc_vector", elems, elems.len() as u64)?;
+                self.set(*dst)
+            }
+            Inst::AllocSet(dst, elems) => {
+                self.emit_alloc("rt_alloc_set", elems, elems.len() as u64)?;
+                self.set(*dst)
+            }
+            Inst::AllocList(dst, elems) => {
+                self.emit_alloc("rt_alloc_list", elems, elems.len() as u64)?;
+                self.set(*dst)
+            }
+            Inst::AllocMap(dst, pairs) => {
+                // Flatten to [k0, v0, k1, v1, ...]; the count is the pair count,
+                // matching `rt_alloc_map`'s contract (mirrors the native backend).
+                let flat: Vec<VarId> = pairs.iter().flat_map(|(k, v)| [*k, *v]).collect();
+                self.emit_alloc("rt_alloc_map", &flat, pairs.len() as u64)?;
+                self.set(*dst)
+            }
+            Inst::AllocCons(dst, head, tail) => {
+                // Two pointer args, no element array.
+                self.get(*head)?;
+                self.get(*tail)?;
+                self.call_import("rt_alloc_cons")?;
+                self.set(*dst)
+            }
             // Resolved on edges / by terminators.
             Inst::Phi(..) | Inst::Recur(..) | Inst::SourceLoc(..) => Ok(()),
             other => Err(WasmError::Unsupported(format!(
@@ -542,6 +598,47 @@ impl Emitter<'_> {
             }
         }
         Ok(())
+    }
+
+    /// Lower a slice-taking allocation bridge (`rt_alloc_vector` etc.): marshal
+    /// the element `*const Value` pointers into the scratch buffer, then call
+    /// `bridge(ptr, count)`.  The boxed result is left on the operand stack.
+    ///
+    /// `elems` are the pointers stored contiguously (for maps, the flattened
+    /// key/value sequence); `count` is the value passed to the bridge (element
+    /// count, or pair count for maps).  Mirrors the native
+    /// `codegen.rs::emit_alloc_collection`.
+    fn emit_alloc(&mut self, bridge: &str, elems: &[VarId], count: u64) -> Result<(), WasmError> {
+        let n = elems.len();
+        if n == 0 {
+            // Empty literal: pass a null array pointer and a zero count.
+            self.ins(&Instruction::I32Const(0));
+            self.ins(&Instruction::I64Const(count as i64));
+            return self.call_import(bridge);
+        }
+
+        self.asm.needs_memory = true;
+
+        // scratch = rt_scratch_ptr(n * 4)  — element pointers are wasm i32s.
+        self.ins(&Instruction::I32Const((n * 4) as i32));
+        self.call_import("rt_scratch_ptr")?;
+        self.ins(&Instruction::LocalSet(self.scratch_local));
+
+        // Store each element pointer at scratch + i*4.
+        for (i, e) in elems.iter().enumerate() {
+            self.ins(&Instruction::LocalGet(self.scratch_local));
+            self.get(*e)?;
+            self.ins(&Instruction::I32Store(MemArg {
+                offset: (i * 4) as u64,
+                align: 2, // 2^2 == 4-byte alignment
+                memory_index: 0,
+            }));
+        }
+
+        // bridge(scratch, count)
+        self.ins(&Instruction::LocalGet(self.scratch_local));
+        self.ins(&Instruction::I64Const(count as i64));
+        self.call_import(bridge)
     }
 }
 
@@ -697,7 +794,52 @@ mod tests {
 
     #[test]
     fn unsupported_instruction_reports_cleanly() {
-        let mut f = IrFunction::new(Some(Arc::from("alloc")), None);
+        // `Deref` is not yet lowered; it should report cleanly.
+        let mut f = IrFunction::new(Some(Arc::from("deref")), None);
+        let x = f.fresh_var();
+        f.params = vec![(Arc::from("x"), x)];
+        let v = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![Inst::Deref(v, x)],
+            terminator: Terminator::Return(v),
+        });
+        match compile(&f) {
+            Err(WasmError::Unsupported(msg)) => assert!(msg.contains("not yet lowered")),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    /// `(fn [x] [x 1])`: build a vector from two boxed elements — exercises the
+    /// scratch-buffer marshalling and the imported linear memory.
+    #[test]
+    fn alloc_vector_validates() {
+        let mut f = IrFunction::new(Some(Arc::from("pair")), None);
+        let x = f.fresh_var();
+        f.params = vec![(Arc::from("x"), x)];
+        let one = f.fresh_var();
+        let v = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![
+                Inst::Const(one, Const::Long(1)),
+                Inst::AllocVector(v, vec![x, one]),
+            ],
+            terminator: Terminator::Return(v),
+        });
+        let bytes = compile(&f).expect("emit");
+        validate(&bytes);
+    }
+
+    /// An empty vector literal passes a null pointer and zero count — no memory
+    /// import needed.
+    #[test]
+    fn alloc_empty_vector_validates() {
+        let mut f = IrFunction::new(Some(Arc::from("empty")), None);
         let v = f.fresh_var();
         let b = f.fresh_block();
         f.blocks.push(Block {
@@ -706,10 +848,47 @@ mod tests {
             insts: vec![Inst::AllocVector(v, vec![])],
             terminator: Terminator::Return(v),
         });
-        match compile(&f) {
-            Err(WasmError::Unsupported(msg)) => assert!(msg.contains("not yet lowered")),
-            other => panic!("expected Unsupported, got {other:?}"),
-        }
+        let bytes = compile(&f).expect("emit");
+        validate(&bytes);
+    }
+
+    /// `(fn [k val] {k val})`: build a map from one key/value pair — the count
+    /// passed to the bridge is the pair count, not the pointer count.
+    #[test]
+    fn alloc_map_validates() {
+        let mut f = IrFunction::new(Some(Arc::from("m")), None);
+        let k = f.fresh_var();
+        let val = f.fresh_var();
+        f.params = vec![(Arc::from("k"), k), (Arc::from("val"), val)];
+        let m = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![Inst::AllocMap(m, vec![(k, val)])],
+            terminator: Terminator::Return(m),
+        });
+        let bytes = compile(&f).expect("emit");
+        validate(&bytes);
+    }
+
+    /// `(fn [h t] (cons h t))`: a cons cell takes two pointer args, no array.
+    #[test]
+    fn alloc_cons_validates() {
+        let mut f = IrFunction::new(Some(Arc::from("c")), None);
+        let h = f.fresh_var();
+        let t = f.fresh_var();
+        f.params = vec![(Arc::from("h"), h), (Arc::from("t"), t)];
+        let c = f.fresh_var();
+        let b = f.fresh_block();
+        f.blocks.push(Block {
+            id: b,
+            phis: vec![],
+            insts: vec![Inst::AllocCons(c, h, t)],
+            terminator: Terminator::Return(c),
+        });
+        let bytes = compile(&f).expect("emit");
+        validate(&bytes);
     }
 
     #[test]

--- a/docs/wasm-aot-plan.md
+++ b/docs/wasm-aot-plan.md
@@ -105,10 +105,11 @@ dependency, so it is reviewable and unit-tested independently):
   `CallWithRegion`→direct call passing the caller's handle as the trailing arg.
   This mirrors `IrFunction::abi_param_count` on the native side.
 - **Import table.** `RT_IMPORTS: &[RtImport]` describes the subset wired so far
-  (safepoint, constants, arithmetic/comparison bridges, GC-heap + region
-  allocation, inline-cache/deopt bridges) as `(name, params, results)` wasm
-  function types. `lookup(name)` resolves one. Completing it to all of `rt_abi`
-  is mechanical — one `RtImport` per `extern "C"` signature.
+  (safepoint, constants, arithmetic/comparison bridges, the `rt_scratch_ptr`
+  marshalling buffer, GC-heap + region allocation, inline-cache/deopt bridges)
+  as `(name, params, results)` wasm function types. `lookup(name)` resolves one.
+  Completing it to all of `rt_abi` is mechanical — one `RtImport` per `extern
+  "C"` signature.
 
 ### Relooper (`reloop.rs`) — complete for reducible CFGs
 
@@ -173,21 +174,42 @@ Produces real, **`wasmparser`-validated** single-function modules.
 
 **Instructions lowered so far:** scalar constants (`nil`/`bool`/`long`/`double`/
 `char`), `LoadLocal` (→ nil, matching the Cranelift backend), folded boxed
-arithmetic (`+ - * / rem`), binary comparison (`= < > <= >=`), and all control
-flow. Everything else returns `WasmError::Unsupported`.
+arithmetic (`+ - * / rem`), binary comparison (`= < > <= >=`), collection
+allocation (`AllocVector`/`AllocMap`/`AllocSet`/`AllocList`/`AllocCons`), and all
+control flow. Everything else returns `WasmError::Unsupported`.
+
+### Allocation (`Alloc*`) — complete
+
+The first lowering to touch linear memory. Element `*const Value` pointers are
+marshalled into a runtime-provided scratch buffer, then the slice-taking
+`rt_alloc_*` bridge is called (mirrors `codegen.rs::emit_alloc_collection`):
+
+- The module **imports `"rt" "memory"`** the first time an allocation needs to
+  store an element array (memory lives in its own index space, so it does not
+  shift the function indices). `ModuleAsm::needs_memory` records this.
+- `rt_scratch_ptr(n_bytes) -> i32` (new `rt_abi` bridge + `RT_IMPORTS` entry)
+  hands back a thread-local, monotonically growing scratch buffer; the emitter
+  stores its pointer in one extra `i32` local past the `VarId` locals.
+- Each element is stored with `i32.store` at `scratch + i*4` (pointers are wasm
+  `i32`s), then `bridge(scratch, count)` is called. For maps the pairs are
+  flattened to `[k0,v0,…]` and `count` is the **pair** count.
+- Empty literals pass a null pointer + zero count and need no memory.
+- `AllocCons` takes two pointer args directly, no array.
 
 ### Tests
 
-`cargo test -p cljrs-compiler wasm::` — 16 tests:
+`cargo test -p cljrs-compiler wasm::` — 20 tests:
 
 - `abi`: Value→wasm-type mapping, region contract well-typed, no duplicate
   imports.
 - `reloop`: empty/single-return/linear-chain/diamond/loop-with-exit/nested
   sequential merges, each asserting **every block is emitted exactly once**.
-- `emit`: an arithmetic function, an if/else diamond with a merge φ, and a loop
-  with a φ counter + conditional `recur` — each **validated with `wasmparser`**;
-  plus `Unsupported` coverage for region variants and un-lowered instructions,
-  and the typed-signature accounting.
+- `emit`: an arithmetic function, an if/else diamond with a merge φ, a loop with
+  a φ counter + conditional `recur`, and collection allocation (a two-element
+  vector exercising the scratch buffer + imported memory, an empty vector, a
+  one-pair map, and a cons) — each **validated with `wasmparser`**; plus
+  `Unsupported` coverage for region variants and un-lowered instructions, and the
+  typed-signature accounting.
 
 Dependencies added to `cljrs-compiler`: `wasm-encoder = "0.244"` (dep),
 `wasmparser = "0.244"` (dev-dep) — both already in the lock transitively.
@@ -196,38 +218,21 @@ Dependencies added to `cljrs-compiler`: `wasm-encoder = "0.244"` (dep),
 
 ## What is next
 
-Ordered by value. The first item is the gateway: it makes real Clojure functions
-(which build collections) compilable, and introduces the first **memory import**
-that the region path also needs.
+Ordered by value. Allocation (the gateway item, now **done** — see the
+"Allocation" section above) made real collection-building functions compilable
+and introduced the linear-memory import + scratch-buffer machinery that the
+region path reuses.
 
-### 1. Allocation (`Alloc*`) — highest value
+### 1. Region operations
 
-`AllocVector`/`AllocMap`/`AllocSet`/`AllocList`/`AllocCons`. The native backend
-(`codegen.rs::emit_alloc_collection`) spills the element `*const Value` pointers
-to a contiguous scratch array, then calls `rt_alloc_*(ptr, n)`. In wasm:
-
-- Import a **linear memory** (`(import "rt" "memory" (memory ...))`) — the first
-  time the emitter needs memory.
-- Reserve a scratch region for the pointer array. Decide ownership: simplest is a
-  runtime-provided scratch buffer (e.g. an `rt_scratch_ptr()` import or a fixed
-  imported global) so the emitter does not have to manage a stack/bump pointer of
-  its own yet.
-- For each element: `local.get elem` (i32), `i32.store` at `scratch + i*4`.
-- Push `scratch`, push `n` (i64), `call rt_alloc_vector` (etc.).
-
-`rt_alloc_*` are already in `RT_IMPORTS`. `AllocCons` is simpler (two pointer
-args, no array). Add tests that allocate and validate.
-
-### 2. Region operations
-
-Once the scratch/memory machinery from (1) exists, region ops are mechanical and
+Now that the scratch/memory machinery exists, region ops are mechanical and
 unlock the escape-analysis payoff. Lower `RegionStart`/`RegionAlloc`/`RegionEnd`
 to the `rt_region_*` imports, and `RegionParam`/`CallWithRegion` to the hidden
 trailing-`i32` ABI (see `abi.rs`). Then drop the
 `takes_region_param()`→`Unsupported` guard in `emit_function`. This needs
-multi-function support (2.5) for `CallWithRegion`.
+multi-function support (item 2) for `CallWithRegion`.
 
-### 3. Calls and multi-function modules
+### 2. Calls and multi-function modules
 
 `CallDirect` (same-module direct call), `Call` (dynamic, via the
 `rt_call_ic` inline-cache bridge), `CallWithRegion`. Requires compiling a
@@ -239,7 +244,7 @@ bodies, and resolves `CallDirect` targets to those indices. Closures
 `rt_make_fn*`). Cross-function tail calls use the wasm tail-call proposal
 (`return_call`) when `WasmBackend::tail_calls`, else a trampoline.
 
-### 4. Constants needing a data segment
+### 3. Constants needing a data segment
 
 `Const::Str` / `Const::Keyword` / `Const::Symbol`. Emit the UTF-8 bytes into a
 **data segment** and pass `(ptr, len)` to `rt_const_string`/`_keyword`/`_symbol`
@@ -247,20 +252,20 @@ bodies, and resolves `CallDirect` targets to those indices. Closures
 coordinated with the runtime's linear-memory layout — decide whether the
 emitter owns a rodata region or the runtime reserves one.
 
-### 5. Globals / vars
+### 4. Globals / vars
 
 `LoadGlobal` / `LoadVar` / `DefVar` / `SetBang`. These resolve namespaced names;
 follow `codegen.rs::emit_load_global` / `emit_def_var`. Needs the name-as-data
-machinery from (4) and the var-resolution `rt_abi` bridges added to `RT_IMPORTS`.
+machinery from (3) and the var-resolution `rt_abi` bridges added to `RT_IMPORTS`.
 
-### 6. Exceptions
+### 5. Exceptions
 
 `Throw` / `KnownFn::TryCatchFinally`. Use the wasm exception-handling proposal
 (`try`/`catch`/`throw`) when `WasmBackend::exceptions`, else thread the
 `rt_abi` thread-local error path the Cranelift backend uses (`rt_throw` +
 `rt_try` checking the thread-local).
 
-### 7. Unboxed specialization
+### 6. Unboxed specialization
 
 Align the emitted signature with `function_signature` (typed ABI): keep
 `Long`/`Double` values unboxed in `i64`/`f64` locals per `typeinfer`, guarding
@@ -268,7 +273,7 @@ specialized params and boxing only at boxed-context uses. Mirrors
 `codegen.rs::compile_function_with_specs`. This is an optimization, not a
 correctness requirement — do it after the functional subset is broad.
 
-### 8. CLI + bundling
+### 7. CLI + bundling
 
 `cljrs compile <file> --target wasm -o <out>.wasm`. Drive `compile_bundle` over a
 whole program, link with the runtime compiled to `wasm32-unknown-unknown` (the


### PR DESCRIPTION
Implements the highest-value next item in the wasm AOT plan: collection
allocation, the first lowering to touch linear memory.

- emit.rs: lower AllocVector/AllocMap/AllocSet/AllocList/AllocCons. Element
  *const Value pointers are marshalled into a runtime scratch buffer
  (rt_scratch_ptr) and the slice-taking rt_alloc_* bridge is called, mirroring
  codegen.rs::emit_alloc_collection. Map count is the pair count; empty literals
  pass null/0; cons takes two pointer args directly. The module imports
  "rt" "memory" on first use (tracked by ModuleAsm::needs_memory); memory lives
  in its own index space, so function indices are unaffected. One extra i32
  local holds the scratch pointer transiently.
- abi.rs: add the rt_scratch_ptr import descriptor to RT_IMPORTS.
- rt_abi.rs: add rt_scratch_ptr — a thread-local, monotonically growing scratch
  buffer (the wasm analogue of the native backend's on-stack slot).
- Tests: four new wasmparser-validated cases (two-element vector, empty vector,
  one-pair map, cons); the unsupported-instruction test now uses Deref.
- Docs: plan, cljrs-compiler README, and TODO.md Phase 11.5 updated in sync.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012utkSEK2PUGMW3R23REfaB