### PR TITLE
Implement :extend-via-metadata protocol dispatch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,7 @@ Implementation roadmap for a Rust-hosted Clojure dialect. Native file extension 
 - [x] `defprotocol` — define named protocol with method signatures
 - [x] `extend-type` / `extend-protocol` — implement protocols on types
 - [x] Protocol dispatch on first-arg type tag (`type_tag_of`)
+- [x] `:extend-via-metadata true` — dispatch consults the first arg's metadata (keyed by the `ProtocolFn`) before falling back to type-tag `impls`
 - [x] `defmulti` / `defmethod` — arbitrary dispatch multimethods
 - [x] `prefer-method`, `remove-method`, `methods`, `satisfies?`, `extends?`, `isa?` (equality stub), `type`
 - [ ] Inline protocol dispatch cache — Phase 10 JIT optimization

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -83,8 +83,14 @@ collection.
 ## apply module
 
 `apply_value` applies an evaluated callee to evaluated args (functions,
-keywords, maps, sets, vars, protocol/multimethod dispatch). Protocol dispatch
-helpers shared with the Phase 10.6 inline caches:
+keywords, maps, sets, vars, protocol/multimethod dispatch). For a
+`Value::ProtocolFn` callee whose protocol has `extend_via_metadata` set (`(defprotocol
+Name :extend-via-metadata true ...)`), dispatch first checks the first arg's
+metadata for an entry keyed by the `ProtocolFn` itself (e.g. `(with-meta {}
+{my-method (fn [this] ...)})`) before falling back to the type-tag `impls`
+lookup — this lets a value implement a protocol without a matching
+`extend-type`/`extend-protocol`. Protocol dispatch helpers shared with the
+Phase 10.6 inline caches:
 
 - `type_tag_of(val: &Value) -> Arc<str>` — canonical protocol dispatch tag of a value
 - `type_tag_matches(val: &Value, tag: &str) -> bool` — allocation-free equality

--- a/crates/cljrs-env/src/apply.rs
+++ b/crates/cljrs-env/src/apply.rs
@@ -165,6 +165,20 @@ pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResul
                     pf_ref.method_name
                 ))
             })?;
+
+            // `(defprotocol P :extend-via-metadata true ...)` — an instance
+            // implements the protocol by carrying an impl fn in its metadata,
+            // keyed by this exact `ProtocolFn` (e.g. `(with-meta {} {my-method
+            // (fn [this] ...)})`).  Metadata impls win over type-tag impls, and
+            // apply even to values (like a plain map) with no `extend-type`.
+            if pf_ref.protocol.get().extend_via_metadata
+                && let Some(Value::Map(m)) = dispatch_val.get_meta()
+                && let Some(impl_fn) = m.get(callee)
+            {
+                let _impl_root = crate::gc_roots::root_value(&impl_fn);
+                return apply_value(&impl_fn, args, env);
+            }
+
             let tag = type_tag_of(dispatch_val);
             let impls = pf_ref.protocol.get().impls.lock().unwrap();
             let impl_fn = impls

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -1141,6 +1141,46 @@ mod tests {
     }
 
     #[test]
+    fn test_extend_via_metadata() {
+        // `:extend-via-metadata true` lets an instance implement a protocol by
+        // carrying the impl fn in its own metadata, keyed by the protocol fn
+        // itself — no `extend-type`/`extend-protocol` needed.
+        let result = eval_str(
+            r#"
+            (defprotocol IRender
+              :extend-via-metadata true
+              (create-element [this tag-name]))
+            (def renderer (with-meta {} {create-element (fn [this tag-name] (str "made-" tag-name))}))
+            (create-element renderer "div")
+            "#,
+        )
+        .unwrap();
+        assert_eq!(result, Value::string("made-div"));
+    }
+
+    #[test]
+    fn test_extend_via_metadata_falls_back_to_type_tag() {
+        // Metadata impls take priority, but a value without metadata still
+        // dispatches on its type tag as usual.
+        let result = eval_str(
+            r#"
+            (defprotocol IRender
+              :extend-via-metadata true
+              (create-element [this tag-name]))
+            (extend-type Map
+              IRender
+              (create-element [this tag-name] (str "type-tag-" tag-name)))
+            [(create-element {} "span")
+             (create-element (with-meta {} {create-element (fn [this tag-name] (str "meta-" tag-name))}) "div")]
+            "#,
+        )
+        .unwrap();
+        let s = format!("{}", result);
+        assert!(s.contains("type-tag-span"), "got: {s}");
+        assert!(s.contains("meta-div"), "got: {s}");
+    }
+
+    #[test]
     fn test_satisfies() {
         let result = eval_str(
             r#"

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -1804,6 +1804,53 @@ mod tests {
     }
 
     #[test]
+    fn test_binding_fully_qualified_cross_ns_dynamic_var() {
+        let (_, mut env) = make_env();
+        let result = eval_src(
+            r#"
+            (ns other.ns)
+            (def ^:dynamic *dispatch* nil)
+            (ns user)
+            (binding [other.ns/*dispatch* (fn [x] x)]
+              (other.ns/*dispatch* 42))
+            "#,
+            &mut env,
+        )
+        .unwrap();
+        assert_eq!(result, Value::Long(42));
+    }
+
+    #[test]
+    fn test_binding_aliased_cross_ns_dynamic_var() {
+        // (binding [alias/*var* v] ...) must resolve `alias` through the
+        // current ns's `:require :as` aliases, exactly like ordinary
+        // qualified-symbol lookup — this is how Replicant's public
+        // `set-dispatch!`/life-cycle dispatch binds `*dispatch*` across
+        // namespaces.
+        let dir = temp_ns_dir("binding_aliased_cross_ns_dynamic_var");
+        std::fs::create_dir_all(dir.join("replicant")).unwrap();
+        std::fs::write(
+            dir.join("replicant").join("core.cljrs"),
+            r#"(ns replicant.core)
+               (def ^:dynamic *dispatch* nil)
+               (defn call-dispatch [x] (*dispatch* x))"#,
+        )
+        .unwrap();
+        let (_, mut env) = make_env_with_paths(vec![dir]);
+        let result = eval_src(
+            r#"
+            (ns life-cycle-test
+              (:require [replicant.core :as r]))
+            (binding [r/*dispatch* (fn [x] x)]
+              (r/call-dispatch 42))
+            "#,
+            &mut env,
+        )
+        .unwrap();
+        assert_eq!(result, Value::Long(42));
+    }
+
+    #[test]
     fn test_meta_on_var() {
         let (_, mut env) = make_env();
         eval_src("(def ^:dynamic *x* 1)", &mut env).unwrap();

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1662,10 +1662,8 @@ fn eval_defprotocol(args: &[Form], env: &mut Env) -> EvalResult {
         // among the method signatures, e.g. `:extend-via-metadata true`.
         if let FormKind::Keyword(kw) = &rest[i].kind {
             if kw == "extend-via-metadata" {
-                extend_via_metadata = matches!(
-                    rest.get(i + 1).map(|f| &f.kind),
-                    Some(FormKind::Bool(true))
-                );
+                extend_via_metadata =
+                    matches!(rest.get(i + 1).map(|f| &f.kind), Some(FormKind::Bool(true)));
             }
             i += 2;
             continue;

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -2003,13 +2003,19 @@ fn eval_binding(args: &[Form], env: &mut Env) -> EvalResult {
             _ => return Err(EvalError::Runtime("binding targets must be symbols".into())),
         };
         let parsed = cljrs_value::Symbol::parse(&sym_str);
-        let ns_part = parsed
-            .namespace
-            .as_deref()
-            .unwrap_or(env.current_ns.as_ref());
+        let ns_part: Arc<str> = match parsed.namespace.as_deref() {
+            // Resolve `alias/*var*` through the current ns's `:require :as`
+            // aliases, same as ordinary qualified-symbol lookup (`eval_symbol`)
+            // — otherwise `(binding [alias/*x* v] ...)` never finds the var.
+            Some(ns_part) => env
+                .globals
+                .resolve_alias(&env.current_ns, ns_part)
+                .unwrap_or_else(|| Arc::from(ns_part)),
+            None => env.current_ns.clone(),
+        };
         let var_ptr = env
             .globals
-            .lookup_var_in_ns(ns_part, &parsed.name)
+            .lookup_var_in_ns(&ns_part, &parsed.name)
             .ok_or_else(|| EvalError::UnboundSymbol(sym_str.clone()))?;
         let val = eval(&pair[1], env)?;
         frame.insert(cljrs_env::dynamics::var_key_of(&var_ptr), val);

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -1653,8 +1653,25 @@ fn eval_defprotocol(args: &[Form], env: &mut Env) -> EvalResult {
     };
 
     let mut methods: Vec<ProtocolMethod> = Vec::new();
+    let mut extend_via_metadata = false;
 
-    for form in &args[methods_start..] {
+    let rest = &args[methods_start..];
+    let mut i = 0;
+    while i < rest.len() {
+        // Protocol options are flat `:keyword value` pairs interspersed
+        // among the method signatures, e.g. `:extend-via-metadata true`.
+        if let FormKind::Keyword(kw) = &rest[i].kind {
+            if kw == "extend-via-metadata" {
+                extend_via_metadata = matches!(
+                    rest.get(i + 1).map(|f| &f.kind),
+                    Some(FormKind::Bool(true))
+                );
+            }
+            i += 2;
+            continue;
+        }
+        let form = &rest[i];
+        i += 1;
         // Each method spec is (method-name [params...] "doc"?)
         let parts = match &form.kind {
             FormKind::List(parts) => parts,
@@ -1694,7 +1711,7 @@ fn eval_defprotocol(args: &[Form], env: &mut Env) -> EvalResult {
     }
 
     let ns: Arc<str> = env.current_ns.clone();
-    let proto = Protocol::new(proto_name.clone(), ns, methods.clone());
+    let proto = Protocol::new(proto_name.clone(), ns, methods.clone(), extend_via_metadata);
     let proto_ptr = GcPtr::new(proto);
 
     // Intern the protocol itself.

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -426,6 +426,9 @@ pub struct Protocol {
     pub methods: Vec<ProtocolMethod>,
     /// type_tag → { method_name → impl fn }
     pub impls: Mutex<HashMap<Arc<str>, MethodMap>>,
+    /// Set by `(defprotocol Name :extend-via-metadata true ...)`; see dispatch
+    /// note below.
+    pub extend_via_metadata: bool,
 }
 
 pub struct ProtocolMethod {
@@ -457,6 +460,11 @@ pub struct MultiFn {
 pub fn protocol_generation() -> u64;
 pub fn bump_protocol_generation();
 ```
+
+When `Protocol::extend_via_metadata` is set, `apply_value`'s `ProtocolFn` arm
+(`cljrs-env/src/apply.rs`) checks the dispatch value's metadata for an entry
+keyed by the exact `ProtocolFn` before falling back to the `impls` type-tag
+lookup — see that crate's README for the dispatch order.
 
 ### `clone` — isolate copy boundary (Phase B2)
 

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -111,15 +111,25 @@ pub struct Protocol {
     pub methods: Vec<ProtocolMethod>,
     /// type_tag → { method_name → impl fn }
     pub impls: Mutex<HashMap<Arc<str>, MethodMap>>,
+    /// `(defprotocol Name :extend-via-metadata true ...)` — when set, protocol
+    /// dispatch consults the dispatch value's metadata (keyed by this
+    /// protocol's `ProtocolFn`s) before falling back to type-tag impls.
+    pub extend_via_metadata: bool,
 }
 
 impl Protocol {
-    pub fn new(name: Arc<str>, ns: Arc<str>, methods: Vec<ProtocolMethod>) -> Self {
+    pub fn new(
+        name: Arc<str>,
+        ns: Arc<str>,
+        methods: Vec<ProtocolMethod>,
+        extend_via_metadata: bool,
+    ) -> Self {
         Self {
             name,
             ns,
             methods,
             impls: Mutex::new(HashMap::new()),
+            extend_via_metadata,
         }
     }
 }


### PR DESCRIPTION
defprotocol now parses the :extend-via-metadata true option. When set,
apply_value's ProtocolFn dispatch checks the first arg's metadata for an
entry keyed by the protocol fn itself before falling back to the
type-tag impls lookup, so a value can implement a protocol via
(with-meta v {method-fn (fn [this ...] ...)}) without a matching
extend-type/extend-protocol. This unblocks Replicant-style fake
renderers that implement IRender purely through metadata.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011K7mgMUmFPVEuSqcv4Qi1K