### PR TITLE
Fix tree-seq always returning nil

### DIFF
--- a/crates/cljrs-builtins/src/bootstrap.cljrs
+++ b/crates/cljrs-builtins/src/bootstrap.cljrs
@@ -185,6 +185,21 @@
                             (map next seqs))))))]
      (step nil (map seq all-colls)))))
 
+(defn tree-seq
+  "Returns a lazy sequence of the nodes in a tree, via a depth-first walk.
+  branch? must be a fn of one arg that returns true if passed a node
+  that can have children (but may not).  children must be a fn of one
+  arg that returns a sequence of the children. Will only be called on
+  nodes for which branch? returns true. Root is the root node of the
+  tree."
+  [branch? children root]
+  (let [walk (fn walk [node]
+               (lazy-seq
+                 (cons node
+                       (when (branch? node)
+                         (mapcat walk (children node))))))]
+    (walk root)))
+
 (defn take
   ([n]
    (fn [rf]

--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -458,7 +458,6 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         ("walk", Arity::Fixed(3), builtin_walk_stub),
         ("postwalk", Arity::Fixed(2), builtin_postwalk_stub),
         ("prewalk", Arity::Fixed(2), builtin_prewalk_stub),
-        ("tree-seq", Arity::Fixed(3), builtin_tree_seq_stub),
         ("printf", Arity::Variadic { min: 1 }, builtin_printf),
         ("newline", Arity::Fixed(0), builtin_newline),
         ("flush", Arity::Fixed(0), builtin_flush),
@@ -6745,10 +6744,6 @@ fn builtin_postwalk_stub(_args: &[Value]) -> ValueResult<Value> {
 }
 
 fn builtin_prewalk_stub(_args: &[Value]) -> ValueResult<Value> {
-    Ok(Value::Nil)
-}
-
-fn builtin_tree_seq_stub(_args: &[Value]) -> ValueResult<Value> {
     Ok(Value::Nil)
 }
 


### PR DESCRIPTION
tree-seq was registered as a native builtin backed by a stub that
unconditionally returned nil. Implement it in Clojure in bootstrap.cljrs
(matching how map/filter/mapcat are implemented) as a lazy depth-first
walk, and drop the dead native stub/registration.