### PR TITLE
Fix namespaced-key :keys/:syms destructuring in both eval paths

### DIFF
--- a/crates/cljrs-eval/tests/destructure_lowering.rs
+++ b/crates/cljrs-eval/tests/destructure_lowering.rs
@@ -82,6 +82,14 @@ fn vec_of(items: impl IntoIterator<Item = Value>) -> Value {
     Value::Vector(cljrs_gc::GcPtr::new(PersistentVector::from_iter(items)))
 }
 
+fn map_of(pairs: impl IntoIterator<Item = (Value, Value)>) -> Value {
+    let mut m = cljrs_value::MapValue::empty();
+    for (k, v) in pairs {
+        m = m.assoc(k, v);
+    }
+    Value::Map(m)
+}
+
 #[test]
 fn sequential_destructure_binds_first_element() {
     // (fn [[a b]] a) called with [10 3] => 10
@@ -94,6 +102,34 @@ fn sequential_destructure_binds_second_element() {
     // (fn [[a b]] b) called with [10 3] => 3
     let got = run_destructured("[a b]", "b", vec_of([Value::Long(10), Value::Long(3)]));
     assert_eq!(got, Value::Long(3));
+}
+
+#[test]
+fn keys_destructure_binds_namespaced_symbol() {
+    // (fn [{:keys [ui/dest]}] dest) called with {:ui/dest 2} => 2
+    let got = run_destructured(
+        "{:keys [ui/dest]}",
+        "dest",
+        map_of([(
+            Value::keyword(cljrs_value::Keyword::qualified("ui", "dest")),
+            Value::Long(2),
+        )]),
+    );
+    assert_eq!(got, Value::Long(2));
+}
+
+#[test]
+fn keys_destructure_binds_namespaced_directive() {
+    // (fn [{:ui/keys [dest]}] dest) called with {:ui/dest 2} => 2
+    let got = run_destructured(
+        "{:ui/keys [dest]}",
+        "dest",
+        map_of([(
+            Value::keyword(cljrs_value::Keyword::qualified("ui", "dest")),
+            Value::Long(2),
+        )]),
+    );
+    assert_eq!(got, Value::Long(2));
 }
 
 #[test]

--- a/crates/cljrs-interp/src/destructure.rs
+++ b/crates/cljrs-interp/src/destructure.rs
@@ -190,19 +190,41 @@ pub fn bind_associative(pattern: &[Form], val: &Value, env: &mut Env) -> EvalRes
         let v = &pattern[i + 1];
         i += 2;
 
+        // A `:keys`/`:strs`/`:syms` keyword may itself be namespace-qualified
+        // (`:person/keys [a b]`), supplying a default namespace for every
+        // unqualified symbol in its vector; an individual symbol's own
+        // namespace (`ui/dest`) takes precedence over that default.
+        let directive_ns = if let FormKind::Keyword(kw) = &k.kind {
+            Keyword::parse(kw).namespace
+        } else {
+            None
+        };
+        let directive_name = if let FormKind::Keyword(kw) = &k.kind {
+            Keyword::parse(kw).name.to_string()
+        } else {
+            String::new()
+        };
+
         match &k.kind {
-            FormKind::Keyword(kw) if kw == "keys" => {
+            FormKind::Keyword(_) if directive_name == "keys" => {
                 if let FormKind::Vector(syms) = &v.kind {
                     for sym_form in syms {
                         if let FormKind::Symbol(sym) = &sym_form.kind {
-                            let key = Value::keyword(Keyword::simple(sym.as_str()));
+                            let parsed = Symbol::parse(sym);
+                            let key =
+                                match parsed.namespace.clone().or_else(|| directive_ns.clone()) {
+                                    Some(ns) => {
+                                        Value::keyword(Keyword::qualified(ns, parsed.name.clone()))
+                                    }
+                                    None => Value::keyword(Keyword::simple(parsed.name.clone())),
+                                };
                             let mut bound_val = get_val(&key);
                             if matches!(bound_val, Value::Nil)
-                                && let Some(d) = defaults.get(sym.as_str())
+                                && let Some(d) = defaults.get(parsed.name.as_ref())
                             {
                                 bound_val = d.clone();
                             }
-                            env.bind(Arc::from(sym.as_str()), bound_val);
+                            env.bind(parsed.name.clone(), bound_val);
                         }
                     }
                 }
@@ -223,18 +245,25 @@ pub fn bind_associative(pattern: &[Form], val: &Value, env: &mut Env) -> EvalRes
                     }
                 }
             }
-            FormKind::Keyword(kw) if kw == "syms" => {
+            FormKind::Keyword(_) if directive_name == "syms" => {
                 if let FormKind::Vector(syms) = &v.kind {
                     for sym_form in syms {
                         if let FormKind::Symbol(sym) = &sym_form.kind {
-                            let key = Value::symbol(Symbol::simple(sym.as_str()));
+                            let parsed = Symbol::parse(sym);
+                            let key =
+                                match parsed.namespace.clone().or_else(|| directive_ns.clone()) {
+                                    Some(ns) => {
+                                        Value::symbol(Symbol::qualified(ns, parsed.name.clone()))
+                                    }
+                                    None => Value::symbol(Symbol::simple(parsed.name.clone())),
+                                };
                             let mut bound_val = get_val(&key);
                             if matches!(bound_val, Value::Nil)
-                                && let Some(d) = defaults.get(sym.as_str())
+                                && let Some(d) = defaults.get(parsed.name.as_ref())
                             {
                                 bound_val = d.clone();
                             }
-                            env.bind(Arc::from(sym.as_str()), bound_val);
+                            env.bind(parsed.name.clone(), bound_val);
                         }
                     }
                 }

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -674,20 +674,36 @@ fn lower_destructure_associative(
         let k = &pairs[i];
         let v = &pairs[i + 1];
 
-        match &k.kind {
-            FormKind::Keyword(kname) if kname == "keys" => {
+        // A `:keys`/`:strs`/`:syms` directive keyword may itself be
+        // namespace-qualified (`:person/keys [a b]`), supplying a default
+        // namespace for every unqualified symbol in its vector; an
+        // individual symbol's own namespace (`ui/dest`) takes precedence.
+        let directive = if let FormKind::Keyword(kname) = &k.kind {
+            Some(split_ns_name(kname))
+        } else {
+            None
+        };
+
+        match directive {
+            Some((directive_ns, "keys")) => {
                 if let FormKind::Vector(syms) = &v.kind {
                     for sym_form in syms {
                         if let FormKind::Symbol(sym) = &sym_form.kind {
-                            let kw_var = ctx.emit_const(Const::Keyword(Arc::from(sym.as_str())));
+                            let (sym_ns, sym_name) = split_ns_name(sym);
+                            let full_key = match sym_ns.or(directive_ns) {
+                                Some(ns) => format!("{ns}/{sym_name}"),
+                                None => sym_name.to_string(),
+                            };
+                            let kw_var =
+                                ctx.emit_const(Const::Keyword(Arc::from(full_key.as_str())));
                             let got = lower_emit_get(ctx, val, kw_var);
-                            let final_var = apply_default_if_nil(ctx, got, sym, &defaults)?;
-                            ctx.bind_local(Arc::from(sym.as_str()), final_var);
+                            let final_var = apply_default_if_nil(ctx, got, sym_name, &defaults)?;
+                            ctx.bind_local(Arc::from(sym_name), final_var);
                         }
                     }
                 }
             }
-            FormKind::Keyword(kname) if kname == "strs" => {
+            Some((_, "strs")) => {
                 if let FormKind::Vector(syms) = &v.kind {
                     for sym_form in syms {
                         if let FormKind::Symbol(sym) = &sym_form.kind {
@@ -699,24 +715,30 @@ fn lower_destructure_associative(
                     }
                 }
             }
-            FormKind::Keyword(kname) if kname == "syms" => {
+            Some((directive_ns, "syms")) => {
                 if let FormKind::Vector(syms) = &v.kind {
                     for sym_form in syms {
                         if let FormKind::Symbol(sym) = &sym_form.kind {
-                            let sym_var = ctx.emit_const(Const::Symbol(Arc::from(sym.as_str())));
+                            let (sym_ns, sym_name) = split_ns_name(sym);
+                            let full_key = match sym_ns.or(directive_ns) {
+                                Some(ns) => format!("{ns}/{sym_name}"),
+                                None => sym_name.to_string(),
+                            };
+                            let sym_var =
+                                ctx.emit_const(Const::Symbol(Arc::from(full_key.as_str())));
                             let got = lower_emit_get(ctx, val, sym_var);
-                            let final_var = apply_default_if_nil(ctx, got, sym, &defaults)?;
-                            ctx.bind_local(Arc::from(sym.as_str()), final_var);
+                            let final_var = apply_default_if_nil(ctx, got, sym_name, &defaults)?;
+                            ctx.bind_local(Arc::from(sym_name), final_var);
                         }
                     }
                 }
             }
-            FormKind::Keyword(kname) if kname == "as" => {
+            Some((_, "as")) => {
                 if let FormKind::Symbol(sym) = &v.kind {
                     ctx.bind_local(Arc::from(sym.as_str()), val);
                 }
             }
-            FormKind::Keyword(kname) if kname == "or" => {
+            Some((_, "or")) => {
                 // Already collected above; skip.
             }
             _ => {
@@ -2686,6 +2708,17 @@ fn split_sym(s: &str, current_ns: &Arc<str>) -> (Arc<str>, Arc<str>) {
             (Arc::from(ns_part), Arc::from(&s[pos + 1..]))
         }
         None => (current_ns.clone(), Arc::from(s)),
+    }
+}
+
+/// Split `s` into an optional namespace and a bare name on the first `/`,
+/// with no namespace defaulting (unlike `split_sym`). Mirrors
+/// `cljrs_value::keyword::Keyword::parse` / `Symbol::parse` (cljrs-ir cannot
+/// depend on cljrs-value).
+fn split_ns_name(s: &str) -> (Option<&str>, &str) {
+    match s.find('/') {
+        Some(idx) if idx > 0 && idx < s.len() - 1 => (Some(&s[..idx]), &s[idx + 1..]),
+        _ => (None, s),
     }
 }
 


### PR DESCRIPTION
{:keys [ui/dest]} and {:ui/keys [dest]} previously bound the local under
the wrong name (or failed to parse at all) because bind_associative and
lower_destructure_associative treated the full "ns/name" text as an
opaque local/key name instead of splitting it. Both the tree-walking
destructure.rs and the IR lowering in anf.rs now split the :keys/:syms
directive keyword and each bound symbol on '/', with the symbol's own
namespace taking precedence over the directive's, and bind the local
using only the bare name part.