### PR TITLE
Add clojure.spec.alpha M1: registry, predicate specs, s/and, s/or

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -520,7 +520,7 @@ inference, `typeinfer`, the `rt_abi` contract) are reused unchanged.
 - [ ] Clojure-style exception hierarchy (`ExceptionInfo`, `ex-info`, `ex-data`, `ex-message`, `ex-cause`)
 - [ ] Stack traces that include both Clojure source locations and Rust frames
 - [ ] `tap>` / `tap` system for non-intrusive value inspection
-- [ ] `clojure.spec.alpha` compatible spec/validation library (stretch goal)
+- [x] `clojure.spec.alpha` compatible spec/validation library (stretch goal) (implemented in cljrs-stdlib; generators/`clojure.spec.gen.alpha` stubbed, deferred)
 - [ ] Debug build mode: retain all source locations and disable JIT optimizations
 
 ---

--- a/clojure-test-suite/test/clojure/spec_test/basics.cljc
+++ b/clojure-test-suite/test/clojure/spec_test/basics.cljc
@@ -1,0 +1,73 @@
+(ns clojure.spec-test.basics
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.spec.alpha :as s]))
+
+;; ── s/def, valid?, conform/unform ──────────────────────────────────────────
+
+(deftest test-def-valid-conform
+  (testing "predicate spec: valid?/conform/invalid?"
+    (s/def ::even even?)
+    (is (s/valid? ::even 4))
+    (is (not (s/valid? ::even 3)))
+    (is (= 4 (s/conform ::even 4)))
+    (is (s/invalid? (s/conform ::even 3)))))
+
+;; ── s/and threading ─────────────────────────────────────────────────────────
+
+(deftest test-and-threading
+  (testing "s/and short-circuits on first failing predicate"
+    (is (s/valid? (s/and int? even?) 4))
+    (is (not (s/valid? (s/and int? even?) 3)))
+    (is (not (s/valid? (s/and int? even?) 4.0)))))
+
+;; ── s/or tagging ────────────────────────────────────────────────────────────
+
+(deftest test-or-tagging
+  (testing "s/or conforms to a [tag value] pair for the first matching branch"
+    (is (= [:i 5] (s/conform (s/or :i int? :s string?) 5)))
+    (is (= [:s "x"] (s/conform (s/or :i int? :s string?) "x")))
+    (is (s/invalid? (s/conform (s/or :i int? :s string?) :kw))))
+
+  (testing "unform undoes the tagging"
+    (is (= 5 (s/unform (s/or :i int? :s string?) [:i 5])))
+    (is (= "x" (s/unform (s/or :i int? :s string?) [:s "x"])))))
+
+;; ── set specs ────────────────────────────────────────────────────────────────
+
+(deftest test-set-spec
+  (testing "a literal set is usable directly as a spec (enum semantics)"
+    (s/def ::color #{:red :green :blue})
+    (is (s/valid? ::color :red))
+    (is (not (s/valid? ::color :purple)))
+    (is (= :green (s/conform ::color :green)))))
+
+;; ── registry forward references ─────────────────────────────────────────────
+
+(deftest test-registry-forward-reference
+  (testing "a spec may reference another spec keyword before it is s/def'd"
+    (s/def ::fwd-a ::fwd-b)
+    (s/def ::fwd-b string?)
+    (is (= "hi" (s/conform ::fwd-a "hi")))
+    (is (s/invalid? (s/conform ::fwd-a 5)))))
+
+;; ── explain-data problems shape ──────────────────────────────────────────────
+;; Only assert on :path/:val/:via/:in, which are stable across our
+;; implementation and upstream clojure.spec.alpha. Deliberately avoid
+;; asserting on the :pred value itself (upstream qualifies predicate symbols
+;; like `clojure.core/pos?`; this runtime records them unqualified as
+;; written) and avoid comparing s/form output.
+
+(deftest test-explain-data-problem-shape
+  (testing "a single failing predicate reports path/val/via/in"
+    (s/def ::pos-int (s/and int? pos?))
+    (let [ed (s/explain-data ::pos-int -5)
+          probs (:clojure.spec.alpha/problems ed)
+          p (first probs)]
+      (is (= 1 (count probs)))
+      (is (= [] (:path p)))
+      (is (= -5 (:val p)))
+      (is (= [::pos-int] (:via p)))
+      (is (= [] (:in p)))))
+
+  (testing "a valid value explains to nil"
+    (is (nil? (s/explain-data ::pos-int 5)))))

--- a/clojure-test-suite/test/clojure/spec_test/collections.cljc
+++ b/clojure-test-suite/test/clojure/spec_test/collections.cljc
@@ -1,0 +1,132 @@
+(ns clojure.spec-test.collections
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.spec.alpha :as s]))
+
+;; ── coll-of ──────────────────────────────────────────────────────────────────
+
+(deftest test-coll-of-basic
+  (testing "coll-of conforms every element and rebuilds the collection"
+    (is (= [1 2 3] (s/conform (s/coll-of int?) [1 2 3])))
+    (is (s/invalid? (s/conform (s/coll-of int?) [1 "x"])))))
+
+(deftest test-coll-of-kind
+  (testing ":kind restricts the accepted collection type"
+    (is (s/invalid? (s/conform (s/coll-of int? :kind vector?) '(1 2 3))))
+    (is (s/valid? (s/coll-of int? :kind vector?) [1 2 3]))))
+
+(deftest test-coll-of-min-max-count
+  (testing ":min-count / :max-count bound the collection size"
+    (is (s/invalid? (s/conform (s/coll-of int? :min-count 3) [1 2])))
+    (is (s/valid? (s/coll-of int? :min-count 3) [1 2 3]))
+    (is (s/invalid? (s/conform (s/coll-of int? :max-count 2) [1 2 3])))
+    (is (s/valid? (s/coll-of int? :max-count 2) [1 2]))))
+
+(deftest test-coll-of-distinct
+  (testing ":distinct requires all elements be unique"
+    (is (= [1 2 3] (s/conform (s/coll-of int? :distinct true) [1 2 3])))
+    (is (s/invalid? (s/conform (s/coll-of int? :distinct true) [1 1 2])))))
+
+(deftest test-coll-of-into
+  (testing ":into controls the output collection type"
+    (is (= #{1 2 3} (s/conform (s/coll-of int? :into #{}) [1 2 3])))
+    (is (= '(1 2 3) (s/conform (s/coll-of int?) '(1 2 3))))))
+
+;; ── map-of ───────────────────────────────────────────────────────────────────
+
+(deftest test-map-of-basic
+  (testing "map-of validates keys and values; original keys are kept by default"
+    (is (= {:a 1 :b 2} (s/conform (s/map-of keyword? int?) {:a 1 :b 2})))
+    (is (s/invalid? (s/conform (s/map-of keyword? int?) {:a "x"})))
+    (is (s/invalid? (s/conform (s/map-of keyword? int?) {"not-kw" 1})))))
+
+(deftest test-map-of-conform-keys
+  (testing ":conform-keys true swaps in the conformed key"
+    (is (= {"a" 1}
+           (s/conform (s/map-of (s/conformer name) int? :conform-keys true) {:a 1})))))
+
+;; ── every vs coll-of ─────────────────────────────────────────────────────────
+
+(deftest test-every-vs-coll-of
+  (testing "coll-of conforms (and tags) every element; every validates only"
+    (let [elem (s/or :i int? :s string?)]
+      (is (= [[:i 1] [:s "x"]] (s/conform (s/coll-of elem) [1 "x"])))
+      (is (= [1 "x"] (s/conform (s/every elem) [1 "x"])))
+      (is (s/invalid? (s/conform (s/every elem) [1 :bad])))))
+
+  (testing "every-kv validates both key and value but never rebuilds"
+    (is (= {:a 1} (s/conform (s/every-kv keyword? int?) {:a 1})))
+    (is (s/invalid? (s/conform (s/every-kv keyword? int?) {:a "x"})))))
+
+;; ── tuple ────────────────────────────────────────────────────────────────────
+
+(deftest test-tuple
+  (testing "tuple validates a fixed-length, positionally-typed vector"
+    (is (= [1 "x"] (s/conform (s/tuple int? string?) [1 "x"])))
+    (is (s/invalid? (s/conform (s/tuple int? string?) [1])))
+    (is (s/invalid? (s/conform (s/tuple int? string?) 5))))
+
+  (testing "explain-data reports the failing index in :path and :in"
+    (let [p (first (:clojure.spec.alpha/problems
+                     (s/explain-data (s/tuple int? string?) [1 :bad])))]
+      (is (= [1] (:path p)))
+      (is (= [1] (:in p)))
+      (is (= :bad (:val p)))))
+
+  (testing "unform round-trips"
+    (let [spec (s/tuple int? string?)]
+      (is (= [1 "x"] (s/unform spec (s/conform spec [1 "x"])))))))
+
+;; ── nilable ──────────────────────────────────────────────────────────────────
+
+(deftest test-nilable
+  (testing "nilable accepts nil or the wrapped spec"
+    (is (= nil (s/conform (s/nilable int?) nil)))
+    (is (= 5 (s/conform (s/nilable int?) 5)))
+    (is (s/invalid? (s/conform (s/nilable int?) "x")))))
+
+;; ── int-in / double-in ───────────────────────────────────────────────────────
+
+(deftest test-int-in
+  (testing "int-in bounds an integer with an exclusive end"
+    (is (s/valid? (s/int-in 0 10) 5))
+    (is (not (s/valid? (s/int-in 0 10) 10)))
+    (is (not (s/valid? (s/int-in 0 10) 5.0)))))
+
+(deftest test-double-in
+  (testing "double-in bounds a double, with optional NaN/infinite checks"
+    (is (s/valid? (s/double-in :min 0.0 :max 10.0) 5.0))
+    (is (not (s/valid? (s/double-in :min 0.0 :max 10.0) 20.0)))
+    (let [nan (/ 0.0 0.0)
+          pos-inf (/ 1.0 0.0)]
+      (is (not (s/valid? (s/double-in :NaN? false) nan)))
+      (is (s/valid? (s/double-in) nan))
+      (is (not (s/valid? (s/double-in :infinite? false) pos-inf)))
+      (is (s/valid? (s/double-in) pos-inf)))))
+
+;; ── multi-spec ───────────────────────────────────────────────────────────────
+
+(defmulti event-type :event/type)
+
+(s/def :event/type keyword?)
+(s/def :event/created (s/keys :req [:event/type]))
+(defmethod event-type :created [_] :event/created)
+
+(s/def :event/event (s/multi-spec event-type :event/type))
+
+(deftest test-multi-spec
+  (testing "multi-spec dispatches conform to the branch registered for the tag"
+    (is (= {:event/type :created} (s/conform :event/event {:event/type :created})))
+    (is (s/invalid? (s/conform :event/event {:event/type :unknown})))))
+
+;; ── conformer ────────────────────────────────────────────────────────────────
+
+(deftest test-conformer
+  (testing "conformer transforms the value on conform"
+    (is (= 10 (s/conform (s/conformer #(* 2 %)) 5))))
+
+  (testing "conformer threads its transformed value through the rest of s/and"
+    (is (= 10 (s/conform (s/and int? (s/conformer #(* 2 %))) 5))))
+
+  (testing "unform applies the given unf fn, or is identity without one"
+    (is (= 5 (s/unform (s/conformer #(* 2 %) #(/ % 2)) 10)))
+    (is (= 10 (s/unform (s/conformer #(* 2 %)) 10)))))

--- a/clojure-test-suite/test/clojure/spec_test/instrument.cljc
+++ b/clojure-test-suite/test/clojure/spec_test/instrument.cljc
@@ -1,0 +1,49 @@
+(ns clojure.spec-test.instrument
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest]))
+
+;; ── fdef + instrument catches a bad call ────────────────────────────────────
+
+(defn spec-test-add [a b] (+ a b))
+(s/fdef spec-test-add :args (s/cat :a int? :b int?) :ret int?)
+
+(deftest test-instrument-catches-bad-call
+  (testing "instrument wraps a var so calls are checked against its :args spec"
+    (stest/instrument `spec-test-add)
+    (is (= 5 (spec-test-add 2 3)))
+    (is (thrown? Exception (spec-test-add 2 "x")))
+    (stest/unstrument `spec-test-add)))
+
+;; ── unstrument restores the raw fn ──────────────────────────────────────────
+
+(defn spec-test-pair [a b] [a b])
+(s/fdef spec-test-pair :args (s/cat :a int? :b int?))
+
+(deftest test-unstrument-restores-raw-fn
+  (testing "after unstrument, the raw (unchecked) fn runs with no :args check"
+    (stest/instrument `spec-test-pair)
+    (is (thrown? Exception (spec-test-pair 1 "x")))
+    (stest/unstrument `spec-test-pair)
+    (is (= [1 "x"] (spec-test-pair 1 "x")))))
+
+;; ── with-instrument-disabled ─────────────────────────────────────────────────
+
+(defn spec-test-listify [a b] (list a b))
+(s/fdef spec-test-listify :args (s/cat :a int? :b int?))
+
+(deftest test-with-instrument-disabled
+  (testing "with-instrument-disabled bypasses the :args check for its extent"
+    (stest/instrument `spec-test-listify)
+    (is (thrown? Exception (spec-test-listify 1 "x")))
+    (stest/with-instrument-disabled
+      (is (= (list 1 "x") (spec-test-listify 1 "x"))))
+    (stest/unstrument `spec-test-listify)))
+
+;; ── s/assert ─────────────────────────────────────────────────────────────────
+
+(deftest test-assert
+  (testing "s/assert returns a valid value unchanged and throws on an invalid one"
+    (s/def ::spec-test-pos-int (s/and int? pos?))
+    (is (= 5 (s/assert ::spec-test-pos-int 5)))
+    (is (thrown? Exception (s/assert ::spec-test-pos-int -5)))))

--- a/clojure-test-suite/test/clojure/spec_test/keys.cljc
+++ b/clojure-test-suite/test/clojure/spec_test/keys.cljc
@@ -1,0 +1,58 @@
+(ns clojure.spec-test.keys
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.spec.alpha :as s]))
+
+;; ── s/keys :req / :opt (namespaced keys) ────────────────────────────────────
+
+(s/def ::a int?)
+(s/def ::b string?)
+
+(deftest test-keys-req-opt
+  (testing "required keys must be present and valid; optional keys are optional"
+    (s/def ::m (s/keys :req [::a] :opt [::b]))
+    (is (s/valid? ::m {::a 1}))
+    (is (s/valid? ::m {::a 1 ::b "x"}))
+    (is (not (s/valid? ::m {::b "x"})))        ; missing required key
+    (is (not (s/valid? ::m {::a "no"})))       ; bad required value
+    (is (not (s/valid? ::m {::a 1 ::b 2})))    ; bad optional value
+    (is (not (s/valid? ::m 42)))))             ; not a map
+
+(deftest test-keys-missing-req-invalid
+  (testing "a map missing a required key is invalid, and conform reports it"
+    (s/def ::needs-a (s/keys :req [::a]))
+    (is (not (s/valid? ::needs-a {})))
+    (is (s/invalid? (s/conform ::needs-a {})))
+    (let [ed (s/explain-data ::needs-a {})]
+      (is (pos? (count (:clojure.spec.alpha/problems ed))))
+      (is (= [] (:path (first (:clojure.spec.alpha/problems ed))))))))
+
+;; ── s/keys :req-un / :opt-un (unqualified keys) ─────────────────────────────
+
+(deftest test-keys-un-variants
+  (testing "req-un/opt-un validate against unqualified map keys"
+    (s/def ::mu (s/keys :req-un [::a] :opt-un [::b]))
+    (is (s/valid? ::mu {:a 1}))
+    (is (s/valid? ::mu {:a 1 :b "x"}))
+    (is (not (s/valid? ::mu {:b "x"})))       ; missing required unqualified key
+    (is (not (s/valid? ::mu {:a "no"})))      ; bad value
+    (is (not (s/valid? ::mu {:a 1 :b 2})))    ; bad optional value
+    (is (= {:a 1} (s/conform ::mu {:a 1})))))
+
+;; ── value conform through a registered spec ─────────────────────────────────
+
+(deftest test-value-conforms-through-registered-spec
+  (testing "conforming a plain value spec returns the value unchanged when valid"
+    (is (= 1 (s/conform ::a 1)))
+    (is (s/invalid? (s/conform ::a "not an int")))))
+
+;; ── s/merge ──────────────────────────────────────────────────────────────────
+
+(deftest test-merge
+  (testing "s/merge is valid only when every constituent keys-spec is satisfied"
+    (s/def ::ma (s/keys :req [::a]))
+    (s/def ::mb (s/keys :req [::b]))
+    (s/def ::mab (s/merge ::ma ::mb))
+    (is (s/valid? ::mab {::a 1 ::b "x"}))
+    (is (not (s/valid? ::mab {::a 1})))
+    (is (= {::a 1 ::b "x"} (s/conform ::mab {::a 1 ::b "x"})))
+    (is (pos? (count (:clojure.spec.alpha/problems (s/explain-data ::mab {::a 1})))))))

--- a/clojure-test-suite/test/clojure/spec_test/regex.cljc
+++ b/clojure-test-suite/test/clojure/spec_test/regex.cljc
@@ -1,0 +1,108 @@
+(ns clojure.spec-test.regex
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.spec.alpha :as s]))
+
+;; ── s/cat ────────────────────────────────────────────────────────────────────
+
+(deftest test-cat-basic
+  (testing "cat conforms a sequential into a tagged map"
+    (is (= {:a 1 :b "x"} (s/conform (s/cat :a int? :b string?) [1 "x"])))
+    (is (s/invalid? (s/conform (s/cat :a int? :b string?) [1 2])))   ; wrong type
+    (is (s/invalid? (s/conform (s/cat :a int? :b string?) [1])))     ; too short
+    (is (s/invalid? (s/conform (s/cat :a int?) [1 2])))              ; too long
+    (is (s/invalid? (s/conform (s/cat :a int?) 5)))))                ; not sequential
+
+;; ── nesting + splicing ───────────────────────────────────────────────────────
+
+(deftest test-cat-nesting-and-splicing
+  (testing "a nested regex op splices its elements into the enclosing sequence"
+    (is (= {:a 1 :b ["x" "y"]}
+           (s/conform (s/cat :a int? :b (s/* string?)) [1 "x" "y"])))))
+
+(deftest test-keyword-ref-splicing
+  (testing "a keyword ref to a regex spec splices; to a non-regex spec it consumes one element"
+    (s/def ::regex-ref-int int?)
+    (is (= {:x 1 :y "x"}
+           (s/conform (s/cat :x ::regex-ref-int :y string?) [1 "x"])))
+    (s/def ::regex-ref-star (s/* int?))
+    (is (= {:nums [1 2] :tail "x"}
+           (s/conform (s/cat :nums ::regex-ref-star :tail string?) [1 2 "x"])))))
+
+;; ── s/spec as a nesting boundary ─────────────────────────────────────────────
+
+(deftest test-spec-boundary
+  (testing "s/spec wraps a regex op so it consumes exactly one (nested) element"
+    (is (= {:nums [1 2] :tail "x"}
+           (s/conform (s/cat :nums (s/spec (s/* int?)) :tail string?)
+                      [[1 2] "x"])))))
+
+;; ── s/alt / s/* / s/+ / s/? ──────────────────────────────────────────────────
+
+(deftest test-alt-star-plus-maybe
+  (testing "alt tags its matching branch"
+    (is (= [:i 5] (s/conform (s/alt :i int? :s string?) [5])))
+    (is (s/invalid? (s/conform (s/alt :i int? :s string?) [:kw]))))
+
+  (testing "* matches zero or more"
+    (is (= [] (s/conform (s/* int?) [])))
+    (is (s/valid? (s/* int?) []))
+    (is (= [1 2 3] (s/conform (s/* int?) [1 2 3])))
+    (is (s/invalid? (s/conform (s/* int?) [1 :a 3]))))
+
+  (testing "+ requires at least one"
+    (is (= [1] (s/conform (s/+ int?) [1])))
+    (is (s/invalid? (s/conform (s/+ int?) []))))
+
+  (testing "? is optional"
+    (is (= 5 (s/conform (s/? int?) [5])))
+    (is (nil? (s/conform (s/? int?) [])))
+    (is (s/valid? (s/? int?) []))
+    (is (s/invalid? (s/conform (s/? int?) [1 2])))))
+
+;; ── s/& post-predicates ──────────────────────────────────────────────────────
+
+(deftest test-amp-post-predicate
+  (testing "& applies an additional predicate to the conformed regex result"
+    (let [even-count? (fn [xs] (even? (count xs)))]
+      (is (= [1 2] (s/conform (s/& (s/* int?) even-count?) [1 2])))
+      (is (s/invalid? (s/conform (s/& (s/* int?) even-count?) [1 2 3]))))))
+
+;; ── insufficient / extra input via explain-data :reason ─────────────────────
+;; These :reason strings are the same ones upstream clojure.spec.alpha uses.
+
+(deftest test-explain-reasons
+  (testing "premature end of input reports \"Insufficient input\""
+    (let [p (first (:clojure.spec.alpha/problems
+                     (s/explain-data (s/cat :a int? :b string?) [1])))]
+      (is (= "Insufficient input" (:reason p)))
+      (is (= [:b] (:path p)))))
+
+  (testing "leftover input reports \"Extra input\""
+    (let [p (first (:clojure.spec.alpha/problems
+                     (s/explain-data (s/cat :a int?) [1 2])))]
+      (is (= "Extra input" (:reason p)))
+      (is (= [1] (:in p)))))
+
+  (testing "an element that fails its predicate reports path/in/val"
+    (let [p (first (:clojure.spec.alpha/problems
+                     (s/explain-data (s/cat :a int? :b string?) [1 :bad])))]
+      (is (= [:b] (:path p)))
+      (is (= [1] (:in p)))
+      (is (= :bad (:val p))))))
+
+;; ── conform/unform round-trips ───────────────────────────────────────────────
+
+(deftest test-regex-unform-roundtrips
+  (testing "unform inverts conform for every regex op"
+    (let [even-count? (fn [xs] (even? (count xs)))
+          cases [[(s/cat :a int? :b string?) [1 "x"]]
+                 [(s/cat :a int? :b (s/* string?)) [1 "x" "y"]]
+                 [(s/alt :i int? :s string?) [5]]
+                 [(s/* int?) [1 2 3]]
+                 [(s/* int?) []]
+                 [(s/+ int?) [1 2]]
+                 [(s/? int?) [5]]
+                 [(s/? int?) []]
+                 [(s/& (s/* int?) even-count?) [1 2]]]]
+      (doseq [[spec input] cases]
+        (is (= input (vec (s/unform spec (s/conform spec input)))))))))

--- a/crates/cljrs-stdlib/README.md
+++ b/crates/cljrs-stdlib/README.md
@@ -26,6 +26,12 @@ src/
     string.cljrs          Clojure source for clojure.string (ns decl; natives pre-registered)
     set.cljrs             Clojure source for clojure.set   (ns decl; natives pre-registered)
     test.cljrs            Pure Clojure implementation of clojure.test
+    spec/
+      alpha.cljrs         Pure Clojure implementation of clojure.spec.alpha (core spec engine)
+      test/
+        alpha.cljrs       Pure Clojure implementation of clojure.spec.test.alpha (instrument/unstrument)
+      gen/
+        alpha.cljrs       clojure.spec.gen.alpha stub — every fn throws (no generator engine)
 build.rs                  Pre-lowers clojure.core to optimized IR (gated on the
                           `prebuild-ir` feature) — runs the ANF lowerer *and*
                           the escape-analysis/region-allocation optimize pass,
@@ -56,6 +62,9 @@ pub fn standard_env_with_paths(source_paths: Vec<PathBuf>) -> Arc<GlobalEnv>;
 | `clojure.string` | `string.rs` + `clojure/string.cljrs` | Native Rust, loaded lazily |
 | `clojure.set` | `set.rs` + `clojure/set.cljrs` | Native Rust, loaded lazily |
 | `clojure.test` | `clojure/test.cljrs` | Pure Clojure, loaded lazily |
+| `clojure.spec.alpha` | `clojure/spec/alpha.cljrs` | Pure Clojure, loaded lazily |
+| `clojure.spec.test.alpha` | `clojure/spec/test/alpha.cljrs` | Pure Clojure, loaded lazily |
+| `clojure.spec.gen.alpha` | `clojure/spec/gen/alpha.cljrs` | Pure Clojure, loaded lazily; every fn throws (no generator engine) |
 
 ### clojure.string functions
 
@@ -72,6 +81,68 @@ replaces all occurrences and `replace-first` replaces only the first.
 
 `union`, `intersection`, `difference`, `subset?`, `superset?`,
 `select`, `map-invert`
+
+### clojure.spec.alpha functions and macros
+
+A from-scratch, spec-compatible-in-spirit implementation of the core spec
+engine: predicate/set/keyword specs, `and`/`or` composition, `keys`/`merge`,
+the derivative-based regex engine (`cat`/`alt`/`*`/`+`/`?`/`&`), collection
+specs, and fn-specs (`fdef`/`fspec`).
+
+Macros: `def`, `spec`, `and`, `or`, `keys`, `merge`, `cat`, `alt`, `*`, `+`,
+`?`, `&`, `every`, `coll-of`, `every-kv`, `map-of`, `tuple`, `nilable`,
+`multi-spec`, `conformer`, `nonconforming`, `fspec`, `fdef`, `assert`
+
+Functions: `registry`, `get-spec`, `invalid`, `invalid?`, `spec-name`,
+`spec?`, `conform`, `unform`, `valid?`, `form`, `describe`, `explain-data`,
+`explain`, `explain-str`, `explain-out`, `regex?`, `int-in`, `double-in`,
+`inst-in` (throws — see deviations), `check-asserts?`, `check-asserts`,
+`with-gen`, `gen`, `exercise`, `exercise-fn` (the last three throw — see
+deviations)
+
+#### Deviations from JVM clojure.spec.alpha
+
+- No generators: `s/gen`, `s/exercise`, `s/exercise-fn`, and
+  `stest/check`/`stest/check-fn` all throw a clear `ex-info` instead of
+  running test.check. `s/with-gen` stores the generator fn without ever
+  invoking it.
+- `s/form` and `s/describe` show forms exactly as written (unqualified) —
+  they do not auto-qualify bare symbols to `clojure.core` the way upstream
+  does.
+- `multi-spec` unform re-dispatches by calling the multimethod on the
+  *conformed* value rather than applying JVM spec's `retag` mechanism.
+- `check-asserts` takes effect immediately (read at assert-expansion time),
+  not just at compile time as on the JVM.
+- `inst-in` always throws — this runtime has no `inst?`/date value type to
+  bound.
+- Users must `:require` the namespace with an alias (`:as s`, the universal
+  convention anyway). `:refer`ing names like `and`, `or`, or `def` collides
+  with clojurust's special forms, and `:refer-clojure :exclude` is a no-op
+  in this runtime, so it cannot be used to work around the collision.
+
+### clojure.spec.test.alpha functions and macros
+
+Macros: `with-instrument-disabled`
+
+Functions: `instrument`, `unstrument`, `instrumentable-syms`, `check` (throws
+— see deviations), `check-fn` (throws — see deviations)
+
+`instrument` wraps a var's root fn so every call conforms its argument list
+against the fn's `fdef`'d `:args` spec before delegating to the original fn;
+only `:args` is checked (never `:ret`/`:fn`, matching upstream). `unstrument`
+restores the original fn. Both are idempotent.
+
+### clojure.spec.gen.alpha functions
+
+`generate`, `sample`, `gen-for-pred`, `choose`, `such-that`, `fmap`, `one-of`,
+`return`, `elements`, `int`, `string`, `keyword`, `boolean`, `double`,
+`simple-type`, `any`
+
+This namespace has no generator engine (no test.check port): every function
+throws a clear `ex-info` explaining that generators are not implemented. It
+exists purely so that idiomatic specs which `(:require [clojure.spec.gen.alpha
+:as gen])` load cleanly. As in upstream, several names (`int`, `string`,
+`keyword`, `boolean`, `double`) intentionally shadow `clojure.core`.
 
 ## Dependency notes
 

--- a/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
@@ -1,6 +1,9 @@
 ;; clojure.spec.alpha — M1: skeleton + predicate specs + and/or;
 ;;                      M2: explain machinery + keys/merge;
-;;                      M3: derivative-based regex engine (cat/alt/*/+/?/&).
+;;                      M3: derivative-based regex engine (cat/alt/*/+/?/&);
+;;                      M4: collection specs (every/coll-of/map-of/every-kv),
+;;                          tuple/nilable/multi-spec/conformer, leaf helpers
+;;                          (int-in/double-in/nonconforming).
 ;;
 ;; This is a from-scratch, spec-compatible-in-spirit implementation for the
 ;; clojurust runtime. It does NOT use `reify` for spec objects (every `reify`
@@ -12,8 +15,7 @@
 ;; regex ops are upstream-style ::op-tagged plain maps given Spec behavior
 ;; via the Map type tag.
 ;;
-;; Later milestones add: collection/leaf specs (M4), fdef/instrument + gen
-;; stub (M5).
+;; Next milestone adds: fdef/instrument + gen stub (M5).
 
 (ns clojure.spec.alpha)
 
@@ -1247,3 +1249,482 @@
   "Like explain, but returns the explanation as a string."
   [spec x]
   (with-out-str (explain spec x)))
+
+;; ── EverySpec (s/every, s/coll-of, s/map-of, s/every-kv) ────────────────────
+;;
+;; Options (all literal at the macro call site): :kind (a whole-collection
+;; predicate, e.g. vector?), :count, :min-count, :max-count, :distinct,
+;; :into ([] () {} #{} — the target shape to conform INTO). :gen-max/:gen are
+;; accepted and silently ignored (generators are not implemented in this
+;; port). `s/coll-of`/`s/map-of` conform every element/entry and rebuild the
+;; collection; `s/every`/`s/every-kv` only VALIDATE elements/entries and
+;; return x unchanged when valid (mirroring upstream's every/every-kv, which
+;; exist so large/infinite collections don't have to be fully conformed).
+;;
+;; `s/map-of` conforms keys with the key-spec only when :conform-keys true;
+;; by default keys must be VALID (checked against the key-spec) but the
+;; ORIGINAL key is kept in the conformed result. `s/every-kv` validates both
+;; keys and values but, like `every`, never rebuilds.
+;;
+;; DEVIATION FROM UPSTREAM: upstream's every-impl always builds the
+;; conformed result via `(reduce conj (empty into-target-or-x) ...)`, even
+;; when :into is omitted — which means a *list* input with no :into would
+;; silently come back element-reversed (conj on a list prepends). We only
+;; replicate that raw conj-onto-empty behavior when :into is given
+;; EXPLICITLY (so `:into '()` still reverses, matching upstream's
+;; well-documented gotcha and plain `into` semantics). When :into is
+;; omitted, we preserve input order for all four kinds — vector/map/set
+;; conj naturally preserves the order that matters for each, and list/seq
+;; input is rebuilt via `map`/`seq` (order-preserving) rather than raw conj
+;; onto `()`. This is judged friendlier and closer to what most callers
+;; actually rely on; documented here since it's an intentional divergence.
+;;
+;; Explain reports only the FIRST failing element/entry (a simplification of
+;; upstream's `*coll-error-limit*`, which defaults to 1 anyway but is a
+;; rebindable dynamic var upstream — not implemented here).
+
+(defrecord EverySpec [form pred kfn kind kind-form
+                       cnt min-count max-count distinct
+                       into-given? into-target conform-all conform-keys name])
+
+(defn- every-kind-ok? [spec x]
+  (let [k (:kind spec)]
+    (or (nil? k) (boolean (k x)))))
+
+(defn- every-count-ok? [spec x]
+  (let [c (count x)
+        cnt (:cnt spec) mn (:min-count spec) mx (:max-count spec)]
+    (and (or (nil? cnt) (= c cnt))
+         (or (nil? mn) (<= mn c))
+         (or (nil? mx) (<= c mx)))))
+
+(defn- every-distinct-ok? [spec x]
+  (or (not (:distinct spec)) (empty? x) (apply distinct? (seq x))))
+
+(defn- every-shape-ok? [spec x]
+  (try
+    (and (every-kind-ok? spec x) (every-count-ok? spec x) (every-distinct-ok? spec x))
+    (catch Exception _e false)))
+
+(defn- every-count-pred-form [spec]
+  (let [cnt (:cnt spec) mn (:min-count spec) mx (:max-count spec)]
+    (cond
+      cnt (list '= (list 'count '%) cnt)
+      (and mn mx) (list '<= mn (list 'count '%) mx)
+      mn (list '<= mn (list 'count '%))
+      mx (list '<= (list 'count '%) mx)
+      :else 'true)))
+
+(defn- every-shape-problem [spec path via in x]
+  (try
+    (cond
+      (not (every-kind-ok? spec x))
+      [(problem path (or (:kind-form spec) (:kind spec)) x via in)]
+      (not (every-count-ok? spec x))
+      [(problem path (every-count-pred-form spec) x via in)]
+      (not (every-distinct-ok? spec x))
+      [(problem path 'distinct? x via in)]
+      :else nil)
+    (catch Exception _e
+      [(problem path (or (:kind-form spec) (:kind spec) 'coll?) x via in)])))
+
+(defn- every-default-empty
+  "The empty accumulator to conj conformed elements/entries onto when no
+  :into was given — chosen so vector/map/set inputs conj back into their
+  own kind directly; list/seq inputs accumulate into a vector (converted to
+  a seq by `every-build-finish` below, to preserve order)."
+  [x]
+  (cond
+    (vector? x) []
+    (map? x) {}
+    (set? x) #{}
+    :else []))
+
+(defn- every-build-empty [spec x]
+  (if (:into-given? spec) (empty (:into-target spec)) (every-default-empty x)))
+
+(defn- every-build-finish [spec x ret]
+  (if (or (:into-given? spec) (vector? x) (map? x) (set? x))
+    ret
+    (seq ret)))
+
+(defn- every-conform-seq [spec x]
+  (loop [ret (every-build-empty spec x) items (seq x)]
+    (if (nil? items)
+      (every-build-finish spec x ret)
+      (let [cv (conform*-dispatch (:pred spec) (first items))]
+        (if (invalid? cv)
+          ::invalid
+          (recur (conj ret cv) (next items)))))))
+
+(defn- every-validate-seq [spec x]
+  (if (every? (fn [v] (not (invalid? (conform*-dispatch (:pred spec) v)))) x)
+    x
+    ::invalid))
+
+(defn- every-conform-map [spec x]
+  (loop [ret (every-build-empty spec x) entries (seq x)]
+    (if (nil? entries)
+      (every-build-finish spec x ret)
+      (let [e (first entries)
+            k (key e)
+            v (val e)
+            ck (conform*-dispatch (:kfn spec) k)
+            vc (conform*-dispatch (:pred spec) v)]
+        (if (or (invalid? ck) (invalid? vc))
+          ::invalid
+          (recur (conj ret [(if (:conform-keys spec) ck k) vc]) (next entries)))))))
+
+(defn- every-validate-map [spec x]
+  (if (every? (fn [e] (and (not (invalid? (conform*-dispatch (:kfn spec) (key e))))
+                           (not (invalid? (conform*-dispatch (:pred spec) (val e))))))
+              (seq x))
+    x
+    ::invalid))
+
+(defn- every-unform-coll [spec x]
+  (let [items (map (fn [v] (unform*-dispatch (:pred spec) v)) x)]
+    (cond
+      (vector? x) (vec items)
+      (set? x) (set items)
+      :else (seq items))))
+
+(defn- every-unform-map [spec x]
+  (into (empty x)
+        (map (fn [e]
+               (let [k (key e)
+                     v (val e)
+                     uk (if (:conform-keys spec) (unform*-dispatch (:kfn spec) k) k)]
+                 [uk (unform*-dispatch (:pred spec) v)]))
+             x)))
+
+(defn- every-explain-seq [spec path via in x]
+  (or (every-shape-problem spec path via in x)
+      (loop [items (seq x) idx 0]
+        (when items
+          (let [probs (explain-1 (:form spec) (:pred spec) path via (conj in idx) (first items))]
+            (if (seq probs)
+              (vec probs)
+              (recur (next items) (inc idx))))))))
+
+(defn- every-explain-map [spec path via in x]
+  (or (every-shape-problem spec path via in x)
+      (loop [entries (seq x)]
+        (when entries
+          (let [e (first entries)
+                k (key e)
+                v (val e)
+                kprobs (explain-1 (:form spec) (:kfn spec) path via (conj in k) k)]
+            (if (seq kprobs)
+              (vec kprobs)
+              (let [vprobs (explain-1 (:form spec) (:pred spec) path via (conj in k) v)]
+                (if (seq vprobs)
+                  (vec vprobs)
+                  (recur (next entries))))))))))
+
+(extend-type EverySpec Spec
+  (conform* [spec x]
+    (if (:kfn spec)
+      (if (or (not (map? x)) (not (every-shape-ok? spec x)))
+        ::invalid
+        (if (:conform-all spec) (every-conform-map spec x) (every-validate-map spec x)))
+      (if (or (not (coll? x)) (not (every-shape-ok? spec x)))
+        ::invalid
+        (if (:conform-all spec) (every-conform-seq spec x) (every-validate-seq spec x)))))
+  (unform* [spec x]
+    (if (:conform-all spec)
+      (if (:kfn spec) (every-unform-map spec x) (every-unform-coll spec x))
+      x))
+  (explain* [spec path via in x]
+    (if (:kfn spec)
+      (if (not (map? x))
+        [(problem path 'map? x via in)]
+        (every-explain-map spec path via in x))
+      (if (not (coll? x))
+        [(problem path 'coll? x via in)]
+        (every-explain-seq spec path via in x))))
+  (describe* [spec] (:form spec)))
+
+(defn every-impl
+  "Shared impl fn for s/every, s/coll-of, s/map-of, s/every-kv. `form` is the
+  literal macro call (for describe/form). `pred` is the evaluated value
+  spec; `kfn` the evaluated key spec (nil unless map-of/every-kv). `kind` is
+  the evaluated :kind predicate (or nil); `kind-form` its literal form.
+  `cnt`/`min-count`/`max-count`/`distinct` are the evaluated option values.
+  `into-given?`/`into-target` record whether :into was supplied and its
+  evaluated value. `conform-all?` is true for coll-of/map-of (rebuild),
+  false for every/every-kv (validate only). `conform-keys?` is only
+  meaningful for map-of."
+  [form pred kfn kind kind-form cnt min-count max-count distinct
+   into-given? into-target conform-all? conform-keys?]
+  (->EverySpec form pred kfn kind kind-form cnt min-count max-count distinct
+               into-given? into-target conform-all? conform-keys? nil))
+
+(defmacro every
+  "Returns a spec that VALIDATES (but does not conform) every element of a
+  collection against pred-form; conform returns x unchanged when valid.
+  Options: :kind :count :min-count :max-count :distinct :into (accepted for
+  describe parity though every never rebuilds) :gen-max :gen (ignored)."
+  [pred-form & opts]
+  (let [o (apply hash-map opts)]
+    `(every-impl '~(list* 'every pred-form opts) ~pred-form nil
+                 ~(:kind o) '~(:kind o)
+                 ~(:count o) ~(:min-count o) ~(:max-count o) ~(:distinct o)
+                 ~(contains? o :into) ~(:into o) false false)))
+
+(defmacro coll-of
+  "Returns a spec that conforms every element of a collection against
+  pred-form and rebuilds the collection (into :into if given, else
+  preserving the input's own kind — see EverySpec doc comment above).
+  Options as per s/every."
+  [pred-form & opts]
+  (let [o (apply hash-map opts)]
+    `(every-impl '~(list* 'coll-of pred-form opts) ~pred-form nil
+                 ~(:kind o) '~(:kind o)
+                 ~(:count o) ~(:min-count o) ~(:max-count o) ~(:distinct o)
+                 ~(contains? o :into) ~(:into o) true false)))
+
+(defmacro every-kv
+  "Returns a spec that VALIDATES every key/value pair of a map against
+  kpred-form/vpred-form; conform returns x unchanged when valid."
+  [kpred-form vpred-form & opts]
+  (let [o (apply hash-map opts)]
+    `(every-impl '~(list* 'every-kv kpred-form vpred-form opts) ~vpred-form ~kpred-form
+                 ~(:kind o) '~(:kind o)
+                 ~(:count o) ~(:min-count o) ~(:max-count o) ~(:distinct o)
+                 ~(contains? o :into) ~(:into o) false false)))
+
+(defmacro map-of
+  "Returns a spec that conforms every key/value pair of a map against
+  kpred-form/vpred-form and rebuilds the map. Keys must be valid against
+  kpred-form always; they are only replaced with their conformed value when
+  :conform-keys true (default false, matching upstream)."
+  [kpred-form vpred-form & opts]
+  (let [o (apply hash-map opts)]
+    `(every-impl '~(list* 'map-of kpred-form vpred-form opts) ~vpred-form ~kpred-form
+                 ~(:kind o) '~(:kind o)
+                 ~(:count o) ~(:min-count o) ~(:max-count o) ~(:distinct o)
+                 ~(contains? o :into) ~(:into o) true ~(:conform-keys o))))
+
+;; ── TupleSpec (s/tuple) ───────────────────────────────────────────────────
+
+(defrecord TupleSpec [form preds forms name])
+
+(extend-type TupleSpec Spec
+  (conform* [spec x]
+    (let [preds (:preds spec) n (count preds)]
+      (if (or (not (vector? x)) (not (= (count x) n)))
+        ::invalid
+        (loop [ret [] i 0]
+          (if (= i n)
+            ret
+            (let [cv (conform*-dispatch (nth preds i) (nth x i))]
+              (if (invalid? cv)
+                ::invalid
+                (recur (conj ret cv) (inc i)))))))))
+  (unform* [spec x]
+    (let [preds (:preds spec) n (count preds)]
+      (loop [ret [] i 0]
+        (if (= i n)
+          ret
+          (recur (conj ret (unform*-dispatch (nth preds i) (nth x i))) (inc i))))))
+  (explain* [spec path via in x]
+    (let [preds (:preds spec) forms (:forms spec) n (count preds)]
+      (cond
+        (not (vector? x)) [(problem path 'vector? x via in)]
+        (not (= (count x) n)) [(problem path (list '= (list 'count '%) n) x via in)]
+        :else
+        (loop [i 0]
+          (when (< i n)
+            (let [cv (conform*-dispatch (nth preds i) (nth x i))]
+              (if (invalid? cv)
+                (explain-1 (nth forms i) (nth preds i) (conj path i) via (conj in i) (nth x i))
+                (recur (inc i)))))))))
+  (describe* [spec] (:form spec)))
+
+(defn tuple-impl
+  "Impl fn for s/tuple. forms/preds parallel: literal per-index spec forms,
+  their evaluated spec values."
+  [forms preds]
+  (->TupleSpec (cons 'tuple forms) (vec preds) (vec forms) nil))
+
+(defmacro tuple
+  "Returns a spec for a fixed-length vector, positionally conforming each
+  element against the corresponding pred-form."
+  [& pred-forms]
+  `(tuple-impl '~(vec pred-forms) [~@pred-forms]))
+
+;; ── NilableSpec (s/nilable) ───────────────────────────────────────────────
+
+(defrecord NilableSpec [form pred name])
+
+(extend-type NilableSpec Spec
+  (conform* [spec x]
+    (if (nil? x) nil (conform*-dispatch (:pred spec) x)))
+  (unform* [spec x]
+    (if (nil? x) nil (unform*-dispatch (:pred spec) x)))
+  (explain* [spec path via in x]
+    ;; Upstream shape: on a non-nil invalid value, report the WRAPPED
+    ;; spec's own problems at path+[::pred] AND a synthetic nil? problem at
+    ;; path+[::nil] (`::pred`/`::nil` auto-resolve to
+    ;; :clojure.spec.alpha/pred and :clojure.spec.alpha/nil in this ns).
+    (when (and (not (nil? x)) (invalid? (conform*-dispatch (:pred spec) x)))
+      (vec (concat (explain-1 (:form spec) (:pred spec) (conj path ::pred) via in x)
+                   [(problem (conj path ::nil) 'nil? x via in)]))))
+  (describe* [spec] (list 'nilable (:form spec))))
+
+(defn nilable-impl
+  [form pred]
+  (->NilableSpec form pred nil))
+
+(defmacro nilable
+  "Returns a spec that accepts nil (conforming to nil) or delegates to
+  pred-form."
+  [pred-form]
+  `(nilable-impl '~pred-form ~pred-form))
+
+;; ── MultiSpec (s/multi-spec) ──────────────────────────────────────────────
+;;
+;; conform*/explain* call `(mm x)` to get the spec registered for x's
+;; dispatch branch, then delegate. A dispatch miss throws in this runtime
+;; (`crates/cljrs-env/src/apply.rs`: "No method in multimethod ... for
+;; dispatch value ..."), caught here via `(catch Exception ...)` — same
+;; pattern already used for predicate-spec calls above. We deliberately do
+;; NOT enumerate `(methods mm)` — its keys are Display strings in this
+;; runtime, not the original dispatch values, so it can't be used to
+;; reconstruct or validate the dispatch table.
+;;
+;; SIMPLIFICATION vs upstream: real clojure.spec.alpha's `retag` re-tags the
+;; conformed value with the dispatch value before unforming, so unform can
+;; work even when the conformed shape no longer carries a natural dispatch
+;; value. We accept and store `retag` (a keyword or fn, per upstream) for
+;; API compatibility but don't apply it: our unform* instead re-dispatches
+;; `(mm x)` directly off the CONFORMED value x. This works whenever the
+;; conformed shape still carries whatever `mm`'s dispatch fn inspects (true
+;; for the common case of a keys-spec branch preserving the dispatch key);
+;; it can misbehave for specs whose conform strips the dispatch value
+;; entirely — a known, documented gap.
+
+(defrecord MultiSpec [form mm retag name])
+
+(extend-type MultiSpec Spec
+  (conform* [spec x]
+    (try
+      (conform*-dispatch ((:mm spec) x) x)
+      (catch Exception _e ::invalid)))
+  (unform* [spec x]
+    (try
+      (unform*-dispatch ((:mm spec) x) x)
+      (catch Exception _e x)))
+  (explain* [spec path via in x]
+    (try
+      (explain*-dispatch ((:mm spec) x) path via in x)
+      (catch Exception _e
+        [{:path path :pred (:form spec) :val x :via via :in in :reason "no method"}])))
+  (describe* [spec] (:form spec)))
+
+(defn multi-spec-impl
+  [form mm retag]
+  (->MultiSpec form mm retag nil))
+
+(defmacro multi-spec
+  "Takes mm-form (a multimethod, e.g. a symbol naming one defined via
+  defmulti/defmethod) and retag-form (a keyword or fn — see doc comment on
+  MultiSpec above for how this runtime's unform* simplifies retagging).
+  Returns a spec whose conform*/explain* delegate to whichever spec
+  `(mm x)` returns."
+  [mm-form retag-form]
+  `(multi-spec-impl '~(list 'multi-spec mm-form retag-form) ~mm-form ~retag-form))
+
+;; ── ConformerSpec (s/conformer) ───────────────────────────────────────────
+
+(defrecord ConformerSpec [form f unf name])
+
+(extend-type ConformerSpec Spec
+  (conform* [spec x]
+    ((:f spec) x))
+  (unform* [spec x]
+    (if (:unf spec) ((:unf spec) x) x))
+  (explain* [spec path via in x]
+    (when (invalid? (conform*-dispatch spec x))
+      [(problem path (:form spec) x via in)]))
+  (describe* [spec] (:form spec)))
+
+(defn conformer-impl
+  ([form f] (conformer-impl form f nil))
+  ([form f unf] (->ConformerSpec form f unf nil)))
+
+(defmacro conformer
+  "Takes a fn f of one arg (returning the conformed value, or ::invalid to
+  fail) and an optional inverse unf for unform. Threads transformed values
+  through s/and like any other predicate/spec."
+  ([f-form] `(conformer-impl '~f-form ~f-form))
+  ([f-form unf-form] `(conformer-impl '~f-form ~f-form ~unf-form)))
+
+;; ── Leaf helpers: int-in / double-in / inst-in / nonconforming ──────────────
+
+(defn int-in-range?
+  "True if x is an int? in the range [start, end) — start inclusive, end
+  exclusive."
+  [start end x]
+  (and (int? x) (>= x start) (< x end)))
+
+(defn int-in
+  "Returns a spec validating ints in the range [start, end)."
+  [start end]
+  (spec-impl (list 'int-in start end) (fn [x] (int-in-range? start end x)) nil))
+
+(defn double-in
+  "Returns a spec validating doubles. Options (all optional, keyword args):
+  :min :max (inclusive bounds), :infinite? (default true — whether ##Inf/
+  ##-Inf are accepted), :NaN? (default true — whether ##NaN is accepted).
+  Reuses this runtime's existing NaN?/infinite? bootstrap predicates
+  (crates/cljrs-builtins/src/bootstrap.cljrs) rather than reimplementing
+  IEEE-754 checks."
+  [& opts]
+  (let [o (apply hash-map opts)
+        mn (:min o)
+        mx (:max o)
+        inf-opt (get o :infinite? true)
+        nan-opt (get o :NaN? true)]
+    (spec-impl (list* 'double-in opts)
+               (fn [x]
+                 (and (double? x)
+                      (cond
+                        (NaN? x) nan-opt
+                        (infinite? x) inf-opt
+                        :else (and (or (nil? mn) (>= x mn))
+                                  (or (nil? mx) (<= x mx))))))
+               nil)))
+
+(defn inst-in
+  "NOT IMPLEMENTED: this runtime has no Instant/Date value type and no real
+  #inst support — the reader parses the #inst tag but
+  `crates/cljrs-interp/src/eval.rs`'s `eval_tagged_literal` just returns the
+  inner string unchanged (TODO there), and there is no `inst?` predicate
+  anywhere in builtins/bootstrap. Throws immediately with a clear message
+  rather than silently misbehaving."
+  [start end]
+  (throw (ex-info
+          "s/inst-in is not implemented: this runtime has no Instant/Date value type or #inst support"
+          {:start start :end end})))
+
+(defrecord NonconformingSpec [pred name])
+
+(extend-type NonconformingSpec Spec
+  (conform* [spec x]
+    (if (invalid? (conform*-dispatch (:pred spec) x)) ::invalid x))
+  (unform* [spec x] x)
+  (explain* [spec path via in x]
+    (explain*-dispatch (:pred spec) path via in x))
+  (describe* [spec] (list 'nonconforming (describe*-dispatch (:pred spec)))))
+
+(defn nonconforming-impl
+  [pred]
+  (->NonconformingSpec pred nil))
+
+(defmacro nonconforming
+  "Wraps pred-form so conform validates but returns x UNCONFORMED on
+  success (::invalid on failure, as usual); unform is identity."
+  [pred-form]
+  `(nonconforming-impl ~pred-form))

--- a/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
@@ -1,0 +1,418 @@
+;; clojure.spec.alpha — milestone 1: skeleton + predicate specs + and/or.
+;;
+;; This is a from-scratch, spec-compatible-in-spirit implementation for the
+;; clojurust runtime. It does NOT use `reify` for spec objects (every `reify`
+;; call here would permanently leak a fresh protocol-impl tag into the global
+;; `Protocol.impls` map — see `crates/cljrs-interp/src/special.rs`), so
+;; compound specs are `defrecord` instances extended with the `Spec` protocol
+;; instead. Bare predicates, sets, keywords, and symbols are made directly
+;; usable as specs (zero wrapping) by extending `Spec` onto their type tags.
+;;
+;; Later milestones add: explain-data/keys/merge (M2), regex ops — cat/alt/
+;; */+/?/& (M3), collection/leaf specs (M4), fdef/instrument + gen stub (M5).
+
+(ns clojure.spec.alpha)
+
+;; ── Spec protocol ─────────────────────────────────────────────────────────────
+;;
+;; Every spec — bare predicate, set, registry-keyword ref, var-symbol ref, or
+;; one of our defrecord-based compound specs — implements these four methods.
+
+(defprotocol Spec
+  (conform* [spec x])
+  (unform* [spec x])
+  (explain* [spec path via in x])
+  (describe* [spec]))
+
+;; ── Runtime workaround: polymorphic re-dispatch inside a method body ──────────
+;;
+;; DISCOVERED RUNTIME BUG (affects any protocol, not spec-specific): every
+;; extend-type method impl fn is named after its method (`build_impl_fn` in
+;; `crates/cljrs-interp/src/special.rs` sets the fn's `name` from the method
+;; symbol), and `call_cljrs_fn` (`crates/cljrs-interp/src/apply.rs:526-534`)
+;; unconditionally self-binds that name inside the fn body on every call (the
+;; mechanism that makes named `fn`/`letfn` self-recursion work). That
+;; self-binding shadows the *global* protocol fn var for the duration of the
+;; method body — so a method impl that calls its own method name again,
+;; intending ordinary polymorphic dispatch on a *different* value (e.g.
+;; `extend-type Keyword`'s `conform*` calling `(conform* resolved-spec x)`),
+;; instead re-enters the same impl. The observable symptom depends on body
+;; shape and tail position — anywhere from an infinite loop to side effects
+;; running twice to accidentally-correct results — confirmed with minimal
+;; defprotocol/extend-type repros outside this file. Calling a
+;; *different*-named protocol method recursively (e.g. `explain*` calling
+;; `conform*`) is unaffected — only same-name recursion is shadowed.
+;;
+;; Workaround (no Rust changes needed): capture each protocol fn under a
+;; private alias *before* any extend-type runs. The alias var's name never
+;; collides with any method impl fn's own self-bound name, so looking it up
+;; from inside a method body always finds the real polymorphic ProtocolFn
+;; value instead of the self-binding. Every same-name recursive call in the
+;; extend-type bodies below uses these aliases instead of calling
+;; conform*/unform*/explain*/describe* directly.
+(def ^:private conform*-dispatch conform*)
+(def ^:private unform*-dispatch unform*)
+(def ^:private explain*-dispatch explain*)
+(def ^:private describe*-dispatch describe*)
+
+;; ── Registry ──────────────────────────────────────────────────────────────────
+;;
+;; Children are stored UNRESOLVED (a bare keyword/symbol/set/fn, or a compound
+;; spec record) and re-resolved lazily every time they're conformed against —
+;; this is what makes forward references and re-`s/def`-ing a spec work with
+;; no `delay`/promise machinery: `extend-type Keyword Spec` below just looks
+;; the keyword back up in the registry on every `conform*` call.
+
+(def ^:private registry-ref (atom {}))
+
+(defn registry
+  "Returns a snapshot (a plain map) of the full spec registry: qualified
+  keyword/symbol name -> registered spec value."
+  []
+  @registry-ref)
+
+(defn get-spec
+  "Returns the spec registered for keyword/symbol k, or nil if unregistered."
+  [k]
+  (get @registry-ref k))
+
+;; ── invalid ───────────────────────────────────────────────────────────────────
+
+(def invalid ::invalid)
+
+(defn invalid?
+  "True if x is the ::invalid sentinel returned by a failed conform."
+  [x]
+  (= x ::invalid))
+
+;; ── explain-data problem helper ────────────────────────────────────────────────
+;;
+;; Full explain-data assembly (spec/via/in roll-ups, printable summaries) is
+;; M2. For M1, `explain*` on every spec kind returns a bare vector of these
+;; problem maps (or nil when the value is valid) so the shape is stable and
+;; ready for M2 to build on.
+
+(defn- problem
+  "Builds a single explain-data problem map."
+  [path pred val via in]
+  {:path path :pred pred :val val :via via :in in})
+
+;; ── Bare values as specs ────────────────────────────────────────────────────────
+;;
+;; `Fn` covers Fn/NativeFunction/ProtocolFn/MultiFn — all callables share the
+;; "Fn" dispatch tag (crates/cljrs-env/src/apply.rs). A predicate call is
+;; wrapped in try/catch so a predicate that throws on an unexpected shape of
+;; `x` (e.g. `even?` on a non-number) fails conform instead of blowing up the
+;; caller.
+
+(extend-type Fn Spec
+  (conform* [spec x]
+    (try
+      (if (spec x) x ::invalid)
+      (catch Exception _e ::invalid)))
+  (unform* [spec x] x)
+  (explain* [spec path via in x]
+    (when (invalid? (conform* spec x))
+      [(problem path spec x via in)]))
+  (describe* [spec] spec))
+
+;; A set used as a spec conforms/validates via set membership (enum spec).
+
+(extend-type Set Spec
+  (conform* [spec x]
+    (if (contains? spec x) x ::invalid))
+  (unform* [spec x] x)
+  (explain* [spec path via in x]
+    (when (invalid? (conform* spec x))
+      [(problem path spec x via in)]))
+  (describe* [spec] spec))
+
+;; A keyword used as a spec is a live reference into the registry, re-resolved
+;; on every call — this is what makes forward references and re-registration
+;; (re-`s/def`-ing a spec) work correctly with no extra bookkeeping.
+
+(extend-type Keyword Spec
+  (conform* [spec x]
+    (if-let [s (get-spec spec)]
+      (conform*-dispatch s x)
+      (throw (ex-info (str "Unable to resolve spec: " spec) {:spec spec}))))
+  (unform* [spec x]
+    (if-let [s (get-spec spec)]
+      (unform*-dispatch s x)
+      (throw (ex-info (str "Unable to resolve spec: " spec) {:spec spec}))))
+  (explain* [spec path via in x]
+    (if-let [s (get-spec spec)]
+      (explain*-dispatch s path (conj via spec) in x)
+      [(problem path spec x via in)]))
+  (describe* [spec]
+    (if-let [s (get-spec spec)]
+      (if (keyword? s) s (describe*-dispatch s))
+      spec)))
+
+;; A symbol used as a spec resolves to a var and delegates to its value —
+;; e.g. `(s/def ::x 'my.ns/my-pred)`.
+
+(extend-type Symbol Spec
+  (conform* [spec x] (conform*-dispatch @(resolve spec) x))
+  (unform* [spec x] (unform*-dispatch @(resolve spec) x))
+  (explain* [spec path via in x]
+    (explain*-dispatch @(resolve spec) path (conj via spec) in x))
+  (describe* [spec] spec))
+
+;; ── PredicateSpec ─────────────────────────────────────────────────────────────
+;;
+;; Wraps a predicate/spec together with its literal form, so `describe`/`form`
+;; can show `even?` instead of an opaque function value. `:pred` is usually a
+;; raw predicate fn, but `(s/spec (s/or ...))`-style wrapping of an
+;; already-compound spec is also supported: conform*/unform* delegate to the
+;; wrapped spec's own protocol methods whenever `:pred` isn't itself callable.
+
+(defrecord PredicateSpec [form pred name])
+
+(extend-type PredicateSpec Spec
+  (conform* [spec x]
+    (let [pred (:pred spec)]
+      (if (fn? pred)
+        (try
+          (if (pred x) x ::invalid)
+          (catch Exception _e ::invalid))
+        (conform*-dispatch pred x))))
+  (unform* [spec x]
+    (let [pred (:pred spec)]
+      (if (fn? pred) x (unform*-dispatch pred x))))
+  (explain* [spec path via in x]
+    (when (invalid? (conform* spec x))
+      [(problem path (:form spec) x via in)]))
+  (describe* [spec] (:form spec)))
+
+;; ── AndSpec ───────────────────────────────────────────────────────────────────
+;;
+;; conform* threads each pred's conformed result into the next, short-
+;; circuiting to ::invalid on the first failure. unform* mirrors upstream
+;; clojure.spec.alpha's simplification: only the *last* pred's unform matters
+;; (all earlier preds are assumed to be plain, non-transforming predicates).
+
+(defrecord AndSpec [form forms preds name])
+
+(extend-type AndSpec Spec
+  (conform* [spec x]
+    (loop [ret x preds (:preds spec)]
+      (if (empty? preds)
+        ret
+        (let [conformed (conform*-dispatch (first preds) ret)]
+          (if (invalid? conformed)
+            ::invalid
+            (recur conformed (rest preds)))))))
+  (unform* [spec x]
+    (if (empty? (:preds spec))
+      x
+      (unform*-dispatch (last (:preds spec)) x)))
+  (explain* [spec path via in x]
+    (loop [ret x preds (:preds spec) forms (:forms spec)]
+      (if (empty? preds)
+        nil
+        (let [conformed (conform* (first preds) ret)]
+          (if (invalid? conformed)
+            [(problem path (first forms) ret via in)]
+            (recur conformed (rest preds) (rest forms)))))))
+  (describe* [spec] (:form spec)))
+
+(defn and-spec-impl
+  "Impl fn for s/and. `forms` are the literal per-branch spec forms (a
+  vector); `preds` are their evaluated spec values in the same order — each
+  may be a bare predicate/set/keyword/symbol or another compound spec, since
+  all of those already implement Spec directly (no `specize` wrapping step
+  needed)."
+  [forms preds]
+  (->AndSpec (cons 'and forms) (vec forms) (vec preds) nil))
+
+;; ── OrSpec ────────────────────────────────────────────────────────────────────
+;;
+;; conform* returns `[tag conformed]` for the first matching branch, else
+;; ::invalid.
+
+(defrecord OrSpec [form keys forms preds name])
+
+(defn- or-pred-for
+  "Looks up the pred registered under tag k in an OrSpec."
+  [spec k]
+  (some (fn [[kk pred]] (when (= kk k) pred))
+        (map vector (:keys spec) (:preds spec))))
+
+(extend-type OrSpec Spec
+  (conform* [spec x]
+    (loop [ks (:keys spec) preds (:preds spec)]
+      (cond
+        (empty? preds) ::invalid
+        :else
+        (let [conformed (conform*-dispatch (first preds) x)]
+          (if (invalid? conformed)
+            (recur (rest ks) (rest preds))
+            [(first ks) conformed])))))
+  (unform* [spec x]
+    (let [[k v] x]
+      (unform*-dispatch (or-pred-for spec k) v)))
+  (explain* [spec path via in x]
+    (when (invalid? (conform* spec x))
+      (vec (map (fn [k form]
+                  (problem (conj path k) form x via in))
+                (:keys spec) (:forms spec)))))
+  (describe* [spec] (:form spec)))
+
+(defn or-spec-impl
+  "Impl fn for s/or. `keys` are the branch tag keywords, `forms` their literal
+  spec forms, `preds` their evaluated spec values — all parallel vectors."
+  [keys forms preds]
+  (->OrSpec (cons 'or (interleave keys forms)) (vec keys) (vec forms) (vec preds) nil))
+
+;; ── def-impl / naming ─────────────────────────────────────────────────────────
+
+(defn- with-name
+  "Attaches name (a qualified keyword or symbol) to spec, returning the
+  (possibly updated) spec. Bare Fn/Set/Keyword/Symbol specs are returned
+  unchanged: they already carry their own identity (a set prints itself, a
+  keyword/symbol re-resolves through the registry every time), and — per the
+  'never with-meta on a dispatching value' rule for this runtime — there is
+  nowhere safe to stash a name on them without breaking protocol dispatch.
+  Only our own defrecord-based spec objects (PredicateSpec/AndSpec/OrSpec,
+  ...) get an assoc'd :name field, since `assoc` on a record preserves its
+  type tag here."
+  [spec name]
+  (if (record? spec)
+    (assoc spec :name name)
+    spec))
+
+(defn spec-name
+  "Returns the registered name of spec, if it has one. Keyword refs report
+  their own keyword; record-based specs report their assoc'd :name (nil if
+  never named via s/def); anything else (bare fn/set/symbol) has none."
+  [spec]
+  (cond
+    (keyword? spec) spec
+    (record? spec) (:name spec)
+    :else nil))
+
+(defn spec-impl
+  "Wraps pred (a predicate fn, or another spec) together with its literal
+  form into a PredicateSpec, so describe/form can show the form as written."
+  ([form pred] (spec-impl form pred nil))
+  ([form pred name] (->PredicateSpec form pred name)))
+
+(defn def-impl
+  "Impl fn for s/def. k must be a qualified keyword or symbol. If spec is
+  already one of our record-based spec objects, or a bare keyword/symbol
+  (registry ref) or set (enum spec), it's stored as-is so live
+  re-resolution/forward-refs keep working; a bare predicate fn is wrapped in
+  a PredicateSpec first so describe/form can show its literal form. Returns
+  k."
+  [k form spec]
+  (when-not (and (ident? k) (namespace k))
+    (throw (ex-info (str "s/def requires a qualified keyword or symbol, got: " (pr-str k))
+                     {:key k})))
+  (let [s (cond
+            (spec? spec) spec
+            (keyword? spec) spec
+            (symbol? spec) spec
+            (set? spec) spec
+            :else (spec-impl form spec nil))]
+    (swap! registry-ref assoc k (with-name s k))
+    k))
+
+;; ── Macros ────────────────────────────────────────────────────────────────────
+;;
+;; NOTE: `def`/`and`/`or` are special forms in this runtime, dispatched on the
+;; raw head-symbol text — so unqualified `(def ...)`/`(and ...)`/`(or ...)`
+;; anywhere ABOVE this point always hits the special form, never these
+;; macros. External callers only reach these via an alias, e.g.
+;; `(s/def ::x even?)`, `(s/and int? even?)`, `(s/or :i int? :s string?)`.
+;;
+;; A second, more surprising consequence of special-form names being
+;; reserved: `defmacro` cannot itself be named `def`/`and`/`or` directly.
+;; `(defmacro def [...] ...)` builds the underlying fn via the same
+;; self-name-as-optional-first-arg logic as `fn*`, which explicitly skips
+;; treating the name as a self-reference when it's a special form
+;; (`crates/cljrs-interp/src/special.rs` — `!is_special_form(s)` guard) —
+;; but the fn-parsing code never falls back to "there's no self-name after
+;; all" in that case, so it misreads the name symbol itself as the arity
+;; clause and throws "fn* expects vector or arity clauses". Worked around by
+;; defining each macro under a `-form`-suffixed name and then re-binding the
+;; resulting `Macro` value onto the desired var with a plain `def` (`def` the
+;; special form just interns whatever value it's given — no such guard on
+;; the *target* name of a `def`, only on fn/macro self-reference names).
+
+(defmacro def-form
+  "Given a namespace-qualified keyword or symbol k, and a spec, predicate, or
+  regex-op form, makes an entry in the registry mapping k to the spec. Do NOT
+  put a def in a defn — spec kits should be at the top level. Returns k."
+  [k spec-form]
+  `(def-impl '~k '~spec-form ~spec-form))
+(def def def-form)
+
+(defmacro spec
+  "Takes a single predicate/spec form and returns a spec object wrapping it,
+  preserving the literal form for describe/form output."
+  [pred-form]
+  `(spec-impl '~pred-form ~pred-form nil))
+
+(defmacro and-form
+  "Takes predicate/spec-forms, e.g. (s/and int? even?), and returns a spec
+  that returns the conformed value of the last predicate if all pass, else
+  ::invalid."
+  [& pred-forms]
+  `(and-spec-impl '~(vec pred-forms) [~@pred-forms]))
+(def and and-form)
+
+(defmacro or-form
+  "Takes key/pred-form pairs, e.g. (s/or :i int? :s string?), and returns a
+  spec that returns [key conformed] for the first matching branch, else
+  ::invalid."
+  [& key-pred-forms]
+  (let [pairs (partition 2 key-pred-forms)
+        ks (mapv first pairs)
+        pred-forms (mapv second pairs)]
+    `(or-spec-impl '~ks '~pred-forms [~@pred-forms])))
+(def or or-form)
+
+;; ── Public API ────────────────────────────────────────────────────────────────
+
+(defn spec?
+  "Returns x if x is one of our own record-based spec objects (created by
+  spec-impl/and-spec-impl/or-spec-impl/...), else nil. Note: this diverges
+  from upstream clojure.spec.alpha, where spec? is true for anything
+  spec-conforming. Here bare predicates/sets/keywords/symbols all implement
+  the Spec protocol directly (via extend-type) but are NOT `spec?` — this is
+  what lets def-impl/with-name know precisely when a :name field can safely
+  be assoc'd, without special-casing every kind of value that can act as a
+  spec."
+  [x]
+  (when (and (record? x) (satisfies? Spec x))
+    x))
+
+(defn conform
+  "Given a spec and a value, returns :clojure.spec.alpha/invalid if the
+  value doesn't match the spec, else the (possibly destructured) conformed
+  value."
+  [spec x]
+  (conform* spec x))
+
+(defn unform
+  "Given a spec and a conformed value, returns the unconformed (original
+  form) value."
+  [spec x]
+  (unform* spec x))
+
+(defn valid?
+  "Returns true if x is valid according to spec."
+  [spec x]
+  (not (invalid? (conform spec x))))
+
+(defn form
+  "Returns the spec as data, in a form suitable for re-parsing."
+  [spec]
+  (describe* spec))
+
+(defn describe
+  "Returns an abbreviated description of the spec, suitable for presenting
+  to a user."
+  [spec]
+  (describe* spec))

--- a/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
@@ -1,5 +1,6 @@
 ;; clojure.spec.alpha — M1: skeleton + predicate specs + and/or;
-;;                      M2: explain machinery + keys/merge.
+;;                      M2: explain machinery + keys/merge;
+;;                      M3: derivative-based regex engine (cat/alt/*/+/?/&).
 ;;
 ;; This is a from-scratch, spec-compatible-in-spirit implementation for the
 ;; clojurust runtime. It does NOT use `reify` for spec objects (every `reify`
@@ -7,10 +8,12 @@
 ;; `Protocol.impls` map — see `crates/cljrs-interp/src/special.rs`), so
 ;; compound specs are `defrecord` instances extended with the `Spec` protocol
 ;; instead. Bare predicates, sets, keywords, and symbols are made directly
-;; usable as specs (zero wrapping) by extending `Spec` onto their type tags.
+;; usable as specs (zero wrapping) by extending `Spec` onto their type tags;
+;; regex ops are upstream-style ::op-tagged plain maps given Spec behavior
+;; via the Map type tag.
 ;;
-;; Later milestones add: regex ops — cat/alt/*/+/?/& (M3), collection/leaf
-;; specs (M4), fdef/instrument + gen stub (M5).
+;; Later milestones add: collection/leaf specs (M4), fdef/instrument + gen
+;; stub (M5).
 
 (ns clojure.spec.alpha)
 
@@ -110,7 +113,7 @@
   (cond
     (keyword? pred)
     (explain*-dispatch pred path via in v)
-    (spec? pred)
+    (or (spec? pred) (regex? pred))
     (explain*-dispatch pred path
                        (if-let [n (spec-name pred)] (conj via n) via)
                        in v)
@@ -472,6 +475,471 @@
   [forms preds]
   (->MergeSpec (cons 'merge forms) (vec forms) (vec preds) nil))
 
+;; ── Regex engine (s/cat, s/alt, s/*, s/+, s/?, s/&) ──────────────────────────
+;;
+;; Port of upstream clojure.spec.alpha's derivative-based regex engine. Regex
+;; ops are plain data — maps tagged with the namespaced ::op key (so user
+;; maps can't collide) — NOT record-wrapped specs. This preserves upstream's
+;; composition semantics: nesting a regex op inside another describes a
+;; SINGLE flat sequence (in `(s/cat :a (s/* int?) :b string?)` the s/*
+;; splices into the cat), and a keyword ref that resolves to a registered
+;; regex ALSO splices (upstream reg-resolve! semantics: after
+;; `(s/def ::r (s/* int?))`, `(s/cat :a ::r :b string?)` conforms [1 2 "x"]
+;; to {:a [1 2] :b "x"}). To match a nested sub-sequence as one element
+;; instead, wrap it with `(s/spec (s/* ...))` — the PredicateSpec boundary
+;; consumes exactly one element. A keyword ref to a NON-regex spec likewise
+;; consumes exactly one element via ordinary protocol dispatch.
+;;
+;; Ops: ::accept ::pcat ::alt ::rep ::amp. nil op = a plain pred (fn / set /
+;; keyword / symbol / spec record) consuming one element.
+;;
+;; The engine fns are mutually recursive; vars resolve at call time in this
+;; runtime, so plain defn- order works without `declare`.
+
+(defn regex?
+  "Returns x if x is a regex op (a map produced by cat/alt/*/+/?/&), else
+  nil/false."
+  [x]
+  (and (map? x) (get x ::op) x))
+
+(defn- op-of
+  "The ::op tag of a regex map; nil for anything else (plain preds)."
+  [p]
+  (when (map? p) (get p ::op)))
+
+(defn- reg-resolve
+  "Resolves an ident through the registry alias chain to the underlying spec
+  or regex value; returns non-idents unchanged; nil if unregistered."
+  [k]
+  (if (ident? k)
+    (let [reg @registry-ref
+          s (get reg k)]
+      (when s
+        (loop [s s]
+          (if (ident? s)
+            (recur (get reg s))
+            s))))
+    k))
+
+(defn- reg-resolve!
+  "Like reg-resolve but throws on an unresolvable ident."
+  [k]
+  (if (ident? k)
+    (or (reg-resolve k)
+        (throw (ex-info (str "Unable to resolve spec: " k) {:spec k})))
+    k))
+
+(defn- accept [x] {::op ::accept :ret x})
+
+(defn- accept? [p] (= ::accept (op-of p)))
+
+(defn- pcat*
+  "Core cat constructor/normalizer over {:ps :ks :forms :ret :rep+}. Any nil
+  in :ps kills the whole branch (returns nil) — that is how failed
+  derivatives propagate."
+  [m]
+  (let [ps (:ps m) ks (:ks m) forms (:forms m) ret (:ret m) rep+form (:rep+ m)
+        p1 (first ps) pr (next ps)
+        k1 (first ks) kr (next ks)
+        fr (next forms)]
+    (when (every? identity ps)
+      (if (accept? p1)
+        (let [r1 (:ret p1)
+              ret (conj ret (if ks {k1 r1} r1))]
+          (if pr
+            (pcat* {:ps pr :ks kr :forms fr :ret ret})
+            (accept ret)))
+        {::op ::pcat :ps ps :ret ret :ks ks :forms forms :rep+ rep+form}))))
+
+(defn cat-impl
+  "Impl fn for s/cat. ks/ps/forms are parallel: tag keywords, evaluated
+  preds, literal pred forms."
+  [ks ps forms]
+  (pcat* {:ks ks :ps ps :forms forms :ret {}}))
+
+(defn- rep* [p1 p2 ret splice form]
+  (when p1
+    (let [r {::op ::rep :p2 p2 :splice splice :forms form}]
+      (if (accept? p1)
+        (assoc r :p1 p2 :ret (conj ret (:ret p1)))
+        (assoc r :p1 p1 :ret ret)))))
+
+(defn rep-impl
+  "Impl fn for s/*."
+  [form p]
+  (rep* p p [] false form))
+
+(defn rep+impl
+  "Impl fn for s/+ — a pcat of one mandatory pred followed by a splicing
+  rep."
+  [form p]
+  (pcat* {:ps [p (rep* p p [] true form)]
+          :forms [form (list '* form)]
+          :ret []
+          :rep+ form}))
+
+(defn amp-impl
+  "Impl fn for s/& — regex re further constrained by preds applied to the
+  conformed result."
+  [re re-form preds pred-forms]
+  {::op ::amp :p1 re :amp re-form :ps preds :forms pred-forms})
+
+(defn- filter-alt [ps ks forms f]
+  (if (or ks forms)
+    (let [pks (filter (fn [t] (f (first t)))
+                      (map vector ps
+                           (or (seq ks) (repeat nil))
+                           (or (seq forms) (repeat nil))))]
+      [(seq (map first pks))
+       (when ks (seq (map second pks)))
+       (when forms (seq (map (fn [t] (nth t 2)) pks)))])
+    [(seq (filter f ps)) ks forms]))
+
+(defn- alt* [ps ks forms]
+  (let [res (filter-alt ps ks forms identity)
+        ps (nth res 0) ks (nth res 1) forms (nth res 2)
+        p1 (first ps) pr (next ps) k1 (first ks)]
+    (when ps
+      (let [ret {::op ::alt :ps ps :ks ks :forms forms}]
+        (if (nil? pr)
+          (if k1
+            (if (accept? p1)
+              (accept [k1 (:ret p1)])
+              ret)
+            p1)
+          ret)))))
+
+(defn- alt2 [p1 p2]
+  (if (and p1 p2)
+    (alt* [p1 p2] nil nil)
+    (or p1 p2)))
+
+(defn alt-impl
+  "Impl fn for s/alt. ks/ps/forms parallel as in cat-impl."
+  [ks ps forms]
+  (alt* ps ks forms))
+
+(defn maybe-impl
+  "Impl fn for s/?."
+  [p form]
+  (assoc (alt* [p (accept ::nil)] nil [form ::nil]) :maybe form))
+
+(defn- and-preds
+  "Threads x through preds (conforming at each step), short-circuiting to
+  ::invalid. forms are display-only (kept for upstream parity)."
+  [x preds forms]
+  (loop [ret x preds (seq preds) forms (seq forms)]
+    (cond
+      (invalid? ret) ::invalid
+      preds (let [nret (conform*-dispatch (first preds) ret)]
+              (if (invalid? nret)
+                ::invalid
+                (recur nret (next preds) (next forms))))
+      :else ret)))
+
+(defn- explain-pred-list
+  [forms preds path via in x]
+  (loop [ret x forms (seq forms) preds (seq preds)]
+    (when preds
+      (let [nret (conform*-dispatch (first preds) ret)]
+        (if (invalid? nret)
+          (explain-1 (first forms) (first preds) path via in ret)
+          (recur nret (next forms) (next preds)))))))
+
+(defn- noret? [p1 pret]
+  (or (= pret ::nil)
+      (and (contains? #{::rep ::pcat}
+                      (op-of (if (ident? p1) (reg-resolve! p1) p1)))
+           (empty? pret))))
+
+(defn- accept-nil? [p]
+  (let [rp (if (ident? p) (reg-resolve! p) p)
+        op (op-of rp)]
+    (cond
+      (= op ::accept) true
+      (nil? op) nil
+      (= op ::amp) (and (accept-nil? (:p1 rp))
+                        (let [ret (and-preds (preturn (:p1 rp)) (:ps rp) (:forms rp))]
+                          (not (invalid? ret))))
+      (= op ::rep) (or (identical? (:p1 rp) (:p2 rp)) (accept-nil? (:p1 rp)))
+      (= op ::pcat) (every? accept-nil? (:ps rp))
+      (= op ::alt) (boolean (some accept-nil? (:ps rp))))))
+
+(defn- preturn [p]
+  (let [rp (if (ident? p) (reg-resolve! p) p)
+        op (op-of rp)]
+    (cond
+      (= op ::accept) (:ret rp)
+      (nil? op) nil
+      (= op ::amp) (let [pret (preturn (:p1 rp))]
+                     (if (noret? (:p1 rp) pret)
+                       ::nil
+                       (and-preds pret (:ps rp) (:forms rp))))
+      (= op ::rep) (add-ret (:p1 rp) (:ret rp) nil)
+      (= op ::pcat) (add-ret (first (:ps rp)) (:ret rp) (first (:ks rp)))
+      (= op ::alt)
+      (let [res (filter-alt (:ps rp) (:ks rp) (:forms rp) accept-nil?)
+            p0 (first (nth res 0))
+            k0 (first (nth res 1))
+            r (if (nil? p0) ::nil (preturn p0))]
+        (if k0 [k0 r] r)))))
+
+(defn- add-ret [p r k]
+  (let [rp (if (ident? p) (reg-resolve! p) p)
+        op (op-of rp)]
+    (cond
+      (nil? op) r
+      (contains? #{::alt ::accept ::amp} op)
+      (let [ret (preturn rp)]
+        (if (= ret ::nil) r (conj r (if k {k ret} ret))))
+      :else ;; ::rep / ::pcat
+      (let [ret (preturn rp)]
+        (if (empty? ret)
+          r
+          ((if (:splice rp) into conj) r (if k {k ret} ret)))))))
+
+(defn- deriv
+  "The derivative of regex p with respect to one input element x — the regex
+  matching the rest of the input — or nil if x can't begin a match."
+  [p x]
+  (let [rp (if (ident? p) (reg-resolve! p) p)]
+    (when rp
+      (let [op (op-of rp)]
+        (cond
+          (= op ::accept) nil
+
+          ;; Plain pred: consumes exactly one element. Dispatches on the
+          ;; ORIGINAL p (not rp) so keyword refs stay live and push
+          ;; themselves onto via during explain.
+          (nil? op)
+          (let [ret (conform*-dispatch p x)]
+            (when (not (invalid? ret)) (accept ret)))
+
+          (= op ::amp)
+          (when-let [p1 (deriv (:p1 rp) x)]
+            (if (= ::accept (op-of p1))
+              (let [ret (and-preds (preturn p1) (:ps rp) (:forms rp))]
+                (when (not (invalid? ret))
+                  (accept ret)))
+              (amp-impl p1 (:amp rp) (:ps rp) (:forms rp))))
+
+          (= op ::pcat)
+          (let [ps (:ps rp) ks (:ks rp) forms (:forms rp) ret (:ret rp)
+                p0 (first ps) pr (next ps) k0 (first ks) kr (next ks)]
+            (alt2 (pcat* {:ps (cons (deriv p0 x) pr) :ks ks :forms forms :ret ret})
+                  (when (accept-nil? p0)
+                    (deriv (pcat* {:ps pr :ks kr :forms (next forms)
+                                   :ret (add-ret p0 ret k0)})
+                           x))))
+
+          (= op ::alt)
+          (alt* (map (fn [q] (deriv q x)) (:ps rp)) (:ks rp) (:forms rp))
+
+          (= op ::rep)
+          (alt2 (rep* (deriv (:p1 rp) x) (:p2 rp) (:ret rp) (:splice rp) (:forms rp))
+                (when (accept-nil? (:p1 rp))
+                  (deriv (rep* (:p2 rp) (:p2 rp) (add-ret (:p1 rp) (:ret rp) nil)
+                               (:splice rp) (:forms rp))
+                         x))))))))
+
+(defn- op-describe [p]
+  (let [rp (if (ident? p) (reg-resolve! p) p)
+        op (op-of rp)]
+    (when rp
+      (cond
+        (= op ::accept) nil
+        (nil? op) (if (ident? p) p (describe*-dispatch p))
+        (= op ::amp) (cons '& (cons (:amp rp) (:forms rp)))
+        (= op ::pcat) (if (:rep+ rp)
+                        (list '+ (:rep+ rp))
+                        (if (:ks rp)
+                          (cons 'cat (interleave (:ks rp) (:forms rp)))
+                          (cons 'cat (:forms rp))))
+        (= op ::alt) (if (:maybe rp)
+                       (list '? (:maybe rp))
+                       (cons 'alt (interleave (:ks rp) (:forms rp))))
+        (= op ::rep) (list (if (:splice rp) '+ '*) (:forms rp))))))
+
+(defn- op-unform
+  "Inverse of the conform machinery for one regex op; returns a SEQ of
+  original input elements."
+  [p x]
+  (let [rp (if (ident? p) (reg-resolve! p) p)
+        op (op-of rp)]
+    (cond
+      (= op ::accept) [(:ret rp)]
+      (nil? op) [(unform*-dispatch p x)]
+      (= op ::amp)
+      (let [px (reduce (fn [acc pred] (unform*-dispatch pred acc))
+                       x (reverse (:ps rp)))]
+        (op-unform (:p1 rp) px))
+      (= op ::rep) (mapcat (fn [v] (op-unform (:p1 rp) v)) x)
+      (= op ::pcat)
+      (if (:rep+ rp)
+        (mapcat (fn [v] (op-unform (first (:ps rp)) v)) x)
+        (let [kps (zipmap (:ks rp) (:ps rp))]
+          (mapcat (fn [k]
+                    (when (contains? x k)
+                      (op-unform (get kps k) (get x k))))
+                  (:ks rp))))
+      (= op ::alt)
+      (if (:maybe rp)
+        ;; conform of an empty ? is nil — unform back to no elements.
+        ;; (Deviation from upstream, which unforms nil through the child
+        ;; pred; ours round-trips (s/? p) on [] correctly instead.)
+        (if (nil? x)
+          []
+          [(unform*-dispatch (first (:ps rp)) x)])
+        (let [k (nth x 0)
+              v (nth x 1)
+              kps (zipmap (:ks rp) (:ps rp))]
+          (op-unform (get kps k) v))))))
+
+(defn- re-conform [p data]
+  (loop [p p data (seq data)]
+    (if (nil? data)
+      (if (accept-nil? p)
+        (let [ret (preturn p)]
+          (if (= ret ::nil)
+            nil
+            ret))
+        ::invalid)
+      (if-let [dp (deriv p (first data))]
+        (recur dp (next data))
+        ::invalid))))
+
+(defn- pad-to
+  "coll as an n-element vector, right-padded with nils."
+  [coll n]
+  (let [v (vec (or coll []))]
+    (mapv (fn [i] (get v i)) (range n))))
+
+(defn- op-explain [form p path via in input]
+  (let [rp (if (ident? p) (reg-resolve! p) p)
+        x (first input)
+        via (if-let [n (when (map? rp) (get rp ::name))] (conj via n) via)
+        op (op-of rp)
+        insufficient (fn [path form]
+                       [{:path path
+                         :reason "Insufficient input"
+                         :pred form
+                         :val ()
+                         :via via
+                         :in in}])]
+    (when rp
+      (cond
+        (= op ::accept) nil
+
+        (nil? op)
+        (if (empty? input)
+          (insufficient path form)
+          (explain-1 form p path via in x))
+
+        (= op ::amp)
+        (if (empty? input)
+          (if (accept-nil? (:p1 rp))
+            (explain-pred-list (:forms rp) (:ps rp) path via in (preturn (:p1 rp)))
+            (insufficient path (:amp rp)))
+          (if-let [p1 (deriv (:p1 rp) x)]
+            (explain-pred-list (:forms rp) (:ps rp) path via in (preturn p1))
+            (op-explain (:amp rp) (:p1 rp) path via in input)))
+
+        (= op ::pcat)
+        (let [ps (vec (:ps rp))
+              n (count ps)
+              ks (pad-to (:ks rp) n)
+              forms (pad-to (:forms rp) n)
+              pkfs (map vector ps ks forms)
+              pkf (if (= 1 n)
+                    (first pkfs)
+                    (first (remove (fn [t] (accept-nil? (first t))) pkfs)))
+              pred (first pkf)
+              k (second pkf)
+              f (nth pkf 2)
+              path (if k (conj path k) path)
+              form (or f (op-describe pred))]
+          (if (and (empty? input) (not pred))
+            (insufficient path form)
+            (op-explain form pred path via in input)))
+
+        (= op ::alt)
+        (if (empty? input)
+          (insufficient path (op-describe rp))
+          (let [ps (vec (:ps rp))
+                n (count ps)
+                ks (pad-to (:ks rp) n)
+                forms (pad-to (:forms rp) n)]
+            (apply concat
+                   (map (fn [k f pred]
+                          (op-explain (or f (op-describe pred))
+                                      pred
+                                      (if k (conj path k) path)
+                                      via in input))
+                        ks forms ps))))
+
+        (= op ::rep)
+        (op-explain (if (identical? (:p1 rp) (:p2 rp))
+                      (:forms rp)
+                      (op-describe (:p1 rp)))
+                    (:p1 rp) path via in input)))))
+
+(defn- re-explain [path via in re input]
+  (loop [p re data (seq input) i 0]
+    (if (nil? data)
+      (if (accept-nil? p)
+        nil
+        (op-explain (op-describe p) p path via in nil))
+      (let [x (first data)
+            dp (deriv p x)]
+        (if dp
+          (recur dp (next data) (inc i))
+          (if (accept? p)
+            [{:path path
+              :reason "Extra input"
+              :pred (op-describe re)
+              :val data
+              :via via
+              :in (conj in i)}]
+            (or (op-explain (op-describe p) p path via (conj in i) data)
+                [{:path path
+                  :reason "Extra input"
+                  :pred (op-describe re)
+                  :val data
+                  :via via
+                  :in (conj in i)}])))))))
+
+;; Regex maps get their Spec behavior via the Map type tag. A plain map that
+;; is NOT a regex op is not a valid spec (upstream: maps are not specs) —
+;; using one as a spec throws an informative error.
+
+(defn- not-a-spec! [m]
+  (throw (ex-info "map is not a valid spec (only regex-op maps produced by cat/alt/*/+/?/& are)"
+                  {:map m})))
+
+(extend-type Map Spec
+  (conform* [spec x]
+    (if (regex? spec)
+      (if (or (nil? x) (sequential? x))
+        (re-conform spec (seq x))
+        ::invalid)
+      (not-a-spec! spec)))
+  (unform* [spec x]
+    (if (regex? spec)
+      (if (nil? x)
+        nil
+        (op-unform spec x))
+      (not-a-spec! spec)))
+  (explain* [spec path via in x]
+    (if (regex? spec)
+      (if (or (nil? x) (sequential? x))
+        (re-explain path via in spec (seq x))
+        [(problem path (op-describe spec) x via in)])
+      (not-a-spec! spec)))
+  (describe* [spec]
+    (if (regex? spec)
+      (op-describe spec)
+      (not-a-spec! spec))))
+
 ;; ── def-impl / naming ─────────────────────────────────────────────────────────
 
 (defn- with-name
@@ -483,20 +951,24 @@
   nowhere safe to stash a name on them without breaking protocol dispatch.
   Only our own defrecord-based spec objects (PredicateSpec/AndSpec/OrSpec,
   ...) get an assoc'd :name field, since `assoc` on a record preserves its
-  type tag here."
+  type tag here; regex-op maps carry their name under the namespaced ::name
+  key (plain assoc keeps them regex maps)."
   [spec name]
-  (if (record? spec)
-    (assoc spec :name name)
-    spec))
+  (cond
+    (record? spec) (assoc spec :name name)
+    (regex? spec) (assoc spec ::name name)
+    :else spec))
 
 (defn spec-name
   "Returns the registered name of spec, if it has one. Keyword refs report
-  their own keyword; record-based specs report their assoc'd :name (nil if
-  never named via s/def); anything else (bare fn/set/symbol) has none."
+  their own keyword; record-based specs report their assoc'd :name; regex
+  maps their ::name (nil if never named via s/def); anything else (bare
+  fn/set/symbol) has none."
   [spec]
   (cond
     (keyword? spec) spec
     (record? spec) (:name spec)
+    (regex? spec) (get spec ::name)
     :else nil))
 
 (defn spec-impl
@@ -518,6 +990,7 @@
                      {:key k})))
   (let [s (cond
             (spec? spec) spec
+            (regex? spec) spec
             (keyword? spec) spec
             (symbol? spec) spec
             (set? spec) spec
@@ -606,6 +1079,65 @@
   returns a spec that returns a conformed map satisfying all of the specs."
   [& pred-forms]
   `(merge-spec-impl '~(vec pred-forms) [~@pred-forms]))
+
+;; Regex-op macros. `cat`/`alt` are plain names; `*` and `+` shadow
+;; clojure.core arithmetic and `cat` shadows the core transducer for
+;; unqualified references in THIS namespace from here on (external callers
+;; are unaffected — they go through the `s/` alias). No code in this file
+;; uses bare `*`, `+`, or `cat` as core fns; if a later milestone needs
+;; arithmetic, it must write clojure.core/+ etc. `?` and `&` occupy otherwise
+;; unused names (`&` is only special inside params vectors).
+
+(defmacro cat
+  "Takes key+pred pairs, e.g. (s/cat :a int? :b string?), and returns a
+  regex op that matches (all) values in sequence, returning a map with the
+  keys of each pred and the corresponding conformed value."
+  [& key-pred-forms]
+  (let [pairs (partition 2 key-pred-forms)
+        ks (mapv first pairs)
+        pred-forms (mapv second pairs)]
+    (when (odd? (count key-pred-forms))
+      (throw (ex-info "s/cat expects an even number of key/pred forms"
+                      {:forms key-pred-forms})))
+    `(cat-impl '~ks [~@pred-forms] '~pred-forms)))
+
+(defmacro alt
+  "Takes key+pred pairs, e.g. (s/alt :i int? :s string?), and returns a
+  regex op that returns a [key conformed-value] vector for the first
+  matching alternative."
+  [& key-pred-forms]
+  (let [pairs (partition 2 key-pred-forms)
+        ks (mapv first pairs)
+        pred-forms (mapv second pairs)]
+    (when (odd? (count key-pred-forms))
+      (throw (ex-info "s/alt expects an even number of key/pred forms"
+                      {:forms key-pred-forms})))
+    `(alt-impl '~ks [~@pred-forms] '~pred-forms)))
+
+(defmacro *
+  "Returns a regex op that matches zero or more values matching pred,
+  conforming to a vector."
+  [pred-form]
+  `(rep-impl '~pred-form ~pred-form))
+
+(defmacro +
+  "Returns a regex op that matches one or more values matching pred,
+  conforming to a vector."
+  [pred-form]
+  `(rep+impl '~pred-form ~pred-form))
+
+(defmacro ?
+  "Returns a regex op that matches zero or one value matching pred,
+  conforming to the single conformed value (or nil when absent)."
+  [pred-form]
+  `(maybe-impl ~pred-form '~pred-form))
+
+(defmacro &
+  "Takes a regex op re and one or more predicates; returns a regex op that
+  matches re and whose conformed result must additionally satisfy all the
+  preds (threaded left to right, like s/and)."
+  [re & preds]
+  `(amp-impl ~re '~re [~@preds] '~(vec preds)))
 
 ;; ── Public API ────────────────────────────────────────────────────────────────
 

--- a/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
@@ -3,7 +3,13 @@
 ;;                      M3: derivative-based regex engine (cat/alt/*/+/?/&);
 ;;                      M4: collection specs (every/coll-of/map-of/every-kv),
 ;;                          tuple/nilable/multi-spec/conformer, leaf helpers
-;;                          (int-in/double-in/nonconforming).
+;;                          (int-in/double-in/nonconforming);
+;;                      M5: fspec/fdef (fn-specs registered into the same
+;;                          registry as s/def, keyed by qualified symbol),
+;;                          s/assert + check-asserts, with-gen/gen/exercise/
+;;                          exercise-fn (throwing stubs — see
+;;                          clojure.spec.gen.alpha). instrument/unstrument
+;;                          live in the sibling clojure.spec.test.alpha ns.
 ;;
 ;; This is a from-scratch, spec-compatible-in-spirit implementation for the
 ;; clojurust runtime. It does NOT use `reify` for spec objects (every `reify`
@@ -15,7 +21,8 @@
 ;; regex ops are upstream-style ::op-tagged plain maps given Spec behavior
 ;; via the Map type tag.
 ;;
-;; Next milestone adds: fdef/instrument + gen stub (M5).
+;; This is the final milestone for this file; clojure.spec.test.alpha and
+;; clojure.spec.gen.alpha (both new files) round out the M5 deliverable.
 
 (ns clojure.spec.alpha)
 
@@ -1728,3 +1735,159 @@
   success (::invalid on failure, as usual); unform is identity."
   [pred-form]
   `(nonconforming-impl ~pred-form))
+
+;; ── FSpec (s/fspec) + fdef / fn-specs registry ──────────────────────────────
+;;
+;; `s/fspec` describes a fn's shape via optional :args/:ret/:fn specs.
+;; Without generative testing (see clojure.spec.gen.alpha — a stub namespace
+;; whose fns all throw), the strongest `conform*` can do is check that x is
+;; callable; the child specs are stored (for `s/form`/`describe`, and for
+;; `clojure.spec.test.alpha/instrument`, which DOES check :args on every real
+;; call) but never exercised here.
+;;
+;; `s/fdef` registers an FSpec into the SAME registry `s/def` uses (fn-specs
+;; are not a separate table upstream either), keyed by the fn's
+;; FULLY-QUALIFIED symbol. An unqualified symbol as written is qualified
+;; against `*ns*` AT MACROEXPANSION TIME — safe because a macro body runs
+;; while evaluating the caller's form, so `*ns*` at that point is the
+;; caller's namespace. This is what makes `(s/get-spec sym)` and
+;; `clojure.spec.test.alpha/instrument` work off a plain symbol key.
+
+(defrecord FSpec [args ret fn form name])
+
+(extend-type FSpec Spec
+  (conform* [spec x]
+    (if (fn? x) x ::invalid))
+  (unform* [spec x] x)
+  (explain* [spec path via in x]
+    (when (not (fn? x))
+      [(problem path 'fn? x via in)]))
+  (describe* [spec] (:form spec)))
+
+(defn fspec-impl
+  "Impl fn for s/fspec. args/ret/fn are the evaluated :args/:ret/:fn specs
+  (nil if that option was omitted); form is the literal (fspec ...) call for
+  describe."
+  [args ret fn-spec form]
+  (->FSpec args ret fn-spec form nil))
+
+(defn fspec?
+  "True if x is an FSpec (created via s/fspec, including indirectly via
+  s/fdef)."
+  [x]
+  (instance? FSpec x))
+
+(defmacro fspec
+  "Returns a spec for a fn, described via optional :args/:ret/:fn specs
+  (each defaults to nil, meaning unconstrained). Without generators,
+  conform* can only check that a value is callable — see the FSpec doc
+  comment above. The :args/:ret/:fn specs are stored and available via
+  s/form / (:args ...) etc., and :args is used by
+  clojure.spec.test.alpha/instrument."
+  [& opts]
+  (let [o (apply hash-map opts)]
+    `(fspec-impl ~(:args o) ~(:ret o) ~(:fn o) '~(list* 'fspec opts))))
+
+(defmacro fdef
+  "Takes a symbol naming a fn (var) and the same options as s/fspec
+  (:args/:ret/:fn, each optional). Registers an FSpec into the spec
+  registry keyed by the fully-qualified symbol — an unqualified sym is
+  qualified against the CALLING ns's *ns* at macroexpansion time. Returns
+  the fully-qualified symbol."
+  [sym & opts]
+  (let [qsym (if (namespace sym) sym (symbol (str (ns-name *ns*)) (name sym)))]
+    `(def-impl '~qsym '(fspec ~@opts) (fspec ~@opts))))
+
+;; ── s/assert ─────────────────────────────────────────────────────────────────
+;;
+;; DEVIATION FROM UPSTREAM (documented): real clojure.spec.alpha reads
+;; *compile-asserts* once, at AOT/JVM compile time, baking the decision into
+;; the compiled bytecode. This interpreter has no separate compile phase —
+;; every top-level form is macroexpanded as part of evaluating it — so `assert`
+;; below reads *compile-asserts* at MACROEXPANSION time, which in practice
+;; means "current value at the moment this particular s/assert form is
+;; evaluated." The net effect (toggling `check-asserts` changes behavior of
+;; s/assert forms evaluated afterward, but not ones already macroexpanded and
+;; cached, e.g. inside a previously-defined fn body) is a harmless divergence
+;; but worth knowing about.
+
+(def ^:dynamic *compile-asserts* true)
+
+(defn check-asserts?
+  "Returns the current value of *compile-asserts*."
+  []
+  *compile-asserts*)
+
+(defn check-asserts
+  "Sets *compile-asserts* to flag (globally, via alter-var-root — this
+  interpreter has no compile-time-only phase to gate on, so the change is
+  visible immediately; see the s/assert doc comment above). Returns flag."
+  [flag]
+  (alter-var-root #'*compile-asserts* (fn [_] flag))
+  flag)
+
+(defn assert-spec
+  "Impl fn for s/assert. Returns x unchanged if it's valid? against spec;
+  otherwise throws an ex-info whose data is explain-data spec x, with
+  :clojure.spec.alpha/failure :assertion-failed assoc'd in, and whose
+  message includes the explain-str output."
+  [spec-form spec x]
+  (if (valid? spec x)
+    x
+    (let [ed (assoc (explain-data spec x) :clojure.spec.alpha/failure :assertion-failed)]
+      (throw (ex-info (str "Spec assertion failed\n" (explain-str spec x)) ed)))))
+
+(defmacro assert
+  "Like clojure.core/assert, but takes a spec (rather than a boolean test)
+  and checks x against it via s/valid?, returning x on success. A no-op
+  (expands to plain x-form, no check at all) when *compile-asserts* is false
+  at MACROEXPANSION time — see the s/assert doc comment above for how that
+  differs from upstream's true compile-time gating."
+  [spec-form x-form]
+  (if *compile-asserts*
+    `(assert-spec '~spec-form ~spec-form ~x-form)
+    x-form))
+
+;; ── with-gen / gen / exercise / exercise-fn ────────────────────────────────
+;;
+;; Generators are not implemented in this port — see clojure.spec.gen.alpha,
+;; a small stub namespace whose public fns all throw a clear ex-info.
+;; `s/with-gen` stores the supplied gen-fn without ever invoking it, which is
+;; harmless since nothing here ever calls :gen. Bare (non-record) specs
+;; (Fn/Set/Keyword/Symbol) have nowhere safe to stash a :gen — same
+;; "never with-meta on a dispatching value" rule as with-name — so with-gen
+;; on one of those is a documented no-op.
+
+(defn with-gen
+  "Takes a spec and a no-arg fn that would (in upstream) return a
+  generator. Stores gen-fn under :gen on record-based specs (assoc
+  preserves the record's type tag in this runtime); bare
+  predicate/set/keyword/symbol specs have no field to stash it on, so this
+  is a no-op for them. Since generators aren't implemented, :gen is never
+  actually invoked anywhere in this file."
+  [spec gen-fn]
+  (if (record? spec)
+    (assoc spec :gen gen-fn)
+    spec))
+
+(defn- gen-not-implemented
+  [spec]
+  (throw (ex-info "clojure.spec.gen.alpha generators are not implemented in clojurust"
+                  {:spec spec})))
+
+(defn gen
+  "NOT IMPLEMENTED: this port has no generative testing support (no
+  clojure.spec.gen.alpha generator engine)."
+  ([spec] (gen-not-implemented spec))
+  ([spec _overrides] (gen-not-implemented spec)))
+
+(defn exercise
+  "NOT IMPLEMENTED: this port has no generative testing support."
+  ([spec] (gen-not-implemented spec))
+  ([spec _n] (gen-not-implemented spec))
+  ([spec _n _overrides] (gen-not-implemented spec)))
+
+(defn exercise-fn
+  "NOT IMPLEMENTED: this port has no generative testing support."
+  ([sym] (gen-not-implemented sym))
+  ([sym _n] (gen-not-implemented sym)))

--- a/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
@@ -1,4 +1,5 @@
-;; clojure.spec.alpha — milestone 1: skeleton + predicate specs + and/or.
+;; clojure.spec.alpha — M1: skeleton + predicate specs + and/or;
+;;                      M2: explain machinery + keys/merge.
 ;;
 ;; This is a from-scratch, spec-compatible-in-spirit implementation for the
 ;; clojurust runtime. It does NOT use `reify` for spec objects (every `reify`
@@ -8,8 +9,8 @@
 ;; instead. Bare predicates, sets, keywords, and symbols are made directly
 ;; usable as specs (zero wrapping) by extending `Spec` onto their type tags.
 ;;
-;; Later milestones add: explain-data/keys/merge (M2), regex ops — cat/alt/
-;; */+/?/& (M3), collection/leaf specs (M4), fdef/instrument + gen stub (M5).
+;; Later milestones add: regex ops — cat/alt/*/+/?/& (M3), collection/leaf
+;; specs (M4), fdef/instrument + gen stub (M5).
 
 (ns clojure.spec.alpha)
 
@@ -85,17 +86,36 @@
   [x]
   (= x ::invalid))
 
-;; ── explain-data problem helper ────────────────────────────────────────────────
+;; ── explain problem helpers ───────────────────────────────────────────────────
 ;;
-;; Full explain-data assembly (spec/via/in roll-ups, printable summaries) is
-;; M2. For M1, `explain*` on every spec kind returns a bare vector of these
-;; problem maps (or nil when the value is valid) so the shape is stable and
-;; ready for M2 to build on.
+;; `explain*` on every spec kind returns a vector of these problem maps, or
+;; nil when the value is valid. `explain-data`/`explain`/`explain-str` (below,
+;; in the public API section) assemble them into the upstream-shaped
+;; explain-data map and printable output.
 
 (defn- problem
   "Builds a single explain-data problem map."
   [path pred val via in]
   {:path path :pred pred :val val :via via :in in})
+
+(defn- explain-1
+  "Upstream-shaped single-child explain: if pred is a keyword (registry ref)
+  or one of our record-based spec objects, delegate to its explain* — the
+  Keyword impl pushes itself onto via; a named record spec pushes its
+  registered name. Bare predicates/sets report a single problem carrying the
+  literal form. (References spec?/spec-name defined later in this file — fine,
+  since vars resolve at call time; and uses the *-dispatch aliases so this
+  helper is safe to call from inside any protocol method body.)"
+  [form pred path via in v]
+  (cond
+    (keyword? pred)
+    (explain*-dispatch pred path via in v)
+    (spec? pred)
+    (explain*-dispatch pred path
+                       (if-let [n (spec-name pred)] (conj via n) via)
+                       in v)
+    :else
+    [(problem path form v via in)]))
 
 ;; ── Bare values as specs ────────────────────────────────────────────────────────
 ;;
@@ -213,7 +233,7 @@
         nil
         (let [conformed (conform* (first preds) ret)]
           (if (invalid? conformed)
-            [(problem path (first forms) ret via in)]
+            (explain-1 (first forms) (first preds) path via in ret)
             (recur conformed (rest preds) (rest forms)))))))
   (describe* [spec] (:form spec)))
 
@@ -254,9 +274,12 @@
       (unform*-dispatch (or-pred-for spec k) v)))
   (explain* [spec path via in x]
     (when (invalid? (conform* spec x))
-      (vec (map (fn [k form]
-                  (problem (conj path k) form x via in))
-                (:keys spec) (:forms spec)))))
+      (let [probs (apply concat
+                         (map (fn [k form pred]
+                                (explain-1 form pred (conj path k) via in x))
+                              (:keys spec) (:forms spec) (:preds spec)))]
+        (when (seq probs)
+          (vec probs)))))
   (describe* [spec] (:form spec)))
 
 (defn or-spec-impl
@@ -264,6 +287,190 @@
   spec forms, `preds` their evaluated spec values — all parallel vectors."
   [keys forms preds]
   (->OrSpec (cons 'or (interleave keys forms)) (vec keys) (vec forms) (vec preds) nil))
+
+;; ── KeysSpec ──────────────────────────────────────────────────────────────────
+;;
+;; `s/keys` with :req/:opt/:req-un/:opt-un. :req and :req-un accept nested
+;; `(and ...)`/`(or ...)` connective forms per upstream (presence logic only —
+;; value validation is per-key regardless). Upstream semantics for values:
+;; EVERY map entry whose (qualified) key has a registered spec is
+;; validated/conformed — even keys never mentioned in the keys spec. For
+;; un-variants the map key is `(keyword (name k))` and the validating spec is
+;; the qualified k; `un-map` below carries that unqualified→qualified mapping.
+;;
+;; Records (TypeInstance) are supported as maps: `seq` yields their fields as
+;; map entries, `assoc` preserves their type tag, and presence checks go
+;; through `get` with a sentinel because `contains?` has no record support in
+;; this runtime.
+
+(def ^:private sentinel ::not-found)
+
+(defn- has-key?
+  "Presence check that works on maps AND records — `contains?` has no
+  TypeInstance arm in this runtime, `get` does."
+  [m k]
+  (not= (get m k sentinel) sentinel))
+
+(defn- map-like?
+  [x]
+  (or (map? x) (record? x)))
+
+(defn- key-present?
+  "Evaluates a :req/:req-un element — a qualified keyword or a nested
+  (and ...)/(or ...) connective form — as a presence check against map m.
+  un? true means check the unqualified (name-only) form of each keyword."
+  [m form un?]
+  (cond
+    (keyword? form)
+    (has-key? m (if un? (keyword (name form)) form))
+
+    (seq? form)
+    (let [op (name (first form))]
+      (cond
+        (= op "and") (every? (fn [f] (key-present? m f un?)) (rest form))
+        (= op "or") (boolean (some (fn [f] (key-present? m f un?)) (rest form)))
+        :else (throw (ex-info (str "s/keys: unsupported connective " (pr-str form))
+                              {:form form}))))
+
+    :else
+    (throw (ex-info (str "s/keys: unsupported :req element " (pr-str form))
+                    {:form form}))))
+
+(defn- req-pred-form
+  "Builds the reportable pred form for a missing-req problem, upstream-style:
+  a keyword k becomes (contains? % k); connectives wrap recursively, e.g.
+  (or (contains? % ::a) (contains? % ::b))."
+  [form un?]
+  (if (keyword? form)
+    (list 'contains? '% (if un? (keyword (name form)) form))
+    (cons (first form) (map (fn [f] (req-pred-form f un?)) (rest form)))))
+
+(defn- req-spec-keys
+  "All qualified keywords mentioned in a :req/:req-un element (a bare keyword
+  or a nested connective form)."
+  [form]
+  (if (keyword? form)
+    [form]
+    (mapcat req-spec-keys (rest form))))
+
+(defrecord KeysSpec [form req opt req-un opt-un un-map name])
+
+(extend-type KeysSpec Spec
+  (conform* [spec x]
+    (if (not (map-like? x))
+      ::invalid
+      (if (not (and (every? (fn [f] (key-present? x f false)) (:req spec))
+                    (every? (fn [f] (key-present? x f true)) (:req-un spec))))
+        ::invalid
+        (loop [ret x entries (seq x)]
+          (if entries
+            (let [e (first entries)
+                  k (key e)
+                  v (val e)
+                  sname (get (:un-map spec) k k)]
+              (if (get-spec sname)
+                (let [cv (conform*-dispatch sname v)]
+                  (if (invalid? cv)
+                    ::invalid
+                    (recur (assoc ret k cv) (next entries))))
+                (recur ret (next entries))))
+            ret)))))
+  (unform* [spec x]
+    (if (not (map-like? x))
+      x
+      (loop [ret x entries (seq x)]
+        (if entries
+          (let [e (first entries)
+                k (key e)
+                v (val e)
+                sname (get (:un-map spec) k k)]
+            (if (get-spec sname)
+              (recur (assoc ret k (unform*-dispatch sname v)) (next entries))
+              (recur ret (next entries))))
+          ret))))
+  (explain* [spec path via in x]
+    (if (not (map-like? x))
+      [(problem path 'map? x via in)]
+      (let [req-probs (keep (fn [f]
+                              (when (not (key-present? x f false))
+                                (problem path (req-pred-form f false) x via in)))
+                            (:req spec))
+            req-un-probs (keep (fn [f]
+                                 (when (not (key-present? x f true))
+                                   (problem path (req-pred-form f true) x via in)))
+                               (:req-un spec))
+            val-probs (mapcat (fn [e]
+                                (let [k (key e)
+                                      v (val e)
+                                      sname (get (:un-map spec) k k)]
+                                  (when (get-spec sname)
+                                    (when (invalid? (conform*-dispatch sname v))
+                                      (explain*-dispatch sname (conj path k) via
+                                                         (conj in k) v)))))
+                              (seq x))
+            probs (concat req-probs req-un-probs val-probs)]
+        (when (seq probs)
+          (vec probs)))))
+  (describe* [spec] (:form spec)))
+
+(defn keys-impl
+  "Impl fn for s/keys. req/opt/req-un/opt-un are the literal (unevaluated)
+  option vectors — req and req-un may contain (and ...)/(or ...) connective
+  forms; opt and opt-un are plain qualified keywords. form is the literal
+  (keys ...) form for describe."
+  [req opt req-un opt-un form]
+  (let [req (vec (or req []))
+        opt (vec (or opt []))
+        req-un (vec (or req-un []))
+        opt-un (vec (or opt-un []))
+        all-ks (concat (mapcat req-spec-keys req) opt
+                       (mapcat req-spec-keys req-un) opt-un)]
+    (when (not (every? (fn [k] (and (keyword? k) (namespace k))) all-ks))
+      (throw (ex-info "s/keys: all key specs must be namespace-qualified keywords"
+                      {:input all-ks})))
+    (let [un-map (into {}
+                       (map (fn [k] [(keyword (name k)) k])
+                            (concat (mapcat req-spec-keys req-un) opt-un)))]
+      (->KeysSpec form req opt req-un opt-un un-map nil))))
+
+;; ── MergeSpec ─────────────────────────────────────────────────────────────────
+;;
+;; `s/merge` — each child (usually a keys spec or a keyword ref to one) is
+;; conformed against the whole value; valid iff all children are valid;
+;; conform returns the clojure.core/merge of the children's conformed maps
+;; (upstream semantics). NOTE: internal uses of core merge below must stay
+;; qualified — this ns shadows `merge` with the s/merge macro.
+
+(defrecord MergeSpec [form forms preds name])
+
+(extend-type MergeSpec Spec
+  (conform* [spec x]
+    (loop [ms [] preds (:preds spec)]
+      (if (empty? preds)
+        (apply clojure.core/merge ms)
+        (let [cv (conform*-dispatch (first preds) x)]
+          (if (invalid? cv)
+            ::invalid
+            (recur (conj ms cv) (rest preds)))))))
+  (unform* [spec x]
+    (apply clojure.core/merge
+           (map (fn [pred] (unform*-dispatch pred x))
+                (reverse (:preds spec)))))
+  (explain* [spec path via in x]
+    (let [probs (apply concat
+                       (map (fn [form pred]
+                              (when (invalid? (conform*-dispatch pred x))
+                                (explain-1 form pred path via in x)))
+                            (:forms spec) (:preds spec)))]
+      (when (seq probs)
+        (vec probs))))
+  (describe* [spec] (:form spec)))
+
+(defn merge-spec-impl
+  "Impl fn for s/merge. `forms` are the literal child spec forms, `preds`
+  their evaluated spec values — parallel vectors."
+  [forms preds]
+  (->MergeSpec (cons 'merge forms) (vec forms) (vec preds) nil))
 
 ;; ── def-impl / naming ─────────────────────────────────────────────────────────
 
@@ -373,6 +580,33 @@
     `(or-spec-impl '~ks '~pred-forms [~@pred-forms])))
 (def or or-form)
 
+;; `keys`/`merge` are NOT special forms, so they can be defmacro'd under their
+;; own names directly — but doing so shadows clojure.core/keys and
+;; clojure.core/merge for ALL unqualified references in this namespace
+;; (interned vars beat refers). Any internal use of the core fns in this file
+;; must be written clojure.core/keys / clojure.core/merge.
+
+(defmacro keys
+  "Creates and returns a map validating spec. :req and :opt are vectors of
+  namespace-qualified keywords (in :req, `(and ...)`/`(or ...)` connective
+  forms are also accepted for presence logic). :req-un/:opt-un use the
+  qualified keyword's spec to validate the UNqualified key in the map.
+  Regardless of options, every map entry whose (qualified) key has a
+  registered spec is conformed/validated."
+  [& kspecs]
+  (let [opts (apply hash-map kspecs)
+        req (get opts :req [])
+        opt (get opts :opt [])
+        req-un (get opts :req-un [])
+        opt-un (get opts :opt-un [])]
+    `(keys-impl '~req '~opt '~req-un '~opt-un '~(cons 'keys kspecs))))
+
+(defmacro merge
+  "Takes map-validating specs (e.g. keys specs or keyword refs to them) and
+  returns a spec that returns a conformed map satisfying all of the specs."
+  [& pred-forms]
+  `(merge-spec-impl '~(vec pred-forms) [~@pred-forms]))
+
 ;; ── Public API ────────────────────────────────────────────────────────────────
 
 (defn spec?
@@ -416,3 +650,68 @@
   to a user."
   [spec]
   (describe* spec))
+
+;; ── explain ───────────────────────────────────────────────────────────────────
+
+(defn explain-data*
+  "Like explain-data but with explicit path/via/in seeds. Returns the
+  explain-data map, or nil when x is valid."
+  [spec path via in x]
+  (let [probs (explain* spec path via in x)]
+    (when (seq probs)
+      {:clojure.spec.alpha/problems (vec probs)
+       :clojure.spec.alpha/spec spec
+       :clojure.spec.alpha/value x})))
+
+(defn explain-data
+  "Given a spec and a value x that fails to conform, returns a map with at
+  least :clojure.spec.alpha/problems (a vector of problem maps with keys
+  :path :pred :val :via :in), plus :clojure.spec.alpha/spec and
+  :clojure.spec.alpha/value. Returns nil when x conforms. (Explicit qualified
+  keywords — the reader has no #:ns{...} literal support.)
+
+  via seeding: only a NAMED record-based spec seeds via with its registered
+  name here. A keyword spec pushes itself onto via inside the Keyword
+  explain* impl, so seeding it here too would double it."
+  [spec x]
+  (explain-data* spec []
+                 (if-let [n (and (record? spec) (spec-name spec))] [n] [])
+                 [] x))
+
+(defn explain-printer
+  "Default printer for explain-data. Prints one line per problem, upstream-ish:
+  <val> - failed: <pred> in: <in> at: <path> spec: <last-via>. Prints
+  Success! when ed is nil."
+  [ed]
+  (if ed
+    (doseq [p (:clojure.spec.alpha/problems ed)]
+      (let [path (:path p)
+            pred (:pred p)
+            v (:val p)
+            via (:via p)
+            in (:in p)]
+        (println (str (pr-str v)
+                      " - failed: " (pr-str pred)
+                      (if (empty? in) "" (str " in: " (pr-str in)))
+                      (if (empty? path) "" (str " at: " (pr-str path)))
+                      (if (empty? via) "" (str " spec: " (pr-str (last via))))))))
+    (println "Success!")))
+
+(def ^:dynamic *explain-out* explain-printer)
+
+(defn explain-out
+  "Prints explanation data (per *explain-out*, default explain-printer) to
+  *out*."
+  [ed]
+  (*explain-out* ed))
+
+(defn explain
+  "Given a spec and a value that fails to conform, prints an explanation to
+  *out*; prints Success! otherwise."
+  [spec x]
+  (explain-out (explain-data spec x)))
+
+(defn explain-str
+  "Like explain, but returns the explanation as a string."
+  [spec x]
+  (with-out-str (explain spec x)))

--- a/crates/cljrs-stdlib/src/clojure/spec/gen/alpha.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/spec/gen/alpha.cljrs
@@ -1,0 +1,114 @@
+;; clojure.spec.gen.alpha — M5 stub.
+;;
+;; This runtime has no generative-testing engine (no test.check port), so
+;; every public fn here throws a clear ex-info instead of doing anything.
+;; The namespace exists purely so `(:require [clojure.spec.gen.alpha :as
+;; gen])` — idiomatic in specs that use `s/with-gen`, `s/gen`, or reference
+;; gen/elements etc. directly — loads cleanly instead of failing to resolve.
+;;
+;; CAUTION for anyone extending this file: several of these names
+;; (`int`/`string`/`keyword`/`boolean`/`double`) intentionally shadow
+;; clojure.core fns, exactly as upstream's real clojure.spec.gen.alpha does.
+;; That shadowing only applies to UNQUALIFIED references from this point
+;; onward within THIS namespace — every fn body below must stay trivial
+;; (call only `not-implemented`, itself defined before any shadowing occurs
+;; and using nothing but `str`/`ex-info`, neither of which is ever
+;; redefined here) so the shadowing can never cause accidental self-
+;; recursion or wrong-fn calls.
+
+(ns clojure.spec.gen.alpha)
+
+(defn- not-implemented
+  "Throws a clear, consistent ex-info for every stubbed generator fn in
+  this namespace. n is the unqualified fn name, as a string."
+  [n]
+  (throw (ex-info
+          (str "clojure.spec.gen.alpha/" n
+               " - generators are not implemented in clojurust")
+          {:fn n})))
+
+(defn generate
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "generate"))
+
+(defn sample
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "sample"))
+
+(defn gen-for-pred
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "gen-for-pred"))
+
+(defn choose
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "choose"))
+
+(defn such-that
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "such-that"))
+
+(defn fmap
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "fmap"))
+
+(defn one-of
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "one-of"))
+
+(defn return
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "return"))
+
+(defn elements
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "elements"))
+
+(defn int
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust.
+  (Shadows clojure.core/int in this ns, matching upstream.)"
+  [& _args]
+  (not-implemented "int"))
+
+(defn string
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust.
+  (Shadows clojure.core/string? co-family naming in this ns, matching
+  upstream's clojure.spec.gen.alpha/string.)"
+  [& _args]
+  (not-implemented "string"))
+
+(defn keyword
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust.
+  (Shadows clojure.core/keyword in this ns, matching upstream.)"
+  [& _args]
+  (not-implemented "keyword"))
+
+(defn boolean
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust.
+  (Shadows clojure.core/boolean in this ns, matching upstream.)"
+  [& _args]
+  (not-implemented "boolean"))
+
+(defn double
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust.
+  (Shadows clojure.core/double in this ns, matching upstream.)"
+  [& _args]
+  (not-implemented "double"))
+
+(defn simple-type
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "simple-type"))
+
+(defn any
+  "NOT IMPLEMENTED: generative testing is not supported in clojurust."
+  [& _args]
+  (not-implemented "any"))

--- a/crates/cljrs-stdlib/src/clojure/spec/test/alpha.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/spec/test/alpha.cljrs
@@ -1,0 +1,147 @@
+;; clojure.spec.test.alpha — M5: instrument/unstrument.
+;;
+;; `instrument` wraps a var's root fn (via `alter-var-root`, verified working
+;; in earlier milestones — see clojure.spec.alpha's doc comments) so every
+;; call conforms its argument list against the fn's fdef'd :args spec before
+;; delegating to the ORIGINAL (raw, pre-instrument) fn. Only :args is
+;; checked — never :ret or :fn — matching upstream's instrument semantics
+;; (those need generative testing to be useful, and `check`/`check-fn` below
+;; are honest stubs for exactly that reason: this runtime has no generator
+;; engine, see clojure.spec.gen.alpha).
+;;
+;; The raw (pre-instrument) fn for each instrumented symbol is kept in a
+;; private atom keyed by the qualified symbol, so `unstrument` can restore it
+;; and so a second `instrument` call on an already-instrumented symbol is a
+;; safe no-op (never double-wraps).
+
+(ns clojure.spec.test.alpha
+  (:require [clojure.spec.alpha :as s]))
+
+;; ── state ─────────────────────────────────────────────────────────────────
+
+(def ^:private instrumented-raw (atom {}))
+
+(def ^:dynamic *instrument-enabled*
+  "When bound to false (see with-instrument-disabled), every instrumented
+  fn calls straight through to its raw implementation without conforming
+  :args at all."
+  true)
+
+;; ── helpers ───────────────────────────────────────────────────────────────
+
+(defn- fn-spec-for
+  "Returns the FSpec registered under sym (via s/fdef), or nil if sym has
+  no registered spec or its spec isn't an fspec (e.g. it's a plain value
+  spec registered under a symbol some other way)."
+  [sym]
+  (let [spec (s/get-spec sym)]
+    (when (s/fspec? spec) spec)))
+
+(defn instrumentable-syms
+  "All symbols in the spec registry that name an fspec (fdef'd) AND resolve
+  to a var — i.e. every symbol instrument/unstrument (no-arg form) would
+  touch."
+  []
+  (vec (filter (fn [k]
+                 (and (symbol? k)
+                      (fn-spec-for k)
+                      (var? (resolve k))))
+               (keys (s/registry)))))
+
+(defn- instrument-1
+  "Wraps the var named by sym so every call conforms its argument list
+  against the fdef'd :args spec before delegating to the raw fn. Silently
+  no-ops if sym has no fspec, the fspec has no :args, or sym doesn't
+  resolve to a var. Idempotent: a symbol already in instrumented-raw is
+  left alone. Returns sym."
+  [sym]
+  (when-not (contains? @instrumented-raw sym)
+    (when-let [fspec (fn-spec-for sym)]
+      (when-let [v (resolve sym)]
+        (when (var? v)
+          (let [raw (var-get v)
+                args-spec (:args fspec)]
+            (swap! instrumented-raw assoc sym raw)
+            (alter-var-root
+             v
+             (fn [_]
+               (fn [& args]
+                 (if (not *instrument-enabled*)
+                   (apply raw args)
+                   (if (nil? args-spec)
+                     (apply raw args)
+                     (let [conformed (s/conform args-spec args)]
+                       (if (s/invalid? conformed)
+                         (throw (ex-info
+                                 (str "Call to " sym " did not conform to spec.")
+                                 (assoc (or (s/explain-data* args-spec [:args] [sym] [] args)
+                                            {})
+                                        :clojure.spec.alpha/failure :instrument
+                                        :clojure.spec.test.alpha/caller nil)))
+                         (apply raw args)))))))))))))
+  sym)
+
+(defn- unstrument-1
+  "Restores sym's original (pre-instrument) fn if currently instrumented;
+  no-op otherwise. Returns sym."
+  [sym]
+  (when (contains? @instrumented-raw sym)
+    (let [raw (get @instrumented-raw sym)
+          v (resolve sym)]
+      (when (var? v)
+        (alter-var-root v (fn [_] raw)))
+      (swap! instrumented-raw dissoc sym)))
+  sym)
+
+(defn- as-syms
+  "Normalizes the 1-arity instrument/unstrument argument into a vector of
+  symbols: a bare symbol becomes a single-element vector; any other
+  collection is used as-is (vec'd)."
+  [sym-or-syms]
+  (cond
+    (symbol? sym-or-syms) [sym-or-syms]
+    (coll? sym-or-syms) (vec sym-or-syms)
+    :else (throw (ex-info "expected a symbol or a collection of symbols"
+                          {:arg sym-or-syms}))))
+
+;; ── public API ────────────────────────────────────────────────────────────
+
+(defn instrument
+  "Instruments the named sym, or every sym in a collection of syms, or (with
+  no args) every instrumentable sym currently in the registry. Returns a
+  vector of the syms instrumented (in the same order given, or
+  instrumentable-syms' order for the 0-arity form)."
+  ([] (instrument (instrumentable-syms)))
+  ([sym-or-syms] (vec (map instrument-1 (as-syms sym-or-syms)))))
+
+(defn unstrument
+  "Un-instruments (restores the raw fn for) the named sym, or every sym in a
+  collection of syms, or (with no args) every currently-instrumented sym.
+  Returns a vector of the syms un-instrumented."
+  ([] (unstrument (vec (keys @instrumented-raw))))
+  ([sym-or-syms] (vec (map unstrument-1 (as-syms sym-or-syms)))))
+
+(defmacro with-instrument-disabled
+  "Evaluates body with instrumentation checks disabled: for the dynamic
+  extent of body, every currently-instrumented fn calls straight through to
+  its raw implementation without conforming :args."
+  [& body]
+  `(binding [*instrument-enabled* false]
+     ~@body))
+
+(defn check-fn
+  "NOT IMPLEMENTED: requires generative testing, which is not supported in
+  clojurust — see clojure.spec.gen.alpha."
+  [f spec & _opts]
+  (throw (ex-info
+          "clojure.spec.test.alpha/check-fn requires generators, which are not implemented in clojurust"
+          {:spec spec})))
+
+(defn check
+  "NOT IMPLEMENTED: requires generative testing, which is not supported in
+  clojurust — see clojure.spec.gen.alpha."
+  ([] (check nil))
+  ([sym-or-syms & _opts]
+   (throw (ex-info
+           "clojure.spec.test.alpha/check requires generators, which are not implemented in clojurust"
+           {:syms sym-or-syms}))))

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -37,6 +37,7 @@ const CLOJURE_EDN_SRC: &str = include_str!("clojure/edn.cljrs");
 const CLOJURE_WALK_SRC: &str = include_str!("clojure/walk.cljrs");
 const CLOJURE_DATA_SRC: &str = include_str!("clojure/data.cljrs");
 const COLJURE_ZIP_SRC: &str = include_str!("clojure/zip.cljrs");
+const CLOJURE_SPEC_ALPHA_SRC: &str = include_str!("clojure/spec/alpha.cljrs");
 
 // ── Macro: register a batch of native fns into a namespace ───────────────────
 
@@ -100,6 +101,9 @@ pub fn register(globals: &Arc<GlobalEnv>) {
 
     // clojure.zip
     globals.register_builtin_source("clojure.zip", COLJURE_ZIP_SRC);
+
+    // clojure.spec.alpha ─ pure Clojure, no native helpers.
+    globals.register_builtin_source("clojure.spec.alpha", CLOJURE_SPEC_ALPHA_SRC);
 }
 
 /// Create a `GlobalEnv` with all built-ins and stdlib registered, **without**
@@ -188,7 +192,7 @@ mod tests {
     use super::*;
     use cljrs_eval::{Env, EvalResult, eval};
     use cljrs_reader::Parser;
-    use cljrs_value::Value;
+    use cljrs_value::{Keyword, Value};
 
     fn make_env() -> (Arc<GlobalEnv>, Env) {
         let globals = standard_env();
@@ -429,5 +433,164 @@ mod tests {
             .unwrap()
             .join()
             .unwrap();
+    }
+
+    // ── clojure.spec.alpha (M1: skeleton + predicate specs + and/or) ─────────
+
+    /// Runs `body` on a thread with a 16MB stack (macro-heavy `spec` loading
+    /// triggers eager IR lowering, which recurses deeply — see
+    /// `test_clojure_test_lazy_load` above for the same pattern).
+    fn run_with_big_stack<F: FnOnce() + Send + 'static>(body: F) {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(body)
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_spec_def_and_valid_conform() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_eq!(
+                run("(s/def ::x even?)", &mut env).unwrap(),
+                Value::keyword(Keyword::qualified("user", "x"))
+            );
+            assert_eq!(
+                run("(s/valid? ::x 4)", &mut env).unwrap(),
+                Value::Bool(true)
+            );
+            assert_eq!(
+                run("(s/valid? ::x 3)", &mut env).unwrap(),
+                Value::Bool(false)
+            );
+            assert_eq!(run("(s/conform ::x 4)", &mut env).unwrap(), Value::Long(4));
+            assert_eq!(
+                run("(s/invalid? (s/conform ::x 3))", &mut env).unwrap(),
+                Value::Bool(true)
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_set_and_keyword_ref() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(s/def ::color #{:red :green})", &mut env).unwrap();
+            assert_eq!(
+                run("(s/valid? ::color :red)", &mut env).unwrap(),
+                Value::Bool(true)
+            );
+            assert_eq!(
+                run("(s/valid? ::color :blue)", &mut env).unwrap(),
+                Value::Bool(false)
+            );
+
+            // keyword-registry-ref spec: ::y re-resolves ::x live.
+            run("(s/def ::x even?)", &mut env).unwrap();
+            run("(s/def ::y ::x)", &mut env).unwrap();
+            assert_eq!(
+                run("(s/valid? ::y 4)", &mut env).unwrap(),
+                Value::Bool(true)
+            );
+            assert_eq!(
+                run("(s/valid? ::y 3)", &mut env).unwrap(),
+                Value::Bool(false)
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_forward_reference() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            // ::a refers to ::b before ::b is defined.
+            run("(s/def ::a ::b)", &mut env).unwrap();
+            run("(s/def ::b string?)", &mut env).unwrap();
+            assert_eq!(
+                run(r#"(s/conform ::a "hi")"#, &mut env).unwrap(),
+                Value::string("hi")
+            );
+            assert_eq!(
+                run("(s/invalid? (s/conform ::a 5))", &mut env).unwrap(),
+                Value::Bool(true)
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_and_or() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_eq!(
+                run("(s/valid? (s/and int? even?) 4)", &mut env).unwrap(),
+                Value::Bool(true)
+            );
+            assert_eq!(
+                run("(s/valid? (s/and int? even?) 3)", &mut env).unwrap(),
+                Value::Bool(false)
+            );
+            let v = run("(s/conform (s/or :i int? :s string?) 5)", &mut env).unwrap();
+            match v {
+                Value::Vector(vec) => {
+                    let items = vec.get().iter().cloned().collect::<Vec<_>>();
+                    assert_eq!(items.len(), 2);
+                    assert_eq!(items[0], Value::keyword(Keyword::simple("i")));
+                    assert_eq!(items[1], Value::Long(5));
+                }
+                other => panic!("expected [:i 5], got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn test_spec_spec_and_registry_introspection() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            // Bare predicates are directly usable but not `spec?`; our own
+            // record-based compound specs are.
+            assert_eq!(run("(s/spec? even?)", &mut env).unwrap(), Value::Nil);
+            let is_spec = run("(s/spec? (s/and int? even?))", &mut env).unwrap();
+            assert!(
+                !matches!(is_spec, Value::Nil),
+                "expected a truthy spec object"
+            );
+
+            run("(s/def ::x even?)", &mut env).unwrap();
+            assert!(!matches!(
+                run("(s/get-spec ::x)", &mut env).unwrap(),
+                Value::Nil
+            ));
+            assert!(matches!(
+                run("(s/get-spec ::does-not-exist)", &mut env).unwrap(),
+                Value::Nil
+            ));
+
+            run("(s/def ::pos-even (s/and int? even? pos?))", &mut env).unwrap();
+            let form_v = run("(s/form ::pos-even)", &mut env).unwrap();
+            assert_eq!(format!("{form_v}"), "(and int? even? pos?)");
+            let describe_v = run("(s/describe ::pos-even)", &mut env).unwrap();
+            assert_eq!(format!("{describe_v}"), "(and int? even? pos?)");
+        });
+    }
+
+    #[test]
+    fn test_spec_conform_unregistered_keyword_throws() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            let err = run("(s/conform ::does-not-exist 1)", &mut env).unwrap_err();
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("Unable to resolve spec"),
+                "expected 'Unable to resolve spec' in error, got: {msg}"
+            );
+        });
     }
 }

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -38,6 +38,8 @@ const CLOJURE_WALK_SRC: &str = include_str!("clojure/walk.cljrs");
 const CLOJURE_DATA_SRC: &str = include_str!("clojure/data.cljrs");
 const COLJURE_ZIP_SRC: &str = include_str!("clojure/zip.cljrs");
 const CLOJURE_SPEC_ALPHA_SRC: &str = include_str!("clojure/spec/alpha.cljrs");
+const CLOJURE_SPEC_GEN_ALPHA_SRC: &str = include_str!("clojure/spec/gen/alpha.cljrs");
+const CLOJURE_SPEC_TEST_ALPHA_SRC: &str = include_str!("clojure/spec/test/alpha.cljrs");
 
 // ── Macro: register a batch of native fns into a namespace ───────────────────
 
@@ -104,6 +106,12 @@ pub fn register(globals: &Arc<GlobalEnv>) {
 
     // clojure.spec.alpha ─ pure Clojure, no native helpers.
     globals.register_builtin_source("clojure.spec.alpha", CLOJURE_SPEC_ALPHA_SRC);
+
+    // clojure.spec.gen.alpha ─ pure Clojure, throwing generator stubs.
+    globals.register_builtin_source("clojure.spec.gen.alpha", CLOJURE_SPEC_GEN_ALPHA_SRC);
+
+    // clojure.spec.test.alpha ─ pure Clojure, instrument/unstrument.
+    globals.register_builtin_source("clojure.spec.test.alpha", CLOJURE_SPEC_TEST_ALPHA_SRC);
 }
 
 /// Create a `GlobalEnv` with all built-ins and stdlib registered, **without**
@@ -1326,6 +1334,191 @@ mod tests {
                 msg.contains("not implemented"),
                 "expected 'not implemented' in error, got: {msg}"
             );
+        });
+    }
+
+    // ── clojure.spec.alpha / .test.alpha / .gen.alpha (M5: fdef/instrument) ──
+
+    #[test]
+    fn test_spec_fdef_registers_qualified_symbol_and_get_spec() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(defn my-add [a b] (+ a b))", &mut env).unwrap();
+            assert_bool(
+                "(= 'user/my-add (s/fdef my-add :args (s/cat :a int? :b int?) :ret int?))",
+                true,
+                &mut env,
+            );
+            assert_bool("(s/fspec? (s/get-spec 'user/my-add))", true, &mut env);
+            assert_bool("(some? (:args (s/get-spec 'user/my-add)))", true, &mut env);
+            // syntax-quote auto-qualification against the current ns resolves
+            // to the same registry entry as the explicit qualified symbol.
+            assert_bool(
+                "(= (s/get-spec 'user/my-add) (s/get-spec `my-add))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_instrument_valid_and_invalid_calls() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(require '[clojure.spec.test.alpha :as stest])", &mut env).unwrap();
+            run("(defn my-add [a b] (+ a b))", &mut env).unwrap();
+            run(
+                "(s/fdef my-add :args (s/cat :a int? :b int?) :ret int?)",
+                &mut env,
+            )
+            .unwrap();
+            run("(stest/instrument 'user/my-add)", &mut env).unwrap();
+            // valid call still returns the normal value through the wrapper.
+            assert_eq!(run("(my-add 2 3)", &mut env).unwrap(), Value::Long(5));
+            // invalid call throws with the expected message and ex-data.
+            run(
+                r#"(def caught
+                     (try (my-add 2 "x") :did-not-throw
+                          (catch Exception e {:msg (ex-message e) :data (ex-data e)})))"#,
+                &mut env,
+            )
+            .unwrap();
+            assert_bool(
+                r#"(= "Call to user/my-add did not conform to spec." (:msg caught))"#,
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(= :instrument (:clojure.spec.alpha/failure (:data caught)))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(contains? (:data caught) :clojure.spec.test.alpha/caller)",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_unstrument_restores_raw_fn() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(require '[clojure.spec.test.alpha :as stest])", &mut env).unwrap();
+            run("(defn my-pair [a b] [a b])", &mut env).unwrap();
+            run("(s/fdef my-pair :args (s/cat :a int? :b int?))", &mut env).unwrap();
+            run("(stest/instrument 'user/my-pair)", &mut env).unwrap();
+            assert!(run("(my-pair 1 \"x\")", &mut env).is_err());
+            run("(stest/unstrument 'user/my-pair)", &mut env).unwrap();
+            // no longer wrapped -- the raw fn has no type constraints, so an
+            // "invalid by spec" call now succeeds instead of throwing.
+            assert_bool("(= [1 \"x\"] (my-pair 1 \"x\"))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_instrument_affects_call_sites_evaluated_before_instrument() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(require '[clojure.spec.test.alpha :as stest])", &mut env).unwrap();
+            run("(defn my-mul [a b] (* a b))", &mut env).unwrap();
+            run("(s/fdef my-mul :args (s/cat :a int? :b int?))", &mut env).unwrap();
+            // Warm up this call site (and any inline-cached/lowered code for
+            // it) BEFORE instrumenting.
+            assert_eq!(run("(my-mul 2 3)", &mut env).unwrap(), Value::Long(6));
+            run("(stest/instrument 'user/my-mul)", &mut env).unwrap();
+            // A stale inline cache pointing at the pre-instrument var root
+            // would silently skip the spec check here.
+            assert!(run("(my-mul 2 \"x\")", &mut env).is_err());
+        });
+    }
+
+    #[test]
+    fn test_spec_instrumentable_syms_and_idempotent_double_instrument() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(require '[clojure.spec.test.alpha :as stest])", &mut env).unwrap();
+            run("(defn my-pair2 [a b] [a b])", &mut env).unwrap();
+            run("(s/fdef my-pair2 :args (s/cat :a int? :b int?))", &mut env).unwrap();
+            assert_bool(
+                "(boolean (some #{'user/my-pair2} (stest/instrumentable-syms)))",
+                true,
+                &mut env,
+            );
+            run("(stest/instrument 'user/my-pair2)", &mut env).unwrap();
+            run("(stest/instrument 'user/my-pair2)", &mut env).unwrap(); // idempotent
+            assert!(run("(my-pair2 1 \"x\")", &mut env).is_err());
+            // A SINGLE unstrument must fully restore -- if double-instrument
+            // had double-wrapped, one layer would still be active and the
+            // call below would still throw.
+            run("(stest/unstrument 'user/my-pair2)", &mut env).unwrap();
+            assert_bool("(= [1 \"x\"] (my-pair2 1 \"x\"))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_with_instrument_disabled_bypasses_checks() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(require '[clojure.spec.test.alpha :as stest])", &mut env).unwrap();
+            run("(defn my-pair3 [a b] [a b])", &mut env).unwrap();
+            run("(s/fdef my-pair3 :args (s/cat :a int? :b int?))", &mut env).unwrap();
+            run("(stest/instrument 'user/my-pair3)", &mut env).unwrap();
+            assert!(run("(my-pair3 1 \"x\")", &mut env).is_err());
+            assert_bool(
+                "(stest/with-instrument-disabled (= [1 \"x\"] (my-pair3 1 \"x\")))",
+                true,
+                &mut env,
+            );
+            // instrumentation resumes outside the dynamic extent.
+            assert!(run("(my-pair3 1 \"x\")", &mut env).is_err());
+        });
+    }
+
+    #[test]
+    fn test_spec_assert_happy_sad_and_check_asserts_toggle() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_eq!(run("(s/assert even? 4)", &mut env).unwrap(), Value::Long(4));
+            assert!(run("(s/assert even? 5)", &mut env).is_err());
+            run("(s/check-asserts false)", &mut env).unwrap();
+            // a freshly (re-)macroexpanded s/assert form reads
+            // *compile-asserts* at macroexpansion time and passes an invalid
+            // value through unchecked.
+            assert_eq!(run("(s/assert even? 5)", &mut env).unwrap(), Value::Long(5));
+            run("(s/check-asserts true)", &mut env).unwrap();
+            assert!(run("(s/assert even? 5)", &mut env).is_err());
+        });
+    }
+
+    #[test]
+    fn test_spec_gen_and_check_throw_not_implemented_and_gen_ns_loads() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(require '[clojure.spec.test.alpha :as stest])", &mut env).unwrap();
+            run("(require '[clojure.spec.gen.alpha :as gen])", &mut env).unwrap();
+            for src in [
+                "(s/gen even?)",
+                "(s/exercise even?)",
+                "(s/exercise-fn 'user/foo)",
+                "(stest/check)",
+                "(stest/check 'user/foo)",
+                "(stest/check-fn (fn [x] x) even?)",
+                "(gen/generate :whatever)",
+                "(gen/sample :whatever)",
+                "(gen/elements [1 2 3])",
+            ] {
+                assert!(run(src, &mut env).is_err(), "expected {src} to throw");
+            }
         });
     }
 }

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -593,4 +593,202 @@ mod tests {
             );
         });
     }
+
+    // ── clojure.spec.alpha (M2: explain + keys/merge) ────────────────────────
+
+    /// Asserts that a Clojure expression evaluates to exactly `true`/`false`.
+    #[track_caller]
+    fn assert_bool(src: &str, expected: bool, env: &mut Env) {
+        assert_eq!(
+            run(src, env).unwrap(),
+            Value::Bool(expected),
+            "expression: {src}"
+        );
+    }
+
+    #[test]
+    fn test_spec_keys_req_opt() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(s/def ::a int?) (s/def ::b string?)", &mut env).unwrap();
+            run("(s/def ::m (s/keys :req [::a] :opt [::b]))", &mut env).unwrap();
+            assert_bool("(s/valid? ::m {::a 1})", true, &mut env);
+            assert_bool("(s/valid? ::m {::a 1 ::b \"x\"})", true, &mut env);
+            assert_bool("(s/valid? ::m {::b \"x\"})", false, &mut env); // missing req
+            assert_bool("(s/valid? ::m {::a \"no\"})", false, &mut env); // bad req value
+            assert_bool("(s/valid? ::m {::a 1 ::b 2})", false, &mut env); // bad opt value
+            assert_bool("(s/valid? ::m 42)", false, &mut env); // not a map
+            // undeclared-but-registered key is still validated (upstream semantics)
+            assert_bool(
+                "(s/valid? (s/keys :req [::a]) {::a 1 ::b :not-a-string})",
+                false,
+                &mut env,
+            );
+            // connectives in :req
+            run("(s/def ::c boolean?)", &mut env).unwrap();
+            run(
+                "(s/def ::conn (s/keys :req [(or ::a (and ::b ::c))]))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(s/valid? ::conn {::a 1})", true, &mut env);
+            assert_bool("(s/valid? ::conn {::b \"x\" ::c true})", true, &mut env);
+            assert_bool("(s/valid? ::conn {::b \"x\"})", false, &mut env);
+            assert_bool("(s/valid? ::conn {})", false, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_keys_un_variants() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(s/def ::a int?) (s/def ::b string?)", &mut env).unwrap();
+            run(
+                "(s/def ::mu (s/keys :req-un [::a] :opt-un [::b]))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(s/valid? ::mu {:a 1})", true, &mut env);
+            assert_bool("(s/valid? ::mu {:a 1 :b \"x\"})", true, &mut env);
+            assert_bool("(s/valid? ::mu {:b \"x\"})", false, &mut env); // missing req-un
+            assert_bool("(s/valid? ::mu {:a \"no\"})", false, &mut env); // bad value
+            assert_bool("(s/valid? ::mu {:a 1 :b 2})", false, &mut env); // bad opt-un value
+            assert_bool("(= {:a 1} (s/conform ::mu {:a 1}))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_keys_record() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(defrecord Point [x y])", &mut env).unwrap();
+            run("(s/def ::x number?) (s/def ::y number?)", &mut env).unwrap();
+            run("(s/def ::point (s/keys :req-un [::x ::y]))", &mut env).unwrap();
+            assert_bool("(s/valid? ::point (->Point 1 2))", true, &mut env);
+            assert_bool("(s/valid? ::point (->Point \"a\" 2))", false, &mut env);
+            // conform on a record returns a record (assoc preserves type tag)
+            assert_bool(
+                "(record? (s/conform ::point (->Point 1 2)))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_explain_data_shape() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(s/def ::a int?) (s/def ::b string?)", &mut env).unwrap();
+            run("(s/def ::m (s/keys :req [::a] :opt [::b]))", &mut env).unwrap();
+
+            // Missing-req problem: (contains? % :user/a)-style pred, path/in [].
+            run("(def ed1 (s/explain-data ::m {::b \"x\"}))", &mut env).unwrap();
+            assert_bool(
+                "(pos? (count (:clojure.spec.alpha/problems ed1)))",
+                true,
+                &mut env,
+            );
+            let pred = run(
+                "(pr-str (:pred (first (:clojure.spec.alpha/problems ed1))))",
+                &mut env,
+            )
+            .unwrap();
+            assert_eq!(pred, Value::string("(contains? % :user/a)"));
+            assert_bool(
+                "(= [] (:path (first (:clojure.spec.alpha/problems ed1))))",
+                true,
+                &mut env,
+            );
+
+            // Bad-value problem: path/in extended by the key, via extended by
+            // both the named keys spec and the failing key's spec.
+            run("(def ed2 (s/explain-data ::m {::a \"no\"}))", &mut env).unwrap();
+            run(
+                "(def p2 (first (:clojure.spec.alpha/problems ed2)))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(= [::a] (:path p2))", true, &mut env);
+            assert_bool("(= [::a] (:in p2))", true, &mut env);
+            assert_bool("(= [::m ::a] (:via p2))", true, &mut env);
+            assert_bool("(= \"no\" (:val p2))", true, &mut env);
+
+            // Valid value → nil.
+            assert_bool("(nil? (s/explain-data ::m {::a 4}))", true, &mut env);
+
+            // Whole-map value and spec recorded on the explain-data map.
+            assert_bool(
+                "(= {::a \"no\"} (:clojure.spec.alpha/value ed2))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_merge() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(s/def ::a int?) (s/def ::b string?)", &mut env).unwrap();
+            run("(s/def ::ma (s/keys :req [::a]))", &mut env).unwrap();
+            run("(s/def ::mb (s/keys :req [::b]))", &mut env).unwrap();
+            run("(s/def ::mab (s/merge ::ma ::mb))", &mut env).unwrap();
+            assert_bool("(s/valid? ::mab {::a 1 ::b \"x\"})", true, &mut env);
+            assert_bool("(s/valid? ::mab {::a 1})", false, &mut env);
+            assert_bool(
+                "(= {::a 1 ::b \"x\"} (s/conform ::mab {::a 1 ::b \"x\"}))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(pos? (count (:clojure.spec.alpha/problems
+                               (s/explain-data ::mab {::a 1}))))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_explain_str_and_printer() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(s/def ::a int?)", &mut env).unwrap();
+            run("(s/def ::m (s/keys :req [::a]))", &mut env).unwrap();
+            let estr = match run("(s/explain-str ::m {::a \"no\"})", &mut env).unwrap() {
+                Value::Str(s) => s.get().clone(),
+                other => panic!("expected string from explain-str, got {other:?}"),
+            };
+            assert!(
+                estr.contains("failed") && estr.contains("int?"),
+                "unexpected explain-str output: {estr}"
+            );
+            let ok = run("(s/explain-str ::m {::a 1})", &mut env).unwrap();
+            assert_eq!(ok, Value::string("Success!\n"));
+        });
+    }
+
+    #[test]
+    fn test_spec_keys_unform_roundtrip() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(s/def ::id (s/or :i int? :s string?))", &mut env).unwrap();
+            run("(s/def ::rm (s/keys :req-un [::id]))", &mut env).unwrap();
+            // conform tags the or-valued key; unform untags it.
+            assert_bool("(= {:id [:i 5]} (s/conform ::rm {:id 5}))", true, &mut env);
+            assert_bool(
+                "(= {:id 5} (s/unform ::rm (s/conform ::rm {:id 5})))",
+                true,
+                &mut env,
+            );
+        });
+    }
 }

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -791,4 +791,229 @@ mod tests {
             );
         });
     }
+
+    // ── clojure.spec.alpha (M3: regex engine — cat/alt/*/+/?/&) ─────────────
+
+    #[test]
+    fn test_spec_regex_cat_and_nesting() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_bool(
+                "(= {:a 1 :b \"x\"} (s/conform (s/cat :a int? :b string?) [1 \"x\"]))",
+                true,
+                &mut env,
+            );
+            // Nested regex splices into the same flat sequence.
+            assert_bool(
+                "(= {:a 1 :b [\"x\" \"y\"]}
+                    (s/conform (s/cat :a int? :b (s/* string?)) [1 \"x\" \"y\"]))",
+                true,
+                &mut env,
+            );
+            // Wrong element type / too short / too long are all invalid.
+            assert_bool(
+                "(s/invalid? (s/conform (s/cat :a int? :b string?) [1 2]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/cat :a int? :b string?) [1]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/cat :a int?) [1 2]))",
+                true,
+                &mut env,
+            );
+            // Non-sequential input is invalid, not an error.
+            assert_bool("(s/invalid? (s/conform (s/cat :a int?) 5))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_regex_alt_star_plus_maybe() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            // alt tags its branch.
+            assert_bool(
+                "(= [:i 5] (s/conform (s/alt :i int? :s string?) [5]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/alt :i int? :s string?) [:kw]))",
+                true,
+                &mut env,
+            );
+            // * matches empty and many; fails on a bad element.
+            assert_bool("(= [] (s/conform (s/* int?) []))", true, &mut env);
+            assert_bool("(s/valid? (s/* int?) [])", true, &mut env);
+            assert_bool("(= [1 2 3] (s/conform (s/* int?) [1 2 3]))", true, &mut env);
+            assert_bool(
+                "(s/invalid? (s/conform (s/* int?) [1 :a 3]))",
+                true,
+                &mut env,
+            );
+            // + requires at least one.
+            assert_bool("(= [1] (s/conform (s/+ int?) [1]))", true, &mut env);
+            assert_bool("(s/invalid? (s/conform (s/+ int?) []))", true, &mut env);
+            // ? is optional: value when present, nil when absent.
+            assert_bool("(= 5 (s/conform (s/? int?) [5]))", true, &mut env);
+            assert_bool("(nil? (s/conform (s/? int?) []))", true, &mut env);
+            assert_bool("(s/valid? (s/? int?) [])", true, &mut env);
+            assert_bool("(s/invalid? (s/conform (s/? int?) [1 2]))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_regex_amp_and_regex_inside_and() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(def even-count? (fn [xs] (even? (count xs))))", &mut env).unwrap();
+            // & applies post-predicates to the conformed regex result.
+            assert_bool(
+                "(= [1 2] (s/conform (s/& (s/* int?) even-count?) [1 2]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/& (s/* int?) even-count?) [1 2 3]))",
+                true,
+                &mut env,
+            );
+            // A regex op nested in s/and conforms the whole seq first, then
+            // threads the conformed value through the remaining preds.
+            run("(def all-even? (fn [xs] (every? even? xs)))", &mut env).unwrap();
+            assert_bool(
+                "(= [2 4] (s/conform (s/and (s/* int?) all-even?) [2 4]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/valid? (s/and (s/* int?) all-even?) [1 2])",
+                false,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_regex_keyword_ref_children() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            // A keyword ref to a NON-regex spec consumes exactly one element.
+            run("(s/def ::a int?)", &mut env).unwrap();
+            assert_bool(
+                "(= {:x 1 :y \"x\"} (s/conform (s/cat :x ::a :y string?) [1 \"x\"]))",
+                true,
+                &mut env,
+            );
+            // A keyword ref to a REGEX spec splices (upstream reg-resolve!
+            // semantics).
+            run("(s/def ::r (s/* int?))", &mut env).unwrap();
+            assert_bool(
+                "(= {:nums [1 2] :tail \"x\"}
+                    (s/conform (s/cat :nums ::r :tail string?) [1 2 \"x\"]))",
+                true,
+                &mut env,
+            );
+            // s/spec wrapping forces a nested one-element boundary instead.
+            assert_bool(
+                "(= {:nums [1 2] :tail \"x\"}
+                    (s/conform (s/cat :nums (s/spec (s/* int?)) :tail string?)
+                               [[1 2] \"x\"]))",
+                true,
+                &mut env,
+            );
+            // Registered regex works at top level via the keyword.
+            assert_bool("(= [1 2 3] (s/conform ::r [1 2 3]))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_regex_explain_reasons() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            // Premature end of input → "Insufficient input" at the missing key.
+            run(
+                "(def p-insuff (first (:clojure.spec.alpha/problems
+                                       (s/explain-data (s/cat :a int? :b string?) [1]))))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool(
+                "(= \"Insufficient input\" (:reason p-insuff))",
+                true,
+                &mut env,
+            );
+            assert_bool("(= [:b] (:path p-insuff))", true, &mut env);
+            // Leftover input → "Extra input" with :in pointing at the index.
+            run(
+                "(def p-extra (first (:clojure.spec.alpha/problems
+                                      (s/explain-data (s/cat :a int?) [1 2]))))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(= \"Extra input\" (:reason p-extra))", true, &mut env);
+            assert_bool("(= [1] (:in p-extra))", true, &mut env);
+            // Element failure mid-sequence: path names the cat key, in the index.
+            run(
+                "(def p-elem (first (:clojure.spec.alpha/problems
+                                     (s/explain-data (s/cat :a int? :b string?) [1 :bad]))))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(= [:b] (:path p-elem))", true, &mut env);
+            assert_bool("(= [1] (:in p-elem))", true, &mut env);
+            assert_bool("(= :bad (:val p-elem))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_regex_unform_roundtrips() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(def even-count? (fn [xs] (even? (count xs))))", &mut env).unwrap();
+            for (spec, input) in [
+                ("(s/cat :a int? :b string?)", "[1 \"x\"]"),
+                ("(s/cat :a int? :b (s/* string?))", "[1 \"x\" \"y\"]"),
+                ("(s/alt :i int? :s string?)", "[5]"),
+                ("(s/* int?)", "[1 2 3]"),
+                ("(s/* int?)", "[]"),
+                ("(s/+ int?)", "[1 2]"),
+                ("(s/? int?)", "[5]"),
+                ("(s/? int?)", "[]"),
+                ("(s/& (s/* int?) even-count?)", "[1 2]"),
+            ] {
+                assert_bool(
+                    &format!(
+                        "(let [re {spec}] (= {input} (vec (s/unform re (s/conform re {input})))))"
+                    ),
+                    true,
+                    &mut env,
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn test_spec_plain_map_is_not_a_spec() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            let err = run("(s/conform {:a 1} 5)", &mut env).unwrap_err();
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("not a valid spec"),
+                "expected 'not a valid spec' in error, got: {msg}"
+            );
+        });
+    }
 }

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -1016,4 +1016,316 @@ mod tests {
             );
         });
     }
+
+    // ── clojure.spec.alpha (M4: collections + leaf specs) ────────────────────
+
+    #[test]
+    fn test_spec_coll_of_options() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            // happy / sad
+            assert_bool(
+                "(= [1 2 3] (s/conform (s/coll-of int?) [1 2 3]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/coll-of int?) [1 \"x\"]))",
+                true,
+                &mut env,
+            );
+            // :kind
+            assert_bool(
+                "(s/invalid? (s/conform (s/coll-of int? :kind vector?) '(1 2 3)))",
+                true,
+                &mut env,
+            );
+            // :min-count / :max-count
+            assert_bool(
+                "(s/invalid? (s/conform (s/coll-of int? :min-count 3) [1 2]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/coll-of int? :max-count 2) [1 2 3]))",
+                true,
+                &mut env,
+            );
+            // :distinct
+            assert_bool(
+                "(= [1 2 3] (s/conform (s/coll-of int? :distinct true) [1 2 3]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/coll-of int? :distinct true) [1 1 2]))",
+                true,
+                &mut env,
+            );
+            // :into
+            assert_bool(
+                "(= #{1 2 3} (s/conform (s/coll-of int? :into #{}) [1 2 3]))",
+                true,
+                &mut env,
+            );
+            // default (no :into) preserves order for list input; explicit
+            // :into '() conjes raw (reverses) — see EverySpec doc comment.
+            assert_bool(
+                "(= '(1 2 3) (s/conform (s/coll-of int?) '(1 2 3)))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(= '(3 2 1) (s/conform (s/coll-of int? :into '()) '(1 2 3)))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_map_of_key_handling() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            // default: keys must be valid but ORIGINAL keys are kept
+            assert_bool(
+                "(= {:a 1 :b 2} (s/conform (s/map-of keyword? int?) {:a 1 :b 2}))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/map-of keyword? int?) {:a \"x\"}))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/map-of keyword? int?) {\"not-kw\" 1}))",
+                true,
+                &mut env,
+            );
+            // :conform-keys true swaps in the conformed key
+            assert_bool(
+                r#"(= {"a" 1} (s/conform (s/map-of (s/conformer name) int? :conform-keys true) {:a 1}))"#,
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_every_vs_coll_of_conform_difference() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(def elem (s/or :i int? :s string?))", &mut env).unwrap();
+            // coll-of conforms every element (tagged vectors)
+            assert_bool(
+                "(= [[:i 1] [:s \"x\"]] (s/conform (s/coll-of elem) [1 \"x\"]))",
+                true,
+                &mut env,
+            );
+            // every only validates — returns x unchanged
+            assert_bool(
+                "(= [1 \"x\"] (s/conform (s/every elem) [1 \"x\"]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/every elem) [1 :bad]))",
+                true,
+                &mut env,
+            );
+            // every-kv validates both k/v but never rebuilds
+            assert_bool(
+                "(= {:a 1} (s/conform (s/every-kv keyword? int?) {:a 1}))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/every-kv keyword? int?) {:a \"x\"}))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_tuple_conform_and_explain() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_bool(
+                "(= [1 \"x\"] (s/conform (s/tuple int? string?) [1 \"x\"]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/tuple int? string?) [1]))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform (s/tuple int? string?) 5))",
+                true,
+                &mut env,
+            );
+            run(
+                "(def tp (first (:clojure.spec.alpha/problems (s/explain-data (s/tuple int? string?) [1 :bad]))))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(= [1] (:path tp))", true, &mut env);
+            assert_bool("(= [1] (:in tp))", true, &mut env);
+            assert_bool("(= :bad (:val tp))", true, &mut env);
+            // round-trip unform
+            assert_bool(
+                "(= [1 \"x\"] (s/unform (s/tuple int? string?) (s/conform (s/tuple int? string?) [1 \"x\"])))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_nilable_both_branches_and_explain_shape() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_bool("(= nil (s/conform (s/nilable int?) nil))", true, &mut env);
+            assert_bool("(= 5 (s/conform (s/nilable int?) 5))", true, &mut env);
+            assert_bool(
+                "(s/invalid? (s/conform (s/nilable int?) \"x\"))",
+                true,
+                &mut env,
+            );
+            run(
+                "(def np (:clojure.spec.alpha/problems (s/explain-data (s/nilable int?) \"x\")))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(= 2 (count np))", true, &mut env);
+            assert_bool(
+                "(some (fn [p] (= [:clojure.spec.alpha/nil] (:path p))) np)",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(some (fn [p] (= [:clojure.spec.alpha/pred] (:path p))) np)",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_multi_spec_conform_and_no_method() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            run("(defmulti event-type :type)", &mut env).unwrap();
+            run("(s/def :evt/type keyword?)", &mut env).unwrap();
+            run("(s/def :evt/a (s/keys :req-un [:evt/type]))", &mut env).unwrap();
+            run("(defmethod event-type :a [_] :evt/a)", &mut env).unwrap();
+            run(
+                "(s/def :evt/event (s/multi-spec event-type :type))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool(
+                "(= {:type :a} (s/conform :evt/event {:type :a}))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/invalid? (s/conform :evt/event {:type :unknown}))",
+                true,
+                &mut env,
+            );
+            run(
+                "(def mp (first (:clojure.spec.alpha/problems (s/explain-data :evt/event {:type :unknown}))))",
+                &mut env,
+            )
+            .unwrap();
+            assert_bool("(= \"no method\" (:reason mp))", true, &mut env);
+        });
+    }
+
+    #[test]
+    fn test_spec_conformer_transforms_and_threads_through_and() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_bool(
+                "(= 10 (s/conform (s/conformer #(* 2 %)) 5))",
+                true,
+                &mut env,
+            );
+            // threads the transformed value through the rest of s/and
+            assert_bool(
+                "(= 10 (s/conform (s/and int? (s/conformer #(* 2 %))) 5))",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(= 5 (s/unform (s/conformer #(* 2 %) #(/ % 2)) 10))",
+                true,
+                &mut env,
+            );
+            // no unf given -> unform is identity
+            assert_bool(
+                "(= 10 (s/unform (s/conformer #(* 2 %)) 10))",
+                true,
+                &mut env,
+            );
+        });
+    }
+
+    #[test]
+    fn test_spec_int_in_and_double_in_bounds() {
+        run_with_big_stack(|| {
+            let (_, mut env) = make_env();
+            run("(require '[clojure.spec.alpha :as s])", &mut env).unwrap();
+            assert_bool("(s/valid? (s/int-in 0 10) 5)", true, &mut env);
+            assert_bool("(s/valid? (s/int-in 0 10) 10)", false, &mut env); // end exclusive
+            assert_bool("(s/valid? (s/int-in 0 10) 5.0)", false, &mut env); // not an int?
+            assert_bool(
+                "(s/valid? (s/double-in :min 0.0 :max 10.0) 5.0)",
+                true,
+                &mut env,
+            );
+            assert_bool(
+                "(s/valid? (s/double-in :min 0.0 :max 10.0) 20.0)",
+                false,
+                &mut env,
+            );
+            // NaN produced via arithmetic (NOT the ##NaN reader literal — that
+            // literal hangs this runtime indefinitely on eval, a pre-existing
+            // bug unrelated to spec.alpha; see M4 report).
+            run("(def nan (/ 0.0 0.0))", &mut env).unwrap();
+            run("(def pos-inf (/ 1.0 0.0))", &mut env).unwrap();
+            assert_bool("(s/valid? (s/double-in :NaN? false) nan)", false, &mut env);
+            assert_bool("(s/valid? (s/double-in) nan)", true, &mut env);
+            assert_bool(
+                "(s/valid? (s/double-in :infinite? false) pos-inf)",
+                false,
+                &mut env,
+            );
+            assert_bool("(s/valid? (s/double-in) pos-inf)", true, &mut env);
+            // nonconforming: validates but returns x unconformed
+            assert_bool(
+                "(= [1 \"x\"] (s/conform (s/nonconforming (s/cat :a int? :b string?)) [1 \"x\"]))",
+                true,
+                &mut env,
+            );
+            // inst-in: not implemented, throws clearly
+            let err = run("(s/inst-in 0 1)", &mut env).unwrap_err();
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("not implemented"),
+                "expected 'not implemented' in error, got: {msg}"
+            );
+        });
+    }
 }

--- a/docs/book/src/language/differences.md
+++ b/docs/book/src/language/differences.md
@@ -109,7 +109,13 @@ my-app.utils  →  my_app/utils.cljrs
 
 The following `clojure.*` namespaces are available:
 `clojure.string`, `clojure.set`, `clojure.test`, `clojure.walk`,
-`clojure.edn`, `clojure.data`.
+`clojure.edn`, `clojure.data`, `clojure.spec.alpha`,
+`clojure.spec.test.alpha`, and `clojure.spec.gen.alpha`. `clojure.core.async`
+is also available (as the `cljrs-async` crate — see the
+[Async & I/O](../async-io/index.md) chapter).
 
-`clojure.zip` and `clojure.pprint` exist as stubs. `clojure.spec.alpha`,
-`clojure.core.async`, and `clojure.core.match` are not available.
+`clojure.zip` and `clojure.pprint` exist as stubs. `clojure.spec.alpha` has
+no generators: `clojure.spec.gen.alpha` and every generative-testing entry
+point (`s/gen`, `s/exercise`, `s/exercise-fn`, `stest/check`) throw a clear
+`ex-info` instead of generating values. `clojure.core.match` is not
+available.

--- a/docs/book/src/language/index.md
+++ b/docs/book/src/language/index.md
@@ -20,7 +20,9 @@ implemented.
 - `clojure.core` — arithmetic, comparison, collection operations, lazy
   sequences, transducers, I/O, concurrency primitives.
 - Standard library namespaces: `clojure.string`, `clojure.set`, `clojure.test`,
-  `clojure.walk`, `clojure.edn`, `clojure.zip`, `clojure.data`.
+  `clojure.walk`, `clojure.edn`, `clojure.zip`, `clojure.data`,
+  `clojure.spec.alpha` (no generators — see
+  [Differences from Clojure](differences.md)).
 - Protocols (`defprotocol`, `extend-type`, `extend-protocol`), multimethods
   (`defmulti`, `defmethod`), records (`defrecord`), and `reify`.
 - Concurrency: `atom`, `future`, `promise`, `delay`, `volatile!`, `agent`.


### PR DESCRIPTION
New pure-Clojure namespace crates/cljrs-stdlib/src/clojure/spec/alpha.cljrs
registered as a builtin source. Implements the Spec protocol (conform*/
unform*/explain*/describe*), a live-resolution registry (forward refs and
re-def work with no delay machinery), bare predicates/sets/keywords/symbols
as specs via extend-type on their type tags, and defrecord-based
PredicateSpec/AndSpec/OrSpec (no reify — avoids the per-call protocol-impls
leak) with the s/def, s/spec, s/and, s/or macro layer.

Works around two interpreter quirks, documented inline: protocol method
impls self-bind their method name (same-name polymorphic re-dispatch is
shadowed; private *-dispatch aliases route around it), and defmacro cannot
be named after a special form (macros defined under -form names, rebound
with plain def).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NGKHKw1Rx5duH9C4TVNtzz