### PR TITLE
Make map entries a dedicated type distinct from 2-element vectors

### DIFF
--- a/clojure-test-suite/test/clojure/core_test/key.cljc
+++ b/clojure-test-suite/test/clojure/core_test/key.cljc
@@ -12,7 +12,7 @@
       ;; https://groups.google.com/g/clojure/c/FVcrbHJpCW4/m/Fh7NsX_Yb7sJ
       (is (= 'k (key #?(:cljs    (cljs.core/MapEntry. 'k 'v nil)
                         :lpy     (map-entry 'k 'v)
-                        :rust    ['k 'v]
+                        :rust    (map-entry 'k 'v)
                         :default (clojure.lang.MapEntry/create 'k 'v)))))
       (when-var-exists sorted-map
         (is (= :a (key (first (sorted-map :a :b))))))
@@ -28,7 +28,6 @@
                  {}
                  {1 2}
                  []
-                 #?@(:rust []
-                     :default [[1 2]])
+                 [1 2]
                  #{}
                  #{1 2}))))

--- a/clojure-test-suite/test/clojure/core_test/val.cljc
+++ b/clojure-test-suite/test/clojure/core_test/val.cljc
@@ -11,7 +11,7 @@
       ;; https://groups.google.com/g/clojure/c/FVcrbHJpCW4/m/Fh7NsX_Yb7sJ
       (is (= 'v (val #?(:cljs    (cljs.core/MapEntry. 'k 'v nil)
                         :lpy     (map-entry 'k 'v)
-                        :rust    ['k 'v]
+                        :rust    (map-entry 'k 'v)
                         :default (clojure.lang.MapEntry/create 'k 'v)))))
       (is (= :b (val (first (hash-map :a :b)))))
       (when-var-exists sorted-map
@@ -27,7 +27,6 @@
                  {}
                  {1 2}
                  []
-                 #?@(:rust [] ; don't really care in rust
-                     :default [[1 2]])
+                 [1 2]
                  #{}
                  #{1 2}))))

--- a/crates/cljrs-builtins/README.md
+++ b/crates/cljrs-builtins/README.md
@@ -3,6 +3,25 @@
 Built-in functions for clojurust (the `clojure.core`-equivalent runtime
 implemented in Rust, registered into a name → fn dispatch table).
 
+## Map entries
+
+Map entries are a dedicated type, not plain 2-element vectors: seq'ing a map,
+`find`, and the `map-entry` constructor produce vectors tagged as entries
+(`PersistentVector::map_entry` in `cljrs-value`).
+
+- `(map-entry k v)` / `(map-entry coll)` — build an entry from a key and
+  value, or from any seqable of exactly two elements.
+- `(map-entry? x)` — true only for real entries; `(map-entry? [:a 1])` is
+  false.
+- `key` / `val` (bootstrap) — accept only real map entries and throw
+  otherwise.
+
+Entries otherwise behave exactly like 2-element vectors (equality, hashing,
+printing, `nth`, destructuring), and, as in Clojure, any vector derived from
+an entry (`conj`, `assoc`, `pop`, `subvec`, ...) is a plain vector again.
+
+## Unchecked arithmetic
+
 Includes the `unchecked-*` integer arithmetic family — `unchecked-add`,
 `unchecked-subtract`, `unchecked-multiply`, `unchecked-inc`, `unchecked-dec`,
 `unchecked-negate` (and their `-int` aliases) — which wrap on overflow, in

--- a/crates/cljrs-builtins/src/bootstrap.cljrs
+++ b/crates/cljrs-builtins/src/bootstrap.cljrs
@@ -1019,13 +1019,13 @@
 
 (defn key
   [x]
-  (if (and (vector? x) (= 2 (count x)))
+  (if (map-entry? x)
     (first x)
     (throw (ex-info "not a map entry" {}))))
 
 (defn val
   [x]
-  (if (and (vector? x) (= 2 (count x)))
+  (if (map-entry? x)
     (second x)
     (throw (ex-info "not a map entry" {}))))
 
@@ -1095,4 +1095,3 @@
   (let [matcher (re-matcher re s)]
     (seq (take-while identity (repeatedly #(re-find matcher))))))
 
-(defn map-entry? [x] (and (vector? x) (= 2 (count x))))

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -227,6 +227,7 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         ("list?", Arity::Fixed(1), builtin_list_q),
         ("case=", Arity::Fixed(2), builtin_case_eq),
         ("map?", Arity::Fixed(1), builtin_map_q),
+        ("map-entry?", Arity::Fixed(1), builtin_map_entry_q),
         ("vector?", Arity::Fixed(1), builtin_vector_q),
         ("set?", Arity::Fixed(1), builtin_set_q),
         ("coll?", Arity::Fixed(1), builtin_coll_q),
@@ -246,6 +247,7 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         ("list", Arity::Variadic { min: 0 }, builtin_list),
         ("list*", Arity::Variadic { min: 1 }, builtin_list_star),
         ("vector", Arity::Variadic { min: 0 }, builtin_vector),
+        ("map-entry", Arity::Variadic { min: 1 }, builtin_map_entry),
         ("hash-map", Arity::Variadic { min: 0 }, builtin_hash_map),
         ("array-map", Arity::Variadic { min: 0 }, builtin_array_map),
         ("hash-set", Arity::Variadic { min: 0 }, builtin_hash_set),
@@ -799,10 +801,7 @@ impl Iterator for ValueIter {
                 Value::Map(m) => {
                     let mut pairs = Vec::new();
                     m.for_each(|k, v| {
-                        pairs.push(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                            k.clone(),
-                            v.clone(),
-                        ]))));
+                        pairs.push(Value::map_entry(k.clone(), v.clone()));
                     });
                     self.current = Value::List(GcPtr::new(PersistentList::from_iter(pairs)));
                 }
@@ -897,10 +896,7 @@ impl Iterator for ValueIter {
                 Value::TypeInstance(ti) => {
                     let mut pairs = Vec::new();
                     ti.get().fields.for_each(|k, v| {
-                        pairs.push(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                            k.clone(),
-                            v.clone(),
-                        ]))));
+                        pairs.push(Value::map_entry(k.clone(), v.clone()));
                     });
                     self.current = Value::List(GcPtr::new(PersistentList::from_iter(pairs)));
                 }
@@ -2279,6 +2275,9 @@ fn builtin_vector_q(args: &[Value]) -> ValueResult<Value> {
         Value::Vector(_)
     )))
 }
+fn builtin_map_entry_q(args: &[Value]) -> ValueResult<Value> {
+    Ok(Value::Bool(args[0].is_map_entry()))
+}
 fn builtin_set_q(args: &[Value]) -> ValueResult<Value> {
     Ok(Value::Bool(matches!(args[0].unwrap_meta(), Value::Set(_))))
 }
@@ -2432,6 +2431,31 @@ fn builtin_vector(args: &[Value]) -> ValueResult<Value> {
     Ok(Value::Vector(GcPtr::new(PersistentVector::from_iter(
         args.iter().cloned(),
     ))))
+}
+
+/// `(map-entry k v)` or `(map-entry [k v])` — build a map entry from a key
+/// and value, or from any seqable of exactly two elements.
+fn builtin_map_entry(args: &[Value]) -> ValueResult<Value> {
+    match args {
+        [key, val] => Ok(Value::map_entry(key.clone(), val.clone())),
+        [coll] => {
+            let items = value_to_seq(coll)?;
+            if items.len() != 2 {
+                return Err(ValueError::Other(format!(
+                    "map-entry requires exactly 2 elements, got {}",
+                    items.len()
+                )));
+            }
+            let mut items = items.into_iter();
+            let key = items.next().unwrap();
+            let val = items.next().unwrap();
+            Ok(Value::map_entry(key, val))
+        }
+        _ => Err(ValueError::Other(format!(
+            "map-entry expects 1 or 2 arguments, got {}",
+            args.len()
+        ))),
+    }
 }
 
 fn builtin_hash_map(args: &[Value]) -> ValueResult<Value> {
@@ -2872,10 +2896,7 @@ fn builtin_rseq(args: &[Value]) -> ValueResult<Value> {
                     .get()
                     .iter()
                     .map(|(k, v)| {
-                        Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                            k.clone(),
-                            v.clone(),
-                        ])))
+                        Value::map_entry(k.clone(), v.clone())
                     })
                     .collect();
                 Ok(cons_from_iter(pairs.into_iter().rev()))
@@ -2921,10 +2942,7 @@ fn builtin_seq(args: &[Value]) -> ValueResult<Value> {
             }
             let mut pairs = Vec::new();
             m.for_each(|k, v| {
-                let pair = Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                    k.clone(),
-                    v.clone(),
-                ])));
+                let pair = Value::map_entry(k.clone(), v.clone());
                 pairs.push(pair);
             });
             Ok(cons_from_iter(pairs))
@@ -3020,10 +3038,7 @@ fn builtin_seq(args: &[Value]) -> ValueResult<Value> {
         Value::TypeInstance(ti) => {
             let mut pairs = Vec::new();
             ti.get().fields.for_each(|k, v| {
-                pairs.push(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                    k.clone(),
-                    v.clone(),
-                ]))));
+                pairs.push(Value::map_entry(k.clone(), v.clone()));
             });
             if pairs.is_empty() {
                 Ok(Value::Nil)
@@ -3055,10 +3070,7 @@ fn builtin_first(args: &[Value]) -> ValueResult<Value> {
             let mut result = None;
             m.for_each(|k, v| {
                 if result.is_none() {
-                    result = Some(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                        k.clone(),
-                        v.clone(),
-                    ]))));
+                    result = Some(Value::map_entry(k.clone(), v.clone()));
                 }
             });
             Ok(result.unwrap_or(Value::Nil))
@@ -3114,10 +3126,7 @@ fn builtin_rest(args: &[Value]) -> ValueResult<Value> {
                 .iter()
                 .skip(1)
                 .map(|(k, v)| {
-                    Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                        k.clone(),
-                        v.clone(),
-                    ])))
+                    Value::map_entry(k.clone(), v.clone())
                 })
                 .collect();
             Ok(Value::List(GcPtr::new(PersistentList::from_iter(items))))
@@ -3168,10 +3177,7 @@ fn builtin_cons(args: &[Value]) -> ValueResult<Value> {
             let kvs = m
                 .iter()
                 .map(|e| {
-                    Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                        e.0.clone(),
-                        e.1.clone(),
-                    ])))
+                    Value::map_entry(e.0.clone(), e.1.clone())
                 })
                 .collect::<Vec<_>>();
             let tail = PersistentList::from_iter(kvs.iter().cloned());
@@ -3444,10 +3450,7 @@ fn concat_first_rest(val: &Value) -> (Option<Value>, Value) {
             // seq on a map produces [k v] pairs.
             let mut pairs = Vec::new();
             m.for_each(|k, v| {
-                pairs.push(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                    k.clone(),
-                    v.clone(),
-                ]))));
+                pairs.push(Value::map_entry(k.clone(), v.clone()));
             });
             if pairs.is_empty() {
                 (None, Value::Nil)
@@ -4773,10 +4776,7 @@ fn seq_first_rest(v: &Value) -> ValueResult<Option<(Value, Value)>> {
         Value::Map(m) => {
             let mut pairs = Vec::new();
             m.for_each(|k, v| {
-                pairs.push(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                    k.clone(),
-                    v.clone(),
-                ]))));
+                pairs.push(Value::map_entry(k.clone(), v.clone()));
             });
             if pairs.is_empty() {
                 Ok(None)
@@ -4854,20 +4854,14 @@ fn builtin_find(args: &[Value]) -> ValueResult<Value> {
     match &args[0] {
         Value::Map(m) => {
             if let Some(v) = m.get(&args[1]) {
-                Ok(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                    args[1].clone(),
-                    v,
-                ]))))
+                Ok(Value::map_entry(args[1].clone(), v))
             } else {
                 Ok(Value::Nil)
             }
         }
         Value::TransientMap(m) => {
             if let Some((k, v)) = m.get().find(&args[1]) {
-                Ok(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                    k.clone(),
-                    v.clone(),
-                ]))))
+                Ok(Value::map_entry(k.clone(), v.clone()))
             } else {
                 Ok(Value::Nil)
             }
@@ -4877,10 +4871,7 @@ fn builtin_find(args: &[Value]) -> ValueResult<Value> {
                 let idx = *idx;
                 if idx >= 0 && (idx as usize) < v.get().count() {
                     let val = v.get().nth(idx as usize).cloned().unwrap();
-                    Ok(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                        args[1].clone(),
-                        val,
-                    ]))))
+                    Ok(Value::map_entry(args[1].clone(), val))
                 } else {
                     Ok(Value::Nil)
                 }

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -2895,9 +2895,7 @@ fn builtin_rseq(args: &[Value]) -> ValueResult<Value> {
                 let pairs: Vec<Value> = m
                     .get()
                     .iter()
-                    .map(|(k, v)| {
-                        Value::map_entry(k.clone(), v.clone())
-                    })
+                    .map(|(k, v)| Value::map_entry(k.clone(), v.clone()))
                     .collect();
                 Ok(cons_from_iter(pairs.into_iter().rev()))
             }
@@ -3125,9 +3123,7 @@ fn builtin_rest(args: &[Value]) -> ValueResult<Value> {
             let items: Vec<Value> = m
                 .iter()
                 .skip(1)
-                .map(|(k, v)| {
-                    Value::map_entry(k.clone(), v.clone())
-                })
+                .map(|(k, v)| Value::map_entry(k.clone(), v.clone()))
                 .collect();
             Ok(Value::List(GcPtr::new(PersistentList::from_iter(items))))
         }
@@ -3176,9 +3172,7 @@ fn builtin_cons(args: &[Value]) -> ValueResult<Value> {
         Value::Map(m) => {
             let kvs = m
                 .iter()
-                .map(|e| {
-                    Value::map_entry(e.0.clone(), e.1.clone())
-                })
+                .map(|e| Value::map_entry(e.0.clone(), e.1.clone()))
                 .collect::<Vec<_>>();
             let tail = PersistentList::from_iter(kvs.iter().cloned());
             let new_list = PersistentList::cons(head, Arc::new(tail));

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -2879,9 +2879,7 @@ pub unsafe extern "C" fn rt_seq(coll: *const Value) -> *const Value {
                 // rt_first/rt_rest don't handle Map, so we must materialise the entry list.
                 let mut pairs = Vec::new();
                 m.for_each(|k, v| {
-                    pairs.push(Value::Vector(GcPtr::new(PersistentVector::from_iter(
-                        vec![k.clone(), v.clone()],
-                    ))));
+                    pairs.push(Value::map_entry(k.clone(), v.clone()));
                 });
                 box_val(Value::List(GcPtr::new(PersistentList::from_iter(pairs))))
             }

--- a/crates/cljrs-compiler/tests/wasm_compile.rs
+++ b/crates/cljrs-compiler/tests/wasm_compile.rs
@@ -102,7 +102,7 @@ fn bundles_required_namespace_initializer() {
     std::fs::write(&src_path, "(ns withdep (:require [helper]))\n(+ 1 2)\n").unwrap();
     let out_path = dir.join("withdep.wasm");
 
-    cljrs_compiler::aot::compile_file_to_wasm(&src_path, &out_path, &[dir.clone()])
+    cljrs_compiler::aot::compile_file_to_wasm(&src_path, &out_path, std::slice::from_ref(&dir))
         .unwrap_or_else(|e| panic!("compile_file_to_wasm failed: {e}"));
 
     let bytes = std::fs::read(&out_path).unwrap();

--- a/crates/cljrs-interp/src/destructure.rs
+++ b/crates/cljrs-interp/src/destructure.rs
@@ -4,7 +4,7 @@ use cljrs_builtins::form::form_to_value;
 use cljrs_gc::GcPtr;
 use cljrs_reader::Form;
 use cljrs_reader::form::FormKind;
-use cljrs_value::{Keyword, PersistentList, PersistentVector, Symbol, Value};
+use cljrs_value::{Keyword, PersistentList, Symbol, Value};
 use std::sync::Arc;
 
 use cljrs_env::env::Env;
@@ -132,10 +132,7 @@ pub fn value_to_seq_vec(val: &Value) -> Vec<Value> {
         Value::Map(m) => {
             let mut result = Vec::new();
             m.for_each(|k, v| {
-                result.push(Value::Vector(GcPtr::new(PersistentVector::from_iter([
-                    k.clone(),
-                    v.clone(),
-                ]))));
+                result.push(Value::map_entry(k.clone(), v.clone()));
             });
             result
         }

--- a/crates/cljrs-interp/tests/map_entry.rs
+++ b/crates/cljrs-interp/tests/map_entry.rs
@@ -1,0 +1,138 @@
+//! Map entries are a dedicated type, not plain 2-element vectors.
+//!
+//! `map-entry?` must be true only for real entries — the `[k v]` pairs
+//! produced by seq'ing a map, `find`, or the `map-entry` constructor — and
+//! false for plain vectors like `[:a 1]`. (A loose `map-entry?` broke
+//! replicant.hiccup/hiccup?: 2-element hiccup such as `[:h1 "hi"]` was
+//! misclassified as a map entry.)
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Value {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, &mut env).expect("eval error");
+    }
+    result
+}
+
+fn assert_bool(src: &str, expected: bool) {
+    assert_eq!(eval_fresh(src), Value::Bool(expected), "{src}");
+}
+
+// ── map-entry? predicate ─────────────────────────────────────────────────────
+
+#[test]
+fn plain_vectors_are_not_map_entries() {
+    assert_bool("(map-entry? [:a 1])", false);
+    assert_bool("(map-entry? [:h1 \"hi\"])", false);
+    assert_bool("(map-entry? (vector :a 1))", false);
+    assert_bool("(map-entry? [])", false);
+    assert_bool("(map-entry? [1 2 3])", false);
+    assert_bool("(map-entry? nil)", false);
+    assert_bool("(map-entry? '(1 2))", false);
+    assert_bool("(map-entry? {:a 1})", false);
+}
+
+#[test]
+fn seq_of_map_yields_map_entries() {
+    assert_bool("(map-entry? (first {:a 1}))", true);
+    assert_bool("(map-entry? (first (seq {:a 1})))", true);
+    assert_bool("(map-entry? (second (seq {:a 1 :b 2})))", true);
+    assert_bool("(map-entry? (first (rest (seq {:a 1 :b 2}))))", true);
+    assert_bool("(every? map-entry? (seq {:a 1 :b 2 :c 3}))", true);
+    assert_bool("(map-entry? (first (hash-map :a 1)))", true);
+    assert_bool("(map-entry? (first (array-map :a 1)))", true);
+    assert_bool("(map-entry? (first (sorted-map :a 1)))", true);
+    assert_bool("(map-entry? (first (rseq (sorted-map :a 1 :b 2))))", true);
+}
+
+#[test]
+fn find_returns_map_entries() {
+    assert_bool("(map-entry? (find {:a 1} :a))", true);
+    assert_bool("(map-entry? (find [10 20] 1))", true);
+    assert_bool("(map-entry? (find (transient {:a 1}) :a))", true);
+}
+
+#[test]
+fn entries_survive_into_and_mapping() {
+    // into a vector conj's the entries through unchanged.
+    assert_bool("(map-entry? (first (into [] {:a 1})))", true);
+    // map/filter over a map see real entries.
+    assert_bool("(every? map-entry? (map identity {:a 1 :b 2}))", true);
+    assert_bool("(every? map-entry? (filter (fn [e] true) {:a 1}))", true);
+}
+
+// ── map-entry constructor ────────────────────────────────────────────────────
+
+#[test]
+fn map_entry_constructor_two_args() {
+    assert_bool("(map-entry? (map-entry :a 1))", true);
+    assert_bool("(= (map-entry :a 1) [:a 1])", true);
+    assert_bool("(= :a (key (map-entry :a 1)))", true);
+    assert_bool("(= 1 (val (map-entry :a 1)))", true);
+}
+
+#[test]
+fn map_entry_constructor_one_seqable_arg() {
+    assert_bool("(map-entry? (map-entry [:a 1]))", true);
+    assert_bool("(map-entry? (map-entry '(:a 1)))", true);
+    assert_bool("(map-entry? (map-entry (map inc [1 2])))", true);
+    assert_bool("(= (map-entry [:a 1]) [:a 1])", true);
+}
+
+#[test]
+fn map_entry_constructor_rejects_wrong_element_count() {
+    assert_bool(
+        "(try (map-entry [1 2 3]) false (catch Exception e true))",
+        true,
+    );
+    assert_bool("(try (map-entry [1]) false (catch Exception e true))", true);
+}
+
+// ── vector behavior of entries ───────────────────────────────────────────────
+
+#[test]
+fn entries_behave_like_vectors() {
+    assert_bool("(vector? (first {:a 1}))", true);
+    assert_bool("(sequential? (first {:a 1}))", true);
+    assert_bool("(coll? (first {:a 1}))", true);
+    assert_bool("(= 2 (count (first {:a 1})))", true);
+    assert_bool("(= :a (nth (first {:a 1}) 0))", true);
+    assert_bool("(= 1 (nth (first {:a 1}) 1))", true);
+    assert_bool("(= [:a 1] (first {:a 1}))", true);
+    // Destructuring works.
+    assert_bool("(let [[k v] (first {:a 1})] (= [k v] [:a 1]))", true);
+}
+
+#[test]
+fn derived_vectors_are_plain_vectors() {
+    assert_bool("(map-entry? (conj (map-entry :a 1) 2))", false);
+    assert_bool("(map-entry? (assoc (map-entry :a 1) 0 :b))", false);
+    assert_bool("(map-entry? (pop (map-entry :a 1)))", false);
+    assert_bool("(map-entry? (subvec (map-entry :a 1) 0 2))", false);
+    assert_bool("(map-entry? (vec (map-entry :a 1)))", false);
+}
+
+// ── key/val are strict ───────────────────────────────────────────────────────
+
+#[test]
+fn key_and_val_reject_plain_vectors() {
+    assert_bool("(try (key [:a 1]) false (catch Exception e true))", true);
+    assert_bool("(try (val [:a 1]) false (catch Exception e true))", true);
+    assert_bool("(= :a (key (first {:a 1})))", true);
+    assert_bool("(= 1 (val (first {:a 1})))", true);
+}

--- a/crates/cljrs-stdlib/src/clojure/walk.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/walk.cljrs
@@ -8,11 +8,12 @@
   Recognizes all Clojure data structures. Consumes seqs as with doall."
   [inner outer form]
   (cond
-    (list? form)    (outer (apply list (map inner form)))
-    (seq? form)     (outer (doall (map inner form)))
-    (record? form)  (outer (reduce (fn [r x] (conj r (inner x))) form form))
-    (coll? form)    (outer (into (empty form) (map inner form)))
-    :else           (outer form)))
+    (list? form)      (outer (apply list (map inner form)))
+    (map-entry? form) (outer (map-entry (inner (key form)) (inner (val form))))
+    (seq? form)       (outer (doall (map inner form)))
+    (record? form)    (outer (reduce (fn [r x] (conj r (inner x))) form form))
+    (coll? form)      (outer (into (empty form) (map inner form)))
+    :else             (outer form)))
 
 (defn postwalk
   "Performs a depth-first, post-order traversal of form. Calls f on

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -227,7 +227,7 @@ Whole-number doubles hash like their `Long` equivalent.
 | Type | Description | Key operations |
 |---|---|---|
 | `PersistentList` | Singly-linked cons list | `cons`, `first`, `rest`, `count` (O(1)) |
-| `PersistentVector` | 32-way trie + tail buffer | `conj`, `nth`, `assoc_nth`, `pop`, `iter` |
+| `PersistentVector` | 32-way trie + tail buffer | `conj`, `nth`, `assoc_nth`, `pop`, `iter`, `map_entry`, `is_map_entry` |
 | `PersistentArrayMap` | Flat key/value vec, ≤8 entries | `assoc` (returns `AssocResult`), `get`, `dissoc`, `iter` |
 | `PersistentHashMap` | 32-way HAMT | `assoc`, `get`, `dissoc`, `merge`, `iter`, `keys`, `vals` |
 | `PersistentHashSet` | Backed by `PersistentHashMap` | `conj`, `disj`, `contains`, `iter` |
@@ -240,6 +240,16 @@ threshold, or `AssocResult::Promote(Vec<(Value, Value)>)` when the map is full.
 All collections implement `PartialEq`, `Debug`, `Clone`, and `cljrs_gc::Trace`.
 `PersistentList`, `PersistentVector`, and `PersistentHashSet` implement
 `std::iter::FromIterator<Value>`.
+
+A `PersistentVector` may be tagged as a **map entry** — the `[key val]` pairs
+produced by seq'ing a map, `find`, or the `map-entry` builtin.
+`PersistentVector::map_entry(key, val)` builds one; `is_map_entry()` reads the
+tag (there is also a `Value::map_entry(k, v)` / `Value::is_map_entry()`
+convenience pair). The tag is invisible to equality, hashing, and printing —
+`(= (first {:a 1}) [:a 1])` still holds — and it exists only so `map-entry?`
+can distinguish real entries from plain 2-element vectors. As in Clojure, any
+derived vector (`conj`, `assoc_nth`, `pop`, `from_iter`, ...) is a plain
+vector again.
 
 All collection Trace impls also override `gc_size_extra` to report the heap
 bytes owned by each collection beyond the GcBox struct.  Approximations used:

--- a/crates/cljrs-value/src/collections/vector.rs
+++ b/crates/cljrs-value/src/collections/vector.rs
@@ -1,20 +1,48 @@
 use crate::Value;
 
 /// An immutable persistent vector backed by `rpds::Vector`.
+///
+/// A vector may additionally be tagged as a *map entry* (see
+/// [`PersistentVector::map_entry`]): a two-element `[key val]` pair produced
+/// by seq'ing a map, `find`, or the `map-entry` builtin. Map entries behave
+/// exactly like vectors (equality, hashing, printing, indexing) — the tag
+/// only answers `map-entry?` — and, as in Clojure, any derived vector
+/// (`conj`, `assoc`, `pop`, ...) is a plain vector again.
 #[derive(Debug, Clone)]
 pub struct PersistentVector {
     inner: rpds::VectorSync<Value>,
+    is_map_entry: bool,
 }
 
 impl PersistentVector {
     pub fn empty() -> Self {
         Self {
             inner: rpds::VectorSync::new_sync(),
+            is_map_entry: false,
         }
     }
 
     pub fn from_vector(vector: rpds::VectorSync<Value>) -> Self {
-        Self { inner: vector }
+        Self {
+            inner: vector,
+            is_map_entry: false,
+        }
+    }
+
+    /// Build a `[key val]` pair tagged as a map entry.
+    pub fn map_entry(key: Value, val: Value) -> Self {
+        let mut inner = rpds::VectorSync::new_sync();
+        inner = inner.push_back(key);
+        inner = inner.push_back(val);
+        Self {
+            inner,
+            is_map_entry: true,
+        }
+    }
+
+    /// True only for vectors created via [`PersistentVector::map_entry`].
+    pub fn is_map_entry(&self) -> bool {
+        self.is_map_entry
     }
 
     pub fn count(&self) -> usize {
@@ -29,6 +57,7 @@ impl PersistentVector {
     pub fn conj(&self, val: Value) -> Self {
         Self {
             inner: self.inner.push_back(val),
+            is_map_entry: false,
         }
     }
 
@@ -49,6 +78,7 @@ impl PersistentVector {
         } else {
             Some(Self {
                 inner: self.inner.set(idx, val)?,
+                is_map_entry: false,
             })
         }
     }
@@ -57,6 +87,7 @@ impl PersistentVector {
     pub fn pop(&self) -> Option<Self> {
         Some(Self {
             inner: self.inner.drop_last()?,
+            is_map_entry: false,
         })
     }
 
@@ -76,7 +107,10 @@ impl std::iter::FromIterator<Value> for PersistentVector {
         for item in iter {
             v = v.push_back(item);
         }
-        Self { inner: v }
+        Self {
+            inner: v,
+            is_map_entry: false,
+        }
     }
 }
 
@@ -180,6 +214,23 @@ mod tests {
         let c = PersistentVector::from_iter([int(1), int(3)]);
         assert_eq!(a, b);
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_map_entry_flag() {
+        let e = PersistentVector::map_entry(int(1), int(2));
+        assert!(e.is_map_entry());
+        assert_eq!(e.count(), 2);
+        assert_eq!(e.nth(0), Some(&int(1)));
+        assert_eq!(e.nth(1), Some(&int(2)));
+        // Equal to a plain vector with the same elements.
+        assert_eq!(e, PersistentVector::from_iter([int(1), int(2)]));
+        // Plain constructors never produce map entries.
+        assert!(!PersistentVector::from_iter([int(1), int(2)]).is_map_entry());
+        // Derived vectors are plain vectors again.
+        assert!(!e.conj(int(3)).is_map_entry());
+        assert!(!e.assoc_nth(0, int(9)).unwrap().is_map_entry());
+        assert!(!e.pop().unwrap().is_map_entry());
     }
 
     #[test]

--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -1210,6 +1210,17 @@ impl Value {
         Value::Str(GcPtr::new(s.into()))
     }
 
+    /// Convenience: build a `[key val]` map entry (a tagged 2-element vector).
+    pub fn map_entry(key: Value, val: Value) -> Self {
+        Value::Vector(GcPtr::new(PersistentVector::map_entry(key, val)))
+    }
+
+    /// True only for map entries (`[k v]` pairs from seq'ing a map, `find`,
+    /// or the `map-entry` constructor) — not for plain 2-element vectors.
+    pub fn is_map_entry(&self) -> bool {
+        matches!(self.unwrap_meta(), Value::Vector(v) if v.get().is_map_entry())
+    }
+
     /// Convenience: wrap a `Symbol`.
     pub fn symbol(s: Symbol) -> Self {
         Value::Symbol(GcPtr::new(s))


### PR DESCRIPTION
(map-entry? [:a 1]) returned true for any 2-element vector, which broke
downstream type dispatch (e.g. replicant.hiccup/hiccup? rendered all
2-element hiccup as text nodes). Map entries are now tagged at creation:

- PersistentVector carries an is_map_entry flag; map_entry(k, v) builds
  a tagged [k v] pair and is_map_entry() reads it. The tag is invisible
  to equality, hashing, and printing, and any derived vector (conj,
  assoc, pop, from_iter, ...) is a plain vector again, as in Clojure.
- All map->seq surfaces produce real entries: seq/first/rest/next/cons/
  rseq on maps, records, and sorted maps, find (on maps, transient maps,
  and vectors), sequential destructuring of maps, and the compiled-tier
  rt_seq materialisation.
- New builtins: (map-entry k v) / (map-entry coll-of-2) constructor and
  a native map-entry? predicate replacing the loose bootstrap defn.
- key/val now accept only real map entries and throw on plain vectors,
  matching Clojure.
- clojure.walk/walk preserves entry-ness via a map-entry? branch,
  matching upstream Clojure.
- Test-suite :rust conditionals for key/val workarounds removed; new
  interp integration tests cover the predicate, constructor, and
  vector-like behavior of entries.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ps3yhPmB1g9GBPmEXF1mYo