### PR TITLE
Fix assoc-in discarding existing keys on metadata-carrying maps

### DIFF
--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -4544,18 +4544,29 @@ fn assoc_in_impl(m: Value, keys: &[Value], val: Value) -> ValueResult<Value> {
     if keys.is_empty() {
         return Ok(val);
     }
+    // Unwrap metadata (like `get`/`assoc` do) so a map carrying meta isn't
+    // mistaken for a non-map and blown away to a fresh single-key map.
+    let meta = m.get_meta().cloned();
+    let base = m.unwrap_meta();
     let k = &keys[0];
-    let inner = match &m {
+    let inner = match base {
         Value::Map(map) => map.get(k).unwrap_or(Value::Nil),
-        Value::Nil => Value::Nil,
+        Value::TypeInstance(ti) => ti.get().fields.get(k).unwrap_or(Value::Nil),
         _ => Value::Nil,
     };
     let updated = assoc_in_impl(inner, &keys[1..], val)?;
-    match m {
-        Value::Map(map) => Ok(Value::Map(map.assoc(k.clone(), updated))),
-        Value::Nil => Ok(Value::Map(MapValue::empty().assoc(k.clone(), updated))),
-        _ => Ok(Value::Map(MapValue::empty().assoc(k.clone(), updated))),
-    }
+    let result = match base {
+        Value::Map(map) => Value::Map(map.assoc(k.clone(), updated)),
+        Value::TypeInstance(ti) => Value::TypeInstance(GcPtr::new(TypeInstance {
+            type_tag: ti.get().type_tag.clone(),
+            fields: ti.get().fields.assoc(k.clone(), updated),
+        })),
+        _ => Value::Map(MapValue::empty().assoc(k.clone(), updated)),
+    };
+    Ok(match meta {
+        Some(meta) => result.with_meta(meta),
+        None => result,
+    })
 }
 
 fn builtin_update_in_stub(_args: &[Value]) -> ValueResult<Value> {

--- a/crates/cljrs-interp/tests/assoc_in_metadata.rs
+++ b/crates/cljrs-interp/tests/assoc_in_metadata.rs
@@ -45,7 +45,10 @@ fn assoc_in_preserves_metadata_on_map() {
     let meta_val = eval_fresh(
         "(:parent (meta (assoc-in (with-meta {:tag-name \"h1\"} {:parent :root}) [:on :click] :handler)))",
     );
-    assert_eq!(meta_val, Value::keyword(cljrs_value::Keyword::simple("root")));
+    assert_eq!(
+        meta_val,
+        Value::keyword(cljrs_value::Keyword::simple("root"))
+    );
 }
 
 #[test]

--- a/crates/cljrs-interp/tests/assoc_in_metadata.rs
+++ b/crates/cljrs-interp/tests/assoc_in_metadata.rs
@@ -1,0 +1,55 @@
+//! Regression test: `assoc-in` must preserve the existing keys (and metadata)
+//! of its target map when that map carries metadata. Previously the match
+//! was on the raw `WithMeta`-wrapped value instead of the unwrapped value,
+//! so a metadata-carrying map fell through to the "not a map" branch and
+//! `assoc-in` silently discarded every existing key, returning a fresh map
+//! containing only the newly assoc'd path.
+
+use std::sync::Arc;
+
+use cljrs_env::env::{Env, GlobalEnv};
+use cljrs_reader::Parser;
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_interp::standard_env(None, None, None);
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Value {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_interp::eval::eval(&form, &mut env).expect("eval error");
+    }
+    result
+}
+
+#[test]
+fn assoc_in_preserves_existing_keys_on_map_with_metadata() {
+    let count = eval_fresh(
+        "(count (assoc-in (with-meta {:tag-name \"h1\" :children []} {:parent :root}) [:on :click] :handler))",
+    );
+    assert_eq!(
+        count,
+        Value::Long(3),
+        "assoc-in must keep the map's existing keys, not just the new path"
+    );
+}
+
+#[test]
+fn assoc_in_preserves_metadata_on_map() {
+    let meta_val = eval_fresh(
+        "(:parent (meta (assoc-in (with-meta {:tag-name \"h1\"} {:parent :root}) [:on :click] :handler)))",
+    );
+    assert_eq!(meta_val, Value::keyword(cljrs_value::Keyword::simple("root")));
+}
+
+#[test]
+fn assoc_in_without_metadata_still_works() {
+    let count = eval_fresh("(count (assoc-in {:a {:b 1}} [:a :c] 2))");
+    assert_eq!(count, Value::Long(1));
+}


### PR DESCRIPTION
assoc_in_impl matched on the raw WithMeta-wrapped value instead of
unwrapping it first, so a map carrying metadata (e.g. a Replicant
element's parent back-reference) fell through to the "not a map"
branch and was replaced by a fresh map containing only the newly
assoc'd path, silently discarding every other key and the metadata.

Mirrors the existing unwrap/rewrap pattern already used by
builtin_assoc/builtin_get, and adds TypeInstance (defrecord) support
for consistency.