### PR TITLE
Fix two more region-escape bugs: Get's arg-escape marking, and ambigu…

### DIFF
--- a/crates/cljrs-ir-viz/examples/dump_escape.rs
+++ b/crates/cljrs-ir-viz/examples/dump_escape.rs
@@ -94,7 +94,9 @@ fn describe_use(kind: &UseKind) -> String {
         UseKind::Throw => "Throw".into(),
         UseKind::StoredInHeap => "StoredInHeap".into(),
         UseKind::Recur => "Recur".into(),
-        UseKind::KnownCallArg { func, arg_index } => {
+        UseKind::KnownCallArg {
+            func, arg_index, ..
+        } => {
             format!("KnownCall({func:?}, arg {arg_index})")
         }
         UseKind::UnknownCallArg { arg_index, .. } => format!("UnknownCall(arg {arg_index})"),

--- a/crates/cljrs-ir-viz/src/blame.rs
+++ b/crates/cljrs-ir-viz/src/blame.rs
@@ -56,7 +56,9 @@ pub fn use_kind_label(kind: &UseKind) -> String {
         UseKind::Throw => "thrown".into(),
         UseKind::StoredInHeap => "stored into heap object".into(),
         UseKind::Recur => "passed to recur".into(),
-        UseKind::KnownCallArg { func, arg_index } => {
+        UseKind::KnownCallArg {
+            func, arg_index, ..
+        } => {
             format!("arg {arg_index} of known call {func:?}")
         }
         UseKind::UnknownCallArg { arg_index, .. } => {

--- a/crates/cljrs-ir/src/lower/escape.rs
+++ b/crates/cljrs-ir/src/lower/escape.rs
@@ -44,8 +44,24 @@ pub enum UseKind {
     Throw,
     StoredInHeap,
     Recur,
-    KnownCallArg { func: KnownFn, arg_index: usize },
-    UnknownCallArg { callee: VarId, arg_index: usize },
+    KnownCallArg {
+        func: KnownFn,
+        arg_index: usize,
+        /// The `dst` of the specific `CallKnown` instruction this use
+        /// belongs to — recorded at use-collection time so callers never
+        /// need to re-scan the block for "a" matching call. Re-scanning by
+        /// `(func, contains(var))` alone is ambiguous whenever the same var
+        /// feeds *multiple* calls to the same known fn in one block (e.g. a
+        /// 4-way destructuring bind lowers to four separate `NthLenient`
+        /// calls on the same tuple var) — a naive first-match re-scan always
+        /// resolves to the same (possibly dead) call, silently losing the
+        /// escape contribution of every other one.
+        dst: VarId,
+    },
+    UnknownCallArg {
+        callee: VarId,
+        arg_index: usize,
+    },
     PhiInput,
     BranchCond,
     Deref,
@@ -64,20 +80,21 @@ pub struct UseInfo {
 pub(crate) fn known_fn_arg_escapes(func: &KnownFn, arg_index: usize) -> bool {
     use KnownFn::*;
     match func {
-        // Non-escaping: predicates, arithmetic, I/O, lookups that return a
-        // freshly boxed/copied element (`Get` clones the value out).
-        Get | Count | CountFilter | Contains | Add | Sub | Mul | Div | Rem | Eq | Lt | Gt | Lte
-        | Gte | IsNil | IsSeq | IsVector | IsMap | IsEmpty | Identical | IsNumber | IsString
+        // Non-escaping: predicates, arithmetic, I/O.
+        Count | CountFilter | Contains | Add | Sub | Mul | Div | Rem | Eq | Lt | Gt | Lte | Gte
+        | IsNil | IsSeq | IsVector | IsMap | IsEmpty | Identical | IsNumber | IsString
         | IsKeyword | IsSymbol | IsBool | IsInt | Str | Deref | AtomDeref | Println | Pr | Prn
         | Print => false,
 
         // These return an *interior pointer* aliasing arg 0's storage
-        // (`rt_first`/`rt_nth`/`rt_peek` hand back `&elem` into the vector/leaf,
-        // not a fresh box).  The returned element therefore shares the
-        // collection's lifetime: if it escapes, arg 0 must be treated as
-        // escaping too, or arg 0 could be region-allocated and freed while the
-        // interior pointer is still live (use-after-free / heap corruption).
-        First | Nth | NthLenient | Peek => arg_index == 0,
+        // (`rt_first`/`rt_nth`/`rt_peek`/`rt_get` hand back a clone of the
+        // stored `Value` — a shallow clone that shares the same `GcPtr` for
+        // any heap-backed element (vector/map/string/...), not a fresh box).
+        // The returned element therefore shares the collection's lifetime: if
+        // it escapes, arg 0 must be treated as escaping too, or arg 0 could be
+        // region-allocated and freed while the interior pointer is still live
+        // (use-after-free / heap corruption).
+        First | Nth | NthLenient | Peek | Get => arg_index == 0,
 
         // These return a modified copy of arg 0 → arg 0 escapes; others don't
         Dissoc | Disj => arg_index == 0,
@@ -137,7 +154,7 @@ fn add_use(uses: &mut HashMap<VarId, Vec<UseInfo>>, var: VarId, block: BlockId, 
 
 fn add_uses_for_inst(uses: &mut HashMap<VarId, Vec<UseInfo>>, inst: &Inst, block_id: BlockId) {
     match inst {
-        Inst::CallKnown(_, func, args) => {
+        Inst::CallKnown(call_dst, func, args) => {
             for (i, &arg) in args.iter().enumerate() {
                 add_use(
                     uses,
@@ -146,6 +163,7 @@ fn add_uses_for_inst(uses: &mut HashMap<VarId, Vec<UseInfo>>, inst: &Inst, block
                     UseKind::KnownCallArg {
                         func: func.clone(),
                         arg_index: i,
+                        dst: *call_dst,
                     },
                 );
             }
@@ -395,25 +413,6 @@ fn resolve_call_target(
 }
 
 // ── Find helpers ─────────────────────────────────────────────────────────────
-
-/// Find the destination of a CallKnown for `known_fn` that uses `used_var` in `block_id`.
-fn find_call_result(
-    used_var: VarId,
-    known_fn: &KnownFn,
-    ir_func: &IrFunction,
-    block_id: BlockId,
-) -> Option<VarId> {
-    let block = ir_func.blocks.iter().find(|b| b.id == block_id)?;
-    for inst in &block.insts {
-        if let Inst::CallKnown(dst, func, args) = inst
-            && func == known_fn
-            && args.contains(&used_var)
-        {
-            return Some(*dst);
-        }
-    }
-    None
-}
 
 /// Walk from a `Recur` use back to the loop-header phi(s) that the
 /// recur arg feeds.  Returns the destination `VarId` of each matching
@@ -711,18 +710,18 @@ pub(crate) fn classify_escape_with_ctx(
                     }
                     let _ = arg_index; // suppress unused warning
                 }
-                UseKind::KnownCallArg { func, arg_index }
-                    if known_fn_arg_escapes(func, *arg_index) =>
-                {
-                    // The call result may carry this alloc
-                    if let Some(call_result) =
-                        find_call_result(current, func, ir_func, use_info.block)
-                    {
-                        worklist.push_back(call_result);
-                    } else {
-                        result = EscapeState::Escapes;
-                        break 'outer;
-                    }
+                UseKind::KnownCallArg {
+                    func,
+                    arg_index,
+                    dst,
+                } if known_fn_arg_escapes(func, *arg_index) => {
+                    // The call result may carry this alloc.  `dst` was
+                    // recorded directly against *this* use at use-collection
+                    // time, so it names the exact `CallKnown` this use
+                    // belongs to — unlike a `(func, contains(var))` re-scan,
+                    // it can't resolve to some other call to the same known
+                    // fn on the same var earlier in the block.
+                    worklist.push_back(*dst);
                 }
                 UseKind::KnownCallArg { .. } => {
                     // doesn't escape through this call

--- a/crates/cljrs-ir/src/lower/optimize.rs
+++ b/crates/cljrs-ir/src/lower/optimize.rs
@@ -303,20 +303,18 @@ pub(crate) fn collect_use_blocks(
         for use_info in uses.get(&current).into_iter().flatten() {
             use_blocks.insert(use_info.block);
             match &use_info.kind {
-                UseKind::KnownCallArg { func, arg_index }
-                    if known_fn_arg_escapes(func, *arg_index) =>
-                {
-                    // Find the call result and propagate
-                    if let Some(block) = ir_func.blocks.iter().find(|b| b.id == use_info.block) {
-                        for inst in &block.insts {
-                            if let Inst::CallKnown(dst, f, args) = inst
-                                && f == func
-                                && args.contains(&current)
-                            {
-                                worklist.push(*dst);
-                            }
-                        }
-                    }
+                UseKind::KnownCallArg {
+                    func,
+                    arg_index,
+                    dst,
+                } if known_fn_arg_escapes(func, *arg_index) => {
+                    // `dst` names the exact `CallKnown` this use belongs to
+                    // (recorded at use-collection time), so propagate to it
+                    // directly instead of re-scanning the block — a
+                    // `(func, contains(var))` re-scan is ambiguous whenever
+                    // the same var feeds multiple calls to the same known fn
+                    // in one block.
+                    worklist.push(*dst);
                 }
                 UseKind::KnownCallArg { .. } => {}
                 UseKind::PhiInput => {

--- a/crates/cljrs-ir/src/lower/regionalize.rs
+++ b/crates/cljrs-ir/src/lower/regionalize.rs
@@ -208,26 +208,6 @@ fn deep_returns_allocs(callee: &IrFunction, shallow: &HashSet<VarId>) -> HashSet
     result
 }
 
-/// Locate the result of a `CallKnown(_, kf, args)` in `block_id` whose
-/// arguments include `used_var`.
-fn find_known_call_result(
-    func: &IrFunction,
-    used_var: VarId,
-    kf: &KnownFn,
-    block_id: crate::BlockId,
-) -> Option<VarId> {
-    let block = func.blocks.iter().find(|b| b.id == block_id)?;
-    for inst in &block.insts {
-        if let Inst::CallKnown(dst, f, args) = inst
-            && f == kf
-            && args.contains(&used_var)
-        {
-            return Some(*dst);
-        }
-    }
-    None
-}
-
 /// Returns `true` when it is safe to co-promote the deep (container-contained)
 /// allocations of a call whose result is `dst`.
 ///
@@ -255,6 +235,7 @@ fn call_result_safe_for_deep(
                 UseKind::KnownCallArg {
                     func: kf,
                     arg_index,
+                    dst: call_dst,
                 } => {
                     // Element extractors return an inner pointer by reference.
                     if matches!(
@@ -267,12 +248,11 @@ fn call_result_safe_for_deep(
                     ) {
                         return false;
                     }
-                    // Forwarding fns: follow into the call result.
+                    // Forwarding fns: follow into the call result. `call_dst`
+                    // was recorded directly against this use, so it names the
+                    // exact `CallKnown` involved — no re-scan needed.
                     if known_fn_arg_escapes(kf, *arg_index) {
-                        match find_known_call_result(func, v, kf, use_info.block) {
-                            Some(r) => worklist.push(r),
-                            None => return false,
-                        }
+                        worklist.push(*call_dst);
                     }
                 }
                 UseKind::PhiInput => {

--- a/crates/cljrs-ir/tests/escape_regression.rs
+++ b/crates/cljrs-ir/tests/escape_regression.rs
@@ -641,3 +641,33 @@ fn count_filter_not_fused_when_filter_escapes() {
 fn _arc_witness() -> Arc<str> {
     Arc::from("x")
 }
+
+#[test]
+fn stage4_skipped_when_one_destructured_binding_escapes() {
+    // A 4-way destructuring bind `[a b c d] (make-pair x x)` lowers to four
+    // separate `NthLenient` calls on the same tuple var, all in one block.
+    // Only `b` is used afterwards (in the returned vector literal); `a`,
+    // `c`, and `d` are dead. A use-chain walk that resolves "the NthLenient
+    // call on this var" by re-scanning the block for *any* matching
+    // `(func, contains(var))` instruction always finds the same (here dead)
+    // first match — so it never looks at `b`'s use, and wrongly concludes
+    // the whole tuple is `NoEscape`. Each use must instead carry the exact
+    // `CallKnown` dst it belongs to, so `b`'s escaping use is the one
+    // actually walked.
+    let ir = lower(
+        "(do
+           (defn make-pair [a b]
+             (let [f (fn [x] x)]
+               [a b :c :d]))
+           (defn wrap [x]
+             (let [[a b c d] (make-pair x x)]
+               [1 b 3])))",
+    );
+    let optimized = optimize(ir);
+    assert_eq!(
+        call_with_region_count(&optimized),
+        0,
+        "no CallWithRegion should be emitted when a destructured binding \
+         escapes into a returned vector; IR:\n{optimized}"
+    );
+}


### PR DESCRIPTION
…ous known-fn use resolution

1. known_fn_arg_escapes() marked Get's container arg as never escaping, on the theory that `get` "clones the value out." In fact `get` (like nth/first/peek, which are already correctly handled) returns a shallow Value::clone() that aliases the same GcPtr for any heap-backed result (vector/map/string/...). Get now joins First/Nth/NthLenient/Peek in the arg_index == 0 group.

2. Escape-chain propagation resolved "the call this use belongs to" by re-scanning the block for the first CallKnown matching (func, contains(var)) — ambiguous whenever the same var feeds *multiple* calls to the same known fn in one block. A 4-way destructuring bind ([a b c d] (some-call ...)) lowers to four separate NthLenient calls on the same tuple var; if the first destructured binding is dead, the re-scan always resolves to it and never sees that another binding (e.g. b) escapes, wrongly classifying the whole tuple NoEscape. UseKind:: KnownCallArg now carries the exact CallKnown dst it was recorded against, so classify_escape_with_ctx (escape.rs), collect_use_blocks (optimize.rs), and call_result_safe_for_deep (regionalize.rs) all propagate through the right call instead of re-scanning ambiguously.

Both were part of the same defect family as the conj!/assoc! fix: stage-4 cross-function region promotion treating a callee's Returns-tagged allocation as NoEscape when it actually escapes the caller, freeing the allocation's region before the value's real lifetime ends.

Verified against Replicant's cljrs backend test suite (replicant.core-test): probe 39 ("stale children after promotion" — an existing node's text/ children silently reading back as empty after ~150 renders) is fixed at the Tier-1 IR interpreter. The same defect also affects Cranelift-JIT'd functions once they cross --jit-threshold (default 1000); it's confirmed absent with --jit-threshold 0 but still reproducible at JIT defaults, which points at codegen.rs/rt_abi.rs's native compilation of RegionAlloc/RegionEnd/CallWithRegion as a separate, deeper bug in the same family as the already-tracked issue #235 — left for follow-up.


Claude-Session: https://claude.ai/code/session_01KsszvNRDiEC42BipoTjVVE