### PR TITLE
Handle metadata on ns forms

### DIFF
--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -7373,6 +7373,7 @@ fn builtin_meta(args: &[Value]) -> ValueResult<Value> {
     match &args[0] {
         Value::Var(vp) => Ok(vp.get().get_meta().unwrap_or(Value::Nil)),
         Value::Atom(a) => Ok(a.get().get_meta().unwrap_or(Value::Nil)),
+        Value::Namespace(ns) => Ok(ns.get().get_meta().unwrap_or(Value::Nil)),
         Value::WithMeta(_, meta) => Ok(meta.as_ref().clone()),
         _ => Ok(Value::Nil),
     }
@@ -7383,6 +7384,10 @@ fn builtin_with_meta(args: &[Value]) -> ValueResult<Value> {
     match &args[0] {
         Value::Var(vp) => {
             vp.get().set_meta(args[1].clone());
+            Ok(args[0].clone())
+        }
+        Value::Namespace(ns) => {
+            ns.get().set_meta(args[1].clone());
             Ok(args[0].clone())
         }
         _ => Ok(args[0].clone().with_meta(args[1].clone())),

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1410,7 +1410,9 @@ fn extract_ns_name_form(form: Option<&Form>, env: &mut Env) -> EvalResult<(Strin
     }
     match &current.kind {
         FormKind::Symbol(s) => Ok((s.clone(), meta_acc)),
-        _ => Err(EvalError::Runtime("ns requires a symbol at position 0".into())),
+        _ => Err(EvalError::Runtime(
+            "ns requires a symbol at position 0".into(),
+        )),
     }
 }
 

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1395,17 +1395,70 @@ fn parse_require_spec_form(form: &Form) -> Result<RequireSpec, String> {
 
 // ── ns ────────────────────────────────────────────────────────────────────────
 
+/// Extract the ns name and optional metadata from the `ns` macro's name form.
+/// Handles plain symbols and `^meta` shorthand / map forms, e.g.
+/// `(ns ^{:doc "..."} my.ns ...)` or `(ns ^:no-doc my.ns ...)`.
+fn extract_ns_name_form(form: Option<&Form>, env: &mut Env) -> EvalResult<(String, Option<Value>)> {
+    let mut current = form
+        .ok_or_else(|| EvalError::Runtime("ns requires a symbol at position 0".into()))?
+        .clone();
+    let mut meta_acc: Option<Value> = None;
+    while let FormKind::Meta(meta_form, inner) = current.kind {
+        let meta_val = compile_meta_form(&meta_form, env)?;
+        meta_acc = merge_meta(meta_acc, Some(meta_val));
+        current = *inner;
+    }
+    match &current.kind {
+        FormKind::Symbol(s) => Ok((s.clone(), meta_acc)),
+        _ => Err(EvalError::Runtime("ns requires a symbol at position 0".into())),
+    }
+}
+
+/// Merge two optional metadata maps, with `overlay` entries taking
+/// precedence over `base` entries (matching Clojure's `(merge base overlay)`).
+fn merge_meta(base: Option<Value>, overlay: Option<Value>) -> Option<Value> {
+    match (base, overlay) {
+        (None, None) => None,
+        (Some(b), None) => Some(b),
+        (None, Some(o)) => Some(o),
+        (Some(Value::Map(b)), Some(Value::Map(o))) => {
+            let mut merged = b;
+            for (k, v) in o.iter() {
+                merged = merged.assoc(k.clone(), v.clone());
+            }
+            Some(Value::Map(merged))
+        }
+        (_, Some(o)) => Some(o),
+    }
+}
+
 fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
-    let name = require_sym(args, 0, "ns")?;
-    env.globals.get_or_create_ns(name);
-    env.current_ns = Arc::from(name);
+    let (name, name_meta) = extract_ns_name_form(args.first(), env)?;
+    env.globals.get_or_create_ns(&name);
+    env.current_ns = Arc::from(name.as_str());
     // Auto-refer clojure.core (Clojure default behaviour).
     if name != "clojure.core" {
-        env.globals.refer_all(name, "clojure.core");
+        env.globals.refer_all(&name, "clojure.core");
     }
     sync_star_ns(env);
 
-    for clause in &args[1..] {
+    // Optional docstring, then optional attr-map, before reference clauses.
+    let mut rest = &args[1..];
+    if matches!(rest.first().map(|f| &f.kind), Some(FormKind::Str(_))) {
+        rest = &rest[1..];
+    }
+    let mut attr_meta = None;
+    if matches!(rest.first().map(|f| &f.kind), Some(FormKind::Map(_))) {
+        attr_meta = Some(eval(&rest[0], env)?);
+        rest = &rest[1..];
+    }
+
+    if let Some(m) = merge_meta(name_meta, attr_meta) {
+        let ns_ptr = env.globals.get_or_create_ns(&env.current_ns);
+        ns_ptr.get().set_meta(m);
+    }
+
+    for clause in rest {
         if let FormKind::List(items) = &clause.kind {
             match items.first().map(|f| &f.kind) {
                 Some(FormKind::Keyword(k)) if k == "require" => {
@@ -1414,7 +1467,7 @@ fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
                     for spec_form in &expanded {
                         let spec =
                             parse_require_spec_form(spec_form).map_err(EvalError::Runtime)?;
-                        load_ns(env.globals.clone(), &spec, name)?;
+                        load_ns(env.globals.clone(), &spec, &name)?;
                     }
                 }
                 // Other clauses (:refer-clojure, :use, :import) — skip for now.

--- a/crates/cljrs-interp/tests/ns_metadata.rs
+++ b/crates/cljrs-interp/tests/ns_metadata.rs
@@ -1,0 +1,90 @@
+//! Metadata on `ns` forms: `(ns ^{:doc "..."} my.ns ...)`, `(ns ^:no-doc my.ns)`,
+//! and the optional attr-map form `(ns my.ns "doc" {:author "x"})`.
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_all(env: &mut Env, src: &str) -> Value {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, env).expect("eval error");
+    }
+    result
+}
+
+#[test]
+fn ns_with_map_metadata() {
+    let (_, mut env) = make_env();
+    let result = eval_all(&mut env, r#"(ns ^{:doc "A namespace"} my.meta.ns)"#);
+    let Value::Namespace(ns) = result else {
+        panic!("expected Namespace, got {result:?}");
+    };
+    let meta = ns.get().get_meta().expect("ns should have metadata");
+    let Value::Map(m) = meta else {
+        panic!("expected map metadata, got {meta:?}");
+    };
+    let doc = m
+        .get(&Value::keyword(cljrs_value::Keyword::parse("doc")))
+        .expect("expected :doc key");
+    assert_eq!(doc, Value::string("A namespace".to_string()));
+}
+
+#[test]
+fn ns_with_keyword_shorthand_metadata() {
+    let (_, mut env) = make_env();
+    let result = eval_all(&mut env, "(ns ^:no-doc my.meta.ns2)");
+    let Value::Namespace(ns) = result else {
+        panic!("expected Namespace, got {result:?}");
+    };
+    let meta = ns.get().get_meta().expect("ns should have metadata");
+    let Value::Map(m) = meta else {
+        panic!("expected map metadata, got {meta:?}");
+    };
+    let v = m
+        .get(&Value::keyword(cljrs_value::Keyword::parse("no-doc")))
+        .expect("expected :no-doc key");
+    assert_eq!(v, Value::Bool(true));
+}
+
+#[test]
+fn ns_without_metadata_still_works() {
+    let (_, mut env) = make_env();
+    let result = eval_all(&mut env, "(ns my.plain.ns)");
+    let Value::Namespace(ns) = result else {
+        panic!("expected Namespace, got {result:?}");
+    };
+    assert!(ns.get().get_meta().is_none());
+}
+
+#[test]
+fn ns_docstring_and_requires_clause_still_work_with_metadata() {
+    let (_, mut env) = make_env();
+    let result = eval_all(
+        &mut env,
+        r#"(ns ^{:doc "top"} my.meta.ns3
+             "a docstring"
+             (:require [clojure.core]))"#,
+    );
+    let Value::Namespace(ns) = result else {
+        panic!("expected Namespace, got {result:?}");
+    };
+    let meta = ns.get().get_meta().expect("ns should have metadata");
+    let Value::Map(m) = meta else {
+        panic!("expected map metadata, got {meta:?}");
+    };
+    let doc = m
+        .get(&Value::keyword(cljrs_value::Keyword::parse("doc")))
+        .expect("expected :doc key");
+    assert_eq!(doc, Value::string("top".to_string()));
+}

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -336,9 +336,21 @@ module is an identity stub (that build keeps its `StaticCtxGuard` discipline).
 ```rust
 pub struct Namespace {
     pub name: Arc<str>,
-    pub interns: Mutex<HashMap<Arc<str>, GcPtr<Var>>>,  // own vars
-    pub refers: Mutex<HashMap<Arc<str>, GcPtr<Var>>>,   // imported names
-    pub aliases: Mutex<HashMap<Arc<str>, Arc<str>>>,    // ns alias → ns name
+    pub interns: Mutex<HashMap<Arc<str>, GcPtr<Var>>>,        // own vars
+    pub refers: Mutex<HashMap<Arc<str>, GcPtr<Var>>>,         // imported names
+    pub aliases: Mutex<HashMap<Arc<str>, Arc<str>>>,          // ns alias → ns name
+    pub source_file: Mutex<Option<Arc<str>>>,                 // path the ns was loaded from
+    pub git_repo_root: Mutex<Option<Arc<str>>>,               // repo root of source_file, if any
+    pub is_versioned: bool,                                   // true for `name@commit` namespaces
+    pub meta: Mutex<Option<Value>>,                           // from `(ns ^{...} name ...)` / attr-map
+}
+
+impl Namespace {
+    pub fn new(name: impl Into<Arc<str>>) -> Self;
+    pub fn new_versioned(name: impl Into<Arc<str>>) -> Self;
+    pub fn set_source_location(&self, file: &str, repo_root: Option<&str>);
+    pub fn get_meta(&self) -> Option<Value>;
+    pub fn set_meta(&self, m: Value);
 }
 ```
 

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -513,6 +513,8 @@ pub struct Namespace {
     /// `true` for namespaces loaded from a specific commit (`name@hash`).
     /// Versioned namespaces are immutable: `intern()` will refuse new bindings.
     pub is_versioned: bool,
+    /// Metadata attached via `(ns ^{...} name ...)` or an `ns` attr-map.
+    pub meta: Mutex<Option<Value>>,
 }
 
 impl Namespace {
@@ -525,6 +527,7 @@ impl Namespace {
             source_file: Mutex::new(None),
             git_repo_root: Mutex::new(None),
             is_versioned: false,
+            meta: Mutex::new(None),
         }
     }
 
@@ -541,6 +544,14 @@ impl Namespace {
         *self.source_file.lock().unwrap() = Some(Arc::from(file));
         *self.git_repo_root.lock().unwrap() = repo_root.map(Arc::from);
     }
+
+    pub fn get_meta(&self) -> Option<Value> {
+        self.meta.lock().unwrap().clone()
+    }
+
+    pub fn set_meta(&self, m: Value) {
+        *self.meta.lock().unwrap() = Some(m);
+    }
 }
 
 impl cljrs_gc::Trace for Namespace {
@@ -556,6 +567,12 @@ impl cljrs_gc::Trace for Namespace {
             let refers = self.refers.lock().unwrap();
             for var in refers.values() {
                 visitor.visit(var);
+            }
+        }
+        {
+            let meta = self.meta.lock().unwrap();
+            if let Some(m) = meta.as_ref() {
+                m.trace(visitor);
             }
         }
     }


### PR DESCRIPTION
`(ns ^{:doc "..."} my.ns)` and `(ns ^:no-doc my.ns)` previously raised
"ns requires a symbol at position 0" because eval_ns only accepted a
bare symbol, not a reader-metadata-wrapped one. ns now peels ^meta
wrappers off the name symbol, accepts an optional attr-map literal
after the docstring, and stores the merged metadata on the Namespace
(new Namespace.meta field, exposed via meta/with-meta).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019DpB9edAndUF1CkTdv1FQK