### PR TITLE
Add map-entry? function and fix newline

### DIFF
--- a/crates/cljrs-builtins/src/bootstrap.cljrs
+++ b/crates/cljrs-builtins/src/bootstrap.cljrs
@@ -1073,3 +1073,5 @@
   [re s]
   (let [matcher (re-matcher re s)]
     (seq (take-while identity (repeatedly #(re-find matcher))))))
+
+(defn map-entry? [x] (and (vector? x) (= 2 (count x))))


### PR DESCRIPTION
Add a newline at the end of the file and define map-entry? function.