### PR TITLE
Tokenize trailing # as part of symbols (auto-gensym)

### DIFF
--- a/crates/cljrs-interp/tests/auto_gensym.rs
+++ b/crates/cljrs-interp/tests/auto_gensym.rs
@@ -38,7 +38,8 @@ fn auto_gensym_symbol_tokenizes_as_one_token() {
 fn auto_gensym_is_consistent_within_one_syntax_quote() {
     // Every occurrence of `x#` in the same syntax-quote must read out to the
     // same generated symbol.
-    let result = eval_src("(let [expanded `(let [x# 1] x#)] (= (nth (nth expanded 1) 0) (nth expanded 2)))");
+    let result =
+        eval_src("(let [expanded `(let [x# 1] x#)] (= (nth (nth expanded 1) 0) (nth expanded 2)))");
     assert_eq!(result, Value::Bool(true));
 }
 

--- a/crates/cljrs-interp/tests/auto_gensym.rs
+++ b/crates/cljrs-interp/tests/auto_gensym.rs
@@ -1,0 +1,68 @@
+//! Regression tests for auto-gensym tokenization: `x#` inside a syntax-quote
+//! must read as a single symbol token (the trailing `#` is part of the
+//! symbol, not a `#`-dispatch reader macro), and every occurrence of the same
+//! `x#` within one syntax-quote must expand to the same generated symbol.
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_src(src: &str) -> Value {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, &mut env).expect("eval error");
+    }
+    result
+}
+
+#[test]
+fn auto_gensym_symbol_tokenizes_as_one_token() {
+    // Before the fix, `x#` would lex as `x` followed by a stray `#`
+    // dispatch token, which fails to parse inside `(let [x# 1] x#)`.
+    let result = eval_src("(count `(let [x# 1] x#))");
+    assert_eq!(result, Value::Long(3));
+}
+
+#[test]
+fn auto_gensym_is_consistent_within_one_syntax_quote() {
+    // Every occurrence of `x#` in the same syntax-quote must read out to the
+    // same generated symbol.
+    let result = eval_src("(let [expanded `(let [x# 1] x#)] (= (nth (nth expanded 1) 0) (nth expanded 2)))");
+    assert_eq!(result, Value::Bool(true));
+}
+
+#[test]
+fn auto_gensym_differs_across_syntax_quotes() {
+    // Two separate syntax-quote forms generate distinct gensyms even for the
+    // same base name `x#`.
+    let result = eval_src(
+        "(let [a (nth (nth `(let [x# 1] x#) 1) 0) b (nth (nth `(let [x# 1] x#) 1) 0)] (= a b))",
+    );
+    assert_eq!(result, Value::Bool(false));
+}
+
+#[test]
+fn auto_gensym_via_defmacro_hygiene() {
+    // Classic hygienic-macro pattern: a macro-introduced `x#` binding must
+    // not capture a caller's `x`.
+    let result = eval_src(
+        r#"
+        (defmacro my-or [a b]
+          `(let [x# ~a] (if x# x# ~b)))
+        (let [x 100]
+          (my-or false x))
+        "#,
+    );
+    assert_eq!(result, Value::Long(100));
+}

--- a/crates/cljrs-reader/README.md
+++ b/crates/cljrs-reader/README.md
@@ -37,7 +37,7 @@ Every distinct lexical form the reader can produce:
 | `Ratio(String)` | `3/4`, `-1/2` | full text including `/` |
 | `Char(char)` | `\a`, `\newline`, `\u0041` | named chars and `\uXXXX` resolved |
 | `Str(String)` | `"hello\n"` | escape sequences fully processed |
-| `Symbol(String)` | `foo`, `ns/name`, `/`, `..` | |
+| `Symbol(String)` | `foo`, `ns/name`, `/`, `..`, `x#` | trailing `#` (auto-gensym) is part of the symbol |
 | `Keyword(String)` | `:foo`, `:ns/name` | leading `:` stripped |
 | `AutoKeyword(String)` | `::foo`, `::ns/alias` | leading `::` stripped |
 | `LParen` / `RParen` | `(` / `)` | |
@@ -102,6 +102,17 @@ impl Iterator for Lexer {
   consumed as part of a ratio when the character immediately after it is a digit.
 - Radix literals: `NNrDIGITS` where `NN` is 2–36. Overflow of `i64` yields
   `BigInt`.
+
+#### `#` mid-symbol (auto-gensym)
+
+`#` is a *non-terminating* macro character: a leading `#` always triggers
+`#`-dispatch (`#(`, `#{`, `#'`, …), but a `#` encountered while a symbol or
+keyword token is already in progress is just appended to that token instead
+of ending it. This is what makes `x#` lex as the single symbol `Symbol("x#")`
+rather than `Symbol("x")` followed by a stray dispatch token — required for
+auto-gensym symbols inside syntax-quote (`` `(let [x# 1] x#) ``), which
+`cljrs-interp::syntax_quote` resolves to a unique `x__N__auto__` symbol per
+syntax-quote form.
 
 ---
 

--- a/crates/cljrs-reader/src/lexer.rs
+++ b/crates/cljrs-reader/src/lexer.rs
@@ -16,6 +16,12 @@ use crate::token::Token;
 /// Returns `true` if `ch` is a valid constituent character for a symbol or
 /// keyword.  Defined *negatively*: everything that isn't a delimiter, whitespace,
 /// or special syntax character is a symbol constituent.
+///
+/// `#` is included here: it is a *non-terminating* macro character in the
+/// Clojure reader, meaning it doesn't end a symbol token that's already in
+/// progress (only a leading `#` triggers `#`-dispatch — see
+/// [`is_symbol_start`]). This is what makes auto-gensym symbols like `x#`
+/// tokenize as a single symbol rather than `x` followed by a stray `#`.
 fn is_symbol_char(ch: char) -> bool {
     !matches!(
         ch,
@@ -35,16 +41,16 @@ fn is_symbol_char(ch: char) -> bool {
             | '~'
             | '^'
             | '@'
-            | '#'
             | '\\'
             | ':'
     )
 }
 
-/// Returns `true` if `ch` can *start* a symbol (not a digit, not `+`/`-` when
-/// the following char is a digit — but the caller handles the `+`/`-` case).
+/// Returns `true` if `ch` can *start* a symbol (not a digit, not `#` since a
+/// leading `#` always triggers `#`-dispatch, not `+`/`-` when the following
+/// char is a digit — but the caller handles the `+`/`-` case).
 fn is_symbol_start(ch: char) -> bool {
-    is_symbol_char(ch) && !ch.is_ascii_digit()
+    is_symbol_char(ch) && !ch.is_ascii_digit() && ch != '#'
 }
 
 // ─── Lexer ───────────────────────────────────────────────────────────────────
@@ -1105,6 +1111,28 @@ mod tests {
         assert_eq!(lex_one("+"), Token::Symbol("+".to_string()));
         assert_eq!(lex_one("-"), Token::Symbol("-".to_string()));
         assert_eq!(lex_one("+foo"), Token::Symbol("+foo".to_string()));
+    }
+
+    #[test]
+    fn test_auto_gensym_symbol() {
+        // `x#` is a single symbol token (trailing `#` is auto-gensym syntax,
+        // not a `#`-dispatch macro — `#` is non-terminating mid-token).
+        assert_eq!(lex_one("x#"), Token::Symbol("x#".to_string()));
+        let toks = lex_all("`(let [x# 1] x#)");
+        assert_eq!(
+            toks,
+            vec![
+                Token::SyntaxQuote,
+                Token::LParen,
+                Token::Symbol("let".to_string()),
+                Token::LBracket,
+                Token::Symbol("x#".to_string()),
+                Token::Int(1),
+                Token::RBracket,
+                Token::Symbol("x#".to_string()),
+                Token::RParen,
+            ]
+        );
     }
 
     // ── Keywords ─────────────────────────────────────────────────────────


### PR DESCRIPTION
The lexer excluded `#` from symbol-constituent characters, so `x#`
split into `Symbol("x")` followed by a stray `#` that the next-token
dispatcher tried to read as a `#`-macro, breaking syntax-quote
auto-gensym (`` `(let [x# 1] x#) ``).

`#` is a non-terminating macro character in Clojure: it only starts
`#`-dispatch when it's the first character of a fresh token, not when
it follows characters already read as part of a symbol/keyword. Allow
`#` to continue an in-progress token while still excluding it from
starting one, so auto-gensym symbols tokenize correctly and
cljrs-interp's existing gensym-qualification logic in
syntax_quote::qualify_symbol can do its job.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015W7qQFo3mEPuHkQGVk51DP