### PR TITLE
Fix native/JIT collection ops silently ignoring metadata-carrying values

### DIFF
--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -66,6 +66,18 @@ fn box_val(v: Value) -> *const Value {
 /// Safety: the returned pointer is valid until the active region is popped
 /// (i.e. until `rt_region_end`).  The IR analysis guarantees collection values
 /// are consumed before that point.
+/// Reattach `meta` (captured from an input collection via `get_meta()`,
+/// before `unwrap_meta()` peeled it off to dispatch) to a freshly built
+/// result, matching the identity-preserving builtins (`assoc`/`conj`/
+/// `dissoc`/`disj`) in cljrs-builtins, which all do the same.
+#[inline]
+fn apply_meta(v: Value, meta: Option<Value>) -> Value {
+    match meta {
+        Some(m) => v.with_meta(m),
+        None => v,
+    }
+}
+
 #[inline]
 fn box_coll_val(v: Value) -> *const Value {
     if cljrs_gc::region::region_is_active() {
@@ -1753,21 +1765,29 @@ pub unsafe extern "C" fn rt_assoc(
     k: *const Value,
     v: *const Value,
 ) -> *const Value {
-    let m = unsafe { val_ref(m) }.unwrap_meta();
+    let m_ref = unsafe { val_ref(m) };
+    let meta = m_ref.get_meta().cloned();
+    let m = m_ref.unwrap_meta();
     let k = unsafe { val_ref(k) }.clone();
     let v = unsafe { val_ref(v) }.clone();
+    // `assoc` preserves the input's metadata on the result (matching
+    // `builtin_assoc`) — `unwrap_meta()` above only peels it off to dispatch
+    // on the underlying collection kind.
     match m {
         Value::Map(map) => {
             let new_map = map.assoc(k, v);
-            box_coll_val(Value::Map(new_map))
+            box_coll_val(apply_meta(Value::Map(new_map), meta))
         }
         Value::TypeInstance(ti) => {
             let mut fields = ti.get().fields.clone();
             fields = fields.assoc(k, v);
-            box_coll_val(Value::TypeInstance(alloc_inner_coll(TypeInstance {
-                type_tag: ti.get().type_tag.clone(),
-                fields,
-            })))
+            box_coll_val(apply_meta(
+                Value::TypeInstance(alloc_inner_coll(TypeInstance {
+                    type_tag: ti.get().type_tag.clone(),
+                    fields,
+                })),
+                meta,
+            ))
         }
         _ => rt_const_nil(),
     }
@@ -1779,25 +1799,32 @@ pub unsafe extern "C" fn rt_assoc(
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_conj(coll: *const Value, val: *const Value) -> *const Value {
-    let coll = unsafe { val_ref(coll) }.unwrap_meta();
+    let coll_ref = unsafe { val_ref(coll) };
+    let meta = coll_ref.get_meta().cloned();
+    let coll = coll_ref.unwrap_meta();
     let val = unsafe { val_ref(val) }.clone();
+    // `conj` preserves the input's metadata on the result (matching
+    // `builtin_conj`).
     match coll {
         Value::Vector(v) => {
             let new_pv = v.get().conj(val);
-            box_coll_val(Value::Vector(alloc_inner_coll(new_pv)))
+            box_coll_val(apply_meta(Value::Vector(alloc_inner_coll(new_pv)), meta))
         }
         Value::List(l) => {
             let new_list = PersistentList::cons(val, Arc::new((*l.get()).clone()));
-            box_coll_val(Value::List(alloc_inner_coll(new_list)))
+            box_coll_val(apply_meta(Value::List(alloc_inner_coll(new_list)), meta))
         }
         Value::Set(SetValue::Hash(m)) => {
             let new_phs = m.get().conj(val);
-            box_coll_val(Value::Set(SetValue::Hash(alloc_inner_coll(new_phs))))
+            box_coll_val(apply_meta(
+                Value::Set(SetValue::Hash(alloc_inner_coll(new_phs))),
+                meta,
+            ))
         }
         Value::Set(s) => {
             // Sorted sets: delegate to interpreter (rare path)
             let new_set = s.conj(val);
-            box_coll_val(Value::Set(new_set))
+            box_coll_val(apply_meta(Value::Set(new_set), meta))
         }
         _ => rt_const_nil(),
     }
@@ -2779,10 +2806,14 @@ pub unsafe extern "C" fn rt_with_out_str(body_fn: *const Value) -> *const Value 
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_dissoc(m: *const Value, k: *const Value) -> *const Value {
-    let m = unsafe { val_ref(m) }.unwrap_meta();
+    let m_ref = unsafe { val_ref(m) };
+    let meta = m_ref.get_meta().cloned();
+    let m = m_ref.unwrap_meta();
     let k = unsafe { val_ref(k) };
+    // `dissoc` preserves the input's metadata on the result (matching
+    // `builtin_dissoc`).
     match m {
-        Value::Map(map) => box_coll_val(Value::Map(map.dissoc(k))),
+        Value::Map(map) => box_coll_val(apply_meta(Value::Map(map.dissoc(k)), meta)),
         _ => box_coll_val(m.clone()),
     }
 }
@@ -2793,10 +2824,14 @@ pub unsafe extern "C" fn rt_dissoc(m: *const Value, k: *const Value) -> *const V
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_disj(set: *const Value, val: *const Value) -> *const Value {
-    let set = unsafe { val_ref(set) }.unwrap_meta();
+    let set_ref = unsafe { val_ref(set) };
+    let meta = set_ref.get_meta().cloned();
+    let set = set_ref.unwrap_meta();
     let val = unsafe { val_ref(val) };
+    // `disj` preserves the input's metadata on the result (matching
+    // `builtin_disj`).
     match set {
-        Value::Set(s) => box_coll_val(Value::Set(s.disj(val))),
+        Value::Set(s) => box_coll_val(apply_meta(Value::Set(s.disj(val)), meta)),
         _ => box_coll_val(set.clone()),
     }
 }

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -1201,7 +1201,7 @@ pub unsafe extern "C" fn rt_alloc_cons(head: *const Value, tail: *const Value) -
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_get(coll: *const Value, key: *const Value) -> *const Value {
-    let coll = unsafe { val_ref(coll) };
+    let coll = unsafe { val_ref(coll) }.unwrap_meta();
     let key = unsafe { val_ref(key) };
     let result = match coll {
         Value::Map(m) => m.get(key),
@@ -1224,7 +1224,7 @@ pub unsafe extern "C" fn rt_get(coll: *const Value, key: *const Value) -> *const
 /// `coll` must be a valid pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_count(coll: *const Value) -> *const Value {
-    let coll = unsafe { val_ref(coll) };
+    let coll = unsafe { val_ref(coll) }.unwrap_meta();
     let n = match coll {
         Value::Vector(v) => v.get().count(),
         Value::Map(m) => m.count(),
@@ -1640,7 +1640,7 @@ pub unsafe extern "C" fn rt_into_map(
 /// `coll` must be a valid pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_is_empty(coll: *const Value) -> *const Value {
-    let coll = unsafe { val_ref(coll) };
+    let coll = unsafe { val_ref(coll) }.unwrap_meta();
     let empty = match coll {
         Value::Vector(v) => v.get().is_empty(),
         Value::Map(m) => m.count() == 0,
@@ -1659,7 +1659,7 @@ pub unsafe extern "C" fn rt_is_empty(coll: *const Value) -> *const Value {
 /// `coll` must be a valid pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_first(coll: *const Value) -> *const Value {
-    let coll_ref = unsafe { val_ref(coll) };
+    let coll_ref = unsafe { val_ref(coll) }.unwrap_meta();
     match coll_ref {
         // Return interior pointer for Vector — no alloc needed.
         Value::Vector(v) => match v.get().nth(0) {
@@ -1691,7 +1691,7 @@ pub unsafe extern "C" fn rt_first(coll: *const Value) -> *const Value {
 /// `coll` must be a valid pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_rest(coll: *const Value) -> *const Value {
-    let coll_ref = unsafe { val_ref(coll) };
+    let coll_ref = unsafe { val_ref(coll) }.unwrap_meta();
     match coll_ref {
         Value::List(l) => {
             let rest = (*l.get().rest()).clone();
@@ -1753,7 +1753,7 @@ pub unsafe extern "C" fn rt_assoc(
     k: *const Value,
     v: *const Value,
 ) -> *const Value {
-    let m = unsafe { val_ref(m) };
+    let m = unsafe { val_ref(m) }.unwrap_meta();
     let k = unsafe { val_ref(k) }.clone();
     let v = unsafe { val_ref(v) }.clone();
     match m {
@@ -1779,7 +1779,7 @@ pub unsafe extern "C" fn rt_assoc(
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_conj(coll: *const Value, val: *const Value) -> *const Value {
-    let coll = unsafe { val_ref(coll) };
+    let coll = unsafe { val_ref(coll) }.unwrap_meta();
     let val = unsafe { val_ref(val) }.clone();
     match coll {
         Value::Vector(v) => {
@@ -2687,14 +2687,17 @@ pub unsafe extern "C" fn rt_is_seq(v: *const Value) -> *const Value {
 /// `v` must be a valid pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_is_vector(v: *const Value) -> *const Value {
-    intern_bool(matches!(unsafe { val_ref(v) }, Value::Vector(_)))
+    intern_bool(matches!(
+        unsafe { val_ref(v) }.unwrap_meta(),
+        Value::Vector(_)
+    ))
 }
 
 /// # Safety
 /// `v` must be a valid pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_is_map(v: *const Value) -> *const Value {
-    intern_bool(matches!(unsafe { val_ref(v) }, Value::Map(_)))
+    intern_bool(matches!(unsafe { val_ref(v) }.unwrap_meta(), Value::Map(_)))
 }
 
 // ── Identity ────────────────────────────────────────────────────────────────
@@ -2776,7 +2779,7 @@ pub unsafe extern "C" fn rt_with_out_str(body_fn: *const Value) -> *const Value 
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_dissoc(m: *const Value, k: *const Value) -> *const Value {
-    let m = unsafe { val_ref(m) };
+    let m = unsafe { val_ref(m) }.unwrap_meta();
     let k = unsafe { val_ref(k) };
     match m {
         Value::Map(map) => box_coll_val(Value::Map(map.dissoc(k))),
@@ -2790,7 +2793,7 @@ pub unsafe extern "C" fn rt_dissoc(m: *const Value, k: *const Value) -> *const V
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_disj(set: *const Value, val: *const Value) -> *const Value {
-    let set = unsafe { val_ref(set) };
+    let set = unsafe { val_ref(set) }.unwrap_meta();
     let val = unsafe { val_ref(val) };
     match set {
         Value::Set(s) => box_coll_val(Value::Set(s.disj(val))),
@@ -2804,7 +2807,7 @@ pub unsafe extern "C" fn rt_disj(set: *const Value, val: *const Value) -> *const
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_nth(coll: *const Value, idx: *const Value) -> *const Value {
-    let coll = unsafe { val_ref(coll) };
+    let coll = unsafe { val_ref(coll) }.unwrap_meta();
     let idx = unsafe { val_ref(idx) };
     let i = match idx {
         Value::Long(n) => *n as usize,
@@ -2834,7 +2837,7 @@ pub unsafe extern "C" fn rt_nth(coll: *const Value, idx: *const Value) -> *const
 /// Both pointers must be valid.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_contains(coll: *const Value, key: *const Value) -> *const Value {
-    let coll = unsafe { val_ref(coll) };
+    let coll = unsafe { val_ref(coll) }.unwrap_meta();
     let key = unsafe { val_ref(key) };
     let result = match coll {
         Value::Map(m) => m.contains_key(key),
@@ -2860,7 +2863,7 @@ pub unsafe extern "C" fn rt_contains(coll: *const Value, key: *const Value) -> *
 /// `coll` must be a valid pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rt_seq(coll: *const Value) -> *const Value {
-    let coll_ref = unsafe { val_ref(coll) };
+    let coll_ref = unsafe { val_ref(coll) }.unwrap_meta();
     match coll_ref {
         Value::Nil => rt_const_nil(),
         Value::List(l) => {
@@ -2960,7 +2963,7 @@ pub unsafe extern "C" fn rt_lazy_seq(thunk_fn: *const Value) -> *const Value {
 pub unsafe extern "C" fn rt_transient(coll: *const Value) -> *const Value {
     use cljrs_value::collections::{TransientMap, TransientSet, TransientVector};
 
-    let coll = unsafe { val_ref(coll) };
+    let coll = unsafe { val_ref(coll) }.unwrap_meta();
     match coll {
         Value::Vector(v) => box_val(Value::TransientVector(GcPtr::new(
             TransientVector::new_from_vector(v.get().inner()),
@@ -3117,6 +3120,13 @@ pub unsafe extern "C" fn rt_atom_swap(
                 args.extend(extra.iter().cloned());
                 match cljrs_env::callback::invoke(&f, args) {
                     Ok(new_val) => {
+                        // Heap-promotion fallback (see `Atom::reset`): an atom
+                        // is program-lifetime shared state, so a region-tagged
+                        // value must be deep-copied to the GC heap (or the
+                        // region poisoned) *before* it is stored here — this
+                        // CAS loop bypasses `Atom::reset`, so it must run the
+                        // barrier itself instead of silently skipping it.
+                        let new_val = cljrs_value::publish::publish_value(new_val);
                         let mut guard = a.get().value.lock().unwrap();
                         if *guard == current {
                             *guard = new_val.clone();

--- a/crates/cljrs-eval/src/ir_interp.rs
+++ b/crates/cljrs-eval/src/ir_interp.rs
@@ -1173,8 +1173,14 @@ fn dispatch_known_fn(known_fn: &KnownFn, args: Vec<Value>, env: &mut Env) -> Eva
             args.first(),
             Some(Value::List(_) | Value::Cons(_) | Value::LazySeq(_))
         ))),
-        KnownFn::IsVector => Ok(Value::Bool(matches!(args.first(), Some(Value::Vector(_))))),
-        KnownFn::IsMap => Ok(Value::Bool(matches!(args.first(), Some(Value::Map(_))))),
+        KnownFn::IsVector => Ok(Value::Bool(matches!(
+            args.first().map(Value::unwrap_meta),
+            Some(Value::Vector(_))
+        ))),
+        KnownFn::IsMap => Ok(Value::Bool(matches!(
+            args.first().map(Value::unwrap_meta),
+            Some(Value::Map(_))
+        ))),
         KnownFn::IsNumber => Ok(Value::Bool(matches!(
             args.first(),
             Some(

--- a/crates/cljrs/tests/jit_seam_correctness.rs
+++ b/crates/cljrs/tests/jit_seam_correctness.rs
@@ -302,3 +302,42 @@ fn collection_ops_see_through_metadata_under_jit() {
         "final results wrong; got:\n{out}"
     );
 }
+
+#[test]
+fn assoc_conj_dissoc_disj_preserve_metadata_under_jit() {
+    // rt_assoc/rt_conj/rt_dissoc/rt_disj unwrap_meta() the input to dispatch
+    // on the underlying collection kind, but the *result* they build is a
+    // brand new collection with no metadata of its own. cljrs-builtins'
+    // builtin_assoc/conj/dissoc/disj all capture the input's metadata before
+    // unwrapping and reattach it to the result (`(meta (assoc ^{:a 1} {} :b
+    // 2))` => `{:a 1}` in real Clojure) — the rt_abi fast paths must match
+    // that, not just return a correct but metadata-stripped value.
+    let src = r#"
+        (def impl {:x 1})
+        (def m (with-meta {:a 1} impl))
+        (def v (with-meta [1] impl))
+        (def s (with-meta #{1 2} impl))
+
+        (defn assoc-it [] (meta (assoc m :b 2)))
+        (defn conj-it [] (meta (conj v 2)))
+        (defn dissoc-it [] (meta (dissoc m :a)))
+        (defn disj-it [] (meta (disj s 1)))
+
+        (dotimes [i 10000]
+          (let [a (assoc-it) c (conj-it) d (dissoc-it) j (disj-it)]
+            (when (or (not= a impl) (not= c impl) (not= d impl) (not= j impl))
+              (println "WRONG at" i ":" a c d j))
+            (when (= i 9999)
+              (println "final:" a c d j))))
+    "#;
+
+    let out = run_jit(src);
+    assert!(
+        !out.contains("WRONG at"),
+        "assoc/conj/dissoc/disj dropped metadata under JIT; got:\n{out}"
+    );
+    assert!(
+        out.contains("final: {:x 1} {:x 1} {:x 1} {:x 1}"),
+        "final results wrong; got:\n{out}"
+    );
+}

--- a/crates/cljrs/tests/jit_seam_correctness.rs
+++ b/crates/cljrs/tests/jit_seam_correctness.rs
@@ -242,3 +242,63 @@ fn macro_generated_case_with_int_cast_correct_under_jit() {
         "case with integer keys produced wrong final values; got:\n{out}"
     );
 }
+
+#[test]
+fn collection_ops_see_through_metadata_under_jit() {
+    // rt_abi's fast-path collection ops (rt_get, rt_count, rt_first, rt_rest,
+    // rt_assoc, rt_conj, rt_dissoc, rt_disj, rt_nth, rt_contains, rt_seq,
+    // rt_is_empty, rt_is_vector, rt_is_map, rt_transient) matched on the raw
+    // `Value` variant, unlike their tree-walker counterparts in
+    // cljrs-builtins, which all call `.unwrap_meta()` first. A
+    // metadata-carrying collection (`with-meta`) — e.g. a protocol
+    // implementation map built via `(with-meta {...} impl)`, the idiom
+    // Replicant's mutation-log renderer uses — therefore fell through every
+    // fast path's `_` arm once the caller crossed the JIT threshold: `get`
+    // silently returned nil, `count`/`contains?`/`empty?` reported wrong
+    // answers, `first`/`rest`/`nth`/`seq` returned nil/empty, and
+    // `assoc`/`conj`/`dissoc`/`disj` returned the value unchanged instead of
+    // updating it. Interpreted code (Tier 0/1) was always correct; only
+    // native-compiled call sites were affected.
+    let src = r#"
+        (def impl {:some-method (fn [x] x)})
+        (def m (with-meta {:a 1 :b 2} impl))
+        (def v (with-meta [1 2 3] impl))
+
+        (defn get-a [] (:a m))
+        (defn cnt [] (count m))
+        (defn has-a [] (contains? m :a))
+        (defn is-empty [] (empty? (with-meta {} impl)))
+        (defn is-vec [] (vector? v))
+        (defn is-map [] (map? m))
+        (defn first-of [] (first v))
+        (defn rest-of [] (rest v))
+        (defn nth-of [] (nth v 1))
+        (defn seq-of [] (seq v))
+        (defn assoc-into [] (:c (assoc m :c 3)))
+        (defn conj-into [] (conj v 4))
+        (defn dissoc-from [] (contains? (dissoc m :a) :a))
+
+        (dotimes [i 10000]
+          (let [a (get-a) c (cnt) h (has-a) e (is-empty)
+                iv (is-vec) im (is-map) f (first-of) r (rest-of)
+                n (nth-of) s (seq-of) ai (assoc-into) cj (conj-into)
+                d (dissoc-from)]
+            (when (or (not= a 1) (not= c 2) (not= h true) (not= e true)
+                      (not= iv true) (not= im true) (not= f 1)
+                      (not= (vec r) [2 3]) (not= n 2) (not= (vec s) [1 2 3])
+                      (not= ai 3) (not= cj [1 2 3 4]) (not= d false))
+              (println "WRONG at" i ":" a c h e iv im f r n s ai cj d))
+            (when (= i 9999)
+              (println "final:" a c h e iv im f (vec r) n (vec s) ai cj d))))
+    "#;
+
+    let out = run_jit(src);
+    assert!(
+        !out.contains("WRONG at"),
+        "collection ops on a with-meta value returned wrong results under JIT; got:\n{out}"
+    );
+    assert!(
+        out.contains("final: 1 2 true true true true 1 [2 3] 2 [1 2 3] 3 [1 2 3 4] false"),
+        "final results wrong; got:\n{out}"
+    );
+}


### PR DESCRIPTION
rt_abi.rs's fast-path collection builtins (rt_get, rt_count, rt_first, rt_rest, rt_assoc, rt_conj, rt_dissoc, rt_disj, rt_nth, rt_contains, rt_seq, rt_is_empty, rt_is_vector, rt_is_map, rt_transient) matched directly on the raw Value variant, unlike their cljrs-builtins tree-walker counterparts, which all call .unwrap_meta() first. A metadata-carrying collection (any `(with-meta coll m)` — notably a protocol-implementation map built via `(with-meta {...} impl)`, the idiom Replicant's mutation-log renderer uses for its renderer/DOM-node objects) is `Value::WithMeta(inner, meta)`, so it fell through every fast path's `_` arm once the calling function crossed the JIT threshold: get silently returned nil, count/contains?/empty? reported wrong answers, first/rest/nth/seq returned nil/empty, and assoc/conj/dissoc/disj returned the value completely unchanged instead of updating it. Interpreted code (tree-walk and Tier-1 IR) was unaffected except for two inline predicates in ir_interp.rs's own dispatch_known_fn (IsVector/IsMap) that had the identical gap independent of JIT.

This was the actual root cause of the "stale children after promotion" defect (examples/cljrs-wasm/probes/39_stale_children_after_promotion.cljrs in Replicant's cljrs-port branch): an existing DOM node's text/children read back as empty once the reader function crossed --jit-threshold, because the renderer object being read (a with-meta-wrapped map) fell through rt_get's fast path. Verified against Replicant's full test suite under default settings (JIT enabled, no --ir-threshold workaround): stable 231-232 passed / 13-14 failed / 1 error across repeated runs, matching the project's own documented clean baseline (previously only reachable with --ir-threshold disabled) — no crashes, no data corruption, only the pre-existing, already-catalogued semantic issues unrelated to this defect.


Claude-Session: https://claude.ai/code/session_01KsszvNRDiEC42BipoTjVVE