### PR TITLE
Add cljrs-tx: bounded no-GC transaction-function runtime with host read API

### DIFF
--- a/crates/cljrs-tx/README.md
+++ b/crates/cljrs-tx/README.md
@@ -31,14 +31,34 @@ impl TxProgram {
 pub struct TxLimits {
     pub memory_bytes: usize,
     pub gas: u64,
+    pub call_depth: u64,
 }
 
 pub enum TxError { /* read, boundary, evaluation, budget, and policy errors */ }
+
+pub trait HostFn: Send + Sync {
+    fn call(&self, args: &[SerializedValue]) -> Result<SerializedValue, String>;
+}
+// Blanket impl for Fn(&[SerializedValue]) -> Result<SerializedValue, String> + Send + Sync.
+
+pub struct HostApi { /* namespaced host functions */ }
+impl HostApi {
+    pub fn new() -> Self;
+    pub fn define(&mut self, namespace: impl Into<Arc<str>>, name: impl Into<Arc<str>>, function: impl HostFn + 'static);
+    pub fn is_empty(&self) -> bool;
+}
 
 pub fn execute(
     program: &TxProgram,
     args: Vec<cljrs_value::clone::SerializedValue>,
     limits: TxLimits,
+) -> Result<cljrs_value::clone::SerializedValue, TxError>;
+
+pub fn execute_with_host(
+    program: &TxProgram,
+    args: Vec<cljrs_value::clone::SerializedValue>,
+    limits: TxLimits,
+    host: &HostApi,
 ) -> Result<cljrs_value::clone::SerializedValue, TxError>;
 ```
 
@@ -46,6 +66,23 @@ pub fn execute(
 bounded arena, structured-clones arguments in, invokes the function under a
 gas meter and transaction capability policy, clones a pure-data result out,
 and then destroys the whole environment.
+
+`execute_with_host` additionally interns each `HostApi` entry as a namespaced
+native function (e.g. `my.host/lookup`) in the invocation environment. Host
+calls are the only seam through the isolation boundary: arguments are
+serialized out of the arena and validated as pure data, the result is
+validated and structured-cloned back in (arena allocation, so the invocation's
+managed-memory budget covers it). Host functions should be deterministic,
+side-effect-free reads; a returned `Err` surfaces inside the transaction as an
+ordinary evaluation error. This is the hook an embedding database uses to
+expose read-only query APIs to transaction functions without letting live
+handles enter the arena.
+
+`call_depth` caps nested interpreted function applications through the
+function-application hook. Each interpreted frame consumes real Rust stack
+and an overflow is process-fatal, so hosts must size the executing thread's
+stack to comfortably cover the configured depth (interpreted frames can run
+to a few kilobytes each).
 
 The memory limit covers arena object boxes and out-of-line memory reported by
 `Trace::gc_size_extra`. It is a managed-allocation limit, not yet a hard RSS

--- a/crates/cljrs-tx/src/lib.rs
+++ b/crates/cljrs-tx/src/lib.rs
@@ -2,12 +2,15 @@
 
 #![cfg(feature = "no-gc")]
 
+use std::cell::Cell;
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
 
 use cljrs_env::env::Env;
 use cljrs_env::error::EvalError;
 use cljrs_reader::{Form, Parser};
 use cljrs_value::clone::{CloneError, SerializedValue, deserialize, serialize};
+use cljrs_value::{Arity, NativeFn, Value, ValueError};
 
 /// A parsed transaction function expression.
 ///
@@ -48,6 +51,11 @@ pub struct TxLimits {
     pub memory_bytes: usize,
     /// Cooperative tree-walker execution credits.
     pub gas: u64,
+    /// Nested function applications the invocation may stack. The
+    /// tree-walking interpreter consumes real Rust stack per frame, so the
+    /// hosting thread's stack must comfortably cover this depth — an
+    /// overflow is not catchable.
+    pub call_depth: u64,
 }
 
 impl Default for TxLimits {
@@ -55,7 +63,91 @@ impl Default for TxLimits {
         Self {
             memory_bytes: 16 * 1024 * 1024,
             gas: 1_000_000,
+            call_depth: 2_000,
         }
+    }
+}
+
+/// A host-provided function callable from transaction code.
+///
+/// Arguments and results cross the isolation boundary as pure boundary data:
+/// the runtime serializes the cljrs argument values out of the invocation
+/// arena, validates them, and validates + deserializes the result back in
+/// (charging the invocation's managed-memory budget). Host functions should
+/// be deterministic, side-effect-free reads — they run inside the
+/// transaction's evaluation and their results become part of it.
+///
+/// A returned `Err` surfaces inside the transaction as an ordinary
+/// evaluation error carrying the message.
+pub trait HostFn: Send + Sync {
+    /// Invoke the host function with pure boundary-data arguments.
+    fn call(&self, args: &[SerializedValue]) -> Result<SerializedValue, String>;
+}
+
+impl<F> HostFn for F
+where
+    F: Fn(&[SerializedValue]) -> Result<SerializedValue, String> + Send + Sync,
+{
+    fn call(&self, args: &[SerializedValue]) -> Result<SerializedValue, String> {
+        self(args)
+    }
+}
+
+/// A registry of [`HostFn`]s exposed to transaction code as namespaced
+/// native functions (e.g. `my.host/lookup`).
+///
+/// The registry is installed fresh into every invocation's environment by
+/// [`execute_with_host`]; the `Arc`ed functions themselves live outside the
+/// arena and survive across invocations.
+#[derive(Clone, Default)]
+pub struct HostApi {
+    entries: Vec<HostEntry>,
+}
+
+#[derive(Clone)]
+struct HostEntry {
+    namespace: Arc<str>,
+    name: Arc<str>,
+    function: Arc<dyn HostFn>,
+}
+
+impl HostApi {
+    /// Creates an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers `function` as `namespace/name`. Later definitions of the
+    /// same name shadow earlier ones.
+    pub fn define(
+        &mut self,
+        namespace: impl Into<Arc<str>>,
+        name: impl Into<Arc<str>>,
+        function: impl HostFn + 'static,
+    ) {
+        self.entries.push(HostEntry {
+            namespace: namespace.into(),
+            name: name.into(),
+            function: Arc::new(function),
+        });
+    }
+
+    /// Whether no host functions are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl std::fmt::Debug for HostApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let names: Vec<String> = self
+            .entries
+            .iter()
+            .map(|entry| format!("{}/{}", entry.namespace, entry.name))
+            .collect();
+        f.debug_struct("HostApi").field("fns", &names).finish()
     }
 }
 
@@ -77,6 +169,8 @@ pub enum TxError {
     Evaluation(String),
     #[error("transaction gas exhausted")]
     GasExhausted,
+    #[error("transaction call depth exceeded")]
+    DepthExceeded,
     #[error("transaction attempted a forbidden effect: {0}")]
     ForbiddenEffect(String),
     #[error(
@@ -104,6 +198,21 @@ pub fn execute(
     args: Vec<SerializedValue>,
     limits: TxLimits,
 ) -> Result<SerializedValue, TxError> {
+    execute_with_host(program, args, limits, &HostApi::default())
+}
+
+/// Like [`execute`], but installs the [`HostApi`]'s functions into the
+/// invocation environment before evaluating `program`.
+///
+/// Host functions appear as namespaced natives (`namespace/name`); every
+/// value crossing between the arena and a host function is serialized and
+/// validated as pure data in both directions.
+pub fn execute_with_host(
+    program: &TxProgram,
+    args: Vec<SerializedValue>,
+    limits: TxLimits,
+    host: &HostApi,
+) -> Result<SerializedValue, TxError> {
     if limits.memory_bytes < 64 {
         return Err(TxError::InvalidMemoryLimit);
     }
@@ -111,7 +220,9 @@ pub fn execute(
         validate_pure_data(arg).map_err(TxError::InvalidInput)?;
     }
 
-    match catch_unwind(AssertUnwindSafe(|| execute_inner(program, args, limits))) {
+    match catch_unwind(AssertUnwindSafe(|| {
+        execute_inner(program, args, limits, host)
+    })) {
         Ok(result) => result,
         Err(payload) => match payload.downcast_ref::<cljrs_gc::region::RegionLimitExceeded>() {
             Some(exhausted) => Err(TxError::MemoryExhausted {
@@ -128,18 +239,30 @@ fn execute_inner(
     program: &TxProgram,
     args: Vec<SerializedValue>,
     limits: TxLimits,
+    host: &HostApi,
 ) -> Result<SerializedValue, TxError> {
     let invocation = cljrs_gc::alloc_ctx::InvocationGuard::new(limits.memory_bytes);
 
     // Bootstrap is trusted but is deliberately constructed inside the arena so
     // the complete namespace/Var/function environment dies with the call.
-    let globals = cljrs_interp::standard_env_minimal(None, None, None);
+    // The call hook enforces the call-depth cap, protecting the hosting
+    // thread's Rust stack from unbounded interpreted recursion.
+    let globals = cljrs_interp::standard_env_minimal(None, Some(hook_call), None);
+    for entry in &host.entries {
+        globals.get_or_create_ns(&entry.namespace);
+        globals.intern(
+            &entry.namespace,
+            Arc::clone(&entry.name),
+            host_native(entry),
+        );
+    }
     let mut env = Env::new(globals, "user");
     let args: Vec<_> = args.into_iter().map(deserialize).collect();
 
     let _policy = cljrs_env::policy::TransactionPolicyGuard::install();
     let meter = cljrs_env::gas::GasMeter::new(limits.gas);
     let _gas = cljrs_env::gas::GasGuard::install(meter);
+    let _depth = DepthGuard::install(limits.call_depth);
 
     let function = env.eval(program.form()).map_err(map_eval_error)?;
     let result =
@@ -155,11 +278,99 @@ fn execute_inner(
     Ok(result)
 }
 
+/// Wraps a host function as an arena-allocated native. The wrapper is the
+/// isolation seam: arguments are serialized out of the arena and validated,
+/// the result is validated and deserialized back in (arena allocation, so
+/// the managed-memory budget covers it).
+fn host_native(entry: &HostEntry) -> Value {
+    let function = Arc::clone(&entry.function);
+    let native = NativeFn::with_closure(
+        Arc::clone(&entry.name),
+        Arity::Variadic { min: 0 },
+        move |args| {
+            let args: Vec<SerializedValue> =
+                args.iter()
+                    .map(serialize)
+                    .collect::<Result<_, _>>()
+                    .map_err(|error| ValueError::Other(format!("host call argument: {error}")))?;
+            for arg in &args {
+                validate_pure_data(arg).map_err(|what| {
+                    ValueError::Other(format!("host call argument is not pure data: {what}"))
+                })?;
+            }
+            let result = function.call(&args).map_err(ValueError::Other)?;
+            validate_pure_data(&result).map_err(|what| {
+                ValueError::Other(format!("host result is not pure data: {what}"))
+            })?;
+            Ok(deserialize(result))
+        },
+    );
+    Value::NativeFunction(cljrs_gc::GcPtr::new(native))
+}
+
+/// Marker text for depth-cap rejection (the hook's error type is fixed by
+/// `GlobalEnv`, so the cap surfaces as a runtime error carrying this text).
+const DEPTH_MSG: &str = "cljrs-tx: transaction call depth exceeded";
+
+thread_local! {
+    /// `(limit, current)` nested-application counter for the running
+    /// invocation; `None` outside one.
+    static CALL_DEPTH: Cell<Option<(u64, u64)>> = const { Cell::new(None) };
+}
+
+/// Installs the call-depth budget for one invocation's dynamic extent.
+struct DepthGuard;
+
+impl DepthGuard {
+    fn install(limit: u64) -> Self {
+        CALL_DEPTH.with(|cell| cell.set(Some((limit, 0))));
+        Self
+    }
+}
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        CALL_DEPTH.with(|cell| cell.set(None));
+    }
+}
+
+/// The pluggable function-application hook: enforces the call-depth cap
+/// (each interpreted application consumes real Rust stack, and an overflow
+/// would abort the process), then delegates to the tree-walking apply.
+#[allow(clippy::result_large_err)]
+fn hook_call(
+    f: &cljrs_value::CljxFn,
+    args: &[Value],
+    env: &mut Env,
+) -> cljrs_env::error::EvalResult {
+    let Some((limit, depth)) = CALL_DEPTH.with(Cell::get) else {
+        return cljrs_interp::apply::call_cljrs_fn(f, args, env);
+    };
+    if depth >= limit {
+        return Err(EvalError::Runtime(DEPTH_MSG.into()));
+    }
+    CALL_DEPTH.with(|cell| cell.set(Some((limit, depth + 1))));
+    let result = cljrs_interp::apply::call_cljrs_fn(f, args, env);
+    CALL_DEPTH.with(|cell| {
+        if let Some((limit, current)) = cell.get() {
+            cell.set(Some((limit, current.saturating_sub(1))));
+        }
+    });
+    result
+}
+
 fn map_eval_error(error: EvalError) -> TxError {
     match error {
         EvalError::GasExhausted => TxError::GasExhausted,
         EvalError::ForbiddenEffect(operation) => TxError::ForbiddenEffect(operation),
-        other => TxError::Evaluation(other.to_string()),
+        other => {
+            let text = other.to_string();
+            if text.contains(DEPTH_MSG) {
+                TxError::DepthExceeded
+            } else {
+                TxError::Evaluation(text)
+            }
+        }
     }
 }
 
@@ -242,6 +453,21 @@ mod tests {
     }
 
     #[test]
+    fn enforces_call_depth_limit() {
+        let program = TxProgram::parse("(fn [] ((fn boom [n] (boom (inc n))) 0))").unwrap();
+        let error = execute(
+            &program,
+            vec![],
+            TxLimits {
+                call_depth: 64,
+                ..TxLimits::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, TxError::DepthExceeded), "got {error:?}");
+    }
+
+    #[test]
     fn enforces_managed_memory_limit() {
         let program = TxProgram::parse("(fn [] (vec (range 100000)))").unwrap();
         let error = execute(
@@ -250,10 +476,140 @@ mod tests {
             TxLimits {
                 memory_bytes: 256 * 1024,
                 gas: 1_000_000,
+                ..TxLimits::default()
             },
         )
         .unwrap_err();
         assert!(matches!(error, TxError::MemoryExhausted { .. }));
+    }
+
+    #[test]
+    fn host_function_is_callable_from_transaction_code() {
+        let mut host = HostApi::new();
+        host.define(
+            "test.host",
+            "double",
+            |args: &[SerializedValue]| match args {
+                [SerializedValue::Long(n)] => Ok(SerializedValue::Long(n * 2)),
+                _ => Err("double takes one long".into()),
+            },
+        );
+        let program = TxProgram::parse("(fn [x] (+ 1 (test.host/double x)))").unwrap();
+        let result = execute_with_host(
+            &program,
+            vec![SerializedValue::Long(20)],
+            TxLimits::default(),
+            &host,
+        )
+        .unwrap();
+        assert!(matches!(result, SerializedValue::Long(41)));
+    }
+
+    #[test]
+    fn host_function_receives_structured_arguments() {
+        let mut host = HostApi::new();
+        host.define("test.host", "lookup", |args: &[SerializedValue]| {
+            let [SerializedValue::ArrayMap(pairs) | SerializedValue::HashMap(pairs)] = args else {
+                return Err("lookup takes one map".into());
+            };
+            pairs
+                .iter()
+                .find(|(key, _)| matches!(key, SerializedValue::Keyword { name, .. } if &**name == "id"))
+                .map(|(_, value)| value.clone())
+                .ok_or_else(|| "missing :id".into())
+        });
+        let program = TxProgram::parse("(fn [] (test.host/lookup {:id 7}))").unwrap();
+        let result = execute_with_host(&program, vec![], TxLimits::default(), &host).unwrap();
+        assert!(matches!(result, SerializedValue::Long(7)));
+    }
+
+    #[test]
+    fn host_function_error_surfaces_as_evaluation_error() {
+        let mut host = HostApi::new();
+        host.define("test.host", "boom", |_: &[SerializedValue]| {
+            Err::<SerializedValue, _>("host exploded".into())
+        });
+        let program = TxProgram::parse("(fn [] (test.host/boom))").unwrap();
+        let error = execute_with_host(&program, vec![], TxLimits::default(), &host).unwrap_err();
+        assert!(
+            matches!(&error, TxError::Evaluation(text) if text.contains("host exploded")),
+            "got {error:?}"
+        );
+    }
+
+    #[test]
+    fn impure_host_result_is_rejected() {
+        let mut host = HostApi::new();
+        host.define("test.host", "leak", |_: &[SerializedValue]| {
+            Ok(SerializedValue::ByteBlob(Arc::from(&b"shared"[..])))
+        });
+        let program = TxProgram::parse("(fn [] (test.host/leak))").unwrap();
+        let error = execute_with_host(&program, vec![], TxLimits::default(), &host).unwrap_err();
+        assert!(
+            matches!(&error, TxError::Evaluation(text) if text.contains("not pure data")),
+            "got {error:?}"
+        );
+    }
+
+    #[test]
+    fn oversized_host_result_hits_memory_budget() {
+        let mut host = HostApi::new();
+        host.define("test.host", "flood", |_: &[SerializedValue]| {
+            Ok(SerializedValue::Vector(
+                (0..100_000).map(SerializedValue::Long).collect(),
+            ))
+        });
+        let program = TxProgram::parse("(fn [] (count (test.host/flood)))").unwrap();
+        let error = execute_with_host(
+            &program,
+            vec![],
+            TxLimits {
+                memory_bytes: 64 * 1024,
+                gas: 10_000_000,
+                ..TxLimits::default()
+            },
+            &host,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, TxError::MemoryExhausted { .. }),
+            "got {error:?}"
+        );
+    }
+
+    #[test]
+    fn host_function_result_flows_into_transaction_data() {
+        let mut host = HostApi::new();
+        host.define(
+            "test.host",
+            "balance",
+            |args: &[SerializedValue]| match args {
+                [SerializedValue::Str(name)] if name == "alice" => Ok(SerializedValue::Long(100)),
+                _ => Err("unknown account".into()),
+            },
+        );
+        let program = TxProgram::parse(
+            "(fn [acct amount] [[:db/add acct :balance (+ (test.host/balance acct) amount)]])",
+        )
+        .unwrap();
+        let result = execute_with_host(
+            &program,
+            vec![
+                SerializedValue::Str("alice".into()),
+                SerializedValue::Long(5),
+            ],
+            TxLimits::default(),
+            &host,
+        )
+        .unwrap();
+        let SerializedValue::Vector(forms) = &result else {
+            panic!("expected tx data vector, got {result:?}");
+        };
+        let SerializedValue::Vector(form) = &forms[0] else {
+            panic!("expected inner vector");
+        };
+        assert!(matches!(&form[0], SerializedValue::Keyword { name, .. } if &**name == "add"));
+        assert!(matches!(form[3], SerializedValue::Long(105)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **`cljrs-tx`** (new crate): tree-walker-only runtime for pure, isolated transaction functions. Each invocation runs in a fresh GC-less arena under gas, managed-memory, and call-depth budgets; the environment, inputs, and every intermediate value are destroyed together when the call returns. Requires the `no-gc` feature (off by default so GC workspace builds don't unify).
- **Host read-API hook**: `HostFn` / `HostApi` / `execute_with_host()` intern host functions as namespaced natives (e.g. `corium.api/q`) inside the invocation environment. The host seam is the only crossing through the isolation boundary — arguments are serialized out of the arena and validated as pure data, results are validated and structured-cloned back in (arena allocation, so the memory budget covers them). This is the hook an embedding database uses to expose read-only queries to transaction functions without letting live handles enter the arena.
- **Call-depth limit**: `TxLimits.call_depth` (default 2000) enforced through the function-application hook, surfacing as `TxError::DepthExceeded`. Interpreted frames consume real Rust stack and an overflow is process-fatal, so unbounded interpreted recursion must fail cleanly before it gets there; hosts size the executing thread's stack for the configured depth.

## Testing

- `cargo test -p cljrs-tx --features no-gc` — 13 tests: pure execution, closures, forbidden effects, gas/memory/depth budgets, deterministic gensyms, host-fn calls (structured args, error propagation, impure-result rejection, oversized results hitting the memory budget, results flowing into tx data).
- `cargo clippy -p cljrs-tx --features no-gc --all-targets` and `cargo fmt --check` clean; featureless build (empty crate) still compiles.
- Exercised downstream by corium's transactor `:db/fn` runtime (11-test acceptance battery incl. CAS/invariant functions querying through the host API, plus a live end-to-end run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)