### PR TITLE
Implement missing cljrs.dom features required by docs/replicant.md

### DIFF
--- a/crates/cljrs-dom/Cargo.toml
+++ b/crates/cljrs-dom/Cargo.toml
@@ -42,7 +42,9 @@ features = [
     "HtmlInputElement",
     "HtmlSelectElement",
     "HtmlTextAreaElement",
+    "HtmlOptionElement",
     "DomTokenList",
     "HtmlHeadElement",
+    "AddEventListenerOptions",
     "console",
 ]

--- a/crates/cljrs-dom/README.md
+++ b/crates/cljrs-dom/README.md
@@ -42,25 +42,32 @@ cljrs_dom::register(&globals);            // registers cljrs.dom namespace
 
 #### Creation
 ```clojure
-(dom/create "div")        ; => DomNode
-(dom/create-text "hello") ; => DomNode (text node)
+(dom/create "div")            ; => DomNode
+(dom/create-text "hello")     ; => DomNode (text node)
+(dom/create-ns ns "tag")      ; => DomNode (createElementNS, e.g. SVG)
 ```
 
 #### Tree manipulation
 ```clojure
-(dom/append!  parent child) ; => parent
-(dom/prepend! parent child) ; => parent
-(dom/remove!  el)           ; => nil
-(dom/replace! old new)      ; => nil
-(dom/parent   el)           ; => DomNode | nil
-(dom/children el)           ; => [DomNode ...]
+(dom/append!        parent child)            ; => parent
+(dom/prepend!       parent child)            ; => parent
+(dom/insert-before! parent child ref-or-nil) ; => parent
+(dom/remove!        el)                      ; => nil
+(dom/replace!       old new)                 ; => nil
+(dom/parent         el)                      ; => DomNode | nil
+(dom/children       el)                      ; => [DomNode ...]
+(dom/child-at       el idx)                  ; => DomNode | nil  (O(1), unlike `children`)
+(dom/child-count    el)                      ; => Long
+(dom/connected?     el)                      ; => boolean  (Node.isConnected)
 ```
 
 #### Attributes
 ```clojure
-(dom/attr         el "name")        ; => String | nil
-(dom/set-attr!    el "name" val)    ; => el
-(dom/remove-attr! el "name")        ; => el
+(dom/attr            el "name")             ; => String | nil
+(dom/set-attr!       el "name" val)         ; => el
+(dom/remove-attr!    el "name")             ; => el
+(dom/set-attr-ns!    el ns "name" val)      ; => el  (setAttributeNS, e.g. xlink:href)
+(dom/remove-attr-ns! el ns "name")          ; => el
 ```
 
 #### Classes
@@ -81,21 +88,42 @@ cljrs_dom::register(&globals);            // registers cljrs.dom namespace
 
 #### Style & form values
 ```clojure
-(dom/style      el "prop")       ; => String
-(dom/set-style! el "prop" val)   ; => el
-(dom/value      el)              ; => String  (input/select/textarea)
-(dom/set-value! el val)          ; => el
+(dom/style          el "prop")       ; => String
+(dom/set-style!     el "prop" val)   ; => el
+(dom/remove-style!  el "prop")       ; => el  (style.removeProperty)
+(dom/computed-style el "prop")       ; => String  (getComputedStyle(el).getPropertyValue)
+(dom/value          el)              ; => String  (input/select/textarea)
+(dom/set-value!     el val)          ; => el
+(dom/set-checked!   el bool)         ; => el  (HtmlInputElement.checked property)
+(dom/set-selected!  el bool)         ; => el  (HtmlOptionElement.selected property)
+(dom/set-prop!      el "name" val)   ; => el  (generic DOM property setter, via Reflect.set)
+(dom/get-prop       el "name")       ; => String | Double | boolean | nil
 ```
 
 #### Events
 ```clojure
 ; Managed callback — returns a DomListener that keeps the handler alive
-(dom/listen!   el "click" handler-fn) ; => DomListener
-(dom/unlisten! listener)              ; => nil  (removes handler immediately)
+; opts is an optional map: {:capture bool :passive bool :once bool}
+(dom/listen!   el "click" handler-fn)       ; => DomListener
+(dom/listen!   el "click" handler-fn opts)  ; => DomListener
+(dom/unlisten! listener)                    ; => nil  (removes handler immediately)
 
 ; Channel-based — returns a core.async channel; listener is leaked
 (dom/event-chan el "input")           ; => channel
 ```
+
+#### Scheduling
+```clojure
+(dom/request-animation-frame f) ; => Long (request id); calls (f) on the next frame
+```
+
+#### Node memory
+```clojure
+(dom/remember! node value) ; => node  (associate an arbitrary value with a node)
+(dom/recall    node)       ; => value | nil
+```
+Identity is tracked via an expando id stamped onto the node; unlike a true
+`WeakMap`, entries are not released when the node itself becomes unreachable.
 
 Event maps delivered to callbacks:
 ```clojure

--- a/crates/cljrs-dom/src/events.rs
+++ b/crates/cljrs-dom/src/events.rs
@@ -105,12 +105,25 @@ pub fn event_to_map(event: &web_sys::Event) -> Value {
 
 pub const DOM_LISTENER_TAG: &str = "DomListener";
 
+/// Event-listener options recognised by `listen!`/`unlisten!`.
+///
+/// `capture` must match between `addEventListener` and `removeEventListener`
+/// or removal silently fails (per the DOM spec, capture is part of the
+/// listener's identity; passive/once are not).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ListenerOptions {
+    pub capture: bool,
+    pub passive: bool,
+    pub once: bool,
+}
+
 /// Holds a live DOM event listener. Removing the event listener and freeing
 /// the wasm-bindgen `Closure` both happen in `Drop`.
 pub struct DomListener {
     target: web_sys::EventTarget,
     event_type: String,
     callback: js_sys::Function,
+    capture: bool,
     // Kept alive so the Rust closure is not freed while the listener is active.
     _closure: Closure<dyn FnMut(web_sys::Event)>,
 }
@@ -141,9 +154,11 @@ impl NativeObject for DomListener {
 
 impl Drop for DomListener {
     fn drop(&mut self) {
-        let _ = self
-            .target
-            .remove_event_listener_with_callback(&self.event_type, &self.callback);
+        let _ = self.target.remove_event_listener_with_callback_and_bool(
+            &self.event_type,
+            &self.callback,
+            self.capture,
+        );
     }
 }
 
@@ -156,6 +171,7 @@ pub fn create_listener(
     target: &web_sys::EventTarget,
     event_type: String,
     handler: Value,
+    opts: ListenerOptions,
 ) -> Result<Value, String> {
     let closure = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
         let ptr = NonNull::from(&event);
@@ -175,14 +191,23 @@ pub fn create_listener(
 
     let callback: js_sys::Function = closure.as_ref().unchecked_ref::<js_sys::Function>().clone();
 
+    let add_opts = web_sys::AddEventListenerOptions::new();
+    add_opts.set_capture(opts.capture);
+    add_opts.set_passive(opts.passive);
+    add_opts.set_once(opts.once);
     target
-        .add_event_listener_with_callback(&event_type, &callback)
+        .add_event_listener_with_callback_and_add_event_listener_options(
+            &event_type,
+            &callback,
+            &add_opts,
+        )
         .map_err(|e| format!("addEventListener failed: {:?}", e))?;
 
     Ok(Value::NativeObject(gc_native_object(DomListener {
         target: target.clone(),
         event_type,
         callback,
+        capture: opts.capture,
         _closure: closure,
     })))
 }
@@ -200,7 +225,11 @@ pub fn remove_listener(val: &Value) -> ValueResult<()> {
                 .expect("DomListener tag but wrong concrete type");
             let _ = listener
                 .target
-                .remove_event_listener_with_callback(&listener.event_type, &listener.callback);
+                .remove_event_listener_with_callback_and_bool(
+                    &listener.event_type,
+                    &listener.callback,
+                    listener.capture,
+                );
             Ok(())
         }
         other => Err(ValueError::WrongType {

--- a/crates/cljrs-dom/src/fns.rs
+++ b/crates/cljrs-dom/src/fns.rs
@@ -1,14 +1,21 @@
 //! Native functions for the `cljrs.dom` namespace.
 
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use cljrs_env::env::GlobalEnv;
 use cljrs_gc::GcPtr;
-use cljrs_value::{Arity, MapValue, NativeFn, PersistentVector, Value, ValueError, ValueResult};
+use cljrs_value::{
+    Arity, Keyword, MapValue, NativeFn, PersistentVector, Value, ValueError, ValueResult,
+};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
-use crate::events::{attach_render_listener, create_event_chan, create_listener, remove_listener};
+use crate::DOM_GLOBALS;
+use crate::events::{
+    ListenerOptions, attach_render_listener, create_event_chan, create_listener, remove_listener,
+};
 use crate::node::{DOM_NODE_TAG, as_web_node, dom_node_value};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -60,6 +67,100 @@ fn to_html_element(node: &web_sys::Node) -> ValueResult<web_sys::HtmlElement> {
     node.dyn_ref::<web_sys::HtmlElement>()
         .cloned()
         .ok_or_else(|| ValueError::Other("DomNode is not an HtmlElement".into()))
+}
+
+fn kw(name: &'static str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn is_truthy(val: &Value) -> bool {
+    !matches!(val, Value::Nil | Value::Bool(false))
+}
+
+fn get_bool_arg(args: &[Value], idx: usize) -> ValueResult<bool> {
+    let val = args
+        .get(idx)
+        .ok_or_else(|| ValueError::Other("missing argument".into()))?;
+    Ok(is_truthy(val))
+}
+
+/// Parse `{:capture .. :passive .. :once ..}` from an optional opts map arg.
+fn listener_opts_from_arg(arg: Option<&Value>) -> ListenerOptions {
+    let mut opts = ListenerOptions::default();
+    if let Some(Value::Map(m)) = arg {
+        if let Some(v) = m.get(&kw("capture")) {
+            opts.capture = is_truthy(&v);
+        }
+        if let Some(v) = m.get(&kw("passive")) {
+            opts.passive = is_truthy(&v);
+        }
+        if let Some(v) = m.get(&kw("once")) {
+            opts.once = is_truthy(&v);
+        }
+    }
+    opts
+}
+
+/// Convert a JS value (as read off a DOM property) to a Clojure `Value`.
+fn js_to_value(js: JsValue) -> Value {
+    if js.is_null() || js.is_undefined() {
+        Value::Nil
+    } else if let Some(b) = js.as_bool() {
+        Value::Bool(b)
+    } else if let Some(n) = js.as_f64() {
+        Value::Double(n)
+    } else if let Some(s) = js.as_string() {
+        Value::string(s)
+    } else {
+        Value::string(format!("{:?}", js))
+    }
+}
+
+/// Convert a Clojure `Value` to a JS value for assignment onto a DOM property.
+fn value_to_js(val: &Value) -> JsValue {
+    match val {
+        Value::Nil => JsValue::NULL,
+        Value::Bool(b) => JsValue::from_bool(*b),
+        Value::Long(n) => JsValue::from_f64(*n as f64),
+        Value::Double(n) => JsValue::from_f64(*n),
+        Value::Str(s) => JsValue::from_str(s.get()),
+        Value::Keyword(k) => JsValue::from_str(k.get().name.as_ref()),
+        other => JsValue::from_str(&format!("{other}")),
+    }
+}
+
+// ── Node memory (IMemory) ────────────────────────────────────────────────────
+//
+// Replicant stores per-node bookkeeping (`replicant.dom/recall`) in a
+// `js/WeakMap` keyed by node identity in the browser. We track identity via a
+// non-enumerable expando id stamped onto the node and keep the values in a
+// Rust-side map. Unlike a real `WeakMap`, entries are not released when the
+// node itself becomes unreachable; callers that churn through many nodes
+// without remembering anything do not pay this cost.
+const MEMORY_EXPANDO_KEY: &str = "__cljrs_memory_id__";
+
+thread_local! {
+    static MEMORY: RefCell<HashMap<u64, Value>> = RefCell::new(HashMap::new());
+    static MEMORY_NEXT_ID: Cell<u64> = const { Cell::new(1) };
+}
+
+fn node_memory_id(node: &web_sys::Node, create: bool) -> Option<u64> {
+    let key = JsValue::from_str(MEMORY_EXPANDO_KEY);
+    if let Ok(existing) = js_sys::Reflect::get(node, &key)
+        && let Some(n) = existing.as_f64()
+    {
+        return Some(n as u64);
+    }
+    if !create {
+        return None;
+    }
+    let id = MEMORY_NEXT_ID.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    });
+    let _ = js_sys::Reflect::set(node, &key, &JsValue::from_f64(id as f64));
+    Some(id)
 }
 
 // ── Selection ─────────────────────────────────────────────────────────────────
@@ -132,6 +233,14 @@ fn builtin_create_text(args: &[Value]) -> ValueResult<Value> {
     Ok(dom_node_value(tn.into()))
 }
 
+fn builtin_create_ns(args: &[Value]) -> ValueResult<Value> {
+    let ns = get_str_arg(args, 0)?;
+    let tag = get_str_arg(args, 1)?;
+    let doc = get_document()?;
+    let el = doc.create_element_ns(Some(&ns), &tag).map_err(js_err)?;
+    Ok(dom_node_value(el.into()))
+}
+
 // ── Tree manipulation ─────────────────────────────────────────────────────────
 
 fn builtin_append(args: &[Value]) -> ValueResult<Value> {
@@ -185,6 +294,48 @@ fn builtin_children(args: &[Value]) -> ValueResult<Value> {
     ))))
 }
 
+fn builtin_insert_before(args: &[Value]) -> ValueResult<Value> {
+    let parent = get_node_arg(args, 0)?.clone();
+    let child = get_node_arg(args, 1)?;
+    let reference = match args.get(2) {
+        None | Some(Value::Nil) => None,
+        Some(v) => Some(as_web_node(v)?.clone()),
+    };
+    parent
+        .insert_before(child, reference.as_ref())
+        .map_err(js_err)?;
+    Ok(args[0].clone())
+}
+
+fn builtin_child_at(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?;
+    let idx = match args.get(1) {
+        Some(Value::Long(n)) if *n >= 0 => *n as u32,
+        Some(other) => {
+            return Err(ValueError::WrongType {
+                expected: "non-negative integer",
+                got: other.type_name().to_string(),
+            });
+        }
+        None => return Err(ValueError::Other("missing argument".into())),
+    };
+    Ok(node
+        .child_nodes()
+        .item(idx)
+        .map(dom_node_value)
+        .unwrap_or(Value::Nil))
+}
+
+fn builtin_child_count(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?;
+    Ok(Value::Long(node.child_nodes().length() as i64))
+}
+
+fn builtin_connected(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?;
+    Ok(Value::Bool(node.is_connected()))
+}
+
 // ── Attributes ────────────────────────────────────────────────────────────────
 
 fn builtin_attr(args: &[Value]) -> ValueResult<Value> {
@@ -211,6 +362,26 @@ fn builtin_remove_attr(args: &[Value]) -> ValueResult<Value> {
     let name = get_str_arg(args, 1)?;
     let el = to_element(&node)?;
     el.remove_attribute(&name).map_err(js_err)?;
+    Ok(args[0].clone())
+}
+
+fn builtin_set_attr_ns(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?.clone();
+    let ns = get_str_arg(args, 1)?;
+    let name = get_str_arg(args, 2)?;
+    let val = get_str_arg(args, 3)?;
+    let el = to_element(&node)?;
+    el.set_attribute_ns(Some(&ns), &name, &val)
+        .map_err(js_err)?;
+    Ok(args[0].clone())
+}
+
+fn builtin_remove_attr_ns(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?.clone();
+    let ns = get_str_arg(args, 1)?;
+    let name = get_str_arg(args, 2)?;
+    let el = to_element(&node)?;
+    el.remove_attribute_ns(Some(&ns), &name).map_err(js_err)?;
     Ok(args[0].clone())
 }
 
@@ -301,6 +472,31 @@ fn builtin_set_style(args: &[Value]) -> ValueResult<Value> {
     Ok(args[0].clone())
 }
 
+fn builtin_remove_style(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?.clone();
+    let prop = get_str_arg(args, 1)?;
+    to_html_element(&node)?
+        .style()
+        .remove_property(&prop)
+        .map_err(js_err)?;
+    Ok(args[0].clone())
+}
+
+fn builtin_computed_style(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?;
+    let prop = get_str_arg(args, 1)?;
+    let el = to_element(node)?;
+    let window =
+        web_sys::window().ok_or_else(|| ValueError::Other("no browser window available".into()))?;
+    let style = window
+        .get_computed_style(&el)
+        .map_err(js_err)?
+        .ok_or_else(|| ValueError::Other("getComputedStyle returned no style".into()))?;
+    Ok(Value::string(
+        style.get_property_value(&prop).unwrap_or_default(),
+    ))
+}
+
 fn builtin_value(args: &[Value]) -> ValueResult<Value> {
     let node = get_node_arg(args, 0)?;
     let val = if let Some(el) = node.dyn_ref::<web_sys::HtmlInputElement>() {
@@ -334,6 +530,43 @@ fn builtin_set_value(args: &[Value]) -> ValueResult<Value> {
     Ok(args[0].clone())
 }
 
+fn builtin_set_checked(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?.clone();
+    let checked = get_bool_arg(args, 1)?;
+    let el = node
+        .dyn_ref::<web_sys::HtmlInputElement>()
+        .ok_or_else(|| ValueError::Other("dom/set-checked! requires an input element".into()))?;
+    el.set_checked(checked);
+    Ok(args[0].clone())
+}
+
+fn builtin_set_selected(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?.clone();
+    let selected = get_bool_arg(args, 1)?;
+    let el = node
+        .dyn_ref::<web_sys::HtmlOptionElement>()
+        .ok_or_else(|| ValueError::Other("dom/set-selected! requires an option element".into()))?;
+    el.set_selected(selected);
+    Ok(args[0].clone())
+}
+
+fn builtin_set_prop(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?.clone();
+    let name = get_str_arg(args, 1)?;
+    let val = args
+        .get(2)
+        .ok_or_else(|| ValueError::Other("missing argument".into()))?;
+    js_sys::Reflect::set(&node, &JsValue::from_str(&name), &value_to_js(val)).map_err(js_err)?;
+    Ok(args[0].clone())
+}
+
+fn builtin_get_prop(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?;
+    let name = get_str_arg(args, 1)?;
+    let js = js_sys::Reflect::get(node, &JsValue::from_str(&name)).map_err(js_err)?;
+    Ok(js_to_value(js))
+}
+
 // ── Events ────────────────────────────────────────────────────────────────────
 
 fn builtin_listen(args: &[Value]) -> ValueResult<Value> {
@@ -343,11 +576,12 @@ fn builtin_listen(args: &[Value]) -> ValueResult<Value> {
         .get(2)
         .cloned()
         .ok_or_else(|| ValueError::Other("listen! requires a handler fn".into()))?;
+    let opts = listener_opts_from_arg(args.get(3));
     let target: web_sys::EventTarget = node
         .dyn_ref::<web_sys::EventTarget>()
         .cloned()
         .ok_or_else(|| ValueError::Other("DomNode is not an EventTarget".into()))?;
-    create_listener(&target, event_type, handler).map_err(ValueError::Other)
+    create_listener(&target, event_type, handler, opts).map_err(ValueError::Other)
 }
 
 fn builtin_unlisten(args: &[Value]) -> ValueResult<Value> {
@@ -366,6 +600,53 @@ fn builtin_event_chan(args: &[Value]) -> ValueResult<Value> {
         .cloned()
         .ok_or_else(|| ValueError::Other("DomNode is not an EventTarget".into()))?;
     Ok(create_event_chan(&target, event_type))
+}
+
+// ── Scheduling ────────────────────────────────────────────────────────────────
+
+fn builtin_request_animation_frame(args: &[Value]) -> ValueResult<Value> {
+    let handler = args.first().cloned().ok_or_else(|| {
+        ValueError::Other("request-animation-frame requires a callback fn".into())
+    })?;
+    let window =
+        web_sys::window().ok_or_else(|| ValueError::Other("no browser window available".into()))?;
+
+    let closure = Closure::once(move || {
+        DOM_GLOBALS.with(|g| {
+            if let Some(globals) = &*g.borrow() {
+                let mut env = cljrs_env::env::Env::new(globals.clone(), "user");
+                let _ = cljrs_env::apply::apply_value(&handler, vec![], &mut env);
+            }
+        });
+    });
+    let id = window
+        .request_animation_frame(closure.as_ref().unchecked_ref())
+        .map_err(js_err)?;
+    closure.forget();
+    Ok(Value::Long(id as i64))
+}
+
+// ── Node memory (IMemory) ────────────────────────────────────────────────────
+
+fn builtin_remember(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?.clone();
+    let value = args
+        .get(1)
+        .cloned()
+        .ok_or_else(|| ValueError::Other("missing argument".into()))?;
+    let id = node_memory_id(&node, true).expect("create=true always yields an id");
+    MEMORY.with(|m| m.borrow_mut().insert(id, value));
+    Ok(args[0].clone())
+}
+
+fn builtin_recall(args: &[Value]) -> ValueResult<Value> {
+    let node = get_node_arg(args, 0)?;
+    match node_memory_id(node, false) {
+        Some(id) => Ok(MEMORY
+            .with(|m| m.borrow().get(&id).cloned())
+            .unwrap_or(Value::Nil)),
+        None => Ok(Value::Nil),
+    }
 }
 
 // ── Hiccup renderer ───────────────────────────────────────────────────────────
@@ -513,6 +794,7 @@ pub fn register(globals: &Arc<GlobalEnv>) {
         // Creation
         ("create", Arity::Fixed(1), builtin_create),
         ("create-text", Arity::Fixed(1), builtin_create_text),
+        ("create-ns", Arity::Fixed(2), builtin_create_ns),
         // Tree manipulation
         ("append!", Arity::Fixed(2), builtin_append),
         ("prepend!", Arity::Fixed(2), builtin_prepend),
@@ -520,10 +802,16 @@ pub fn register(globals: &Arc<GlobalEnv>) {
         ("replace!", Arity::Fixed(2), builtin_replace),
         ("parent", Arity::Fixed(1), builtin_parent),
         ("children", Arity::Fixed(1), builtin_children),
+        ("insert-before!", Arity::Fixed(3), builtin_insert_before),
+        ("child-at", Arity::Fixed(2), builtin_child_at),
+        ("child-count", Arity::Fixed(1), builtin_child_count),
+        ("connected?", Arity::Fixed(1), builtin_connected),
         // Attributes
         ("attr", Arity::Fixed(2), builtin_attr),
         ("set-attr!", Arity::Fixed(3), builtin_set_attr),
         ("remove-attr!", Arity::Fixed(2), builtin_remove_attr),
+        ("set-attr-ns!", Arity::Fixed(4), builtin_set_attr_ns),
+        ("remove-attr-ns!", Arity::Fixed(3), builtin_remove_attr_ns),
         // Classes
         ("add-class!", Arity::Fixed(2), builtin_add_class),
         ("remove-class!", Arity::Fixed(2), builtin_remove_class),
@@ -537,12 +825,27 @@ pub fn register(globals: &Arc<GlobalEnv>) {
         // Style & form
         ("style", Arity::Fixed(2), builtin_style),
         ("set-style!", Arity::Fixed(3), builtin_set_style),
+        ("remove-style!", Arity::Fixed(2), builtin_remove_style),
+        ("computed-style", Arity::Fixed(2), builtin_computed_style),
         ("value", Arity::Fixed(1), builtin_value),
         ("set-value!", Arity::Fixed(2), builtin_set_value),
+        ("set-checked!", Arity::Fixed(2), builtin_set_checked),
+        ("set-selected!", Arity::Fixed(2), builtin_set_selected),
+        ("set-prop!", Arity::Fixed(3), builtin_set_prop),
+        ("get-prop", Arity::Fixed(2), builtin_get_prop),
         // Events
-        ("listen!", Arity::Fixed(3), builtin_listen),
+        ("listen!", Arity::Variadic { min: 3 }, builtin_listen),
         ("unlisten!", Arity::Fixed(1), builtin_unlisten),
         ("event-chan", Arity::Fixed(2), builtin_event_chan),
+        // Scheduling
+        (
+            "request-animation-frame",
+            Arity::Fixed(1),
+            builtin_request_animation_frame,
+        ),
+        // Node memory
+        ("remember!", Arity::Fixed(2), builtin_remember),
+        ("recall", Arity::Fixed(1), builtin_recall),
         // Hiccup
         ("render!", Arity::Fixed(2), builtin_render),
     ];


### PR DESCRIPTION
Adds the 11 upstream cljrs-dom additions Replicant's :rust IRender/IMemory
backend needs: insert-before!, child-at/child-count, create-ns,
set-attr-ns!/remove-attr-ns!, remove-style!, set-checked!/set-selected!/
set-prop!/get-prop, listen!/unlisten! with capture/passive/once options,
connected?, request-animation-frame, computed-style, and remember!/recall.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RyrAwqu1BUAb3K21b66GHy