### PR TITLE
aot: discover harness binary via cargo JSON messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "clap",
  "cljrs-async",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-async"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-builtins",
  "cljrs-env",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-base64"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "base64",
  "cljrs-env",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-blake3"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "blake3",
  "cljrs-env",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-builtins"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "bigdecimal",
  "cljrs-env",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-charset"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-async",
  "cljrs-env",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-compiler"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-async",
  "cljrs-base64",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-deps"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-gc",
  "cljrs-reader",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-dom"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-async",
  "cljrs-env",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-dylib"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-deps",
  "cljrs-env",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-env"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-deps",
  "cljrs-gc",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-eval"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-builtins",
  "cljrs-env",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-export-macro"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-gc"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "bigdecimal",
  "cljrs-logging",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-interop"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-env",
  "cljrs-export-macro",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-interp"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-builtins",
  "cljrs-env",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-io"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-async",
  "cljrs-env",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-ir"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-reader",
  "cljrs-types",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-ir-prebuild"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "clap",
  "cljrs-env",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-ir-viz"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-compiler",
  "cljrs-ir",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-jit"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-async",
  "cljrs-compiler",
@@ -1062,11 +1062,11 @@ dependencies = [
 
 [[package]]
 name = "cljrs-logging"
-version = "0.1.0"
+version = "0.1.228"
 
 [[package]]
 name = "cljrs-lsp"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-reader",
  "cljrs-types",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-net"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "bytes",
  "cljrs-async",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-nrepl"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-builtins",
  "cljrs-env",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-reader"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-types",
  "miette",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-runtime"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-eval",
  "cljrs-gc",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-stdlib"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-builtins",
  "cljrs-env",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-tx"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-env",
  "cljrs-gc",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-types"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "miette",
  "serde",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-value"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "arc-swap",
  "bigdecimal",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-vcs"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "gix",
  "pgp",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cljrs-wasm"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-async",
  "cljrs-builtins",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "rust-interop-example"
-version = "0.1.0"
+version = "0.1.228"
 dependencies = [
  "cljrs-eval",
  "cljrs-gc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "serde_json",
  "target-lexicon",
  "tempfile",
  "wasm-encoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,36 +42,36 @@ license = "EPL-1.0"
 repository = "https://github.com/csm/clojurust"
 
 [workspace.dependencies]
-cljrs-types        = { path = "crates/cljrs-types",        version = "0.1.0" }
-cljrs-gc           = { path = "crates/cljrs-gc",           version = "0.1.0" }
-cljrs-value        = { path = "crates/cljrs-value",        version = "0.1.0" }
-cljrs-reader       = { path = "crates/cljrs-reader",       version = "0.1.0" }
-cljrs-eval         = { path = "crates/cljrs-eval",         version = "0.1.0" }
-cljrs-stdlib       = { path = "crates/cljrs-stdlib",       version = "0.1.0" }
-cljrs-runtime      = { path = "crates/cljrs-runtime",      version = "0.1.0" }
-cljrs-ir           = { path = "crates/cljrs-ir",           version = "0.1.0" }
-cljrs-compiler     = { path = "crates/cljrs-compiler",     version = "0.1.0" }
-cljrs-interop      = { path = "crates/cljrs-interop",      version = "0.1.0" }
-cljrs-export-macro = { path = "crates/cljrs-export-macro", version = "0.1.0" }
-cljrs-logging      = { path = "crates/cljrs-logging",      version = "0.1.0" }
-cljrs-env          = { path = "crates/cljrs-env",          version = "0.1.0" }
-cljrs-builtins     = { path = "crates/cljrs-builtins",     version = "0.1.0" }
-cljrs-interp       = { path = "crates/cljrs-interp",       version = "0.1.0" }
-cljrs-ir-prebuild  = { path = "crates/cljrs-ir-prebuild",  version = "0.1.0" }
-cljrs-ir-viz       = { path = "crates/cljrs-ir-viz",       version = "0.1.0" }
-cljrs-deps         = { path = "crates/cljrs-deps",         version = "0.1.0" }
-cljrs-vcs          = { path = "crates/cljrs-vcs",          version = "0.1.0" }
-cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0" }
-cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
-cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
-cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0" }
-cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.0" }
-cljrs-nrepl        = { path = "crates/cljrs-nrepl",        version = "0.1.0" }
-cljrs-base64       = { path = "crates/cljrs-base64",       version = "0.1.0" }
-cljrs-jit          = { path = "crates/cljrs-jit",          version = "0.1.0" }
-cljrs-dylib        = { path = "crates/cljrs-dylib",        version = "0.1.0" }
-cljrs-dom          = { path = "crates/cljrs-dom",          version = "0.1.0" }
-cljrs-tx           = { path = "crates/cljrs-tx",           version = "0.1.0" }
+cljrs-types        = { path = "crates/cljrs-types",        version = "0.1.228" }
+cljrs-gc           = { path = "crates/cljrs-gc",           version = "0.1.228" }
+cljrs-value        = { path = "crates/cljrs-value",        version = "0.1.228" }
+cljrs-reader       = { path = "crates/cljrs-reader",       version = "0.1.228" }
+cljrs-eval         = { path = "crates/cljrs-eval",         version = "0.1.228" }
+cljrs-stdlib       = { path = "crates/cljrs-stdlib",       version = "0.1.228" }
+cljrs-runtime      = { path = "crates/cljrs-runtime",      version = "0.1.228" }
+cljrs-ir           = { path = "crates/cljrs-ir",           version = "0.1.228" }
+cljrs-compiler     = { path = "crates/cljrs-compiler",     version = "0.1.228" }
+cljrs-interop      = { path = "crates/cljrs-interop",      version = "0.1.228" }
+cljrs-export-macro = { path = "crates/cljrs-export-macro", version = "0.1.228" }
+cljrs-logging      = { path = "crates/cljrs-logging",      version = "0.1.228" }
+cljrs-env          = { path = "crates/cljrs-env",          version = "0.1.228" }
+cljrs-builtins     = { path = "crates/cljrs-builtins",     version = "0.1.228" }
+cljrs-interp       = { path = "crates/cljrs-interp",       version = "0.1.228" }
+cljrs-ir-prebuild  = { path = "crates/cljrs-ir-prebuild",  version = "0.1.228" }
+cljrs-ir-viz       = { path = "crates/cljrs-ir-viz",       version = "0.1.228" }
+cljrs-deps         = { path = "crates/cljrs-deps",         version = "0.1.228" }
+cljrs-vcs          = { path = "crates/cljrs-vcs",          version = "0.1.228" }
+cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.228" }
+cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.228" }
+cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.228" }
+cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.228" }
+cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.228" }
+cljrs-nrepl        = { path = "crates/cljrs-nrepl",        version = "0.1.228" }
+cljrs-base64       = { path = "crates/cljrs-base64",       version = "0.1.228" }
+cljrs-jit          = { path = "crates/cljrs-jit",          version = "0.1.228" }
+cljrs-dylib        = { path = "crates/cljrs-dylib",        version = "0.1.228" }
+cljrs-dom          = { path = "crates/cljrs-dom",          version = "0.1.228" }
+cljrs-tx           = { path = "crates/cljrs-tx",           version = "0.1.228" }
 
 miette       = { version = "7", features = ["fancy"] }
 thiserror    = "2"

--- a/crates/cljrs-async/Cargo.toml
+++ b/crates/cljrs-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-async"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Async support for clojurust — clojure.core.async via Tokio"
 license.workspace = true

--- a/crates/cljrs-base64/Cargo.toml
+++ b/crates/cljrs-base64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-base64"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Base64 library for Clojurust wrapping rust-base64"
 license.workspace = true

--- a/crates/cljrs-blake3/Cargo.toml
+++ b/crates/cljrs-blake3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-blake3"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "BLAKE3 cryptographic hash functions exposed as Clojure native functions"
 license.workspace = true

--- a/crates/cljrs-builtins/Cargo.toml
+++ b/crates/cljrs-builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-builtins"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Built-in function implementations for clojurust (arithmetic, collections, I/O, regex)"
 license.workspace = true

--- a/crates/cljrs-charset/Cargo.toml
+++ b/crates/cljrs-charset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-charset"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Charset encoding and decoding with stream support — clojure.rust.charset"
 license.workspace = true

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-compiler"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "JIT (Cranelift) and AOT compiler backend for clojurust"
 license.workspace = true

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -37,6 +37,8 @@ target-lexicon     = { workspace = true }
 
 wasm-encoder       = "0.244"
 
+serde_json         = "1"
+
 [dev-dependencies]
 tempfile = "3"
 wasmparser = "0.244"

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -1853,25 +1853,9 @@ const TEST_HARNESS_RUNTIME_CRATES: &[&str] = &[
 fn link_with_cargo(harness_dir: &Path, out_path: &Path, offline: bool) -> AotResult<()> {
     eprintln!("[aot] building harness with cargo...");
 
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.arg("build").arg("--release");
-    if offline {
-        cmd.arg("--offline");
-    }
-    let output = cmd.current_dir(harness_dir).output()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(AotError::Link(format!("cargo build failed:\n{stderr}")));
-    }
-
-    // The binary is at target/release/cljrs-aot-harness.
-    let bin_name = if cfg!(target_os = "windows") {
-        "cljrs-aot-harness.exe"
-    } else {
-        "cljrs-aot-harness"
-    };
-    let built = harness_dir.join("target/release").join(bin_name);
+    let output = cargo_build_harness_release(harness_dir, offline)?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let built = harness_bin_from_cargo_stdout(&stdout)?;
     std::fs::copy(&built, out_path)?;
 
     // Clean up the harness directory.
@@ -1889,8 +1873,26 @@ fn link_with_cargo_test_harness(
 ) -> AotResult<()> {
     eprintln!("[aot] building harness with cargo...");
 
+    let output = cargo_build_harness_release(harness_dir, offline)?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let built = harness_bin_from_cargo_stdout(&stdout)?;
+    std::fs::copy(&built, out_path)?;
+
+    // Keep the harness directory for debugging
+    eprintln!("[aot] harness directory kept at {}", harness_dir.display());
+
+    Ok(())
+}
+
+/// Run `cargo build --release --message-format=json` in the harness directory.
+fn cargo_build_harness_release(
+    harness_dir: &Path,
+    offline: bool,
+) -> AotResult<std::process::Output> {
     let mut cmd = std::process::Command::new("cargo");
-    cmd.arg("build").arg("--release");
+    cmd.arg("build")
+        .arg("--release")
+        .arg("--message-format=json");
     if offline {
         cmd.arg("--offline");
     }
@@ -1900,20 +1902,59 @@ fn link_with_cargo_test_harness(
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(AotError::Link(format!("cargo build failed:\n{stderr}")));
     }
+    Ok(output)
+}
 
-    // The binary is at target/release/cljrs-aot-harness.
-    let bin_name = if cfg!(target_os = "windows") {
-        "cljrs-aot-harness.exe"
-    } else {
-        "cljrs-aot-harness"
-    };
-    let built = harness_dir.join("target/release").join(bin_name);
-    std::fs::copy(&built, out_path)?;
+/// Name of the temporary harness package / bin target generated for AOT link.
+const AOT_HARNESS_BIN: &str = "cljrs-aot-harness";
 
-    // Keep the harness directory for debugging
-    eprintln!("[aot] harness directory kept at {}", harness_dir.display());
+/// Select the harness executable from cargo `--message-format=json` NDJSON.
+///
+/// Cargo may place binaries under `target/release`, a custom `CARGO_TARGET_DIR`,
+/// or a target-triple subdir. The last matching `compiler-artifact` message for
+/// bin `cljrs-aot-harness` with a non-null `executable` is authoritative.
+fn harness_bin_from_cargo_stdout(stdout: &str) -> AotResult<PathBuf> {
+    let mut last: Option<PathBuf> = None;
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(path) = compiler_artifact_bin_executable(line, AOT_HARNESS_BIN) {
+            last = Some(path);
+        }
+    }
+    last.ok_or_else(|| {
+        AotError::Link(format!(
+            "cargo build produced no compiler-artifact executable for bin `{AOT_HARNESS_BIN}` \
+             (expected via --message-format=json; handles CARGO_TARGET_DIR / triple layouts)"
+        ))
+    })
+}
 
-    Ok(())
+/// Parse one cargo JSON message line.
+///
+/// Returns `Some(executable)` only for a `compiler-artifact` whose target is
+/// bin `bin_name` and whose `executable` field is a non-empty string.
+fn compiler_artifact_bin_executable(line: &str, bin_name: &str) -> Option<PathBuf> {
+    let msg: serde_json::Value = serde_json::from_str(line).ok()?;
+    if msg.get("reason")?.as_str()? != "compiler-artifact" {
+        return None;
+    }
+    let target = msg.get("target")?;
+    if target.get("name")?.as_str()? != bin_name {
+        return None;
+    }
+    let kinds = target.get("kind")?.as_array()?;
+    let is_bin = kinds.iter().any(|k| k.as_str() == Some("bin"));
+    if !is_bin {
+        return None;
+    }
+    let exe = msg.get("executable")?.as_str()?;
+    if exe.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(exe))
 }
 
 /// How the generated harness depends on the clojurust runtime crates.
@@ -2592,5 +2633,54 @@ mod tests {
         {
             assert_eq!(v, env!("CARGO_PKG_VERSION"));
         }
+    }
+
+    #[test]
+    fn harness_bin_picks_last_matching_compiler_artifact() {
+        let stdout = r#"
+{"reason":"compiler-artifact","package_id":"lib 0.1.0","target":{"kind":["lib"],"name":"other","src_path":"/x"},"executable":null}
+{"reason":"compiler-artifact","package_id":"cljrs-aot-harness 0.1.0","target":{"kind":["bin"],"name":"cljrs-aot-harness","src_path":"/h"},"executable":"/tmp/first/target/release/cljrs-aot-harness"}
+{"reason":"build-finished","success":true}
+{"reason":"compiler-artifact","package_id":"cljrs-aot-harness 0.1.0","target":{"kind":["bin"],"crate_types":["bin"],"name":"cljrs-aot-harness","src_path":"/h"},"executable":"/custom/CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/cljrs-aot-harness","filenames":["/custom/CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/cljrs-aot-harness"]}
+"#;
+        let path = harness_bin_from_cargo_stdout(stdout).unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from(
+                "/custom/CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/cljrs-aot-harness"
+            )
+        );
+    }
+
+    #[test]
+    fn harness_bin_ignores_wrong_name_non_bin_and_null_executable() {
+        let stdout = r#"
+{"reason":"compiler-artifact","target":{"kind":["bin"],"name":"other-bin"},"executable":"/tmp/other"}
+{"reason":"compiler-artifact","target":{"kind":["lib"],"name":"cljrs-aot-harness"},"executable":"/tmp/lib.rlib"}
+{"reason":"compiler-artifact","target":{"kind":["bin"],"name":"cljrs-aot-harness"},"executable":null}
+{"reason":"compiler-artifact","target":{"kind":["bin"],"name":"cljrs-aot-harness"},"executable":""}
+{"reason":"not-an-artifact","target":{"kind":["bin"],"name":"cljrs-aot-harness"},"executable":"/tmp/nope"}
+"#;
+        let err = harness_bin_from_cargo_stdout(stdout).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cljrs-aot-harness"),
+            "error should mention missing harness bin, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn harness_bin_errors_on_empty_stdout() {
+        let err = harness_bin_from_cargo_stdout("").unwrap_err();
+        assert!(matches!(err, AotError::Link(_)));
+    }
+
+    #[test]
+    fn compiler_artifact_helper_accepts_bin_with_executable() {
+        let line = r#"{"reason":"compiler-artifact","target":{"kind":["bin"],"name":"cljrs-aot-harness"},"executable":"/out/cljrs-aot-harness"}"#;
+        assert_eq!(
+            compiler_artifact_bin_executable(line, AOT_HARNESS_BIN),
+            Some(PathBuf::from("/out/cljrs-aot-harness"))
+        );
     }
 }

--- a/crates/cljrs-deps/Cargo.toml
+++ b/crates/cljrs-deps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-deps"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "cljrs.edn project configuration parser and dependency model"
 license.workspace = true

--- a/crates/cljrs-dom/Cargo.toml
+++ b/crates/cljrs-dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-dom"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Clean DOM interaction API for WASM targets (cljrs.dom namespace)"
 license.workspace = true

--- a/crates/cljrs-dylib/Cargo.toml
+++ b/crates/cljrs-dylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-dylib"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Pinned native packages for clojurust: build a dependency's Rust crate at a pinned commit as a cdylib and load it (:rust/load :dylib)"
 license.workspace = true

--- a/crates/cljrs-env/Cargo.toml
+++ b/crates/cljrs-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-env"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Namespace and environment management for clojurust"
 license.workspace = true

--- a/crates/cljrs-eval/Cargo.toml
+++ b/crates/cljrs-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-eval"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "IR-accelerated evaluation for clojurust (tier-1 IR interpreter + lowering)"
 license.workspace = true

--- a/crates/cljrs-export-macro/Cargo.toml
+++ b/crates/cljrs-export-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-export-macro"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Proc-macro: #[export] for automatic registration of Rust functions as Clojurust native functions"
 license.workspace = true

--- a/crates/cljrs-gc/Cargo.toml
+++ b/crates/cljrs-gc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-gc"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Tracing garbage collector for clojurust"
 license.workspace = true

--- a/crates/cljrs-interop/Cargo.toml
+++ b/crates/cljrs-interop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-interop"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Rust<->Clojure FFI, type marshalling, and NativeObject support"
 license.workspace = true

--- a/crates/cljrs-interp/Cargo.toml
+++ b/crates/cljrs-interp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-interp"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Tree-walking interpreter for clojurust (special forms, macros, destructuring)"
 license.workspace = true

--- a/crates/cljrs-io/Cargo.toml
+++ b/crates/cljrs-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-io"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Asynchronous file I/O for clojurust — tokio-backed reads/writes delivered over core.async channels"
 license.workspace = true

--- a/crates/cljrs-ir-prebuild/Cargo.toml
+++ b/crates/cljrs-ir-prebuild/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-ir-prebuild"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Pre-compilation tool that serialises standard library forms to IR for clojurust"
 license.workspace = true

--- a/crates/cljrs-ir-viz/Cargo.toml
+++ b/crates/cljrs-ir-viz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-ir-viz"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "HTML visualizer for clojurust IR — source ↔ IR mapping with region-allocation color-coding"
 license.workspace = true

--- a/crates/cljrs-ir/Cargo.toml
+++ b/crates/cljrs-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-ir"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Intermediate representation types for clojurust compiler and interpreter"
 license.workspace = true

--- a/crates/cljrs-jit/Cargo.toml
+++ b/crates/cljrs-jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-jit"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "In-process JIT compiler (Cranelift) for clojurust — Phase 10.1"
 license.workspace = true

--- a/crates/cljrs-logging/Cargo.toml
+++ b/crates/cljrs-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-logging"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Feature-gated debug/trace logging for clojurust"
 license.workspace = true

--- a/crates/cljrs-lsp/Cargo.toml
+++ b/crates/cljrs-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-lsp"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Language Server Protocol implementation for clojurust (.cljrs/.cljc)"
 license.workspace = true

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-net"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "TCP/Unix/TLS networking for clojurust — channel-oriented sockets over core.async"
 license.workspace = true

--- a/crates/cljrs-nrepl/Cargo.toml
+++ b/crates/cljrs-nrepl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-nrepl"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "nREPL server for clojurust — bencode wire protocol for editor integration"
 license.workspace = true

--- a/crates/cljrs-reader/Cargo.toml
+++ b/crates/cljrs-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-reader"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Lexer and parser producing Form AST nodes for clojurust"
 license.workspace = true

--- a/crates/cljrs-runtime/Cargo.toml
+++ b/crates/cljrs-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-runtime"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Core standard library (clojure.core equivalent) for clojurust"
 license.workspace = true

--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-stdlib"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Built-in standard library namespaces for clojurust (clojure.string, clojure.set, clojure.test, …)"
 license.workspace = true

--- a/crates/cljrs-tx/Cargo.toml
+++ b/crates/cljrs-tx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-tx"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "GC-less isolated transaction-function runtime for clojurust"
 license.workspace = true

--- a/crates/cljrs-types/Cargo.toml
+++ b/crates/cljrs-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-types"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Core types, source spans, and diagnostics for clojurust"
 license.workspace = true

--- a/crates/cljrs-value/Cargo.toml
+++ b/crates/cljrs-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-value"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Runtime Value type and persistent collections for clojurust"
 license.workspace = true

--- a/crates/cljrs-vcs/Cargo.toml
+++ b/crates/cljrs-vcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-vcs"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "Git subprocess helpers for versioned symbol resolution"
 license.workspace = true

--- a/crates/cljrs-wasm/Cargo.toml
+++ b/crates/cljrs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs-wasm"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "WebAssembly browser REPL for clojurust"
 license.workspace = true

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cljrs"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 description = "clojurust CLI — run, repl, compile, and eval"
 license.workspace = true

--- a/examples/rust-interop/Cargo.toml
+++ b/examples/rust-interop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-interop-example"
-version = "0.1.0"
+version = "0.1.228"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary

AOT linking assumed the harness binary always lands at `target/release/cljrs-aot-harness`. That breaks when `CARGO_TARGET_DIR` is set or cargo places artifacts under a target-triple directory (e.g. `target/<triple>/release/...`).

This change:

- Runs `cargo build --release --message-format=json` for both `link_with_cargo` and `link_with_cargo_test_harness`
- Parses NDJSON compiler messages and selects the **last** `compiler-artifact` for bin `cljrs-aot-harness` with a non-null `executable`
- Uses that path for the copy to the final output (so layouts from `CARGO_TARGET_DIR` / triples are handled by cargo itself)
- Adds `serde_json` as a direct `cljrs-compiler` dependency for safe message parsing
- Adds unit tests covering last-match wins, non-bin/wrong-name/null/empty executable filtering, and empty stdout errors

Branched from tag `v0.1.228`.

## Test plan

- [x] `cargo test -p cljrs-compiler --lib` (85 passed)
- [ ] Confirm AOT link with default `target/` layout still finds the harness
- [ ] Confirm AOT link with `CARGO_TARGET_DIR` / triple layout finds the harness via JSON `executable`