### PR TITLE
Support metadata on defmacro; fix keyword colon tokenization and ::alias/kw resolution

### DIFF
--- a/crates/cljrs-env/src/env.rs
+++ b/crates/cljrs-env/src/env.rs
@@ -287,6 +287,24 @@ impl GlobalEnv {
         aliases.get(alias).cloned()
     }
 
+    /// Resolve an auto-resolved keyword name (the text after `::`) to its
+    /// fully-qualified `ns/name` form.
+    ///
+    /// `::kw` qualifies with `current_ns` directly; `::alias/kw` looks
+    /// `alias` up in `current_ns`'s alias table (populated by `(require
+    /// '[... :as alias])`) and qualifies with the resolved namespace.
+    pub fn resolve_auto_keyword(&self, current_ns: &str, name: &str) -> Result<String, String> {
+        match name.split_once('/') {
+            Some((alias, kw_name)) => match self.resolve_alias(current_ns, alias) {
+                Some(ns) => Ok(format!("{ns}/{kw_name}")),
+                None => Err(format!(
+                    "invalid token: ::{name} (no such namespace alias: {alias})"
+                )),
+            },
+            None => Ok(format!("{current_ns}/{name}")),
+        }
+    }
+
     /// Return the namespace with this name, creating it if it doesn't exist.
     pub fn get_or_create_ns(&self, name: &str) -> GcPtr<Namespace> {
         // Fast path: already exists.

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -696,11 +696,10 @@ fn macro_apply(
     // In Clojure, ::kw is resolved at read time; we approximate that here so a
     // macro splicing its arguments into a new form cannot re-resolve them against
     // the macro's own namespace.
-    let ns = env.current_ns.clone();
     let resolved_args: Vec<Form> = arg_forms
         .iter()
-        .map(|f| crate::macros::resolve_auto_kws(f, &ns))
-        .collect();
+        .map(|f| crate::macros::resolve_auto_kws(f, env))
+        .collect::<EvalResult<Vec<Form>>>()?;
 
     // &form: the whole call expression as a list value.
     let form_val = {

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -45,7 +45,10 @@ pub fn eval(form: &Form, env: &mut Env) -> EvalResult {
         FormKind::Symbol(s) => eval_symbol(s, env),
         FormKind::Keyword(s) => Ok(Value::keyword(Keyword::parse(s))),
         FormKind::AutoKeyword(s) => {
-            let full = format!("{}/{}", env.current_ns, s);
+            let full = env
+                .globals
+                .resolve_auto_keyword(&env.current_ns, s)
+                .map_err(EvalError::Runtime)?;
             Ok(Value::keyword(Keyword::parse(&full)))
         }
 

--- a/crates/cljrs-interp/src/macros.rs
+++ b/crates/cljrs-interp/src/macros.rs
@@ -21,7 +21,7 @@ pub fn macroexpand_1(form: &Form, env: &mut Env) -> EvalResult<Form> {
         // them.  In Clojure, ::kw is resolved at READ time; since cljrs keeps
         // AutoKeyword forms in the AST until eval, we resolve them here — the
         // last point at which env.current_ns reflects the call site.
-        let resolved = resolve_auto_kws(form, &env.current_ns);
+        let resolved = resolve_auto_kws(form, env)?;
         let parts = if let FormKind::List(p) = &resolved.kind {
             p
         } else {
@@ -48,39 +48,59 @@ pub fn macroexpand_1(form: &Form, env: &mut Env) -> EvalResult<Form> {
     Ok(form.clone())
 }
 
-/// Walk a form tree and replace every `AutoKeyword(s)` with `Keyword("{ns}/{s}")`.
+/// Walk a form tree and replace every `AutoKeyword(s)` with its
+/// fully-qualified `Keyword`, resolving an `alias/name` prefix against the
+/// caller's namespace alias table (see `GlobalEnv::resolve_auto_keyword`).
 ///
 /// `::kw` must be resolved using the namespace at the call site (not the
 /// macro's definition namespace).  Clojure resolves it at read time; we do it
 /// here, just before the form is handed to the macro, so the macro always
 /// receives fully-qualified keywords.
-pub(crate) fn resolve_auto_kws(form: &Form, ns: &str) -> Form {
+pub(crate) fn resolve_auto_kws(form: &Form, env: &Env) -> EvalResult<Form> {
     let kind = match &form.kind {
-        FormKind::AutoKeyword(s) => FormKind::Keyword(format!("{ns}/{s}")),
-        FormKind::List(items) => {
-            FormKind::List(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
+        FormKind::AutoKeyword(s) => {
+            let full = env
+                .globals
+                .resolve_auto_keyword(&env.current_ns, s)
+                .map_err(EvalError::Runtime)?;
+            FormKind::Keyword(full)
         }
-        FormKind::Vector(items) => {
-            FormKind::Vector(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
-        }
-        FormKind::Map(items) => {
-            FormKind::Map(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
-        }
-        FormKind::Set(items) => {
-            FormKind::Set(items.iter().map(|f| resolve_auto_kws(f, ns)).collect())
-        }
+        FormKind::List(items) => FormKind::List(
+            items
+                .iter()
+                .map(|f| resolve_auto_kws(f, env))
+                .collect::<EvalResult<Vec<_>>>()?,
+        ),
+        FormKind::Vector(items) => FormKind::Vector(
+            items
+                .iter()
+                .map(|f| resolve_auto_kws(f, env))
+                .collect::<EvalResult<Vec<_>>>()?,
+        ),
+        FormKind::Map(items) => FormKind::Map(
+            items
+                .iter()
+                .map(|f| resolve_auto_kws(f, env))
+                .collect::<EvalResult<Vec<_>>>()?,
+        ),
+        FormKind::Set(items) => FormKind::Set(
+            items
+                .iter()
+                .map(|f| resolve_auto_kws(f, env))
+                .collect::<EvalResult<Vec<_>>>()?,
+        ),
         // ::kw is resolved at read time in Clojure, so resolve inside quote too.
-        FormKind::Quote(inner) => FormKind::Quote(Box::new(resolve_auto_kws(inner, ns))),
+        FormKind::Quote(inner) => FormKind::Quote(Box::new(resolve_auto_kws(inner, env)?)),
         FormKind::SyntaxQuote(inner) => {
-            FormKind::SyntaxQuote(Box::new(resolve_auto_kws(inner, ns)))
+            FormKind::SyntaxQuote(Box::new(resolve_auto_kws(inner, env)?))
         }
-        FormKind::Unquote(inner) => FormKind::Unquote(Box::new(resolve_auto_kws(inner, ns))),
+        FormKind::Unquote(inner) => FormKind::Unquote(Box::new(resolve_auto_kws(inner, env)?)),
         FormKind::UnquoteSplice(inner) => {
-            FormKind::UnquoteSplice(Box::new(resolve_auto_kws(inner, ns)))
+            FormKind::UnquoteSplice(Box::new(resolve_auto_kws(inner, env)?))
         }
-        _ => return form.clone(),
+        _ => return Ok(form.clone()),
     };
-    Form::new(kind, form.span.clone())
+    Ok(Form::new(kind, form.span.clone()))
 }
 
 /// Fully expand a form until the head is no longer a macro.

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1132,12 +1132,34 @@ fn prepend_macro_params(form: &Form) -> Form {
 }
 
 fn eval_defmacro(args: &[Form], env: &mut Env) -> EvalResult {
-    let name = require_sym(args, 0, "defmacro")?;
+    // The name may carry reader metadata, e.g. `(defmacro ^:private foo ...)`,
+    // possibly stacked (`^:a ^:b foo`).
+    let mut current = args
+        .first()
+        .ok_or_else(|| EvalError::Runtime("defmacro requires a symbol at position 0".into()))?
+        .clone();
+    let mut name_meta: Option<Value> = None;
+    while let FormKind::Meta(meta_form, inner) = current.kind {
+        let meta_val = compile_meta_form(&meta_form, env)?;
+        name_meta = merge_meta(name_meta, Some(meta_val));
+        current = *inner;
+    }
+    let name = match &current.kind {
+        FormKind::Symbol(s) => s.clone(),
+        _ => {
+            return Err(EvalError::Runtime(
+                "defmacro requires a symbol at position 0".into(),
+            ));
+        }
+    };
+
     let mut rest_start = 1;
     if rest_start < args.len() && matches!(args[rest_start].kind, FormKind::Str(_)) {
         rest_start += 1;
     }
+    let mut attr_meta = None;
     if rest_start < args.len() && matches!(args[rest_start].kind, FormKind::Map(_)) {
+        attr_meta = Some(eval(&args[rest_start], env)?);
         rest_start += 1;
     }
     // Prepend implicit &form and &env params to each arity.
@@ -1166,7 +1188,10 @@ fn eval_defmacro(args: &[Form], env: &mut Env) -> EvalResult {
 
     let var = env
         .globals
-        .intern(&env.current_ns, Arc::from(name), macro_val.clone());
+        .intern(&env.current_ns, Arc::from(name.as_str()), macro_val.clone());
+    if let Some(m) = merge_meta(name_meta, attr_meta) {
+        var.get().set_meta(m);
+    }
     Ok(Value::Var(var))
 }
 

--- a/crates/cljrs-interp/src/syntax_quote.rs
+++ b/crates/cljrs-interp/src/syntax_quote.rs
@@ -52,7 +52,10 @@ fn sq_form(
         FormKind::Char(c) => Ok(Value::Char(*c)),
         FormKind::Keyword(s) => Ok(Value::keyword(Keyword::parse(s))),
         FormKind::AutoKeyword(s) => {
-            let full = format!("{}/{}", env.current_ns, s);
+            let full = env
+                .globals
+                .resolve_auto_keyword(&env.current_ns, s)
+                .map_err(EvalError::Runtime)?;
             Ok(Value::keyword(Keyword::parse(&full)))
         }
 

--- a/crates/cljrs-interp/tests/auto_keyword_macro.rs
+++ b/crates/cljrs-interp/tests/auto_keyword_macro.rs
@@ -119,3 +119,60 @@ fn auto_kw_equality_with_direct_let() {
     let result = eval_in_ns("my.app", r#"(= ::error ::error)"#);
     assert_eq!(result, Value::Bool(true));
 }
+
+// ── ::alias/kw resolution via namespace aliases ──────────────────────────────
+//
+// These set up the alias directly via `add_alias` (what `(require '[ns :as
+// alias])` does internally) rather than loading a real namespace from disk,
+// so the test doesn't depend on the stdlib source path being configured.
+
+fn eval_with_alias(ns: &str, alias: &str, target_ns: &str, src: &str) -> Value {
+    let (globals, mut env) = make_env();
+    env.current_ns = Arc::from(ns);
+    globals.get_or_create_ns(ns);
+    globals.get_or_create_ns(target_ns);
+    globals.add_alias(ns, alias, target_ns);
+    let mut parser = cljrs_reader::Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, &mut env).expect("eval error");
+    }
+    result
+}
+
+#[test]
+fn auto_kw_alias_resolves_via_require_as() {
+    let result = eval_with_alias("my.app", "s", "clojure.string", "::s/foo");
+    assert_eq!(result, kw("clojure.string", "foo"));
+}
+
+#[test]
+fn auto_kw_alias_resolves_inside_syntax_quote() {
+    let result = eval_with_alias("my.app", "s", "clojure.string", "`::s/foo");
+    assert_eq!(result, kw("clojure.string", "foo"));
+}
+
+#[test]
+fn auto_kw_alias_resolves_when_spliced_through_macro() {
+    let result = eval_with_alias(
+        "my.app",
+        "s",
+        "clojure.string",
+        r#"(do (defmacro show [k] k) (show ::s/foo))"#,
+    );
+    assert_eq!(result, kw("clojure.string", "foo"));
+}
+
+#[test]
+fn auto_kw_unknown_alias_is_an_error() {
+    let (_, mut env) = make_env();
+    env.current_ns = Arc::from("my.app");
+    let mut parser = cljrs_reader::Parser::new("::nope/foo".to_string(), "<test>".to_string());
+    let form = parser.parse_all().expect("parse error").remove(0);
+    let result = cljrs_interp::eval::eval(&form, &mut env);
+    assert!(
+        result.is_err(),
+        "unresolved alias must error, not silently produce a bogus keyword"
+    );
+}

--- a/crates/cljrs-reader/src/lexer.rs
+++ b/crates/cljrs-reader/src/lexer.rs
@@ -22,6 +22,12 @@ use crate::token::Token;
 /// progress (only a leading `#` triggers `#`-dispatch — see
 /// [`is_symbol_start`]). This is what makes auto-gensym symbols like `x#`
 /// tokenize as a single symbol rather than `x` followed by a stray `#`.
+///
+/// `:` is included here too — it is also non-terminating, so a keyword like
+/// `:xlink:href` reads as one token with the literal name `xlink:href`
+/// rather than splitting into two keywords at the embedded colon. Only a
+/// *leading* `:`/`::` is special (it triggers keyword dispatch — see
+/// [`is_symbol_start`]).
 fn is_symbol_char(ch: char) -> bool {
     !matches!(
         ch,
@@ -42,15 +48,15 @@ fn is_symbol_char(ch: char) -> bool {
             | '^'
             | '@'
             | '\\'
-            | ':'
     )
 }
 
 /// Returns `true` if `ch` can *start* a symbol (not a digit, not `#` since a
-/// leading `#` always triggers `#`-dispatch, not `+`/`-` when the following
-/// char is a digit — but the caller handles the `+`/`-` case).
+/// leading `#` always triggers `#`-dispatch, not `:` since a leading `:`
+/// always triggers keyword dispatch, not `+`/`-` when the following char is
+/// a digit — but the caller handles the `+`/`-` case).
 fn is_symbol_start(ch: char) -> bool {
-    is_symbol_char(ch) && !ch.is_ascii_digit() && ch != '#'
+    is_symbol_char(ch) && !ch.is_ascii_digit() && ch != '#' && ch != ':'
 }
 
 // ─── Lexer ───────────────────────────────────────────────────────────────────
@@ -1141,6 +1147,25 @@ mod tests {
     fn test_keyword() {
         assert_eq!(lex_one(":foo"), Token::Keyword("foo".to_string()));
         assert_eq!(lex_one(":ns/name"), Token::Keyword("ns/name".to_string()));
+    }
+
+    #[test]
+    fn test_keyword_with_embedded_colon() {
+        // An embedded `:` is a literal name character, not a sub-token
+        // boundary — `:xlink:href` is one keyword, not two.
+        assert_eq!(
+            lex_one(":xlink:href"),
+            Token::Keyword("xlink:href".to_string())
+        );
+        let toks = lex_all("[:xlink:href]");
+        assert_eq!(
+            toks,
+            vec![
+                Token::LBracket,
+                Token::Keyword("xlink:href".to_string()),
+                Token::RBracket,
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
- defmacro now accepts reader metadata on the name (^:private foo, stacked
  ^a ^b forms, and an attr-map after an optional docstring), merging it onto
  the resulting var's metadata the same way def/ns already do. Previously
  any ^meta on a defmacro name crashed with "defmacro requires a symbol".

- The lexer no longer treats ':' as a token-terminating character once a
  symbol/keyword token is underway, so embedded colons like :xlink:href and
  foo:bar read as a single token instead of being split at the colon.

- ::alias/kw now resolves the alias against the current namespace's alias
  table (populated by `(require '[ns :as alias])`) instead of always
  qualifying with the current namespace. Fixed in all three places that
  resolve AutoKeyword forms: plain eval, syntax-quote, and macro-argument
  resolution (added a shared GlobalEnv::resolve_auto_keyword helper).