### PR TITLE
Fix (str ...) treating nil as literal "nil" after IR lowering

### DIFF
--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -1195,7 +1195,12 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
         KnownFn::Str => {
             let s: String = args
                 .iter()
-                .map(|v| format!("{}", cljrs_value::value::PrintValue(v)))
+                .map(|v| match v {
+                    Value::Nil => String::new(),
+                    Value::Str(s) => s.get().to_string(),
+                    Value::Char(c) => c.to_string(),
+                    other => format!("{}", cljrs_value::value::PrintValue(other)),
+                })
                 .collect();
             Ok(Value::Str(GcPtr::new(s)))
         }

--- a/crates/cljrs/tests/background_lowering.rs
+++ b/crates/cljrs/tests/background_lowering.rs
@@ -102,6 +102,28 @@ fn background_lowering_publishes_ir() {
     );
 }
 
+/// `(str tag id)` with a `nil` arg must keep treating `nil` as the empty
+/// string once the caller tiers up from tree-walk to the IR interpreter —
+/// not print the literal `"nil"`.
+#[test]
+fn str_with_nil_arg_stays_correct_after_tiering_up() {
+    let src = r#"
+        (defn get-tag [tag id] (str tag id))
+        (loop [i 0]
+          (when (< i 200)
+            (let [got (get-tag "h1" nil)]
+              (when (not= got "h1") (println "WRONG at" i got)))
+            (recur (+ i 1))))
+        (println "done")
+    "#;
+    let (stdout, stderr) = run_warm(src, &["--jit-threshold", "0"], &[]);
+    assert!(
+        !stdout.contains("WRONG"),
+        "str(nil) corrupted after IR lowering:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("done"), "stdout:\n{stdout}");
+}
+
 /// Rebinding a defn while its caller is warm/hot must be reflected
 /// immediately: the dependent's IR is invalidated and re-lowered in the
 /// background, and every interim call (tree-walk fallback) already resolves


### PR DESCRIPTION
The IR interpreter's KnownFn::Str handler formatted every arg with
PrintValue, unlike the tree-walker's builtin_str which special-cases
Nil/Str/Char. Once a function tiers up past the background IR-lowering
threshold, (str tag nil) started rendering "tagnil" instead of "tag".