### PR TITLE
Fix use-after-free: conj!/assoc! wrongly marked as not retaining their value arg

### DIFF
--- a/crates/cljrs-ir/src/lower/escape.rs
+++ b/crates/cljrs-ir/src/lower/escape.rs
@@ -84,8 +84,14 @@ pub(crate) fn known_fn_arg_escapes(func: &KnownFn, arg_index: usize) -> bool {
         Rest | Next | Seq => arg_index == 0,
         Pop | Vec => arg_index == 0,
         Transient => arg_index == 0,
-        AssocBang | ConjBang => arg_index == 0,
         PersistentBang => arg_index == 0,
+
+        // `assoc!`/`conj!` mutate arg 0 *and* retain the newly stored
+        // value(s) inside it — unlike `dissoc`/`disj` (which only consult a
+        // key/item to discard), the added value's lifetime becomes bound to
+        // the transient's. Falls through to the default (all args escape),
+        // matching how plain `assoc`/`conj` are handled (neither is listed
+        // above, so both already use the `true` default).
 
         // Default: argument escapes
         _ => true,

--- a/crates/cljrs-ir/tests/escape_regression.rs
+++ b/crates/cljrs-ir/tests/escape_regression.rs
@@ -380,6 +380,33 @@ fn stage4_skipped_when_callee_result_escapes() {
 }
 
 #[test]
+fn stage4_skipped_when_callee_result_conjd_into_transient() {
+    // `conj!`/`assoc!` mutate their collection arg *and* retain the newly
+    // added value inside it — same as plain `conj`/`assoc`.  A caller that
+    // conj!'s a callee's `Returns`-tagged result into a transient it then
+    // returns must classify that result as escaping (`Returns`), not
+    // `NoEscape` — otherwise stage 4 clones the callee into a region-scoped
+    // variant whose allocation is freed at the *conj! call site*, well before
+    // the transient (and the value it retains) escapes to this function's own
+    // caller. This mirrors the real-world `(conj! coll (f x))` shape used by
+    // Replicant's `flatten-map-seqs*`/`get-children-ks`.
+    let ir = lower(
+        "(do
+           (defn make-pair [a b]
+             (let [f (fn [x] x)]
+               [a b]))
+           (defn collect-pair [coll x] (conj! coll (make-pair x x))))",
+    );
+    let optimized = optimize(ir);
+    assert_eq!(
+        call_with_region_count(&optimized),
+        0,
+        "no CallWithRegion should be emitted when the call result is conj!'d \
+         into a collection that escapes; IR:\n{optimized}"
+    );
+}
+
+#[test]
 fn stage4_inline_first_falls_back_to_promotion() {
     // When the callee is small enough to inline, stage-1 inlining handles it
     // and stage 4 has nothing to do.  This test verifies that the small


### PR DESCRIPTION
known_fn_arg_escapes() special-cased AssocBang/ConjBang to arg_index == 0,
meaning the newly assoc!'d/conj!'d value was treated as not escaping into the
mutated transient. That let stage-4 cross-function region promotion treat a
callee's Returns-tagged allocation as NoEscape whenever the only caller-side
use was `(conj! coll (call ...))`, region-promoting the callee and freeing its
result at the conj! call site — before the transient (and the value it
retains) escaped further up the stack. Plain conj/assoc aren't listed in the
table and already fall through to the (correct) "argument escapes" default;
the bang variants now do too.

This was the root cause of the vector-truncation/use-after-free crash seen
under Replicant's cljrs backend (9-element hiccup-headers tuples reading back
as length 2-3), reproduced here via Replicant's replicant.core-test suite —
previously an intermittent GcPtr-freed-object assertion, rpds index-out-of-
bounds panic, or SIGSEGV; now clean (assertion-level test failures only, no
crashes) across repeated runs.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KsszvNRDiEC42BipoTjVVE