### PR TITLE
Fix :extend-via-metadata protocol dispatch key

### DIFF
--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -4696,6 +4696,25 @@ pub unsafe extern "C" fn rt_call_ic(
     {
         let arg_slice = unsafe { std::slice::from_raw_parts(args, nargs as usize) };
         let dispatch_val = unsafe { val_ref(arg_slice[0]) };
+        let pf_ref = pf.get();
+
+        // `:extend-via-metadata true` — mirror `apply_value`'s priority
+        // exactly: a metadata impl wins over any type-tag impl, and (unlike
+        // the type-tag impl) can vary per instance, so it is checked on
+        // every call rather than being folded into the inline cache below.
+        if pf_ref.protocol.get().extend_via_metadata
+            && let Some(Value::Map(m)) = dispatch_val.get_meta()
+        {
+            let proto = pf_ref.protocol.get();
+            let method_sym = Value::Symbol(GcPtr::new(Symbol::qualified(
+                proto.ns.clone(),
+                pf_ref.method_name.clone(),
+            )));
+            if let Some(impl_fn) = m.get(&method_sym) {
+                return invoke_boxed(&impl_fn, unsafe { collect_args(args, nargs as i64) });
+            }
+        }
+
         let generation = cljrs_value::protocol_generation();
         let callee_id = pf.get() as *const _ as usize;
 
@@ -4726,7 +4745,6 @@ pub unsafe extern "C" fn rt_call_ic(
         // `rt_call` for the canonical error path.
         jit_stats::PROTO_IC_MISSES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let tag = cljrs_env::apply::type_tag_of(dispatch_val);
-        let pf_ref = pf.get();
         let impl_fn = {
             let impls = pf_ref.protocol.get().impls.lock().unwrap();
             impls
@@ -4975,6 +4993,89 @@ mod tests {
         let _ = take_pending_exception(); // drain any prior pending exception
         assert_eq!(unsafe { rt_coerce_long(rt_const_nil()) }, 0);
         assert!(take_pending_exception().is_some());
+    }
+
+    /// `rt_call_ic` must consult `:extend-via-metadata` before (and in
+    /// preference to) its type-tag inline cache — otherwise a JIT-compiled
+    /// call site would silently stop honoring per-instance metadata impls
+    /// once a generic `extend-type` impl warms the cache.  Regression for
+    /// the JIT-tier half of the metadata-dispatch bugfix in
+    /// `cljrs_env::apply::apply_value`.
+    #[test]
+    fn test_rt_call_ic_prefers_metadata_impl_over_type_tag() {
+        use cljrs_value::{NativeFn, Protocol, ProtocolFn, ProtocolMethod};
+
+        let _mutator = cljrs_gc::register_mutator();
+        let globals = cljrs_interp::standard_env_minimal(None, None, None);
+        let env = cljrs_env::env::Env::new(globals, "user");
+        cljrs_env::callback::push_eval_context(&env);
+
+        let method_name: Arc<str> = Arc::from("create-element");
+        let proto_ns: Arc<str> = Arc::from("test.ns");
+
+        let proto = Protocol::new(
+            Arc::from("IRender"),
+            proto_ns.clone(),
+            vec![ProtocolMethod {
+                name: method_name.clone(),
+                min_arity: 1,
+                variadic: false,
+            }],
+            true, // :extend-via-metadata true
+        );
+        // A generic type-tag impl for Map — must lose to the metadata impl.
+        let type_tag_impl = Value::NativeFunction(GcPtr::new(NativeFn::new(
+            "type-tag-impl",
+            cljrs_value::Arity::Fixed(1),
+            |_args| Ok(Value::Long(111)),
+        )));
+        proto
+            .impls
+            .lock()
+            .unwrap()
+            .entry(Arc::from("Map"))
+            .or_default()
+            .insert(method_name.clone(), type_tag_impl);
+        let proto_ptr = GcPtr::new(proto);
+
+        let pf = ProtocolFn {
+            protocol: proto_ptr,
+            method_name: method_name.clone(),
+            min_arity: 1,
+            variadic: false,
+        };
+        let callee = box_val(Value::ProtocolFn(GcPtr::new(pf)));
+
+        // Per-instance metadata impl, keyed by the fully-qualified method
+        // symbol — exactly what `(with-meta {} {`create-element (fn ...)})`
+        // produces via syntax-quote.
+        let meta_impl = Value::NativeFunction(GcPtr::new(NativeFn::new(
+            "meta-impl",
+            cljrs_value::Arity::Fixed(1),
+            |_args| Ok(Value::Long(222)),
+        )));
+        let meta_map = Value::Map(MapValue::from_pairs(vec![(
+            Value::Symbol(GcPtr::new(Symbol::qualified(proto_ns, method_name))),
+            meta_impl,
+        )]));
+        let dispatch_val = box_val(Value::Map(MapValue::from_pairs(vec![])).with_meta(meta_map));
+
+        let mut slot: usize = 0;
+        let args = [dispatch_val];
+        let result = unsafe { rt_call_ic(callee, args.as_ptr(), 1, &mut slot) };
+        assert!(
+            matches!(unsafe { &*result }, Value::Long(222)),
+            "expected metadata impl (222) to win, got {:?}",
+            unsafe { &*result }
+        );
+
+        // The metadata check bypasses the IC entirely for metadata-dispatch
+        // protocols, so a second call must still consult it (not the stale
+        // type-tag cache slot, which was never filled).
+        let result2 = unsafe { rt_call_ic(callee, args.as_ptr(), 1, &mut slot) };
+        assert!(matches!(unsafe { &*result2 }, Value::Long(222)));
+
+        cljrs_env::callback::pop_eval_context();
     }
 
     #[test]

--- a/crates/cljrs-env/src/apply.rs
+++ b/crates/cljrs-env/src/apply.rs
@@ -168,15 +168,25 @@ pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResul
 
             // `(defprotocol P :extend-via-metadata true ...)` — an instance
             // implements the protocol by carrying an impl fn in its metadata,
-            // keyed by this exact `ProtocolFn` (e.g. `(with-meta {} {my-method
-            // (fn [this] ...)})`).  Metadata impls win over type-tag impls, and
-            // apply even to values (like a plain map) with no `extend-type`.
+            // keyed by the fully-qualified symbol naming the protocol method
+            // (e.g. `` (with-meta {} {`my-method (fn [this] ...)}) ``, which
+            // syntax-quote expands to `{my.ns/my-method (fn [this] ...)}`).
+            // This mirrors real Clojure's `MethodImplCache` dispatch, which
+            // looks the method up in `(meta x)` by `(.sym cache)` — the var's
+            // qualified symbol, not the callable itself.  Metadata impls win
+            // over type-tag impls, and apply even to values (like a plain
+            // map) with no `extend-type`.
             if pf_ref.protocol.get().extend_via_metadata
                 && let Some(Value::Map(m)) = dispatch_val.get_meta()
-                && let Some(impl_fn) = m.get(callee)
             {
-                let _impl_root = crate::gc_roots::root_value(&impl_fn);
-                return apply_value(&impl_fn, args, env);
+                let proto = pf_ref.protocol.get();
+                let method_sym = Value::Symbol(cljrs_gc::GcPtr::new(
+                    cljrs_value::Symbol::qualified(proto.ns.clone(), pf_ref.method_name.clone()),
+                ));
+                if let Some(impl_fn) = m.get(&method_sym) {
+                    let _impl_root = crate::gc_roots::root_value(&impl_fn);
+                    return apply_value(&impl_fn, args, env);
+                }
             }
 
             let tag = type_tag_of(dispatch_val);

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -1143,14 +1143,17 @@ mod tests {
     #[test]
     fn test_extend_via_metadata() {
         // `:extend-via-metadata true` lets an instance implement a protocol by
-        // carrying the impl fn in its own metadata, keyed by the protocol fn
-        // itself — no `extend-type`/`extend-protocol` needed.
+        // carrying the impl fn in its own metadata, keyed by the protocol
+        // method's fully-qualified symbol (matching real Clojure's
+        // `MethodImplCache` dispatch, which looks up `(.sym cache)` in
+        // `(meta x)`) — no `extend-type`/`extend-protocol` needed. Idiomatic
+        // usage produces that qualified symbol via syntax-quote.
         let result = eval_str(
             r#"
             (defprotocol IRender
               :extend-via-metadata true
               (create-element [this tag-name]))
-            (def renderer (with-meta {} {create-element (fn [this tag-name] (str "made-" tag-name))}))
+            (def renderer (with-meta {} {`create-element (fn [this tag-name] (str "made-" tag-name))}))
             (create-element renderer "div")
             "#,
         )
@@ -1171,13 +1174,45 @@ mod tests {
               IRender
               (create-element [this tag-name] (str "type-tag-" tag-name)))
             [(create-element {} "span")
-             (create-element (with-meta {} {create-element (fn [this tag-name] (str "meta-" tag-name))}) "div")]
+             (create-element (with-meta {} {`create-element (fn [this tag-name] (str "meta-" tag-name))}) "div")]
             "#,
         )
         .unwrap();
         let s = format!("{}", result);
         assert!(s.contains("type-tag-span"), "got: {s}");
         assert!(s.contains("meta-div"), "got: {s}");
+    }
+
+    #[test]
+    fn test_extend_via_metadata_cross_ns() {
+        // Mirrors Replicant's mutation_log fake renderer: `IRender` is
+        // defined in `replicant.core`, and a test namespace `:refer`s the
+        // method and implements it purely via metadata (no `extend-type`).
+        // Syntax-quoting `create-element` there must resolve to the
+        // protocol's home namespace (`replicant.core/create-element`), which
+        // is exactly the key the dispatcher looks up.
+        let dir = temp_ns_dir("extend_via_metadata_cross_ns");
+        std::fs::create_dir_all(dir.join("replicant")).unwrap();
+        std::fs::write(
+            dir.join("replicant").join("core.cljrs"),
+            r#"(ns replicant.core)
+               (defprotocol IRender
+                 :extend-via-metadata true
+                 (create-element [this tag-name]))"#,
+        )
+        .unwrap();
+        let (_, mut env) = make_env_with_paths(vec![dir]);
+        let result = eval_src(
+            r#"
+            (ns mutation-log-test
+              (:require [replicant.core :refer [create-element]]))
+            (def renderer (with-meta {} {`create-element (fn [this tag-name] (str "made-" tag-name))}))
+            (create-element renderer "div")
+            "#,
+            &mut env,
+        )
+        .unwrap();
+        assert_eq!(result, Value::string("made-div"));
     }
 
     #[test]


### PR DESCRIPTION
apply_value's metadata-dispatch check keyed the lookup by the ProtocolFn value itself, so `(with-meta {} {create-element (fn ...)})` only worked when `create-element` evaluated to the exact same ProtocolFn used at the call site -- brittle across namespaces, and not how the feature actually works. Real Clojure's :extend-via-metadata dispatch (MethodImplCache) looks the method up in `(meta x)` by the protocol method's fully-qualified symbol, produced idiomatically via syntax-quote: `(with-meta {} {`create-element (fn ...)})`. Rekeyed the lookup to match: `ns/method-name`, built from the protocol's `ns` and the ProtocolFn's `method_name`.

This is what broke Replicant's mutation_log fake renderer, which implements IRender purely via metadata (no extend-type) -- every call fell through to the type-tag path and raised "No implementation of protocol IRender for type Object".

The JIT tier's inline-cache dispatch (rt_call_ic in cljrs-compiler) had the same class of bug in a different shape: it never consulted metadata at all, and its (dispatch type -> impl) cache would permanently pin a call site to a generic extend-type impl the first time one existed, silently overriding any per-instance metadata impl on every subsequent call once the site warmed up. Metadata impls are now checked first, every call, before the type-tag cache is consulted or filled -- matching apply_value's priority (metadata wins) and its non-caching per-instance semantics.


Claude-Session: https://claude.ai/code/session_011K7mgMUmFPVEuSqcv4Qi1K