### PR TITLE
Fix empty to preserve metadata and collection type

### DIFF
--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -3710,7 +3710,7 @@ fn builtin_empty(args: &[Value]) -> ValueResult<Value> {
             None => v,
         }
     };
-    Ok(apply_meta(match &args[0] {
+    Ok(apply_meta(match args[0].unwrap_meta() {
         Value::List(_) => Value::List(GcPtr::new(PersistentList::empty())),
         Value::Vector(_) => Value::Vector(GcPtr::new(PersistentVector::empty())),
         Value::Map(_) => Value::Map(MapValue::empty()),

--- a/crates/cljrs-interp/tests/empty_metadata.rs
+++ b/crates/cljrs-interp/tests/empty_metadata.rs
@@ -1,0 +1,71 @@
+//! Regression test: `empty` must preserve the metadata of its argument, and
+//! must still return the correct empty collection type when the argument
+//! carries metadata (previously it fell through to `nil` because the match
+//! was on the raw `WithMeta`-wrapped value instead of the unwrapped value).
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Value {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, &mut env).expect("eval error");
+    }
+    result
+}
+
+#[test]
+fn empty_preserves_metadata_on_vector() {
+    let result = eval_fresh("(meta (empty (with-meta [1 2 3] {:a 1})))");
+    assert!(
+        !matches!(result, Value::Nil),
+        "expected metadata to survive (empty ...), got nil"
+    );
+}
+
+#[test]
+fn empty_preserves_type_and_metadata_on_list() {
+    let is_list = eval_fresh("(list? (empty (with-meta '(1 2 3) {:a 1})))");
+    assert_eq!(is_list, Value::Bool(true));
+
+    let meta_val = eval_fresh("(:a (meta (empty (with-meta '(1 2 3) {:a 1}))))");
+    assert_eq!(meta_val, Value::Long(1));
+}
+
+#[test]
+fn empty_preserves_type_and_metadata_on_map() {
+    let is_map = eval_fresh("(map? (empty (with-meta {:x 1} {:a 1})))");
+    assert_eq!(is_map, Value::Bool(true));
+
+    let meta_val = eval_fresh("(:a (meta (empty (with-meta {:x 1} {:a 1}))))");
+    assert_eq!(meta_val, Value::Long(1));
+}
+
+#[test]
+fn empty_preserves_type_and_metadata_on_set() {
+    let is_set = eval_fresh("(set? (empty (with-meta #{1 2} {:a 1})))");
+    assert_eq!(is_set, Value::Bool(true));
+
+    let meta_val = eval_fresh("(:a (meta (empty (with-meta #{1 2} {:a 1}))))");
+    assert_eq!(meta_val, Value::Long(1));
+}
+
+#[test]
+fn empty_without_metadata_still_works() {
+    let cnt = eval_fresh("(count (empty [1 2 3]))");
+    assert_eq!(cnt, Value::Long(0));
+    let is_vec = eval_fresh("(vector? (empty [1 2 3]))");
+    assert_eq!(is_vec, Value::Bool(true));
+}


### PR DESCRIPTION
builtin_empty matched on the raw arg instead of args[0].unwrap_meta(),
so any collection carrying metadata (wrapped in Value::WithMeta) fell
through every arm to the Nil case, discarding both its type and the
metadata that apply_meta was supposed to reattach.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Mn6wjbQfHHfx3ZGBB4mYu