### PR TITLE
Fix filter/keep to return () instead of nil for zero matches

### DIFF
--- a/crates/cljrs-builtins/src/bootstrap.cljrs
+++ b/crates/cljrs-builtins/src/bootstrap.cljrs
@@ -118,7 +118,7 @@
        (if (pred (first s))
          (recur (next s) (conj acc (first s)))
          (recur (next s) acc))
-       (seq acc)))))
+       (or (seq acc) '())))))
 
 (defn remove
   ([pred] (filter (complement pred)))
@@ -140,7 +140,7 @@
          (if (nil? v)
            (recur (next s) acc)
            (recur (next s) (conj acc v))))
-       (seq acc)))))
+       (or (seq acc) '())))))
 
 (defn cat
   "A transducer which concatenates the contents of each input, which must


### PR DESCRIPTION
Matches real Clojure semantics where filter and keep always return a
seq (possibly empty), never nil. remove, filterv, and other callers
that funnel through the compiled/JIT paths (rt_filter, KnownFn::Filter,
etc.) all delegate to this same clojure.core/filter definition, so the
fix applies uniformly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SXSyWNa2Khh6EehMgYwHXH