### PR TITLE
cljrs: silence cranelift IR dumps in the default log output

### DIFF
--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -136,6 +136,13 @@ These appear before the subcommand and apply to every command:
 - `--stack-size-mb <MB>` — thread stack size (default 64).  Raise if you hit stack overflows in deeply recursive code.
 - `--debug` — enable debug logging
 - `--trace` — enable trace logging (implies `--debug`)
+
+  Codegen crates (`cranelift_*`, `regalloc2`) are pinned to `warn` at all
+  verbosity levels — `cranelift-jit`/`cranelift-object` log every compiled
+  function's whole CLIF body at `info`, which otherwise buries real output.
+  Set `RUST_LOG` (`tracing` target=level syntax) to replace the defaults and
+  get them back, e.g. `RUST_LOG=info,cranelift_jit=info cljrs run app.cljrs`.
+
 - `-X <LEVEL:FEATURES>` — feature-level logging, repeatable.  Format: `<level>:<feat1>,<feat2>,…`.  Levels: `debug`, `trace`.  Example: `-X debug:gc,jit`.
 - `--gc-stats [FILE]` — print a `cljrs_gc::GC_STATS` snapshot at program exit (allocations, region/bump usage, GC pause count + total duration, freed objects/bytes).  No value → stdout; with a path → that file.  Honoured by `run`, `eval`, and `test`.
 - `--jit-stats [FILE]` — print a JIT specialization / inline-cache counter snapshot at program exit (boxed arithmetic bridge calls, entry-guard deopts, keyword IC fills, protocol IC hits/misses; Phase 10.6, `cljrs_compiler::rt_abi::jit_stats`).  No value → stdout; with a path → that file.  Honoured by `run`, `eval`, and `test`.

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -5,6 +5,9 @@ use std::time::Instant;
 
 use clap::{Parser, Subcommand};
 use miette::IntoDiagnostic as _;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
 
 use cljrs_eval::{Env, EvalError, GlobalEnv, eval};
 use cljrs_gc::GcConfig;
@@ -339,6 +342,56 @@ fn build_gc_config(soft_limit_mb: Option<usize>, hard_limit_mb: Option<usize>) -
     }
 }
 
+/// Crates whose logging is noisy enough to drown out everything else.
+///
+/// Cranelift (and its register allocator) log whole function bodies of IR at
+/// `info`/`debug` through the `log` crate, which `tracing-subscriber`'s
+/// `tracing-log` bridge forwards into our subscriber.  A single JIT compile
+/// therefore buries any real message.  These stay at `warn` regardless of
+/// `--debug`/`--trace`; set `RUST_LOG` to see them.
+const NOISY_TARGETS: &[&str] = &[
+    "cranelift_codegen",
+    "cranelift_frontend",
+    "cranelift_jit",
+    "cranelift_module",
+    "cranelift_native",
+    "cranelift_object",
+    "regalloc2",
+];
+
+/// Install the global tracing subscriber.
+///
+/// The default verbosity comes from `--debug`/`--trace`, with the noisy
+/// codegen crates pinned to `warn`.  `RUST_LOG` (in `tracing` target=level
+/// syntax, e.g. `RUST_LOG=info,cranelift_codegen=debug`) replaces those
+/// defaults entirely, so the IR dumps are still reachable when wanted.
+fn init_tracing(cli: &Cli) {
+    let default_level = if cli.trace {
+        tracing::Level::TRACE
+    } else if cli.debug {
+        tracing::Level::DEBUG
+    } else {
+        tracing::Level::INFO
+    };
+
+    let mut filter = Targets::new().with_default(default_level);
+    for target in NOISY_TARGETS {
+        filter = filter.with_target(*target, tracing::Level::WARN);
+    }
+
+    if let Ok(spec) = std::env::var("RUST_LOG")
+        && !spec.trim().is_empty()
+        && let Ok(from_env) = spec.parse::<Targets>()
+    {
+        filter = from_env;
+    }
+
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .try_init();
+}
+
 fn main() -> miette::Result<()> {
     miette::set_hook(Box::new(|_| {
         Box::new(
@@ -350,16 +403,7 @@ fn main() -> miette::Result<()> {
     .into_diagnostic()?;
 
     let cli = Cli::parse();
-    let _ = tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_max_level(if cli.trace {
-            tracing::Level::TRACE
-        } else if cli.debug {
-            tracing::Level::DEBUG
-        } else {
-            tracing::Level::INFO
-        })
-        .try_init();
+    init_tracing(&cli);
 
     // Parse -X feature logging flags
     for flag in &cli.x_flags {


### PR DESCRIPTION
cranelift-jit and cranelift-object log every function they define at
`info`, including the function's full CLIF body, and regalloc2 dumps its
allocation results at the same level. Those go through the `log` crate,
which tracing-subscriber's tracing-log bridge forwards into our
subscriber, so a single JIT compile buried everything else at the
default verbosity.

Replace the plain max-level fmt subscriber with a registry carrying a
`Targets` filter: the `--debug`/`--trace` level still sets the default,
but the codegen crates are pinned to `warn`. `RUST_LOG` replaces the
whole filter when set, so the IR dumps stay reachable on demand.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0133w9cif5iePpTZG4iN4YDd