### PR TITLE
Pin kstring to 2.0.2 to restore builds on current stable rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "kstring"
-version = "2.0.4"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b609e7ca5ea38f093c20a4a102335b247221c9643b7a6bc3510f196f99499a9e"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "static_assertions",
 ]


### PR DESCRIPTION
The lockfile pinned kstring 2.0.4, which declares a minimum rustc of
1.96.0. Current stable is 1.94.1, so every cargo invocation failed
before compiling anything:

    error: rustc 1.94.1 is not supported by the following package:
      kstring@2.0.4 requires rustc 1.96.0

kstring arrives transitively via gix-config -> gix (cljrs-vcs); nothing
in the workspace depends on it directly or needs 2.0.4. Downgrading to
2.0.2 restores the build. With this change `cargo check --workspace
--all-targets`, `cargo clippy --workspace --all-targets`, and `cargo fmt
--check` are all clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016NrQrqXZ73vfG5CPinypvk