### PR TITLE
Add isolated no-GC transaction function runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cljrs-tx"
+version = "0.1.0"
+dependencies = [
+ "cljrs-env",
+ "cljrs-gc",
+ "cljrs-interp",
+ "cljrs-reader",
+ "cljrs-types",
+ "cljrs-value",
+ "thiserror",
+]
+
+[[package]]
 name = "cljrs-types"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ members = [
     "crates/cljrs-base64",
     "crates/cljrs-jit",
     "crates/cljrs-dylib",
-    "crates/cljrs-dom"]
+    "crates/cljrs-dom",
+    "crates/cljrs-tx",
+]
 resolver = "2"
 
 [workspace.package]
@@ -69,6 +71,7 @@ cljrs-base64       = { path = "crates/cljrs-base64",       version = "0.1.0" }
 cljrs-jit          = { path = "crates/cljrs-jit",          version = "0.1.0" }
 cljrs-dylib        = { path = "crates/cljrs-dylib",        version = "0.1.0" }
 cljrs-dom          = { path = "crates/cljrs-dom",          version = "0.1.0" }
+cljrs-tx           = { path = "crates/cljrs-tx",           version = "0.1.0" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ See [`TODO.md`](TODO.md) for the full itemised roadmap.
 | [`cljrs-env`](crates/cljrs-env) | Shared runtime environment: `GlobalEnv`, `Env`, dynamic bindings, namespace loader, GC roots | complete |
 | [`cljrs-builtins`](crates/cljrs-builtins) | Native Clojure core functions (~300 builtins), transients, regex, bitops | complete |
 | [`cljrs-interp`](crates/cljrs-interp) | Tree-walking Clojure interpreter: eval, special forms, macros, destructuring | complete |
+| [`cljrs-tx`](crates/cljrs-tx) | Pure tree-walked transaction functions in a bounded, invocation-lifetime no-GC arena | initial |
 | [`cljrs-ir`](crates/cljrs-ir) | IR types (ANF/SSA) with serialization (postcard); ANF lowering, escape analysis, OSR | complete |
 | [`cljrs-eval`](crates/cljrs-eval) | IR-accelerated evaluation: IR interpreter, IR cache, tiering/JIT state, lower worker, prebuilt IR loading | complete |
 | [`cljrs-ir-prebuild`](crates/cljrs-ir-prebuild) | Pre-lowers Clojure namespaces to serialized IR bundles; library backing `cljrs ir build` and the standalone `cljrs-ir-prebuild` binary | complete |

--- a/crates/cljrs-env/README.md
+++ b/crates/cljrs-env/README.md
@@ -15,6 +15,17 @@ the evaluator. `EvalError::GasExhausted` is the dedicated caller-facing error.
 Exhaustion state is scoped per guard, so an exhausted inner evaluation cannot
 poison a healthy outer evaluation after the inner guard drops.
 
+## policy module
+
+Dynamic capability policy used by isolated transaction functions.
+`TransactionPolicyGuard::install()` denies filesystem and output operations,
+clocks, randomness, process-global mutable facilities, blocking/concurrency,
+versioned namespace loading, and Rust object construction. `check_native`,
+`check_special`, and `check_versioned_lookup` are enforced at the interpreter's
+final dispatch seams. `next_transaction_gensym()` supplies an invocation-local
+deterministic sequence for syntax-quote hygiene. Violations return
+`EvalError::ForbiddenEffect(String)`.
+
 ## versioned module (non-WASM)
 
 Shared versioned-symbol/namespace resolution service used by **every**

--- a/crates/cljrs-env/src/apply.rs
+++ b/crates/cljrs-env/src/apply.rs
@@ -133,6 +133,7 @@ pub fn apply_value(callee: &Value, args: Vec<Value>, env: &mut Env) -> EvalResul
 
     match callee {
         Value::NativeFunction(nf) => {
+            crate::policy::check_native(&nf.get().name)?;
             check_arity(&nf.get().arity, args.len(), &nf.get().name)?;
             // Register the caller's env as a GC root: native functions may
             // call back into Clojure (via invoke()), which creates a fresh Env

--- a/crates/cljrs-env/src/error.rs
+++ b/crates/cljrs-env/src/error.rs
@@ -12,6 +12,11 @@ pub enum EvalError {
     #[error("gas exhausted")]
     GasExhausted,
 
+    /// An operation attempted to use a capability unavailable to an isolated
+    /// transaction function.
+    #[error("effect forbidden in transaction function: {0}")]
+    ForbiddenEffect(String),
+
     #[error("unbound symbol: {0}")]
     UnboundSymbol(String),
 

--- a/crates/cljrs-env/src/lib.rs
+++ b/crates/cljrs-env/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod gas;
 pub mod gc_roots;
 pub mod loader;
+pub mod policy;
 pub mod taps;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod versioned;

--- a/crates/cljrs-env/src/policy.rs
+++ b/crates/cljrs-env/src/policy.rs
@@ -1,0 +1,131 @@
+//! Dynamic execution policy for restricted evaluator profiles.
+
+use std::cell::Cell;
+
+use crate::error::{EvalError, EvalResult};
+
+thread_local! {
+    static TRANSACTION_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static TRANSACTION_GENSYM: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Installs the side-effect-free transaction policy for its dynamic extent.
+#[must_use = "dropping the guard removes the transaction execution policy"]
+pub struct TransactionPolicyGuard;
+
+impl TransactionPolicyGuard {
+    pub fn install() -> Self {
+        TRANSACTION_DEPTH.with(|depth| {
+            if depth.get() == 0 {
+                TRANSACTION_GENSYM.with(|counter| counter.set(0));
+            }
+            depth.set(depth.get() + 1);
+        });
+        Self
+    }
+}
+
+impl Drop for TransactionPolicyGuard {
+    fn drop(&mut self) {
+        TRANSACTION_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
+pub fn transaction_policy_active() -> bool {
+    TRANSACTION_DEPTH.with(|depth| depth.get() != 0)
+}
+
+/// Return an invocation-local deterministic gensym sequence number when the
+/// transaction policy is active.
+pub fn next_transaction_gensym() -> Option<u64> {
+    if !transaction_policy_active() {
+        return None;
+    }
+    Some(TRANSACTION_GENSYM.with(|counter| {
+        let current = counter.get();
+        counter.set(current.wrapping_add(1));
+        current
+    }))
+}
+
+fn forbidden(operation: &str) -> EvalError {
+    EvalError::ForbiddenEffect(operation.to_string())
+}
+
+/// Check a native builtin at its final call boundary.
+///
+/// The transaction environment registers only clojurust's builtins, so this
+/// denylist is the capability surface: filesystem, output, clocks, randomness,
+/// process-global state, blocking/concurrency, and Rust object construction.
+pub fn check_native(name: &str) -> EvalResult<()> {
+    if !transaction_policy_active() {
+        return Ok(());
+    }
+    const DENIED: &[&str] = &[
+        "print",
+        "println",
+        "pr",
+        "prn",
+        "printf",
+        "newline",
+        "flush",
+        "spit",
+        "slurp",
+        "close",
+        "nanotime",
+        "sleep",
+        "rand",
+        "rand-int",
+        "random-sample",
+        "shuffle",
+        "random-uuid",
+        "gensym",
+        "add-tap",
+        "remove-tap",
+        "tap>",
+        "shared-atom",
+        "promise",
+        "deliver",
+        "send",
+        "send-off",
+        "new",
+        "Exception.",
+        "push-precision!",
+        "pop-precision!",
+    ];
+    if DENIED.contains(&name) {
+        Err(forbidden(name))
+    } else {
+        Ok(())
+    }
+}
+
+/// Check special forms that can reach outside the invocation environment.
+pub fn check_special(name: &str) -> EvalResult<()> {
+    if !transaction_policy_active() {
+        return Ok(());
+    }
+    const DENIED: &[&str] = &[
+        ".",
+        "ns",
+        "require",
+        "in-ns",
+        "alias",
+        "load-file",
+        "with-out-str",
+        "await",
+    ];
+    if DENIED.contains(&name) {
+        Err(forbidden(name))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn check_versioned_lookup() -> EvalResult<()> {
+    if transaction_policy_active() {
+        Err(forbidden("versioned namespace lookup"))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/cljrs-gc/README.md
+++ b/crates/cljrs-gc/README.md
@@ -41,6 +41,11 @@ and `recur` arguments are evaluated in the caller's context (the
 and live for the program lifetime.
 No `GcHeap`, no stop-the-world pauses, no `Trace` overhead at runtime.
 
+An isolated invocation can instead install `alloc_ctx::InvocationGuard`. In
+that profile every allocation uses one bounded region; nested `ScratchGuard`
+and `StaticCtxGuard` values become no-ops, so arbitrary internal graphs share
+the invocation lifetime and are reclaimed together at the boundary.
+
 **Phase 7 (debug provenance):** in `debug_assertions` builds with `no-gc`,
 `StaticArena` tracks chunk ranges and exposes `is_static_addr(usize) -> bool`.
 `GcPtr::is_static_alloc()` uses this to check pointer provenance at O(chunks)
@@ -62,7 +67,7 @@ src/
   static_arena.rs — (no-gc mode) global program-lifetime bump allocator;
                     in debug builds, tracks chunk ranges for is_static_addr()
   alloc_ctx.rs    — (no-gc mode) thread-local allocation context stack;
-                    ScratchGuard, StaticCtxGuard
+                    ScratchGuard, StaticCtxGuard, InvocationGuard
   region.rs       — Region bump allocator, RegionGuard, thread-local region
                     stack; trace_active_regions() (GC-root scan of live regions);
                     poison/retire protocol (Phase 10.5 heap-promotion fallback):
@@ -76,8 +81,8 @@ src/
                     isolate-boundary crossings (bytes copied + serialize time)
 tests/
   no_gc_alloc.rs  — (no-gc mode) integration tests for the allocation context stack:
-                    ScratchGuard, StaticCtxGuard, pop_for_return protocol,
-                    nested guards, destructor ordering
+                    ScratchGuard, StaticCtxGuard, InvocationGuard,
+                    pop_for_return protocol, nested guards, destructor ordering
 ```
 
 ---
@@ -238,12 +243,35 @@ pub struct Region { /* chunks, bump pointer, drop registry */ }
 impl Region {
     pub fn new() -> Self
     pub fn with_capacity(cap: usize) -> Self
+    pub fn with_limit(limit: usize) -> Self
     pub fn alloc<T: Trace + 'static>(&mut self, value: T) -> GcPtr<T>
     pub fn reset(&mut self)
     pub fn bytes_used(&self) -> usize
+    pub fn accounted_bytes(&self) -> usize
+    pub fn byte_limit(&self) -> Option<usize>
     pub fn object_count(&self) -> usize
 }
 ```
+
+`with_limit` raises the typed `RegionLimitExceeded` panic payload when the
+managed allocation budget is exhausted. It charges boxes plus
+`Trace::gc_size_extra`; it is not a process-wide RSS limiter.
+
+### `alloc_ctx::InvocationGuard` (`no-gc` only)
+
+```rust
+pub struct InvocationGuard { /* one bounded Region */ }
+impl InvocationGuard {
+    pub fn new(byte_limit: usize) -> Self;
+    pub fn accounted_bytes(&self) -> usize;
+    pub fn object_count(&self) -> usize;
+}
+pub fn invocation_is_active() -> bool;
+```
+
+All `GcPtr::new` calls within the guard use its single arena, including calls
+made beneath evaluator scratch/static guards. Copy or serialize results before
+the guard drops.
 
 Bump allocator for short-lived objects. ~2.6x faster than `GcHeap::alloc`
 (no mutex, no `Box::new`). Objects are NOT in the GC heap linked list.

--- a/crates/cljrs-gc/src/alloc_ctx.rs
+++ b/crates/cljrs-gc/src/alloc_ctx.rs
@@ -27,6 +27,10 @@ pub(crate) enum AllocCtx {
     Static,
     /// Allocate in the given bump region.
     Region(*mut Region),
+    /// One arena owns every allocation made during an isolated invocation.
+    /// Nested function/loop scratch guards and static-sink guards become
+    /// no-ops while this entry is active.
+    Invocation(*mut Region),
 }
 
 // SAFETY: AllocCtx values are only accessed from their owning thread.
@@ -44,12 +48,69 @@ pub(crate) fn alloc_in_ctx<T: Trace + 'static>(value: T) -> GcPtr<T> {
         let ctx = ctx.borrow();
         match ctx.last() {
             None | Some(AllocCtx::Static) => static_arena().alloc(value),
-            Some(AllocCtx::Region(ptr)) => {
+            Some(AllocCtx::Region(ptr) | AllocCtx::Invocation(ptr)) => {
                 // SAFETY: The Region pointer is valid while the owning ScratchGuard is live.
                 unsafe { &mut **ptr }.alloc(value)
             }
         }
     })
+}
+
+pub fn invocation_is_active() -> bool {
+    ALLOC_CTX.with(|ctx| {
+        ctx.borrow()
+            .iter()
+            .any(|entry| matches!(entry, AllocCtx::Invocation(_)))
+    })
+}
+
+/// Owns the single bounded arena used by a GC-less isolated invocation.
+///
+/// Every `GcPtr::new` within the guard's dynamic extent lands in this arena.
+/// Existing evaluator scratch/static guards deliberately do not change that
+/// routing, which gives every value the same lifetime and permits arbitrary
+/// internal object graphs. Values must be serialized or otherwise copied out
+/// before this guard drops.
+pub struct InvocationGuard {
+    region: Box<Region>,
+    in_ctx: bool,
+}
+
+impl InvocationGuard {
+    pub fn new(byte_limit: usize) -> Self {
+        assert!(
+            !invocation_is_active(),
+            "nested isolated allocation invocations are not supported"
+        );
+        let mut region = Box::new(Region::with_limit(byte_limit));
+        let ptr = region.as_mut() as *mut Region;
+        ALLOC_CTX.with(|ctx| ctx.borrow_mut().push(AllocCtx::Invocation(ptr)));
+        Self {
+            region,
+            in_ctx: true,
+        }
+    }
+
+    pub fn accounted_bytes(&self) -> usize {
+        self.region.accounted_bytes()
+    }
+
+    pub fn object_count(&self) -> usize {
+        self.region.object_count()
+    }
+}
+
+impl Drop for InvocationGuard {
+    fn drop(&mut self) {
+        if self.in_ctx {
+            ALLOC_CTX.with(|ctx| {
+                let popped = ctx.borrow_mut().pop();
+                debug_assert!(matches!(popped, Some(AllocCtx::Invocation(_))));
+            });
+            self.in_ctx = false;
+        }
+        self.region.reset();
+    }
 }
 
 // ── ScratchGuard ──────────────────────────────────────────────────────────────
@@ -67,18 +128,24 @@ pub(crate) fn alloc_in_ctx<T: Trace + 'static>(value: T) -> GcPtr<T> {
 /// 4. Evaluate the tail (return) expression → lands in the caller's context.
 /// 5. `ScratchGuard` drops → scratch memory is reset (intermediates freed).
 pub struct ScratchGuard {
-    region: Box<Region>,
+    region: Option<Box<Region>>,
     /// Whether the ctx entry is currently on the stack.
     in_ctx: bool,
 }
 
 impl ScratchGuard {
     pub fn new() -> Self {
+        if invocation_is_active() {
+            return Self {
+                region: None,
+                in_ctx: false,
+            };
+        }
         let mut region = Box::new(Region::new());
         let ptr = region.as_mut() as *mut Region;
         ALLOC_CTX.with(|ctx| ctx.borrow_mut().push(AllocCtx::Region(ptr)));
         Self {
-            region,
+            region: Some(region),
             in_ctx: true,
         }
     }
@@ -110,7 +177,9 @@ impl Drop for ScratchGuard {
         }
         // Reset the region: runs destructors on all contained values and
         // reclaims bump-allocator memory for reuse.
-        self.region.reset();
+        if let Some(region) = &mut self.region {
+            region.reset();
+        }
     }
 }
 
@@ -124,12 +193,17 @@ impl Drop for ScratchGuard {
 /// - `atom` / `Var` initializers
 /// - `reset!` / `vreset!` new-value expressions
 /// - the function passed to `swap!` / `vswap!`
-pub struct StaticCtxGuard;
+pub struct StaticCtxGuard {
+    pushed: bool,
+}
 
 impl StaticCtxGuard {
     pub fn new() -> Self {
+        if invocation_is_active() {
+            return Self { pushed: false };
+        }
         ALLOC_CTX.with(|ctx| ctx.borrow_mut().push(AllocCtx::Static));
-        Self
+        Self { pushed: true }
     }
 }
 
@@ -141,6 +215,8 @@ impl Default for StaticCtxGuard {
 
 impl Drop for StaticCtxGuard {
     fn drop(&mut self) {
-        ALLOC_CTX.with(|ctx| ctx.borrow_mut().pop());
+        if self.pushed {
+            ALLOC_CTX.with(|ctx| ctx.borrow_mut().pop());
+        }
     }
 }

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -409,7 +409,7 @@ impl<T: Trace + 'static> GcPtr<T> {
     /// region-local values being stored in program-lifetime containers.
     #[cfg(all(feature = "no-gc", debug_assertions))]
     pub fn is_static_alloc(&self) -> bool {
-        static_arena::is_static_addr(self.0.as_ptr() as usize)
+        alloc_ctx::invocation_is_active() || static_arena::is_static_addr(self.0.as_ptr() as usize)
     }
 }
 

--- a/crates/cljrs-gc/src/region.rs
+++ b/crates/cljrs-gc/src/region.rs
@@ -28,6 +28,19 @@ use crate::{GcBox, GcPtr, Trace};
 /// Default chunk size (4 KiB).  Chunks grow if a single allocation is larger.
 const DEFAULT_CHUNK_SIZE: usize = 4096;
 
+/// Raised when a bounded region cannot satisfy an allocation.
+///
+/// `GcPtr::new` is intentionally infallible throughout the runtime, so a
+/// bounded invocation reports exhaustion by unwinding with this typed payload.
+/// Execution boundaries can catch it with `catch_unwind` and turn it into a
+/// normal transaction error without confusing it with a user panic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RegionLimitExceeded {
+    pub limit: usize,
+    pub used: usize,
+    pub requested: usize,
+}
+
 // ── Internal: chunk of raw memory ───────────────────────────────────────────
 
 struct Chunk {
@@ -79,6 +92,12 @@ pub struct Region {
     drops: Vec<DropEntry>,
     /// Cumulative bytes consumed by objects (excludes alignment padding).
     bytes_used: usize,
+    /// Managed bytes charged to this region, including out-of-line storage
+    /// reported by `Trace::gc_size_extra`.
+    accounted_bytes: usize,
+    /// Optional hard ceiling for managed bytes. A bounded region is backed by
+    /// one fixed-size chunk and never grows.
+    byte_limit: Option<usize>,
     /// Number of objects allocated.
     object_count: usize,
 }
@@ -100,6 +119,32 @@ impl Region {
             end: base + cap,
             drops: Vec::new(),
             bytes_used: 0,
+            accounted_bytes: 0,
+            byte_limit: None,
+            object_count: 0,
+        }
+    }
+
+    /// Create a region with a fixed managed-memory budget.
+    ///
+    /// The region allocates one `limit`-byte chunk and will never grow it.
+    /// Object boxes, alignment, and out-of-line bytes reported through
+    /// [`Trace::gc_size_extra`] are charged to the limit. Allocations made by
+    /// ordinary Rust containers that are not owned by a traced value are not
+    /// visible here; callers that require a process-wide hard RSS ceiling must
+    /// add an outer sandbox (for example a WASM linear-memory limit).
+    pub fn with_limit(limit: usize) -> Self {
+        assert!(limit >= 64, "Region: byte limit must be at least 64");
+        let chunk = Chunk::new(limit, 16);
+        let base = chunk.data.as_ptr() as usize;
+        Self {
+            chunks: vec![chunk],
+            ptr: base,
+            end: base + limit,
+            drops: Vec::new(),
+            bytes_used: 0,
+            accounted_bytes: 0,
+            byte_limit: Some(limit),
             object_count: 0,
         }
     }
@@ -110,6 +155,8 @@ impl Region {
     /// The object is **not** registered in the global GC heap.
     pub fn alloc<T: Trace + 'static>(&mut self, value: T) -> GcPtr<T> {
         let layout = Layout::new::<GcBox<T>>();
+        let requested = layout.size().saturating_add(value.gc_size_extra());
+        self.charge(requested);
         let raw = self.bump_alloc(layout);
 
         let gc_box = raw as *mut GcBox<T>;
@@ -187,6 +234,7 @@ impl Region {
         }
 
         self.bytes_used = 0;
+        self.accounted_bytes = 0;
         self.object_count = 0;
     }
 
@@ -198,6 +246,16 @@ impl Region {
     /// Number of objects currently in the region.
     pub fn object_count(&self) -> usize {
         self.object_count
+    }
+
+    /// Managed bytes charged against this region's optional limit.
+    pub fn accounted_bytes(&self) -> usize {
+        self.accounted_bytes
+    }
+
+    /// Configured managed-memory limit, if this is a bounded region.
+    pub fn byte_limit(&self) -> Option<usize> {
+        self.byte_limit
     }
 
     // ── internal ────────────────────────────────────────────────────────────
@@ -220,9 +278,29 @@ impl Region {
         }
     }
 
+    fn charge(&mut self, requested: usize) {
+        if let Some(limit) = self.byte_limit
+            && self.accounted_bytes.saturating_add(requested) > limit
+        {
+            std::panic::panic_any(RegionLimitExceeded {
+                limit,
+                used: self.accounted_bytes,
+                requested,
+            });
+        }
+        self.accounted_bytes = self.accounted_bytes.saturating_add(requested);
+    }
+
     /// Allocate a new chunk large enough, then bump-allocate from it.
     fn grow_and_alloc(&mut self, layout: Layout) -> *mut u8 {
         let size = layout.size();
+        if let Some(limit) = self.byte_limit {
+            std::panic::panic_any(RegionLimitExceeded {
+                limit,
+                used: self.accounted_bytes.saturating_sub(size),
+                requested: size,
+            });
+        }
         let chunk_size = DEFAULT_CHUNK_SIZE.max(size * 2);
         let chunk = Chunk::new(chunk_size, layout.align());
         let base = chunk.data.as_ptr() as usize;

--- a/crates/cljrs-gc/tests/no_gc_alloc.rs
+++ b/crates/cljrs-gc/tests/no_gc_alloc.rs
@@ -10,7 +10,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use cljrs_gc::alloc_ctx::{ScratchGuard, StaticCtxGuard};
+use cljrs_gc::alloc_ctx::{InvocationGuard, ScratchGuard, StaticCtxGuard};
 use cljrs_gc::{GcPtr, MarkVisitor, Trace};
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -273,4 +273,31 @@ fn return_value_protocol_allocates_in_caller_context() {
     };
 
     assert_eq!(*return_value.get(), 42);
+}
+
+#[test]
+fn invocation_uses_one_region_across_nested_guards() {
+    let invocation = InvocationGuard::new(4096);
+    let before = invocation.object_count();
+    {
+        let mut scratch = ScratchGuard::new();
+        let _static_ctx = StaticCtxGuard::new();
+        let _a = GcPtr::new(1i64);
+        scratch.pop_for_return();
+        let _b = GcPtr::new(2i64);
+    }
+    assert_eq!(invocation.object_count(), before + 2);
+}
+
+#[test]
+fn invocation_runs_all_destructors_at_boundary() {
+    let dropped = Arc::new(Mutex::new(false));
+    {
+        let _invocation = InvocationGuard::new(4096);
+        let _value = GcPtr::new(DropTracked {
+            dropped: dropped.clone(),
+        });
+        assert!(!*dropped.lock().unwrap());
+    }
+    assert!(*dropped.lock().unwrap());
 }

--- a/crates/cljrs-interp/README.md
+++ b/crates/cljrs-interp/README.md
@@ -22,6 +22,9 @@ interval (GC fires only at explicit safepoints, with a one-cycle grace period â€
 see `cljrs-gc`). Under the `no-gc` Cargo feature the same scoping is achieved
 with the allocation-context stack protocol (scratch regions for function/loop
 scopes; `StaticArena` for static-sink expressions).
+When `cljrs-env`'s transaction policy and `InvocationGuard` are active, the
+same tree walker denies external capabilities and routes all allocations into
+one invocation-lifetime region instead.
 
 ---
 

--- a/crates/cljrs-interp/src/apply.rs
+++ b/crates/cljrs-interp/src/apply.rs
@@ -204,6 +204,7 @@ pub fn eval_call(func_form: &Form, arg_forms: &[Form], env: &mut Env) -> EvalRes
 
     // Special case: `apply` native fn — spread last arg.
     if let Value::NativeFunction(nf) = &callee {
+        cljrs_env::policy::check_native(&nf.get().name)?;
         match nf.get().name.as_ref() {
             "apply" => return handle_apply_call(arg_forms, env),
             "atom" => return handle_atom_call(arg_forms, env),

--- a/crates/cljrs-interp/src/eval.rs
+++ b/crates/cljrs-interp/src/eval.rs
@@ -207,6 +207,7 @@ fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
     // namespace-level lookup — no local-frame fallback.
     #[cfg(not(target_arch = "wasm32"))]
     if let Some(ref commit) = sym.version.clone() {
+        cljrs_env::policy::check_versioned_lookup()?;
         return crate::versioned::resolve_versioned_symbol(&sym, commit, env);
     }
     #[cfg(target_arch = "wasm32")]

--- a/crates/cljrs-interp/src/special.rs
+++ b/crates/cljrs-interp/src/special.rs
@@ -20,6 +20,7 @@ use cljrs_value::{
 
 /// Dispatch to the right special-form handler.
 pub fn eval_special(head: &str, args: &[Form], env: &mut Env) -> EvalResult {
+    cljrs_env::policy::check_special(head)?;
     match head {
         "def" => eval_def(args, env),
         "fn*" | "fn" => eval_fn(args, env),

--- a/crates/cljrs-interp/src/syntax_quote.rs
+++ b/crates/cljrs-interp/src/syntax_quote.rs
@@ -209,7 +209,8 @@ fn qualify_symbol(
     // Auto-gensym: `foo#`.
     if let Some(base) = s.strip_suffix('#') {
         let generated = gensyms.entry(s.to_string()).or_insert_with(|| {
-            let n = GENSYM_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let n = cljrs_env::policy::next_transaction_gensym()
+                .unwrap_or_else(|| GENSYM_COUNTER.fetch_add(1, Ordering::Relaxed));
             Arc::from(format!("{base}__{n}__auto__"))
         });
         return generated.as_ref().to_string();

--- a/crates/cljrs-tx/Cargo.toml
+++ b/crates/cljrs-tx/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "cljrs-tx"
+version = "0.1.0"
+edition = "2024"
+description = "GC-less isolated transaction-function runtime for clojurust"
+license.workspace = true
+repository.workspace = true
+
+[features]
+no-gc = [
+    "cljrs-gc/no-gc",
+    "cljrs-value/no-gc",
+    "cljrs-env/no-gc",
+    "cljrs-interp/no-gc",
+]
+
+[dependencies]
+cljrs-gc = { workspace = true }
+cljrs-types = { workspace = true }
+cljrs-value = { workspace = true }
+cljrs-reader = { workspace = true }
+cljrs-env = { workspace = true }
+cljrs-interp = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/cljrs-tx/README.md
+++ b/crates/cljrs-tx/README.md
@@ -1,0 +1,54 @@
+# cljrs-tx
+
+## Purpose
+
+Runs pure Datomic-style transaction functions in a fresh, GC-less,
+tree-walker-only invocation arena.
+
+## Status
+
+Initial transaction-runtime implementation. IR lowering, JIT, AOT, async,
+I/O, clocks, randomness, process-global mutable values, and Rust interop are
+outside this crate's execution profile.
+
+Build with the crate's `no-gc` feature (`cargo test -p cljrs-tx --features
+no-gc`). The feature is not enabled by default so workspace-wide GC builds do
+not accidentally unify every clojurust dependency into `no-gc` mode.
+
+## File layout
+
+- `src/lib.rs` — parsed program, limits, isolated execution boundary, pure-data validation, and tests.
+
+## Public API
+
+```rust
+pub struct TxProgram { /* parsed immutable form */ }
+impl TxProgram {
+    pub fn parse(source: &str) -> Result<Self, TxError>;
+    pub fn form(&self) -> &cljrs_reader::Form;
+}
+
+pub struct TxLimits {
+    pub memory_bytes: usize,
+    pub gas: u64,
+}
+
+pub enum TxError { /* read, boundary, evaluation, budget, and policy errors */ }
+
+pub fn execute(
+    program: &TxProgram,
+    args: Vec<cljrs_value::clone::SerializedValue>,
+    limits: TxLimits,
+) -> Result<cljrs_value::clone::SerializedValue, TxError>;
+```
+
+`execute` creates and bootstraps a new interpreter environment inside one
+bounded arena, structured-clones arguments in, invokes the function under a
+gas meter and transaction capability policy, clones a pure-data result out,
+and then destroys the whole environment.
+
+The memory limit covers arena object boxes and out-of-line memory reported by
+`Trace::gc_size_extra`. It is a managed-allocation limit, not yet a hard RSS
+limit: ordinary Rust allocations outside traced values are not fully charged.
+A WASM linear-memory or process sandbox remains necessary when an adversarial
+hard address-space ceiling is required.

--- a/crates/cljrs-tx/src/lib.rs
+++ b/crates/cljrs-tx/src/lib.rs
@@ -1,0 +1,270 @@
+//! Tree-walker-only runtime for pure, isolated transaction functions.
+
+#![cfg(feature = "no-gc")]
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use cljrs_env::env::Env;
+use cljrs_env::error::EvalError;
+use cljrs_reader::{Form, Parser};
+use cljrs_value::clone::{CloneError, SerializedValue, deserialize, serialize};
+
+/// A parsed transaction function expression.
+///
+/// The expression must evaluate to a callable value, normally `(fn [db arg]
+/// ...)`. Parsing is intentionally outside the invocation arena: installed
+/// transaction code is treated as immutable program data rather than working
+/// memory charged on every call.
+#[derive(Clone, Debug)]
+pub struct TxProgram {
+    form: Form,
+}
+
+impl TxProgram {
+    pub fn parse(source: &str) -> Result<Self, TxError> {
+        let mut parser = Parser::new(source.to_string(), "<transaction-function>".to_string());
+        let form = parser
+            .parse_one()
+            .map_err(|error| TxError::Read(Box::new(error)))?
+            .ok_or(TxError::EmptyProgram)?;
+        if parser
+            .parse_one()
+            .map_err(|error| TxError::Read(Box::new(error)))?
+            .is_some()
+        {
+            return Err(TxError::MultipleForms);
+        }
+        Ok(Self { form })
+    }
+
+    pub fn form(&self) -> &Form {
+        &self.form
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TxLimits {
+    /// Managed allocation budget for the invocation arena.
+    pub memory_bytes: usize,
+    /// Cooperative tree-walker execution credits.
+    pub gas: u64,
+}
+
+impl Default for TxLimits {
+    fn default() -> Self {
+        Self {
+            memory_bytes: 16 * 1024 * 1024,
+            gas: 1_000_000,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TxError {
+    #[error("transaction function source is empty")]
+    EmptyProgram,
+    #[error("transaction function source must contain exactly one form")]
+    MultipleForms,
+    #[error("transaction memory limit must be at least 64 bytes")]
+    InvalidMemoryLimit,
+    #[error("transaction function read error: {0}")]
+    Read(Box<cljrs_types::error::CljxError>),
+    #[error("transaction input is not isolated pure data: {0}")]
+    InvalidInput(&'static str),
+    #[error("transaction result is not isolated pure data: {0}")]
+    InvalidResult(&'static str),
+    #[error("transaction evaluation failed: {0}")]
+    Evaluation(String),
+    #[error("transaction gas exhausted")]
+    GasExhausted,
+    #[error("transaction attempted a forbidden effect: {0}")]
+    ForbiddenEffect(String),
+    #[error(
+        "transaction managed-memory budget exhausted (limit {limit} bytes, used {used}, requested {requested})"
+    )]
+    MemoryExhausted {
+        limit: usize,
+        used: usize,
+        requested: usize,
+    },
+    #[error("transaction result cannot cross the isolation boundary: {0}")]
+    Clone(#[from] CloneError),
+    #[error("transaction runtime panicked")]
+    Panic,
+}
+
+/// Execute `program` in a fresh GC-less arena and return an owned data value.
+///
+/// Inputs are structured-cloned into the invocation. The environment, inputs,
+/// closures, lazy sequences, local mutable cells, and all intermediate values
+/// are destroyed together when execution finishes. The result is cloned out
+/// before the arena is freed.
+pub fn execute(
+    program: &TxProgram,
+    args: Vec<SerializedValue>,
+    limits: TxLimits,
+) -> Result<SerializedValue, TxError> {
+    if limits.memory_bytes < 64 {
+        return Err(TxError::InvalidMemoryLimit);
+    }
+    for arg in &args {
+        validate_pure_data(arg).map_err(TxError::InvalidInput)?;
+    }
+
+    match catch_unwind(AssertUnwindSafe(|| execute_inner(program, args, limits))) {
+        Ok(result) => result,
+        Err(payload) => match payload.downcast_ref::<cljrs_gc::region::RegionLimitExceeded>() {
+            Some(exhausted) => Err(TxError::MemoryExhausted {
+                limit: exhausted.limit,
+                used: exhausted.used,
+                requested: exhausted.requested,
+            }),
+            None => Err(TxError::Panic),
+        },
+    }
+}
+
+fn execute_inner(
+    program: &TxProgram,
+    args: Vec<SerializedValue>,
+    limits: TxLimits,
+) -> Result<SerializedValue, TxError> {
+    let invocation = cljrs_gc::alloc_ctx::InvocationGuard::new(limits.memory_bytes);
+
+    // Bootstrap is trusted but is deliberately constructed inside the arena so
+    // the complete namespace/Var/function environment dies with the call.
+    let globals = cljrs_interp::standard_env_minimal(None, None, None);
+    let mut env = Env::new(globals, "user");
+    let args: Vec<_> = args.into_iter().map(deserialize).collect();
+
+    let _policy = cljrs_env::policy::TransactionPolicyGuard::install();
+    let meter = cljrs_env::gas::GasMeter::new(limits.gas);
+    let _gas = cljrs_env::gas::GasGuard::install(meter);
+
+    let function = env.eval(program.form()).map_err(map_eval_error)?;
+    let result =
+        cljrs_env::apply::apply_value(&function, args, &mut env).map_err(map_eval_error)?;
+    let result = serialize(&result)?;
+    validate_pure_data(&result).map_err(TxError::InvalidResult)?;
+
+    // Make the lifetime ordering explicit: all GcPtrs disappear before the
+    // invocation arena is reset by its guard.
+    drop(env);
+    drop(function);
+    let _managed_bytes = invocation.accounted_bytes();
+    Ok(result)
+}
+
+fn map_eval_error(error: EvalError) -> TxError {
+    match error {
+        EvalError::GasExhausted => TxError::GasExhausted,
+        EvalError::ForbiddenEffect(operation) => TxError::ForbiddenEffect(operation),
+        other => TxError::Evaluation(other.to_string()),
+    }
+}
+
+fn validate_pure_data(value: &SerializedValue) -> Result<(), &'static str> {
+    use SerializedValue::*;
+    match value {
+        SharedAtom(_) => Err("shared atom"),
+        ByteBlob(_) => Err("shared byte blob"),
+        Var { .. } => Err("Var"),
+        Error(_) => Err("error object"),
+        List(items) | Vector(items) | HashSet(items) | SortedSet(items) | Queue(items)
+        | ObjectArray(items) => items.iter().try_for_each(validate_pure_data),
+        ArrayMap(pairs) | HashMap(pairs) | SortedMap(pairs) => {
+            pairs.iter().try_for_each(|(key, value)| {
+                validate_pure_data(key).and_then(|()| validate_pure_data(value))
+            })
+        }
+        Cons { head, tail } => validate_pure_data(head).and_then(|()| validate_pure_data(tail)),
+        TypeInstance { fields, .. } => fields.iter().try_for_each(|(key, value)| {
+            validate_pure_data(key).and_then(|()| validate_pure_data(value))
+        }),
+        WithMeta { value, meta } => {
+            validate_pure_data(value).and_then(|()| validate_pure_data(meta))
+        }
+        Reduced(inner) => validate_pure_data(inner),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn executes_pure_tree_walked_function() {
+        let program = TxProgram::parse("(fn [x] (assoc x :seen true))").unwrap();
+        let input = SerializedValue::ArrayMap(vec![(
+            SerializedValue::Keyword {
+                namespace: None,
+                name: "id".into(),
+            },
+            SerializedValue::Long(7),
+        )]);
+        let result = execute(&program, vec![input], TxLimits::default()).unwrap();
+        assert!(matches!(result, SerializedValue::ArrayMap(_)));
+    }
+
+    #[test]
+    fn permits_internal_closure_that_does_not_escape() {
+        let program = TxProgram::parse("(fn [x] (let [f (fn [y] (+ x y))] (f 2)))").unwrap();
+        let result = execute(
+            &program,
+            vec![SerializedValue::Long(40)],
+            TxLimits::default(),
+        )
+        .unwrap();
+        assert!(matches!(result, SerializedValue::Long(42)));
+    }
+
+    #[test]
+    fn rejects_effectful_builtin() {
+        let program = TxProgram::parse("(fn [] (spit \"/tmp/cljrs-tx-test\" \"no\"))").unwrap();
+        let error = execute(&program, vec![], TxLimits::default()).unwrap_err();
+        assert!(matches!(error, TxError::ForbiddenEffect(name) if name == "spit"));
+    }
+
+    #[test]
+    fn enforces_gas_limit() {
+        let program = TxProgram::parse("(fn [] (loop [x 0] (recur (inc x))))").unwrap();
+        let error = execute(
+            &program,
+            vec![],
+            TxLimits {
+                gas: 100,
+                ..TxLimits::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, TxError::GasExhausted));
+    }
+
+    #[test]
+    fn enforces_managed_memory_limit() {
+        let program = TxProgram::parse("(fn [] (vec (range 100000)))").unwrap();
+        let error = execute(
+            &program,
+            vec![],
+            TxLimits {
+                memory_bytes: 256 * 1024,
+                gas: 1_000_000,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, TxError::MemoryExhausted { .. }));
+    }
+
+    #[test]
+    fn syntax_quote_gensyms_are_deterministic_per_invocation() {
+        let program = TxProgram::parse("(fn [] `local#)").unwrap();
+        let first = execute(&program, vec![], TxLimits::default()).unwrap();
+        let second = execute(&program, vec![], TxLimits::default()).unwrap();
+        let symbol_name = |value: &SerializedValue| match value {
+            SerializedValue::Symbol { name, .. } => name.to_string(),
+            other => panic!("expected symbol, got {other:?}"),
+        };
+        assert_eq!(symbol_name(&first), symbol_name(&second));
+    }
+}

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -1250,6 +1250,9 @@ fn format_eval_error(e: EvalError) -> miette::Report {
         EvalError::NotCallable(s) => miette::miette!("Not a function: {}", s),
         EvalError::Runtime(msg) => miette::miette!("{}", msg),
         EvalError::GasExhausted => miette::miette!("gas exhausted"),
+        EvalError::ForbiddenEffect(operation) => {
+            miette::miette!("effect forbidden in transaction function: {operation}")
+        }
         EvalError::Read(e) => miette::Report::from(e),
         EvalError::Recur(_) => miette::miette!("recur outside of loop/fn"),
         EvalError::CommitSignatureVerificationFailed { commit, reason } => {


### PR DESCRIPTION
## Summary

- add a tree-walker-only `cljrs-tx` runtime for pure, Datomic-style transaction functions
- route every `GcPtr` allocation in an invocation into one bounded arena and reclaim the complete environment at the boundary
- structured-clone pure inputs into the invocation and pure results back out
- enforce cooperative gas limits and a transaction capability policy that blocks I/O, clocks, randomness, shared state, concurrency, versioned loading, and Rust object construction
- use invocation-local deterministic syntax-quote gensyms
- preserve the existing strict `no-gc` allocation behavior outside transaction invocations

## Why

The existing `no-gc` feature is optimized for statically analyzed AOT code and rejects constructs whose values could escape short-lived scratch regions. Transaction functions have a simpler lifetime: the entire isolated environment can share one arena and be freed after the call. That permits internal closures, lazy values, atoms, transients, cycles, and other arbitrary object graphs without a tracing collector.

This first scope intentionally targets only the tree-walking interpreter. IR lowering, JIT, AOT, async, and external capabilities are excluded.

## Memory-budget note

The current limit is exact for managed arena object boxes and out-of-line memory reported by `Trace::gc_size_extra`. It is not yet a hard process RSS ceiling for incidental Rust allocations outside traced values. A WASM linear-memory or process sandbox would be required for adversarial hard address-space enforcement.

## Validation

- `cargo test -p cljrs-tx --features no-gc`
- `cargo test -p cljrs-gc --features no-gc --test no_gc_alloc`
- `cargo test -p cljrs-interp`
- `cargo check --workspace`
- `cargo clippy -p cljrs-tx --features no-gc -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`