### PR TITLE
Add declare macro to bootstrap.cljrs

### DIFF
--- a/crates/cljrs-builtins/src/bootstrap.cljrs
+++ b/crates/cljrs-builtins/src/bootstrap.cljrs
@@ -301,6 +301,11 @@
   ([test then] (list 'if test nil then))
   ([test then else] (list 'if test else then)))
 
+(defmacro declare
+  "defs the supplied var names with no bindings, useful for making forward declarations."
+  [& names]
+  (cons 'do (map (fn [n] (list 'def n)) names)))
+
 (defmacro if-let
   ([bindings then] (list 'if-let bindings then nil))
   ([bindings then else]

--- a/crates/cljrs-interp/tests/declare_macro.rs
+++ b/crates/cljrs-interp/tests/declare_macro.rs
@@ -1,0 +1,55 @@
+//! Regression tests for the `declare` macro (bootstrap.cljrs): it must def
+//! each supplied name with no binding, enabling forward references, the way
+//! `(def name)` does when written out by hand.
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_gc::GcPtr;
+use cljrs_reader::Parser;
+use cljrs_value::{Keyword, Value};
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_src(src: &str) -> Value {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, &mut env).expect("eval error");
+    }
+    result
+}
+
+#[test]
+fn declare_allows_forward_reference() {
+    let result = eval_src("(declare foo) (defn baz [] (foo)) (defn foo [] 42) (baz)");
+    assert_eq!(result, Value::Long(42));
+}
+
+#[test]
+fn declare_accepts_multiple_names() {
+    let result = eval_src("(declare a b c) [a b c]");
+    // Each name is bound (unbound var, no throw); the vector should contain
+    // three vars' unbound placeholders without erroring.
+    assert!(matches!(result, Value::Vector(_)));
+}
+
+#[test]
+fn if_not_multi_arity() {
+    // test is falsy -> the `then` branch runs.
+    assert_eq!(
+        eval_src("(if-not false :a :b)"),
+        Value::Keyword(GcPtr::new(Keyword::simple("a")))
+    );
+    // test is truthy -> the `else` branch runs.
+    assert_eq!(
+        eval_src("(if-not true :a :b)"),
+        Value::Keyword(GcPtr::new(Keyword::simple("b")))
+    );
+}


### PR DESCRIPTION
`declare` was the last missing form from issue #196 — `if-not` and
defmacro metadata support were already fixed on main. `declare` defs
each supplied name with no binding, matching clojure.core and enabling
forward references.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AWYggpCVwzGZp6Xs8eDDm7