### PR TITLE
feat(aot): --require-fully-compiled gate on embedded source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitfields"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +873,7 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "proptest",
  "target-lexicon",
  "tempfile",
  "wasm-encoder",
@@ -2452,6 +2468,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -2459,7 +2487,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -4939,6 +4967,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5007,6 +5060,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -5034,8 +5093,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5060,12 +5129,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -5081,6 +5169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5531,6 +5628,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -6528,6 +6637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6659,6 +6774,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6682,6 +6806,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -7069,6 +7202,12 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -40,3 +40,4 @@ wasm-encoder       = "0.244"
 [dev-dependencies]
 tempfile = "3"
 wasmparser = "0.244"
+proptest = "1"

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -317,13 +317,56 @@ via an inline signed-overflow branch matching `rt_add`/etc.), wrapping
 ### AOT driver (`aot.rs`)
 
 ```rust
-pub fn compile_file(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf], rust_config: Option<&RustConfig>, verify_commit_signatures: bool) -> AotResult<()>;
+pub fn compile_file(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf], rust_config: Option<&RustConfig>, verify_commit_signatures: bool, opacity: OpacityPolicy) -> AotResult<()>;
 pub fn compile_file_to_wasm(src_path: &Path, out_path: &Path, src_dirs: &[PathBuf]) -> AotResult<()>;
 pub fn compile_test_harness(test_dir: &Path, out_path: &Path, src_dirs: &[PathBuf]) -> AotResult<()>;
 pub fn lower_via_clojure(name: Option<&str>, ns: &str, params: &[Arc<str>], forms: &[Form], env: &mut Env) -> AotResult<IrFunction>;
+pub fn audit_source(interpreted_source: &str, compiled_namespaces: &[CompiledNamespace], versioned_bundled: &[(Arc<str>, String)]) -> SourceAudit;
 
-pub enum AotError { Io, Parse, Codegen, Eval, Link, Wasm(WasmError), NoGcBlacklist(Vec<BlacklistViolation>) /* no-gc only */ }
+pub enum AotError { Io, Parse, Codegen, Eval, Link, Wasm(WasmError), SourceEmbedded(SourceAudit), NoGcBlacklist(Vec<BlacklistViolation>) /* no-gc only */ }
+
+pub struct CompiledNamespace { pub ns: Arc<str>, pub init_symbol: Option<String>, pub preamble: String }
+pub struct SourceLeak { pub channel: SourceLeakChannel, pub ns: Option<String>, pub bytes: usize }
+pub enum SourceLeakChannel { EntryPreamble, NamespacePreamble, BundledNamespace }
+
+pub struct SourceAudit { /* private */ }
+impl SourceAudit {
+    pub fn leaks(&self) -> &[SourceLeak];
+    pub fn is_clean(&self) -> bool;
+    pub fn total_bytes(&self) -> usize;
+    pub fn verdict(&self, policy: OpacityPolicy) -> OpacityVerdict;
+}
+
+pub enum OpacityPolicy { Report /* default */, RequireFullyCompiled }
+pub enum OpacityVerdict { Clean, Tolerated, Rejected }
 ```
+
+### Source-embedding audit (`--require-fully-compiled`)
+
+Only plain `defn` bodies reach machine code. Forms that `needs_interpreter`
+reports - `ns`, `require`, `defmacro`, `defonce`, `defprotocol`, `defrecord`,
+`defmulti`, `defmethod`, `extend-type`, `extend-protocol` - are written to the
+harness as `.cljrs` files and pulled in with `include_str!`, method bodies
+included, even when the enclosing namespace compiles successfully. A namespace
+that fails lowering or codegen falls back to source the same way, and pinned
+versioned dependencies always do.
+
+Four steps, each usable on its own:
+
+| step | function | purity |
+|---|---|---|
+| collect | `embedded_fragments` - the source-carrying channels as raw `(channel, ns, text)` | pure |
+| promote | `audit_source` - fragments to a `SourceAudit`, empties dropped | pure |
+| decide  | `SourceAudit::verdict(OpacityPolicy)` | pure |
+| apply   | `compile_file` - errors, warns, or proceeds | effectful |
+
+A new source-carrying channel is one entry in `embedded_fragments`; a new
+policy is one `OpacityPolicy` variant. `OpacityPolicy::Report` is the default
+and preserves existing behaviour.
+
+Property tests: `tests/source_leak_audit.rs`; end-to-end:
+`require_fully_compiled_{rejects_embedded_source,accepts_plain_defn}` in
+`tests/aot_e2e.rs`.
 
 `compile_file_to_wasm` is the `cljrs compile --target wasm` entry point: it lowers
 the source **and its transitively-required user namespaces** to a bundle of IR

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -364,6 +364,12 @@ A new source-carrying channel is one entry in `embedded_fragments`; a new
 policy is one `OpacityPolicy` variant. `OpacityPolicy::Report` is the default
 and preserves existing behaviour.
 
+The audit is reached through `compile_file` only. `compile_test_harness`
+(`--test`) and `compile_file_to_wasm` (`--target wasm`) do not run it, so the
+CLI rejects `--require-fully-compiled` in combination with either
+(`resolve_opacity_policy` in `crates/cljrs/src/main.rs`) rather than accept a
+flag it would not honour.
+
 Property tests: `tests/source_leak_audit.rs`; end-to-end:
 `require_fully_compiled_{rejects_embedded_source,accepts_plain_defn}` in
 `tests/aot_e2e.rs`.

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -29,6 +29,9 @@ pub enum AotError {
     Link(String),
     /// The wasm backend could not lower a construct in the program.
     Wasm(crate::wasm::WasmError),
+    /// The opacity policy forbids embedded Clojure source and the binary would
+    /// still carry some.
+    SourceEmbedded(SourceAudit),
     /// One or more no-gc memory-safety violations were found by the blacklist
     /// analysis.  Only emitted when the `no-gc` Cargo feature is active.
     #[cfg(feature = "no-gc")]
@@ -44,6 +47,23 @@ impl std::fmt::Display for AotError {
             AotError::Eval(e) => write!(f, "eval/lowering error: {e}"),
             AotError::Link(e) => write!(f, "link error: {e}"),
             AotError::Wasm(e) => write!(f, "wasm backend error: {e}"),
+            AotError::SourceEmbedded(audit) => {
+                writeln!(
+                    f,
+                    "--require-fully-compiled: {} source fragment(s) ({} bytes) would be \
+                     embedded in the binary as readable Clojure text:",
+                    audit.leaks().len(),
+                    audit.total_bytes()
+                )?;
+                for l in audit.leaks() {
+                    writeln!(f, "  • {l}")?;
+                }
+                write!(
+                    f,
+                    "Only plain `defn` bodies are compiled to machine code. Move the forms above \
+                     out of the compiled unit, or drop --require-fully-compiled."
+                )
+            }
             #[cfg(feature = "no-gc")]
             AotError::NoGcBlacklist(vs) => {
                 writeln!(f, "no-gc blacklist violations:")?;
@@ -546,13 +566,16 @@ pub fn compile_file_to_wasm(
 /// before loading any Clojure code.  `verify_commit_signatures` enables
 /// `git verify-commit` on every versioned pin resolved during compilation
 /// (the produced binary trusts its embedded sources, so verification happens
-/// here, at compile time).
+/// here, at compile time).  `opacity` decides what happens when the binary
+/// would still carry readable Clojure source; [`audit_source`] reports the same
+/// set without applying any policy.
 pub fn compile_file(
     src_path: &Path,
     out_path: &Path,
     src_dirs: &[PathBuf],
     rust_config: Option<&cljrs_deps::RustConfig>,
     verify_commit_signatures: bool,
+    opacity: OpacityPolicy,
 ) -> AotResult<()> {
     eprintln!("[aot] reading {}", src_path.display());
     let source = std::fs::read_to_string(src_path)?;
@@ -816,6 +839,23 @@ pub fn compile_file(
     let obj_bytes = compiler.finish();
     eprintln!("[aot] generated {} bytes of object code", obj_bytes.len());
 
+    // ── 4b. Opacity gate (before the harness is written) ────────────────
+    let audit = audit_source(
+        &interpreted_source,
+        &compiled_namespaces,
+        &versioned_bundled,
+    );
+    match audit.verdict(opacity) {
+        OpacityVerdict::Clean => {}
+        OpacityVerdict::Tolerated => eprintln!(
+            "[aot] {} source fragment(s) ({} bytes) embedded as readable text \
+             (--require-fully-compiled makes this an error)",
+            audit.leaks().len(),
+            audit.total_bytes()
+        ),
+        OpacityVerdict::Rejected => return Err(AotError::SourceEmbedded(audit)),
+    }
+
     // ── 5. Generate harness project & build ─────────────────────────────
     let (harness_dir, offline) = build_harness(
         out_path,
@@ -830,6 +870,139 @@ pub fn compile_file(
 
     eprintln!("[aot] wrote {}", out_path.display());
     Ok(())
+}
+
+/// One place the produced binary would carry Clojure source text verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceLeak {
+    /// Which bundling channel would carry the text.
+    pub channel: SourceLeakChannel,
+    /// The namespace it belongs to, when one is known.
+    pub ns: Option<String>,
+    /// Size of the embedded text in bytes.
+    pub bytes: usize,
+}
+
+/// The channel a [`SourceLeak`] travels through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceLeakChannel {
+    /// The entry file's own interpreted preamble (`src/preamble.cljrs`).
+    EntryPreamble,
+    /// A required namespace's interpreted preamble (`src/ns_<n>_preamble.cljrs`).
+    NamespacePreamble,
+    /// A whole namespace bundled as source: a pinned versioned dependency, or
+    /// one that fell back to interpretation.
+    BundledNamespace,
+}
+
+impl std::fmt::Display for SourceLeakChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceLeakChannel::EntryPreamble => write!(f, "entry preamble"),
+            SourceLeakChannel::NamespacePreamble => write!(f, "namespace preamble"),
+            SourceLeakChannel::BundledNamespace => write!(f, "bundled namespace"),
+        }
+    }
+}
+
+impl std::fmt::Display for SourceLeak {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.ns {
+            Some(ns) => write!(f, "{} ({ns}): {} bytes", self.channel, self.bytes),
+            None => write!(f, "{}: {} bytes", self.channel, self.bytes),
+        }
+    }
+}
+
+/// What the caller will accept in the produced binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OpacityPolicy {
+    /// Embedded source is noted on stderr and the build proceeds.
+    #[default]
+    Report,
+    /// Any embedded source fails the build.
+    RequireFullyCompiled,
+}
+
+/// Outcome of applying an [`OpacityPolicy`] to a [`SourceAudit`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpacityVerdict {
+    /// No readable program text would ship.
+    Clean,
+    /// Source would ship; the policy tolerates it.
+    Tolerated,
+    /// Source would ship; the policy forbids it.
+    Rejected,
+}
+
+/// Every fragment of Clojure source the harness would embed, as one value.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SourceAudit {
+    leaks: Vec<SourceLeak>,
+}
+
+impl SourceAudit {
+    pub fn leaks(&self) -> &[SourceLeak] {
+        &self.leaks
+    }
+
+    /// True when the binary would carry object code and no readable text.
+    pub fn is_clean(&self) -> bool {
+        self.leaks.is_empty()
+    }
+
+    pub fn total_bytes(&self) -> usize {
+        self.leaks.iter().map(|l| l.bytes).sum()
+    }
+
+    pub fn verdict(&self, policy: OpacityPolicy) -> OpacityVerdict {
+        match (self.is_clean(), policy) {
+            (true, _) => OpacityVerdict::Clean,
+            (false, OpacityPolicy::Report) => OpacityVerdict::Tolerated,
+            (false, OpacityPolicy::RequireFullyCompiled) => OpacityVerdict::Rejected,
+        }
+    }
+}
+
+/// Collect: the source-carrying channels of the harness, as raw fragments.
+/// A new channel is one entry here and nothing else.
+fn embedded_fragments<'a>(
+    interpreted_source: &'a str,
+    compiled_namespaces: &'a [CompiledNamespace],
+    versioned_bundled: &'a [(Arc<str>, String)],
+) -> impl Iterator<Item = (SourceLeakChannel, Option<&'a str>, &'a str)> {
+    std::iter::once((SourceLeakChannel::EntryPreamble, None, interpreted_source))
+        .chain(compiled_namespaces.iter().map(|cns| {
+            (
+                SourceLeakChannel::NamespacePreamble,
+                Some(cns.ns.as_ref()),
+                cns.preamble.as_str(),
+            )
+        }))
+        .chain(versioned_bundled.iter().map(|(ns, src)| {
+            (
+                SourceLeakChannel::BundledNamespace,
+                Some(ns.as_ref()),
+                src.as_str(),
+            )
+        }))
+}
+
+/// Promote: raw fragments to a [`SourceAudit`], dropping the empty ones.
+pub fn audit_source(
+    interpreted_source: &str,
+    compiled_namespaces: &[CompiledNamespace],
+    versioned_bundled: &[(Arc<str>, String)],
+) -> SourceAudit {
+    let leaks = embedded_fragments(interpreted_source, compiled_namespaces, versioned_bundled)
+        .filter(|(_, _, text)| !text.is_empty())
+        .map(|(channel, ns, text)| SourceLeak {
+            channel,
+            ns: ns.map(str::to_owned),
+            bytes: text.len(),
+        })
+        .collect();
+    SourceAudit { leaks }
 }
 
 /// Check if a top-level form needs the interpreter (can't be AOT-compiled yet).
@@ -1087,10 +1260,11 @@ fn find_user_source(rel: &str, src_dirs: &[PathBuf]) -> Option<String> {
 /// definitions that must run through the interpreter) and the symbol of its
 /// natively compiled initializer (`None` when the namespace has no compilable
 /// top-level forms — e.g. a namespace consisting only of `defmacro`s).
-struct CompiledNamespace {
-    ns: Arc<str>,
-    init_symbol: Option<String>,
-    preamble: String,
+#[derive(Debug, Clone)]
+pub struct CompiledNamespace {
+    pub ns: Arc<str>,
+    pub init_symbol: Option<String>,
+    pub preamble: String,
 }
 
 /// Write each compiled namespace's interpreted preamble into `harness_dir/src`

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -37,7 +37,16 @@ fn compile_and_run(name: &str, source: &str) -> String {
         .spawn({
             let src = src_path.clone();
             let bin = bin_path.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[], None, false)
+            move || {
+                cljrs_compiler::aot::compile_file(
+                    &src,
+                    &bin,
+                    &[],
+                    None,
+                    false,
+                    cljrs_compiler::aot::OpacityPolicy::Report,
+                )
+            }
         })
         .unwrap()
         .join()
@@ -1200,7 +1209,16 @@ fn compile_and_run_multi(name: &str, main_source: &str, deps: &[(&str, &str)]) -
             let src = src_path.clone();
             let bin = bin_path.clone();
             let src_dir = src_dir.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None, false)
+            move || {
+                cljrs_compiler::aot::compile_file(
+                    &src,
+                    &bin,
+                    &[src_dir],
+                    None,
+                    false,
+                    cljrs_compiler::aot::OpacityPolicy::Report,
+                )
+            }
         })
         .unwrap()
         .join()
@@ -2473,7 +2491,16 @@ fn test_versioned_snapshot_is_self_contained() {
             let src = src_path.clone();
             let bin = bin_path.clone();
             let src_dir = src_dir.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None, false)
+            move || {
+                cljrs_compiler::aot::compile_file(
+                    &src,
+                    &bin,
+                    &[src_dir],
+                    None,
+                    false,
+                    cljrs_compiler::aot::OpacityPolicy::Report,
+                )
+            }
         })
         .unwrap()
         .join()
@@ -2571,7 +2598,16 @@ fn test_versioned_bad_commit_fails_at_compile_time() {
             let src = src_path.clone();
             let bin = bin_path.clone();
             let src_dir = src_dir.clone();
-            move || cljrs_compiler::aot::compile_file(&src, &bin, &[src_dir], None, false)
+            move || {
+                cljrs_compiler::aot::compile_file(
+                    &src,
+                    &bin,
+                    &[src_dir],
+                    None,
+                    false,
+                    cljrs_compiler::aot::OpacityPolicy::Report,
+                )
+            }
         })
         .unwrap()
         .join()
@@ -2636,4 +2672,71 @@ fn test_auto_kw_qualified_keyword_aot() {
 "#,
         ":acme.core/status",
     );
+}
+
+/// Compile `source` with the opacity gate on, returning the compile result.
+#[allow(clippy::result_large_err)]
+fn compile_gated(name: &str, source: &str) -> cljrs_compiler::aot::AotResult<()> {
+    let _guard = AOT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let dir = std::env::temp_dir().join("cljrs_aot_tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let src_path = dir.join(format!("{name}.cljrs"));
+    let bin_path = dir.join(format!("{name}_bin"));
+    std::fs::write(&src_path, source).unwrap();
+
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn({
+            let src = src_path.clone();
+            let bin = bin_path.clone();
+            move || {
+                cljrs_compiler::aot::compile_file(
+                    &src,
+                    &bin,
+                    &[],
+                    None,
+                    false,
+                    cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled,
+                )
+            }
+        })
+        .unwrap()
+        .join()
+        .unwrap()
+}
+
+#[test]
+fn require_fully_compiled_rejects_embedded_source() {
+    let err = compile_gated(
+        "gate_rejects",
+        r#"
+(defprotocol IWeigh (weigh [this x]))
+(defrecord Weigher [bias] IWeigh (weigh [this x] (+ (* x 31) (:bias this))))
+(defn -main [& _] (println (weigh (->Weigher 7) 10)))
+"#,
+    )
+    .expect_err("gate must reject a program whose forms ship as source");
+
+    let cljrs_compiler::aot::AotError::SourceEmbedded(audit) = &err else {
+        panic!("expected SourceEmbedded, got {err:?}");
+    };
+    assert!(!audit.is_clean());
+    assert!(audit.total_bytes() > 0);
+
+    let rendered = err.to_string();
+    assert!(rendered.contains("--require-fully-compiled"), "{rendered}");
+    assert!(rendered.contains("defn"), "{rendered}");
+}
+
+#[test]
+fn require_fully_compiled_accepts_plain_defn() {
+    compile_gated(
+        "gate_accepts",
+        r#"
+(defn weigh [x] (+ (* x 31) 7))
+(defn total [n] (reduce + (map weigh (range n))))
+"#,
+    )
+    .expect("a defn-only program must pass the gate");
 }

--- a/crates/cljrs-compiler/tests/source_leak_audit.rs
+++ b/crates/cljrs-compiler/tests/source_leak_audit.rs
@@ -1,0 +1,257 @@
+//! Property tests for `aot::audit_source` - the invariant behind
+//! `cljrs compile --require-fully-compiled`.
+
+use std::sync::Arc;
+
+use cljrs_compiler::aot::{
+    AotError, CompiledNamespace, OpacityPolicy, OpacityVerdict, SourceLeakChannel, audit_source,
+};
+use proptest::prelude::*;
+
+fn ns_of(name: &str, preamble: &str) -> CompiledNamespace {
+    CompiledNamespace {
+        ns: Arc::from(name),
+        init_symbol: Some(format!("__cljrs_ns_init_{name}")),
+        preamble: preamble.to_string(),
+    }
+}
+
+fn bundled_of(pairs: Vec<(String, String)>) -> Vec<(Arc<str>, String)> {
+    pairs
+        .into_iter()
+        .map(|(n, s)| (Arc::from(n.as_str()), s))
+        .collect()
+}
+
+/// Every non-empty source fragment, in every channel, weighed once.
+fn expected_bytes(entry: &str, nss: &[CompiledNamespace], bundled: &[(Arc<str>, String)]) -> usize {
+    entry.len()
+        + nss.iter().map(|n| n.preamble.len()).sum::<usize>()
+        + bundled.iter().map(|(_, s)| s.len()).sum::<usize>()
+}
+
+proptest! {
+    /// Soundness: the audit is silent exactly when no readable text ships.
+    /// A false negative here is a binary that leaks source while the gate
+    /// reports success.
+    #[test]
+    fn empty_audit_iff_no_embedded_text(
+        entry in "[a-z(); \n]{0,40}",
+        preambles in prop::collection::vec("[a-z(); \n]{0,30}", 0..5),
+        bundled in prop::collection::vec(("[a-z.]{1,8}", "[a-z(); \n]{0,30}"), 0..5),
+    ) {
+        let nss: Vec<_> = preambles.iter().enumerate()
+            .map(|(i, p)| ns_of(&format!("ns{i}"), p)).collect();
+        let bundled = bundled_of(bundled);
+
+        let audit = audit_source(&entry, &nss, &bundled);
+        let any_text = expected_bytes(&entry, &nss, &bundled) > 0;
+
+        prop_assert_eq!(audit.is_clean(), !any_text);
+    }
+
+    /// Byte accounting is exact - no fragment is under-counted or double-counted.
+    #[test]
+    fn reported_bytes_equal_embedded_bytes(
+        entry in "[a-z(); \n]{0,40}",
+        preambles in prop::collection::vec("[a-z(); \n]{0,30}", 0..5),
+        bundled in prop::collection::vec(("[a-z.]{1,8}", "[a-z(); \n]{0,30}"), 0..5),
+    ) {
+        let nss: Vec<_> = preambles.iter().enumerate()
+            .map(|(i, p)| ns_of(&format!("ns{i}"), p)).collect();
+        let bundled = bundled_of(bundled);
+
+        let reported = audit_source(&entry, &nss, &bundled).total_bytes();
+
+        prop_assert_eq!(reported, expected_bytes(&entry, &nss, &bundled));
+    }
+
+    /// One entry per non-empty fragment, attributed to the right channel.
+    #[test]
+    fn one_leak_per_nonempty_fragment(
+        entry in "[a-z(); \n]{0,40}",
+        preambles in prop::collection::vec("[a-z(); \n]{0,30}", 0..5),
+        bundled in prop::collection::vec(("[a-z.]{1,8}", "[a-z(); \n]{0,30}"), 0..5),
+    ) {
+        let nss: Vec<_> = preambles.iter().enumerate()
+            .map(|(i, p)| ns_of(&format!("ns{i}"), p)).collect();
+        let bundled = bundled_of(bundled);
+
+        let audit = audit_source(&entry, &nss, &bundled);
+        let leaks = audit.leaks();
+        let count = |c: SourceLeakChannel| leaks.iter().filter(|l| l.channel == c).count();
+
+        prop_assert_eq!(count(SourceLeakChannel::EntryPreamble), usize::from(!entry.is_empty()));
+        prop_assert_eq!(
+            count(SourceLeakChannel::NamespacePreamble),
+            nss.iter().filter(|n| !n.preamble.is_empty()).count()
+        );
+        prop_assert_eq!(
+            count(SourceLeakChannel::BundledNamespace),
+            bundled.iter().filter(|(_, s)| !s.is_empty()).count()
+        );
+    }
+
+    /// Every leaking namespace is named, so the report is actionable.
+    #[test]
+    fn leaking_namespaces_are_attributed(
+        preambles in prop::collection::vec("[a-z(); \n]{1,30}", 1..5),
+        bundled in prop::collection::vec(("[a-z.]{1,8}", "[a-z(); \n]{1,30}"), 1..5),
+    ) {
+        let nss: Vec<_> = preambles.iter().enumerate()
+            .map(|(i, p)| ns_of(&format!("ns{i}"), p)).collect();
+        let bundled = bundled_of(bundled);
+
+        let audit = audit_source("", &nss, &bundled);
+        let leaks = audit.leaks();
+        let named: Vec<&str> = leaks.iter().filter_map(|l| l.ns.as_deref()).collect();
+
+        for n in &nss {
+            prop_assert!(named.contains(&n.ns.as_ref()));
+        }
+        for (ns, _) in &bundled {
+            prop_assert!(named.contains(&ns.as_ref()));
+        }
+        prop_assert!(leaks.iter().all(|l| l.bytes > 0));
+    }
+
+    /// Monotonic: adding source can never shrink the report. Guards against a
+    /// gate that silently stops looking once it has found something.
+    #[test]
+    fn adding_source_never_shrinks_the_report(
+        entry in "[a-z(); \n]{0,40}",
+        preambles in prop::collection::vec("[a-z(); \n]{0,30}", 0..4),
+        extra in "[a-z(); \n]{1,30}",
+    ) {
+        let nss: Vec<_> = preambles.iter().enumerate()
+            .map(|(i, p)| ns_of(&format!("ns{i}"), p)).collect();
+
+        let before = audit_source(&entry, &nss, &[]);
+        let mut more = nss.clone();
+        more.push(ns_of("extra", &extra));
+        let after = audit_source(&entry, &more, &[]);
+
+        prop_assert!(after.leaks().len() > before.leaks().len());
+        prop_assert!(after.total_bytes() > before.total_bytes());
+    }
+}
+
+proptest! {
+    /// The report names the channel and the namespace, and quotes the byte
+    /// count - it is the only thing telling a caller *what* to fix.
+    #[test]
+    fn rendered_leak_identifies_channel_ns_and_size(
+        name in "[a-z.]{1,10}",
+        src in "[a-z(); \n]{1,30}",
+    ) {
+        let nss = vec![ns_of(&name, &src)];
+        let audit = audit_source("", &nss, &[]);
+        let rendered = audit.leaks()[0].to_string();
+
+        prop_assert!(rendered.contains(&name), "missing ns: {rendered}");
+        prop_assert!(rendered.contains(&src.len().to_string()), "missing size: {rendered}");
+        prop_assert!(rendered.contains("namespace preamble"), "missing channel: {rendered}");
+    }
+
+    /// The aggregate error lists every leak and the total, so a failed gate is
+    /// actionable without re-running anything.
+    #[test]
+    fn rendered_error_lists_every_leak(
+        entry in "[a-z(); \n]{1,20}",
+        names in prop::collection::vec("[a-z.]{3,10}", 1..4),
+    ) {
+        let nss: Vec<_> = names.iter().map(|n| ns_of(n, "(ns x)\n")).collect();
+        let audit = audit_source(&entry, &nss, &[]);
+        let total = audit.total_bytes();
+        let n = audit.leaks().len();
+        let rendered = AotError::SourceEmbedded(audit).to_string();
+
+        prop_assert!(rendered.contains(&n.to_string()));
+        prop_assert!(rendered.contains(&total.to_string()));
+        prop_assert!(rendered.contains("entry preamble"));
+        for n in &names {
+            prop_assert!(rendered.contains(n), "unlisted ns {n}: {rendered}");
+        }
+    }
+}
+
+#[test]
+fn channel_names_are_distinct_and_stable() {
+    let rendered: Vec<String> = [
+        SourceLeakChannel::EntryPreamble,
+        SourceLeakChannel::NamespacePreamble,
+        SourceLeakChannel::BundledNamespace,
+    ]
+    .iter()
+    .map(|c| c.to_string())
+    .collect();
+
+    assert_eq!(
+        rendered,
+        ["entry preamble", "namespace preamble", "bundled namespace"]
+    );
+}
+
+#[test]
+fn unattributed_leak_renders_without_a_namespace() {
+    let audit = audit_source("(ns app)\n", &[], &[]);
+    assert_eq!(audit.leaks()[0].to_string(), "entry preamble: 9 bytes");
+}
+
+#[test]
+fn nothing_to_embed_is_clean() {
+    assert!(audit_source("", &[], &[]).is_clean());
+}
+
+#[test]
+fn compiled_namespace_still_leaks_its_preamble() {
+    // The measured case: a namespace reported as successfully compiled ships
+    // its defprotocol/defrecord/defmulti forms as readable text anyway.
+    let nss = vec![ns_of(
+        "helper",
+        "(ns helper)\n(defrecord Weigher [bias] IWeigh (weigh [_ x] (+ (* x 31) bias)))\n",
+    )];
+    let audit = audit_source("", &nss, &[]);
+    let leaks = audit.leaks();
+
+    assert_eq!(leaks.len(), 1);
+    assert_eq!(leaks[0].channel, SourceLeakChannel::NamespacePreamble);
+    assert_eq!(leaks[0].ns.as_deref(), Some("helper"));
+    assert!(leaks[0].bytes > 0);
+}
+
+proptest! {
+    /// The policy layer is total and depends only on cleanliness: a clean audit
+    /// passes under every policy, a dirty one is rejected only by the strict one.
+    #[test]
+    fn verdict_follows_cleanliness_and_policy(
+        entry in "[a-z(); \n]{0,30}",
+        preambles in prop::collection::vec("[a-z(); \n]{0,20}", 0..4),
+    ) {
+        let nss: Vec<_> = preambles.iter().enumerate()
+            .map(|(i, p)| ns_of(&format!("ns{i}"), p)).collect();
+        let audit = audit_source(&entry, &nss, &[]);
+
+        let expected = |p| match (audit.is_clean(), p) {
+            (true, _) => OpacityVerdict::Clean,
+            (false, OpacityPolicy::Report) => OpacityVerdict::Tolerated,
+            (false, OpacityPolicy::RequireFullyCompiled) => OpacityVerdict::Rejected,
+        };
+
+        for p in [OpacityPolicy::Report, OpacityPolicy::RequireFullyCompiled] {
+            prop_assert_eq!(audit.verdict(p), expected(p));
+        }
+        // Only the strict policy may ever reject.
+        prop_assert_ne!(audit.verdict(OpacityPolicy::Report), OpacityVerdict::Rejected);
+    }
+}
+
+#[test]
+fn default_policy_never_breaks_an_existing_build() {
+    let dirty = audit_source("(ns app)\n", &[], &[]);
+    assert_eq!(
+        dirty.verdict(OpacityPolicy::default()),
+        OpacityVerdict::Tolerated
+    );
+    assert_eq!(OpacityPolicy::default(), OpacityPolicy::Report);
+}

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -69,7 +69,7 @@ run to completion. A synchronous `-main` is awaited as a no-op pass-through.
 - `--target <native|wasm>` — code-generation target (default `native`). `wasm` emits a WebAssembly module via the AOT wasm backend (the entry namespace's functions; the `"rt"` imports are satisfied by the runtime built for `wasm32-unknown-unknown`). `--test` is not yet supported with `wasm`.
 - `--main <NS>` — namespace containing `-main`; overrides `:main` in `cljrs.edn` and auto-detection
 - `--test` — compile a test harness that runs every test in the given file/directory
-- `--require-fully-compiled` — fail the build if the binary would embed readable Clojure source text (interpreted preambles, bundled namespaces).  The audit runs in `compile_file`, so the flag is an error with `--test` and with `--target wasm`, whose paths do not audit; it is rejected there rather than accepted and ignored.
+- `--require-fully-compiled` - fail the build if the binary would embed readable Clojure source text (interpreted preambles, bundled namespaces).  The audit runs in `compile_file`, so the flag is an error with `--test` and with `--target wasm`, whose paths do not audit; it is rejected there rather than accepted and ignored.
 
 `ir build` accepts:
 - `-n, --ns <NS>` — repeatable; namespaces to lower (default `clojure.core`)

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -69,6 +69,7 @@ run to completion. A synchronous `-main` is awaited as a no-op pass-through.
 - `--target <native|wasm>` — code-generation target (default `native`). `wasm` emits a WebAssembly module via the AOT wasm backend (the entry namespace's functions; the `"rt"` imports are satisfied by the runtime built for `wasm32-unknown-unknown`). `--test` is not yet supported with `wasm`.
 - `--main <NS>` — namespace containing `-main`; overrides `:main` in `cljrs.edn` and auto-detection
 - `--test` — compile a test harness that runs every test in the given file/directory
+- `--require-fully-compiled` — fail the build if the binary would embed readable Clojure source text (interpreted preambles, bundled namespaces).  The audit runs in `compile_file`, so the flag is an error with `--test` and with `--target wasm`, whose paths do not audit; it is rejected there rather than accepted and ignored.
 
 `ir build` accepts:
 - `-n, --ns <NS>` — repeatable; namespaces to lower (default `clojure.core`)

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -169,7 +169,8 @@ enum Commands {
         #[arg(long)]
         test: bool,
         /// Fail the build if the binary would embed readable Clojure source
-        /// text (interpreted preambles, bundled namespaces).
+        /// text (interpreted preambles, bundled namespaces).  Rejected with
+        /// `--test` and `--target wasm`, which do not run the audit.
         #[arg(long = "require-fully-compiled")]
         require_fully_compiled: bool,
         /// GC soft memory limit in MB (triggers collection when exceeded).
@@ -577,6 +578,8 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
                     "--test is not supported with --target wasm yet"
                 ));
             }
+            let opacity = resolve_opacity_policy(require_fully_compiled, &target, test)
+                .map_err(|e| miette::miette!("{e}"))?;
 
             if test {
                 let test_dir = file.as_deref().unwrap_or_else(|| std::path::Path::new("."));
@@ -648,11 +651,7 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
                         &all_src_paths,
                         rust_config.as_ref(),
                         versioning.verify_commit_signatures,
-                        if require_fully_compiled {
-                            cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled
-                        } else {
-                            cljrs_compiler::aot::OpacityPolicy::Report
-                        },
+                        opacity,
                     )
                     .map_err(|e| miette::miette!("{e}"))?;
                 }
@@ -723,6 +722,37 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
             Ok(0)
         }
     }
+}
+
+/// Resolve the opacity policy a `compile` invocation runs under, rejecting the
+/// flag combinations that would not honour it.
+///
+/// The source-embedding audit lives in `compile_file`, the native non-test
+/// path.  `--test` goes through `compile_test_harness` and `--target wasm`
+/// through `compile_file_to_wasm`; neither audits, so accepting
+/// `--require-fully-compiled` there would report success while promising a
+/// guarantee nothing checked.  Reject the combination rather than ignore it.
+fn resolve_opacity_policy(
+    require_fully_compiled: bool,
+    target: &str,
+    test: bool,
+) -> Result<cljrs_compiler::aot::OpacityPolicy, String> {
+    if !require_fully_compiled {
+        return Ok(cljrs_compiler::aot::OpacityPolicy::Report);
+    }
+    if test {
+        return Err("--require-fully-compiled is not supported with --test: \
+                    the test harness is not audited for embedded source"
+            .to_string());
+    }
+    if target == "wasm" {
+        return Err(
+            "--require-fully-compiled is not supported with --target wasm: \
+                    the wasm backend is not audited for embedded source"
+                .to_string(),
+        );
+    }
+    Ok(cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled)
 }
 
 /// Dispatch the `ir` subcommands: `build`, `dump`, `viz`.
@@ -1914,4 +1944,53 @@ fn run_repl(globals: Arc<GlobalEnv>) {
     }
 
     println!("Bye.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_opacity_policy;
+    use cljrs_compiler::aot::OpacityPolicy;
+
+    /// Without the flag every target/test combination is the reporting default.
+    #[test]
+    fn absent_flag_reports_under_every_combination() {
+        for target in ["native", "wasm"] {
+            for test in [false, true] {
+                assert_eq!(
+                    resolve_opacity_policy(false, target, test),
+                    Ok(OpacityPolicy::Report),
+                    "target={target} test={test}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn flag_selects_the_strict_policy_on_the_audited_path() {
+        assert_eq!(
+            resolve_opacity_policy(true, "native", false),
+            Ok(OpacityPolicy::RequireFullyCompiled)
+        );
+    }
+
+    /// The unaudited paths reject rather than silently ignore the flag.
+    #[test]
+    fn flag_is_rejected_on_unaudited_paths() {
+        for (target, test) in [("native", true), ("wasm", false), ("wasm", true)] {
+            let err = resolve_opacity_policy(true, target, test)
+                .expect_err("target={target} test={test} must be rejected");
+            assert!(
+                err.contains("--require-fully-compiled"),
+                "error names the flag: {err}"
+            );
+        }
+    }
+
+    /// `--test` is reported ahead of `--target wasm` when both are given, so the
+    /// message names a flag the caller actually passed.
+    #[test]
+    fn test_combination_is_reported_before_wasm() {
+        let err = resolve_opacity_policy(true, "wasm", true).expect_err("rejected");
+        assert!(err.contains("--test"), "{err}");
+    }
 }

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -168,6 +168,10 @@ enum Commands {
         /// Compile a test harness that runs all tests in the given file/directory.
         #[arg(long)]
         test: bool,
+        /// Fail the build if the binary would embed readable Clojure source
+        /// text (interpreted preambles, bundled namespaces).
+        #[arg(long = "require-fully-compiled")]
+        require_fully_compiled: bool,
         /// GC soft memory limit in MB (triggers collection when exceeded).
         #[arg(long)]
         gc_soft_limit_mb: Option<usize>,
@@ -533,6 +537,7 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
             src_paths,
             main_ns,
             test,
+            require_fully_compiled,
             gc_soft_limit_mb,
             gc_hard_limit_mb,
         } => {
@@ -643,6 +648,11 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
                         &all_src_paths,
                         rust_config.as_ref(),
                         versioning.verify_commit_signatures,
+                        if require_fully_compiled {
+                            cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled
+                        } else {
+                            cljrs_compiler::aot::OpacityPolicy::Report
+                        },
                     )
                     .map_err(|e| miette::miette!("{e}"))?;
                 }

--- a/crates/cljrs/tests/compile_flag_combinations.rs
+++ b/crates/cljrs/tests/compile_flag_combinations.rs
@@ -1,0 +1,60 @@
+//! CLI-level contract for `cljrs compile --require-fully-compiled`.
+//!
+//! The source-embedding audit only runs on the native, non-test path. These
+//! tests drive the built binary (via `CARGO_BIN_EXE_cljrs`) to pin that the
+//! unaudited combinations are rejected outright rather than accepted and
+//! ignored, and that the audited one is not caught by the same check.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn compile(args: &[&str]) -> std::process::Output {
+    let out: PathBuf =
+        std::env::temp_dir().join(format!("cljrs-flag-combo-{}", std::process::id()));
+    Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .arg("compile")
+        .args(args)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("run cljrs binary")
+}
+
+fn stderr_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[test]
+fn require_fully_compiled_rejects_test_harness() {
+    let out = compile(&["--test", "--require-fully-compiled", "."]);
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "should fail; stderr: {stderr}");
+    assert!(
+        stderr.contains("--require-fully-compiled") && stderr.contains("--test"),
+        "message names both flags: {stderr}"
+    );
+}
+
+#[test]
+fn require_fully_compiled_rejects_wasm_target() {
+    let out = compile(&["--target", "wasm", "--require-fully-compiled", "app.cljrs"]);
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "should fail; stderr: {stderr}");
+    assert!(
+        stderr.contains("--require-fully-compiled") && stderr.contains("wasm"),
+        "message names both flags: {stderr}"
+    );
+}
+
+/// The combination check must not fire on the path that does audit. Compiling
+/// a missing file fails for its own reason; what matters is that the failure is
+/// not the combination rejection.
+#[test]
+fn require_fully_compiled_is_accepted_on_the_native_path() {
+    let out = compile(&["--require-fully-compiled", "no-such-file.cljrs"]);
+    let stderr = stderr_of(&out);
+    assert!(
+        !stderr.contains("is not supported with"),
+        "native compile must not be rejected for the flag: {stderr}"
+    );
+}


### PR DESCRIPTION
## The problem

`cljrs compile` compiles plain `defn` bodies to machine code. Everything `needs_interpreter` reports (`ns`, `require`, `defmacro`, `defonce`, `defprotocol`, `defrecord`, `defmulti`, `defmethod`, `extend-type`, `extend-protocol`) is written into the harness and pulled in with `include_str!`, **method bodies included**, even when the enclosing namespace compiles successfully. Namespaces that fail lowering or codegen fall back to source the same way, and pinned versioned deps are bundled as source unconditionally.

Today the only signal is an `eprintln!` during the build. On a two-file program whose `helper` namespace the compiler reported as successfully compiled (`[aot] compiled namespace helper -> src/ns_0_preamble.cljrs + __cljrs_ns_init_0`), plain `strings` on the output binary recovers:

```
(ns helper)
(defprotocol IWeigh (weigh [this x]))
(defrecord Weigher [bias]
  IWeigh
  (weigh [_ x] (+ (* x *tuning*) bias)))
(defmulti route (fn [m] (:kind m)))
(defmethod route :alpha [m] (weigh (->Weigher 7) (:v m)))
(defmethod route :default [_] 0)
```

That is fine as a default, since interpretation has to come from somewhere. It is less fine that there is currently no way to ask whether it happened.

## What this adds

An audit of the source-carrying channels, and a policy for what to do about it. Four steps, each usable on its own:

| step | function | purity |
|---|---|---|
| collect | `embedded_fragments`, the channels as raw `(channel, ns, text)` | pure |
| promote | `audit_source`, fragments to a `SourceAudit`, empties dropped | pure |
| decide | `SourceAudit::verdict(OpacityPolicy)` | pure |
| apply | `compile_file` | effectful |

```rust
pub fn audit_source(interpreted_source: &str, compiled_namespaces: &[CompiledNamespace],
                    versioned_bundled: &[(Arc<str>, String)]) -> SourceAudit;

impl SourceAudit {
    pub fn leaks(&self) -> &[SourceLeak];
    pub fn is_clean(&self) -> bool;
    pub fn total_bytes(&self) -> usize;
    pub fn verdict(&self, policy: OpacityPolicy) -> OpacityVerdict;
}

pub enum OpacityPolicy  { Report /* default */, RequireFullyCompiled }
pub enum OpacityVerdict { Clean, Tolerated, Rejected }
```

`compile_file` takes the policy rather than deciding for itself, and applies the verdict before the harness is written, so nothing lands on disk on rejection. A new source-carrying channel is one entry in `embedded_fragments`; a new policy is one `OpacityPolicy` variant.

## Behaviour

`OpacityPolicy::Report` is the default and preserves current behaviour, plus one summary line:

```
[aot] 2 source fragment(s) (162 bytes) embedded as readable text (--require-fully-compiled makes this an error)
```

`cljrs compile --require-fully-compiled` fails instead, listing what would have shipped and where:

```
Error:   × --require-fully-compiled: 2 source fragment(s) (162 bytes) would be
  │ embedded in the binary as readable Clojure text:
  │   • entry preamble: 35 bytes
  │   • namespace preamble (helper): 127 bytes
  │ Only plain `defn` bodies are compiled to machine code. Move the forms
  │ above out of the compiled unit, or drop --require-fully-compiled.
```

## Tests

- `tests/source_leak_audit.rs`: 13 property tests (proptest, added as a dev-dependency) covering the audit, its rendering, and the policy layer. The load-bearing one is soundness, that the audit is silent exactly when no readable text would ship, since a false negative there is a binary that leaks source while the gate reports success. Also byte accounting, per-channel cardinality, namespace attribution, monotonicity, and that only the strict policy can ever reject.
- `tests/aot_e2e.rs`: `require_fully_compiled_rejects_embedded_source` (a `defprotocol`/`defrecord` program) and `require_fully_compiled_accepts_plain_defn`.
- Checked with `cargo-mutants` over the new code, all mutants caught. The first pass left both `Display` impls unkilled. The report text is the only thing telling a caller which namespace to fix, so it is contract, and it is now covered.

`cargo fmt` and `cargo clippy --tests` are clean. Crate README updated in the same commit, per CLAUDE.md.

## Notes

`SourceLeak` and `OpacityPolicy` is how I named them. But, if you prefer otherwise, it's reasonable to also change them. The CLI flag and the library API can also land separately if you would rather take them one at a time.

Found #292 while measuring this.
