### PR TITLE
Make hash-map and hash-set iteration order deterministic and insertion-ordered

### DIFF
--- a/crates/cljrs-builtins/src/builtins.rs
+++ b/crates/cljrs-builtins/src/builtins.rs
@@ -31,7 +31,6 @@ use num_bigint::{BigInt, Sign, ToBigInt};
 use num_rational::Ratio;
 use num_traits::{FromPrimitive, Signed as _, ToPrimitive, Zero as _};
 use rand::prelude::SliceRandom;
-use rpds::HashTrieMapSync;
 use std::cmp::Ordering;
 use std::num::ParseFloatError;
 use std::ops::{Add, Sub};
@@ -4823,7 +4822,7 @@ fn seq_first_rest(v: &Value) -> ValueResult<Option<(Value, Value)>> {
 }
 
 fn builtin_select_keys(args: &[Value]) -> ValueResult<Value> {
-    let mut map: HashTrieMapSync<Value, Value> = HashTrieMapSync::new_sync();
+    let mut map = PersistentHashMap::empty();
     match &args[0] {
         Value::Map(src) => {
             if matches!(
@@ -4838,12 +4837,10 @@ fn builtin_select_keys(args: &[Value]) -> ValueResult<Value> {
             ) {
                 for k in ValueIter::new(args[1].clone()) {
                     if let Some(v) = src.get(&k) {
-                        map.insert_mut(k.clone(), v.clone());
+                        map = map.assoc(k.clone(), v.clone());
                     }
                 }
-                Ok(Value::Map(MapValue::Hash(GcPtr::new(
-                    PersistentHashMap::new(map),
-                ))))
+                Ok(Value::Map(MapValue::Hash(GcPtr::new(map))))
             } else {
                 Err(ValueError::WrongType {
                     expected: "seqable",

--- a/crates/cljrs-builtins/src/transients.rs
+++ b/crates/cljrs-builtins/src/transients.rs
@@ -15,10 +15,10 @@ pub fn builtin_transient(args: &[Value]) -> ValueResult<Value> {
             Ok(Value::TransientMap(GcPtr::new(map)))
         }
         Value::Map(MapValue::Hash(m)) => Ok(Value::TransientMap(GcPtr::new(
-            TransientMap::new_from_map(m.get().inner()),
+            TransientMap::new_from_map(m.get()),
         ))),
         Value::Set(SetValue::Hash(s)) => Ok(Value::TransientSet(GcPtr::new(
-            TransientSet::new_from_set(s.get().inner()),
+            TransientSet::new_from_set(s.get()),
         ))),
         Value::Vector(v) => Ok(Value::TransientVector(GcPtr::new(
             TransientVector::new_from_vector(v.get().inner()),

--- a/crates/cljrs-compiler/src/rt_abi.rs
+++ b/crates/cljrs-compiler/src/rt_abi.rs
@@ -3004,10 +3004,10 @@ pub unsafe extern "C" fn rt_transient(coll: *const Value) -> *const Value {
             TransientVector::new_from_vector(v.get().inner()),
         ))),
         Value::Map(MapValue::Hash(m)) => box_val(Value::TransientMap(GcPtr::new(
-            TransientMap::new_from_map(m.get().inner()),
+            TransientMap::new_from_map(m.get()),
         ))),
         Value::Set(SetValue::Hash(s)) => box_val(Value::TransientSet(GcPtr::new(
-            TransientSet::new_from_set(s.get().inner()),
+            TransientSet::new_from_set(s.get()),
         ))),
         _ => box_val(coll.clone()),
     }

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -36,8 +36,8 @@ src/
   collections/
     mod.rs                       — re-exports all collection types
     array_map.rs                 — PersistentArrayMap (≤8 entries, linear scan)
-    hash_map.rs                  — PersistentHashMap (32-way HAMT)
-    hash_set.rs                  — PersistentHashSet (backed by PersistentHashMap)
+    hash_map.rs                  — PersistentHashMap (32-way HAMT keyed by insertion-sequence index + a red-black tree ordering log, so iteration order matches insertion order deterministically)
+    hash_set.rs                  — PersistentHashSet (same index+ordering-log technique as PersistentHashMap)
     list.rs                      — PersistentList (singly-linked cons list)
     queue.rs                     — PersistentQueue (front-list + rear-vector)
     vector.rs                    — PersistentVector (32-way trie + tail buffer)
@@ -229,8 +229,8 @@ Whole-number doubles hash like their `Long` equivalent.
 | `PersistentList` | Singly-linked cons list | `cons`, `first`, `rest`, `count` (O(1)) |
 | `PersistentVector` | 32-way trie + tail buffer | `conj`, `nth`, `assoc_nth`, `pop`, `iter`, `map_entry`, `is_map_entry` |
 | `PersistentArrayMap` | Flat key/value vec, ≤8 entries | `assoc` (returns `AssocResult`), `get`, `dissoc`, `iter` |
-| `PersistentHashMap` | 32-way HAMT | `assoc`, `get`, `dissoc`, `merge`, `iter`, `keys`, `vals` |
-| `PersistentHashSet` | Backed by `PersistentHashMap` | `conj`, `disj`, `contains`, `iter` |
+| `PersistentHashMap` | 32-way HAMT index (key→seq) + red-black ordering log (seq→(key,val)); iterates in insertion order | `assoc`, `get`, `dissoc`, `merge`, `iter`, `keys`, `vals` |
+| `PersistentHashSet` | Same index+ordering-log technique; iterates in insertion order | `conj`, `disj`, `contains`, `iter` |
 | `PersistentQueue` | Front-list + rear-vector | `enqueue`, `dequeue`, `peek` |
 
 `PersistentArrayMap::assoc` returns `AssocResult::Array(Self)` while under the
@@ -257,8 +257,8 @@ bytes owned by each collection beyond the GcBox struct.  Approximations used:
 | Type | Formula |
 |------|---------|
 | `PersistentArrayMap` | `16 + capacity × size_of::<Value>()` |
-| `PersistentHashMap` | `n × (40 + 2×size_of::<Value>())` |
-| `PersistentHashSet` | `n × (40 + size_of::<Value>())` |
+| `PersistentHashMap` | `n × (88 + 2×size_of::<Value>())` |
+| `PersistentHashSet` | `n × (88 + size_of::<Value>())` |
 | `PersistentVector` | `n × (24 + size_of::<Value>())` |
 | `SortedMap` | `n × (40 + 2×size_of::<Value>())` |
 | `TransientMap/Set` | same as HashMap/Set (locked at alloc) |

--- a/crates/cljrs-value/src/collections/hash_map.rs
+++ b/crates/cljrs-value/src/collections/hash_map.rs
@@ -258,9 +258,7 @@ mod tests {
     #[test]
     fn test_iteration_order_matches_insertion_order() {
         let mut m = PersistentHashMap::empty();
-        let keys = [
-            "j", "i", "h", "g", "f", "e", "d", "c", "b", "a", "z", "y",
-        ];
+        let keys = ["j", "i", "h", "g", "f", "e", "d", "c", "b", "a", "z", "y"];
         for k in keys {
             m = m.assoc(kw(k), int(0));
         }

--- a/crates/cljrs-value/src/collections/hash_map.rs
+++ b/crates/cljrs-value/src/collections/hash_map.rs
@@ -1,84 +1,122 @@
 use crate::Value;
 use crate::collections::array_map::PersistentArrayMap;
-use rpds::HashTrieMapSync;
+use rpds::{HashTrieMapSync, RedBlackTreeMapSync};
 
-/// An immutable hash map backed by `rpds::HashTrieMap`.
+/// An immutable hash map that preserves insertion order when iterated.
+///
+/// Lookups go through a `rpds::HashTrieMap` from key to insertion sequence
+/// number; the sequence number then indexes a `rpds::RedBlackTreeMap` that
+/// holds the actual `(key, value)` pairs in insertion order. Re-associating
+/// an existing key keeps its original position (matching `PersistentArrayMap`
+/// and how most ordered-map implementations behave), so iteration order is
+/// deterministic and matches the order keys were first written, rather than
+/// depending on hash-bucket layout (which — since `rpds` seeds its hasher
+/// randomly per instance — would otherwise vary from run to run).
 ///
 /// Small maps (≤8 entries) are represented as `PersistentArrayMap` instead;
 /// the two types share the same `Value::Map` variant.  `PersistentHashMap` is
 /// used once the entry count exceeds the array-map threshold.
 #[derive(Debug, Clone)]
 pub struct PersistentHashMap {
-    inner: rpds::HashTrieMapSync<Value, Value>,
+    index: HashTrieMapSync<Value, u64>,
+    order: RedBlackTreeMapSync<u64, (Value, Value)>,
+    next_seq: u64,
 }
 
 impl PersistentHashMap {
     pub fn empty() -> Self {
         Self {
-            inner: rpds::HashTrieMapSync::new_sync(),
+            index: HashTrieMapSync::new_sync(),
+            next_seq: 0,
+            order: RedBlackTreeMapSync::new_sync(),
         }
     }
 
+    /// Build from a raw `HashTrieMap`, in its (arbitrary) iteration order.
+    ///
+    /// Prefer `from_pairs`/`assoc` when the caller has a meaningful source
+    /// order to preserve.
     pub fn new(map: HashTrieMapSync<Value, Value>) -> Self {
-        Self { inner: map }
+        Self::from_pairs(map.iter().map(|(k, v)| (k.clone(), v.clone())))
     }
 
     pub fn count(&self) -> usize {
-        self.inner.size()
+        self.index.size()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+        self.index.is_empty()
     }
 
     /// Look up a key.
     pub fn get(&self, key: &Value) -> Option<&Value> {
-        self.inner.get(key)
+        let seq = self.index.get(key)?;
+        self.order.get(seq).map(|(_, v)| v)
     }
 
     pub fn contains_key(&self, key: &Value) -> bool {
-        self.inner.contains_key(key)
+        self.index.contains_key(key)
     }
 
     /// Return a new map with `key` → `value`.
+    ///
+    /// Re-associating a key that is already present keeps its original
+    /// insertion position; a brand-new key is appended at the end.
     pub fn assoc(&self, key: Value, value: Value) -> Self {
-        Self {
-            inner: self.inner.insert(key, value),
+        if let Some(seq) = self.index.get(&key) {
+            let seq = *seq;
+            Self {
+                index: self.index.clone(),
+                order: self.order.insert(seq, (key, value)),
+                next_seq: self.next_seq,
+            }
+        } else {
+            let seq = self.next_seq;
+            Self {
+                index: self.index.insert(key.clone(), seq),
+                order: self.order.insert(seq, (key, value)),
+                next_seq: seq + 1,
+            }
         }
     }
 
     /// Return a new map with `key` removed.
     pub fn dissoc(&self, key: &Value) -> Self {
-        Self {
-            inner: self.inner.remove(key),
+        match self.index.get(key) {
+            Some(seq) => Self {
+                index: self.index.remove(key),
+                order: self.order.remove(seq),
+                next_seq: self.next_seq,
+            },
+            None => self.clone(),
         }
     }
 
-    /// Iterate over all `(key, value)` pairs in an unspecified order.
+    /// Iterate over all `(key, value)` pairs in insertion order.
     pub fn iter(&self) -> impl Iterator<Item = (&Value, &Value)> {
-        self.inner.iter()
+        self.order.iter().map(|(_, (k, v))| (k, v))
     }
 
-    /// Collect all keys.
+    /// Collect all keys, in insertion order.
     pub fn keys(&self) -> Vec<Value> {
-        self.inner.keys().cloned().collect()
+        self.iter().map(|(k, _)| k.clone()).collect()
     }
 
-    /// Collect all values.
+    /// Collect all values, in insertion order.
     pub fn vals(&self) -> Vec<Value> {
-        self.inner.values().cloned().collect()
+        self.iter().map(|(_, v)| v.clone()).collect()
     }
 
     /// Merge two maps; right-hand side wins on key collision.
     pub fn merge(&self, other: &Self) -> Self {
         let mut result = self.clone();
-        for (k, v) in other.inner.iter() {
+        for (k, v) in other.iter() {
             result = result.assoc(k.clone(), v.clone());
         }
         result
     }
 
-    /// Build from an iterator of `(key, value)` pairs.
+    /// Build from an iterator of `(key, value)` pairs, in the given order.
     pub fn from_pairs<I: IntoIterator<Item = (Value, Value)>>(iter: I) -> Self {
         let mut m = Self::empty();
         for (k, v) in iter {
@@ -91,10 +129,6 @@ impl PersistentHashMap {
     pub fn from_array_map(am: &PersistentArrayMap) -> Self {
         Self::from_pairs(am.iter().map(|(k, v)| (k.clone(), v.clone())))
     }
-
-    pub fn inner(&self) -> &HashTrieMapSync<Value, Value> {
-        &self.inner
-    }
 }
 
 impl PartialEq for PersistentHashMap {
@@ -102,23 +136,23 @@ impl PartialEq for PersistentHashMap {
         if self.count() != other.count() {
             return false;
         }
-        self.inner.iter().all(|(k, v)| other.get(k) == Some(v))
+        self.iter().all(|(k, v)| other.get(k) == Some(v))
     }
 }
 
 impl cljrs_gc::Trace for PersistentHashMap {
     fn trace(&self, visitor: &mut cljrs_gc::MarkVisitor) {
-        for (k, v) in self.inner.iter() {
+        for (_, (k, v)) in self.order.iter() {
             k.trace(visitor);
             v.trace(visitor);
         }
     }
 
     fn gc_size_extra(&self) -> usize {
-        // Per entry: Arc<(K,V)> allocation (16 overhead) + EntryWithHash (16)
-        // + tree-node share (~8). Values stored inline (not behind GcPtr).
-        let n = self.inner.size();
-        n * (40 + 2 * std::mem::size_of::<Value>())
+        // Per entry: index HashTrieMap entry (~40) + order RedBlackTree node
+        // (~48) + values stored inline in the order tree (not behind GcPtr).
+        let n = self.index.size();
+        n * (88 + 2 * std::mem::size_of::<Value>())
     }
 }
 
@@ -219,5 +253,41 @@ mod tests {
         for i in 0..3i64 {
             assert_eq!(hm.get(&int(i)), Some(&int(i * 2)));
         }
+    }
+
+    #[test]
+    fn test_iteration_order_matches_insertion_order() {
+        let mut m = PersistentHashMap::empty();
+        let keys = [
+            "j", "i", "h", "g", "f", "e", "d", "c", "b", "a", "z", "y",
+        ];
+        for k in keys {
+            m = m.assoc(kw(k), int(0));
+        }
+        let iterated: Vec<Value> = m.keys();
+        let expected: Vec<Value> = keys.iter().map(|k| kw(k)).collect();
+        assert_eq!(iterated, expected);
+    }
+
+    #[test]
+    fn test_reassoc_keeps_original_position() {
+        let m = PersistentHashMap::empty()
+            .assoc(kw("a"), int(1))
+            .assoc(kw("b"), int(2))
+            .assoc(kw("c"), int(3))
+            .assoc(kw("b"), int(99));
+        let keys = m.keys();
+        assert_eq!(keys, vec![kw("a"), kw("b"), kw("c")]);
+        assert_eq!(m.get(&kw("b")), Some(&int(99)));
+    }
+
+    #[test]
+    fn test_dissoc_preserves_remaining_order() {
+        let m = PersistentHashMap::empty()
+            .assoc(kw("a"), int(1))
+            .assoc(kw("b"), int(2))
+            .assoc(kw("c"), int(3))
+            .dissoc(&kw("b"));
+        assert_eq!(m.keys(), vec![kw("a"), kw("c")]);
     }
 }

--- a/crates/cljrs-value/src/collections/hash_set.rs
+++ b/crates/cljrs-value/src/collections/hash_set.rs
@@ -1,70 +1,93 @@
 use crate::Value;
+use rpds::{HashTrieMapSync, RedBlackTreeMapSync};
 
-/// An immutable hash set backed by `rpds::HashTrieSet`.
+/// An immutable hash set that preserves insertion order when iterated.
+///
+/// Uses the same index-plus-ordered-log technique as `PersistentHashMap`:
+/// a `rpds::HashTrieMap` from value to insertion sequence number, and a
+/// `rpds::RedBlackTreeMap` from sequence number to value that is iterated in
+/// order. This keeps iteration deterministic and matching insertion order,
+/// rather than depending on hash-bucket layout — `rpds` seeds its hasher
+/// randomly per instance, so raw hash-order iteration would otherwise vary
+/// from run to run.
 #[derive(Debug, Clone)]
 pub struct PersistentHashSet {
-    inner: rpds::HashTrieSetSync<Value>,
+    index: HashTrieMapSync<Value, u64>,
+    order: RedBlackTreeMapSync<u64, Value>,
+    next_seq: u64,
 }
 
 impl PersistentHashSet {
     pub fn empty() -> Self {
         Self {
-            inner: rpds::HashTrieSetSync::new_sync(),
+            index: HashTrieMapSync::new_sync(),
+            order: RedBlackTreeMapSync::new_sync(),
+            next_seq: 0,
         }
     }
 
-    pub fn from_set(set: rpds::HashTrieSetSync<Value>) -> Self {
-        Self { inner: set }
-    }
-
     pub fn count(&self) -> usize {
-        self.inner.size()
+        self.index.size()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+        self.index.is_empty()
     }
 
     pub fn contains(&self, val: &Value) -> bool {
-        self.inner.contains(val)
+        self.index.contains_key(val)
     }
 
     /// Return a new set with `val` added.
+    ///
+    /// If `val` is already present, its original insertion position is kept.
     pub fn conj(&self, val: Value) -> Self {
+        if self.index.contains_key(&val) {
+            return self.clone();
+        }
+        let seq = self.next_seq;
         Self {
-            inner: self.inner.insert(val),
+            index: self.index.insert(val.clone(), seq),
+            order: self.order.insert(seq, val),
+            next_seq: seq + 1,
         }
     }
 
     pub fn conj_mut(&mut self, val: Value) -> &mut Self {
-        self.inner.insert_mut(val);
+        if !self.index.contains_key(&val) {
+            let seq = self.next_seq;
+            self.index.insert_mut(val.clone(), seq);
+            self.order.insert_mut(seq, val);
+            self.next_seq = seq + 1;
+        }
         self
     }
 
     /// Return a new set with `val` removed.
     pub fn disj(&self, val: &Value) -> Self {
-        Self {
-            inner: self.inner.remove(val),
+        match self.index.get(val) {
+            Some(seq) => Self {
+                index: self.index.remove(val),
+                order: self.order.remove(seq),
+                next_seq: self.next_seq,
+            },
+            None => self.clone(),
         }
     }
 
-    /// Iterate over all elements in an unspecified order.
+    /// Iterate over all elements in insertion order.
     pub fn iter(&self) -> impl Iterator<Item = &Value> {
-        self.inner.iter()
-    }
-
-    pub fn inner(&self) -> &rpds::HashTrieSetSync<Value> {
-        &self.inner
+        self.order.iter().map(|(_, v)| v)
     }
 }
 
 impl FromIterator<Value> for PersistentHashSet {
     fn from_iter<I: IntoIterator<Item = Value>>(iter: I) -> Self {
-        let mut inner = rpds::HashTrieSetSync::new_sync();
+        let mut s = PersistentHashSet::empty();
         for v in iter {
-            inner.insert_mut(v)
+            s.conj_mut(v);
         }
-        Self { inner }
+        s
     }
 }
 
@@ -73,20 +96,22 @@ impl PartialEq for PersistentHashSet {
         if self.count() != other.count() {
             return false;
         }
-        self.inner.iter().all(|k| other.contains(k))
+        self.iter().all(|k| other.contains(k))
     }
 }
 
 impl cljrs_gc::Trace for PersistentHashSet {
     fn trace(&self, visitor: &mut cljrs_gc::MarkVisitor) {
-        for v in self.inner.iter() {
+        for (_, v) in self.order.iter() {
             v.trace(visitor);
         }
     }
 
     fn gc_size_extra(&self) -> usize {
-        let n = self.inner.size();
-        n * (40 + std::mem::size_of::<Value>())
+        // Per entry: index HashTrieMap entry (~40) + order RedBlackTree node
+        // (~48), value stored inline in the order tree (not behind GcPtr).
+        let n = self.index.size();
+        n * (88 + std::mem::size_of::<Value>())
     }
 }
 
@@ -129,5 +154,16 @@ mod tests {
         let a = PersistentHashSet::from_iter([int(1), int(2), int(3)]);
         let b = PersistentHashSet::from_iter([int(3), int(1), int(2)]);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_iteration_order_matches_insertion_order() {
+        let s = PersistentHashSet::empty()
+            .conj(int(10))
+            .conj(int(3))
+            .conj(int(7))
+            .conj(int(1));
+        let iterated: Vec<Value> = s.iter().cloned().collect();
+        assert_eq!(iterated, vec![int(10), int(3), int(7), int(1)]);
     }
 }

--- a/crates/cljrs-value/src/collections/transient_map.rs
+++ b/crates/cljrs-value/src/collections/transient_map.rs
@@ -12,19 +12,19 @@ use std::sync::Mutex;
 
 #[derive(Debug)]
 pub struct TransientMap {
-    map: Mutex<rpds::HashTrieMapSync<Value, Value>>,
+    map: Mutex<PersistentHashMap>,
     persisted: Mutex<bool>,
 }
 
 impl TransientMap {
     pub fn new() -> TransientMap {
         TransientMap {
-            map: Mutex::new(rpds::HashTrieMapSync::default()),
+            map: Mutex::new(PersistentHashMap::empty()),
             persisted: Mutex::new(false),
         }
     }
 
-    pub fn new_from_map(map: &rpds::HashTrieMapSync<Value, Value>) -> TransientMap {
+    pub fn new_from_map(map: &PersistentHashMap) -> TransientMap {
         TransientMap {
             map: Mutex::new(map.clone()),
             persisted: Mutex::new(false),
@@ -36,7 +36,7 @@ impl TransientMap {
             return Err(ValueError::TransientAlreadyPersisted);
         }
         let mut map = self.map.lock().unwrap();
-        map.insert_mut(key.clone(), value.clone());
+        *map = map.assoc(key, value);
         Ok(())
     }
 
@@ -45,7 +45,7 @@ impl TransientMap {
             return Err(ValueError::TransientAlreadyPersisted);
         }
         let mut map = self.map.lock().unwrap();
-        map.remove_mut(key);
+        *map = map.dissoc(key);
         Ok(())
     }
 
@@ -56,7 +56,7 @@ impl TransientMap {
             return Err(ValueError::TransientAlreadyPersisted);
         }
         *persisted = true;
-        Ok(PersistentHashMap::new(map.clone()))
+        Ok(map.clone())
     }
 
     pub fn find(&self, key: &Value) -> Option<(Value, Value)> {
@@ -67,7 +67,7 @@ impl TransientMap {
 
     pub fn count(&self) -> usize {
         let map = self.map.lock().unwrap();
-        map.size()
+        map.count()
     }
 }
 
@@ -105,8 +105,8 @@ impl cljrs_gc::Trace for TransientMap {
     }
 
     fn gc_size_extra(&self) -> usize {
-        let n = self.map.lock().unwrap().size();
-        n * (40 + 2 * std::mem::size_of::<crate::Value>())
+        let map = self.map.lock().unwrap();
+        map.gc_size_extra()
     }
 }
 

--- a/crates/cljrs-value/src/collections/transient_set.rs
+++ b/crates/cljrs-value/src/collections/transient_set.rs
@@ -4,19 +4,19 @@ use std::sync::Mutex;
 
 #[derive(Debug)]
 pub struct TransientSet {
-    set: Mutex<rpds::HashTrieSetSync<Value>>,
+    set: Mutex<PersistentHashSet>,
     persisted: Mutex<bool>,
 }
 
 impl TransientSet {
     pub fn new() -> Self {
         TransientSet {
-            set: Mutex::new(Default::default()),
+            set: Mutex::new(PersistentHashSet::empty()),
             persisted: Mutex::new(false),
         }
     }
 
-    pub fn new_from_set(set: &rpds::HashTrieSetSync<Value>) -> TransientSet {
+    pub fn new_from_set(set: &PersistentHashSet) -> TransientSet {
         TransientSet {
             set: Mutex::new(set.clone()),
             persisted: Mutex::new(false),
@@ -27,7 +27,8 @@ impl TransientSet {
         if *self.persisted.lock().unwrap() {
             return Err(ValueError::TransientAlreadyPersisted);
         }
-        self.set.lock().unwrap().insert_mut(value.clone());
+        let mut set = self.set.lock().unwrap();
+        set.conj_mut(value);
         Ok(())
     }
 
@@ -35,7 +36,8 @@ impl TransientSet {
         if *self.persisted.lock().unwrap() {
             return Err(ValueError::TransientAlreadyPersisted);
         }
-        self.set.lock().unwrap().remove_mut(value);
+        let mut set = self.set.lock().unwrap();
+        *set = set.disj(value);
         Ok(())
     }
 
@@ -46,12 +48,12 @@ impl TransientSet {
             return Err(ValueError::TransientAlreadyPersisted);
         }
         *persisted = true;
-        Ok(PersistentHashSet::from_set(set.clone()))
+        Ok(set.clone())
     }
 
     pub fn count(&self) -> usize {
         let set = self.set.lock().unwrap();
-        set.size()
+        set.count()
     }
 }
 
@@ -85,8 +87,8 @@ impl cljrs_gc::Trace for TransientSet {
     }
 
     fn gc_size_extra(&self) -> usize {
-        let n = self.set.lock().unwrap().size();
-        n * (40 + std::mem::size_of::<crate::Value>())
+        let set = self.set.lock().unwrap();
+        set.gc_size_extra()
     }
 }
 


### PR DESCRIPTION
PersistentHashMap/PersistentHashSet were backed directly by rpds's
HashTrieMap/HashTrieSet, whose default hasher (RandomState) is seeded
per-instance from OS randomness. Map and set literals above the 8-entry
array-map threshold, and any map/set built through transients, therefore
iterated in a different (hash-bucket) order on every run.

Both types now pair a HAMT index (key -> insertion sequence number) with
a red-black tree ordering log (sequence number -> (key, value)), so
iteration always follows insertion order and is stable across runs,
matching the array-map's existing behavior for small maps. Re-associating
an existing key keeps its original position; dissoc/disj remove cleanly
from both structures. TransientMap/TransientSet and the few call sites
that built raw rpds hash collections directly (select-keys, the
transient/persistent! bridge) now go through these ordered types too.