### PR TITLE
fix(cli): quiet cranelift-jit IR dumps by defaulting log level to WARN

### DIFF
--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -357,7 +357,7 @@ fn main() -> miette::Result<()> {
         } else if cli.debug {
             tracing::Level::DEBUG
         } else {
-            tracing::Level::INFO
+            tracing::Level::WARN
         })
         .try_init();
 


### PR DESCRIPTION
A plain `cljrs run file.clj` prints each JIT-compiled function's full clif IR to stderr, burying the program's own output.

The cause is the default tracing subscriber max-level: `main.rs` sets it to `INFO` when neither `--debug` nor `--trace` is given, and the `cranelift-jit` dependency logs its IR dumps at INFO. cljrs itself emits no INFO-level logs, so the only thing that level was carrying was that dependency noise.

### Fix

One line — the no-flag default becomes `WARN`. `--debug` and `--trace` still escalate to `DEBUG` / `TRACE`, so the cranelift IR is one flag away for anyone who wants it.

### Before

```
$ cljrs run hello.clj
function u0:0(i64) -> i64 system_v {
    ss0 = explicit_slot 8
    ...
```

### After

```
$ cljrs run hello.clj
hello
```
