### PR TITLE
Resolve ns aliases in syntax-quoted qualified symbols

### DIFF
--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -1216,6 +1216,40 @@ mod tests {
     }
 
     #[test]
+    fn test_extend_via_metadata_cross_ns_via_alias() {
+        // The `:refer` case above never touches the buggy path: a `:refer`d
+        // bare symbol resolves through `lookup_var_in_ns`, which was always
+        // correct. Real usage syntax-quotes an *aliased* symbol instead —
+        // `` `p/attached? `` — which used to hit `qualify_symbol`'s "already
+        // has a slash, keep as-is" branch and leak the alias text (`p/...`)
+        // into the produced symbol instead of resolving it to the protocol's
+        // home namespace (`replicant.protocols/...`), so the metadata key
+        // never matched.
+        let dir = temp_ns_dir("extend_via_metadata_cross_ns_via_alias");
+        std::fs::create_dir_all(dir.join("replicant")).unwrap();
+        std::fs::write(
+            dir.join("replicant").join("protocols.cljrs"),
+            r#"(ns replicant.protocols)
+               (defprotocol IRender
+                 :extend-via-metadata true
+                 (attached? [this el]))"#,
+        )
+        .unwrap();
+        let (_, mut env) = make_env_with_paths(vec![dir]);
+        let result = eval_src(
+            r#"
+            (ns mutation-log-test
+              (:require [replicant.protocols :as p]))
+            (def r (with-meta {:log []} {`p/attached? (fn [_ el] el)}))
+            (p/attached? r :el)
+            "#,
+            &mut env,
+        )
+        .unwrap();
+        assert_eq!(result, Value::keyword(Keyword::simple("el")));
+    }
+
+    #[test]
     fn test_satisfies() {
         let result = eval_str(
             r#"

--- a/crates/cljrs-interp/src/syntax_quote.rs
+++ b/crates/cljrs-interp/src/syntax_quote.rs
@@ -176,7 +176,10 @@ fn sq_seq(
 /// Qualify a symbol name for use inside syntax-quote.
 ///
 /// - `foo#` → unique gensym `foo__N__auto__` (same N within one backtick).
-/// - `ns/foo` → kept as-is (already qualified).
+/// - `alias/foo` → resolved through the current ns's `:require :as` aliases
+///   to `real-ns/foo`, exactly like `::alias/kw` and `(binding [alias/*x*
+///   ...])`; not just kept as-is, since call sites (e.g. protocol-metadata
+///   dispatch) key on the *resolved* qualified symbol, not the alias text.
 /// - Special literals (`nil`, `true`, `false`) → kept as-is.
 /// - Special forms (`def`, `if`, `try`, `catch`, `let`, …) → kept as-is.
 /// - Symbols that resolve in the current namespace → qualified with resolved ns.
@@ -186,8 +189,17 @@ fn qualify_symbol(
     env: &Env,
     gensyms: &mut std::collections::HashMap<String, Arc<str>>,
 ) -> String {
-    // Already qualified.
-    if s.contains('/') {
+    // Already qualified (but not the bare `/` division symbol, or a
+    // dangling/leading slash — neither has a real ns part to resolve).
+    if let Some(idx) = s.find('/') {
+        if idx > 0 && idx < s.len() - 1 {
+            let (ns_part, name_part) = (&s[..idx], &s[idx + 1..]);
+            let resolved_ns = env
+                .globals
+                .resolve_alias(&env.current_ns, ns_part)
+                .unwrap_or_else(|| Arc::from(ns_part));
+            return format!("{resolved_ns}/{name_part}");
+        }
         return s.to_string();
     }
     // Special literals.


### PR DESCRIPTION
qualify_symbol's "already qualified, keep as-is" branch treated any symbol containing '/' as fully resolved, so `` `alias/method `` kept the raw alias text instead of resolving it to the namespace it points to -- unlike every other alias-aware resolution path in the codebase (eval_symbol, eval_binding, resolve_auto_keyword for ::alias/kw).

This broke :extend-via-metadata dispatch across namespaces via the idiomatic `:as` form: `` (with-meta {} {`p/attached? (fn ...)}) `` produced a literal `p/attached?` key instead of
`replicant.protocols/attached?`, which never matches the qualified symbol the dispatcher looks up (previous commit). The :refer-based regression test added for that fix didn't exercise this path, since a referred bare symbol resolves through lookup_var_in_ns instead.


Claude-Session: https://claude.ai/code/session_011K7mgMUmFPVEuSqcv4Qi1K