### PR TITLE
feat(aot): audit what the wasm module leaves out, under the same policy

### DIFF
--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -338,6 +338,16 @@ impl SourceAudit {
 }
 
 pub enum OpacityPolicy { Report /* default */, RequireFullyCompiled }
+
+pub struct BundleAudit;                 // what the wasm module would omit
+impl BundleAudit {
+    pub fn of(omissions: impl IntoIterator<Item = Omission>) -> Self;
+    pub fn omissions(&self) -> &[Omission];
+    pub fn is_complete(&self) -> bool;
+    pub fn count(&self) -> usize;
+    pub fn verdict(&self, policy: OpacityPolicy) -> OpacityVerdict;
+}
+pub enum OmissionKind { Namespace, EntryForm }
 pub enum OpacityVerdict { Clean, Tolerated, Rejected }
 ```
 
@@ -364,17 +374,26 @@ A new source-carrying channel is one entry in `embedded_fragments`; a new
 policy is one `OpacityPolicy` variant. `OpacityPolicy::Report` is the default
 and preserves existing behaviour.
 
-The audit is reached through `compile_file` only. `compile_test_harness`
-(`--test`) and `compile_file_to_wasm` (`--target wasm`) do not run it, so the
-CLI rejects `--require-fully-compiled` in combination with either
-(`resolve_opacity_policy` in `crates/cljrs/src/main.rs`) rather than accept a
-flag it would not honour.
+`SourceAudit` covers the native backend. The wasm backend embeds no source at
+all, so it falls short the other way: a namespace it cannot lower is skipped
+and an entry form needing the interpreter is filtered out of `__cljrs_main`,
+both left for an IR-interpreter tier that is not wired up yet. `BundleAudit`
+collects those omissions during `lower_file_to_ir_bundle` and
+`compile_file_to_wasm` applies the SAME `OpacityPolicy` to them, so
+`--require-fully-compiled` means "the artifact fully represents the program"
+on both backends and each reports its own way of falling short.
+
+`compile_test_harness` (`--test`) has no audit and cannot have one: it bundles
+every test namespace as interpreted source unconditionally, so a strict policy
+could never be satisfied. The CLI refuses that combination
+(`resolve_opacity_policy` in `crates/cljrs/src/main.rs`).
 
 Property tests: `tests/source_leak_audit.rs`; end-to-end:
 `require_fully_compiled_{rejects_embedded_source,accepts_plain_defn}` in
 `tests/aot_e2e.rs`.
 
-`compile_file_to_wasm` is the `cljrs compile --target wasm` entry point: it lowers
+`compile_file_to_wasm(src, out, src_dirs, opacity)` is the `cljrs compile
+--target wasm` entry point: it lowers
 the source **and its transitively-required user namespaces** to a bundle of IR
 functions (`lower_file_to_ir_bundle`: entry `__cljrs_main` + one
 `__cljrs_ns_init_N` per lowerable required namespace, mirroring `compile_file`'s

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -420,7 +420,7 @@ pub fn lower_file_to_ir(
 fn lower_file_to_ir_bundle(
     src_path: &Path,
     src_dirs: &[PathBuf],
-) -> AotResult<Vec<(String, IrFunction)>> {
+) -> AotResult<(Vec<(String, IrFunction)>, BundleAudit)> {
     eprintln!("[aot] reading {}", src_path.display());
     let source = std::fs::read_to_string(src_path)?;
     let filename = src_path.display().to_string();
@@ -461,6 +461,7 @@ fn lower_file_to_ir_bundle(
     // ── Discovered required namespaces → initializers (graceful skip) ────────
     let discovered = discover_bundled_sources(&env.globals, &pre_loaded, src_dirs);
     let mut bundle: Vec<(String, IrFunction)> = Vec::new();
+    let mut audit = BundleAudit::default();
     for (i, (ns, src)) in discovered.iter().enumerate() {
         let init_symbol = format!("__cljrs_ns_init_{i}");
         match lower_namespace(ns, src, &init_symbol, &env.globals) {
@@ -469,6 +470,11 @@ fn lower_file_to_ir_bundle(
             }
             _ => {
                 eprintln!("[aot] {ns}: not wasm-compilable, left for the IR-interpreter tier");
+                audit.record(
+                    OmissionKind::Namespace,
+                    Some(ns.to_string()),
+                    "not wasm-compilable".to_string(),
+                );
             }
         }
     }
@@ -483,6 +489,11 @@ fn lower_file_to_ir_bundle(
     let mut compilable = Vec::new();
     for (i, form) in expanded.iter().enumerate() {
         if needs_interpreter(&forms[i]) || expanded_needs_interpreter(form) {
+            audit.record(
+                OmissionKind::EntryForm,
+                Some(env.current_ns.to_string()),
+                form_head(&forms[i]),
+            );
             continue;
         }
         compilable.push(form.clone());
@@ -514,7 +525,27 @@ fn lower_file_to_ir_bundle(
     // Entry main first, then the namespace initializers.
     let mut out = vec![("__cljrs_main".to_string(), main)];
     out.extend(bundle);
-    Ok(out)
+    Ok((out, audit))
+}
+
+/// How a dropped form was spelled: `(defmulti route ...)` renders as
+/// `(defmulti route)`, enough to find it without echoing the body.
+fn form_head(form: &cljrs_reader::Form) -> String {
+    use cljrs_reader::form::FormKind;
+    match &form.kind {
+        FormKind::List(parts) => {
+            let names: Vec<String> = parts
+                .iter()
+                .take(2)
+                .map(|p| match &p.kind {
+                    FormKind::Symbol(s) => s.clone(),
+                    other => format!("{other:?}"),
+                })
+                .collect();
+            format!("({})", names.join(" "))
+        }
+        other => format!("{other:?}"),
+    }
 }
 
 /// AOT-compile a source file to a standalone WebAssembly module.
@@ -540,8 +571,19 @@ pub fn compile_file_to_wasm(
     src_path: &Path,
     out_path: &Path,
     src_dirs: &[PathBuf],
+    opacity: OpacityPolicy,
 ) -> AotResult<()> {
-    let bundle = lower_file_to_ir_bundle(src_path, src_dirs)?;
+    let (bundle, audit) = lower_file_to_ir_bundle(src_path, src_dirs)?;
+
+    match audit.verdict(opacity) {
+        OpacityVerdict::Rejected => return Err(AotError::Eval(audit.to_string())),
+        OpacityVerdict::Tolerated => eprintln!(
+            "[aot] {} unit(s) of the program left out of the wasm module \
+             (--require-fully-compiled makes this an error)",
+            audit.count()
+        ),
+        OpacityVerdict::Clean => {}
+    }
 
     eprintln!("[aot] emitting wasm module ({} function(s))", bundle.len());
     let refs: Vec<&IrFunction> = bundle.iter().map(|(_, ir)| ir).collect();
@@ -924,15 +966,118 @@ pub enum OpacityPolicy {
     RequireFullyCompiled,
 }
 
-/// Outcome of applying an [`OpacityPolicy`] to a [`SourceAudit`].
+/// Outcome of applying an [`OpacityPolicy`] to a [`SourceAudit`] or a
+/// [`BundleAudit`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpacityVerdict {
-    /// No readable program text would ship.
+    /// The artifact fully represents the program.
     Clean,
-    /// Source would ship; the policy tolerates it.
+    /// It falls short; the policy tolerates that.
     Tolerated,
-    /// Source would ship; the policy forbids it.
+    /// It falls short; the policy forbids that.
     Rejected,
+}
+
+/// A part of the program the wasm module would not contain.
+///
+/// The wasm backend embeds no source, so [`SourceAudit`] finds nothing there.
+/// It falls short the other way: what it cannot lower it drops, leaving the
+/// module opaque and incomplete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Omission {
+    pub kind: OmissionKind,
+    /// The namespace it belongs to, when one is known.
+    pub ns: Option<String>,
+    /// How the dropped unit was spelled, for locating it in the source.
+    pub detail: String,
+}
+
+/// The reason a unit is missing from the module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OmissionKind {
+    /// A required namespace the backend could not lower or codegen.
+    Namespace,
+    /// A top-level entry form filtered out of `__cljrs_main`.
+    EntryForm,
+}
+
+impl std::fmt::Display for OmissionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OmissionKind::Namespace => write!(f, "namespace"),
+            OmissionKind::EntryForm => write!(f, "entry form"),
+        }
+    }
+}
+
+impl std::fmt::Display for Omission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.ns {
+            Some(ns) => write!(f, "{} ({ns}): {}", self.kind, self.detail),
+            None => write!(f, "{}: {}", self.kind, self.detail),
+        }
+    }
+}
+
+/// Everything the wasm module would leave out, as one value.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BundleAudit {
+    omissions: Vec<Omission>,
+}
+
+impl BundleAudit {
+    /// Promote raw omissions into an audit. The lowering pass records into one
+    /// as it goes; this is the pure way to build the same value.
+    pub fn of(omissions: impl IntoIterator<Item = Omission>) -> Self {
+        Self {
+            omissions: omissions.into_iter().collect(),
+        }
+    }
+
+    pub fn omissions(&self) -> &[Omission] {
+        &self.omissions
+    }
+
+    /// True when the module carries every namespace and form of the program.
+    pub fn is_complete(&self) -> bool {
+        self.omissions.is_empty()
+    }
+
+    pub fn count(&self) -> usize {
+        self.omissions.len()
+    }
+
+    pub(crate) fn record(&mut self, kind: OmissionKind, ns: Option<String>, detail: String) {
+        self.omissions.push(Omission { kind, ns, detail });
+    }
+
+    pub fn verdict(&self, policy: OpacityPolicy) -> OpacityVerdict {
+        match (self.is_complete(), policy) {
+            (true, _) => OpacityVerdict::Clean,
+            (false, OpacityPolicy::Report) => OpacityVerdict::Tolerated,
+            (false, OpacityPolicy::RequireFullyCompiled) => OpacityVerdict::Rejected,
+        }
+    }
+}
+
+impl std::fmt::Display for BundleAudit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "--require-fully-compiled: {} unit(s) of the program would be missing \
+             from the wasm module:",
+            self.omissions.len()
+        )?;
+        for o in &self.omissions {
+            writeln!(f, "  • {o}")?;
+        }
+        write!(
+            f,
+            "The wasm backend drops what it cannot lower, leaving it for an \
+             IR-interpreter tier that is not wired up yet. Move the forms above \
+             out of the compiled unit, or drop --require-fully-compiled."
+        )
+    }
 }
 
 /// Every fragment of Clojure source the harness would embed, as one value.

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -2740,3 +2740,43 @@ fn require_fully_compiled_accepts_plain_defn() {
     )
     .expect("a defn-only program must pass the gate");
 }
+
+#[test]
+fn require_fully_compiled_rejects_an_incomplete_wasm_module() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("omit.cljrs");
+    std::fs::write(
+        &src,
+        "(defmulti route (fn [m] (:kind m)))\n\
+         (defmethod route :alpha [m] (:v m))\n\
+         (defn add [a b] (+ a b))\n",
+    )
+    .expect("write");
+    let out = dir.path().join("omit.wasm");
+    let err = cljrs_compiler::aot::compile_file_to_wasm(
+        &src,
+        &out,
+        &[],
+        cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled,
+    )
+    .expect_err("defmulti/defmethod cannot be lowered, so the module is incomplete");
+    let msg = format!("{err}");
+    assert!(msg.contains("defmulti"), "names the dropped form: {msg}");
+    assert!(!out.exists(), "nothing may be written on rejection");
+}
+
+#[test]
+fn require_fully_compiled_accepts_a_complete_wasm_module() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("clean.cljrs");
+    std::fs::write(&src, "(defn add [a b] (+ a b))\n").expect("write");
+    let out = dir.path().join("clean.wasm");
+    cljrs_compiler::aot::compile_file_to_wasm(
+        &src,
+        &out,
+        &[],
+        cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled,
+    )
+    .expect("a plain defn lowers, so nothing is omitted");
+    assert!(out.exists());
+}

--- a/crates/cljrs-compiler/tests/source_leak_audit.rs
+++ b/crates/cljrs-compiler/tests/source_leak_audit.rs
@@ -255,3 +255,69 @@ fn default_policy_never_breaks_an_existing_build() {
     );
     assert_eq!(OpacityPolicy::default(), OpacityPolicy::Report);
 }
+
+// ── BundleAudit: the wasm side of the same policy ────────────────────────────
+
+use cljrs_compiler::aot::{BundleAudit, Omission, OmissionKind};
+
+fn omission_kind() -> impl Strategy<Value = OmissionKind> {
+    prop_oneof![Just(OmissionKind::Namespace), Just(OmissionKind::EntryForm)]
+}
+
+fn bundle_audit() -> impl Strategy<Value = BundleAudit> {
+    prop::collection::vec((omission_kind(), "[a-z.]{1,12}", "[a-z() ]{1,12}"), 0..6).prop_map(
+        |rows| {
+            BundleAudit::of(rows.into_iter().map(|(kind, ns, detail)| Omission {
+                kind,
+                ns: Some(ns),
+                detail,
+            }))
+        },
+    )
+}
+
+proptest! {
+    /// Completeness is exactly "recorded nothing", the wasm analogue of
+    /// SourceAudit's soundness property.
+    #[test]
+    fn complete_iff_no_omissions(a in bundle_audit()) {
+        prop_assert_eq!(a.is_complete(), a.count() == 0);
+        prop_assert_eq!(a.count(), a.omissions().len());
+    }
+
+    /// A complete module satisfies every policy; only the strict one can
+    /// reject, and only an incomplete module.
+    #[test]
+    fn only_the_strict_policy_rejects(a in bundle_audit()) {
+        prop_assert_ne!(a.verdict(OpacityPolicy::Report), OpacityVerdict::Rejected);
+        let strict = a.verdict(OpacityPolicy::RequireFullyCompiled);
+        if a.is_complete() {
+            prop_assert_eq!(strict, OpacityVerdict::Clean);
+        } else {
+            prop_assert_eq!(strict, OpacityVerdict::Rejected);
+        }
+    }
+
+    /// The report names every omission, since it is the only thing telling a
+    /// caller which unit to move out of the compiled unit.
+    #[test]
+    fn the_report_lists_every_omission(a in bundle_audit()) {
+        prop_assume!(!a.is_complete());
+        let rendered = a.to_string();
+        for o in a.omissions() {
+            prop_assert!(rendered.contains(&o.detail), "{} missing from {}", o.detail, rendered);
+        }
+    }
+
+    /// Adding an omission never removes one.
+    #[test]
+    fn recording_is_monotonic(a in bundle_audit(), ns in "[a-z]{1,8}") {
+        let before = a.count();
+        let grown = BundleAudit::of(a.omissions().iter().cloned().chain([Omission {
+            kind: OmissionKind::Namespace,
+            ns: Some(ns),
+            detail: "x".to_string(),
+        }]));
+        prop_assert_eq!(grown.count(), before + 1);
+    }
+}

--- a/crates/cljrs-compiler/tests/wasm_compile.rs
+++ b/crates/cljrs-compiler/tests/wasm_compile.rs
@@ -21,8 +21,13 @@ fn compile_to_wasm(name: &str, source: &str) -> Vec<u8> {
     let out_path = dir.join(format!("{name}.wasm"));
     std::fs::write(&src_path, source).unwrap();
 
-    cljrs_compiler::aot::compile_file_to_wasm(&src_path, &out_path, &[])
-        .unwrap_or_else(|e| panic!("compile_file_to_wasm failed: {e}"));
+    cljrs_compiler::aot::compile_file_to_wasm(
+        &src_path,
+        &out_path,
+        &[],
+        cljrs_compiler::aot::OpacityPolicy::Report,
+    )
+    .unwrap_or_else(|e| panic!("compile_file_to_wasm failed: {e}"));
 
     std::fs::read(&out_path).unwrap()
 }
@@ -102,8 +107,13 @@ fn bundles_required_namespace_initializer() {
     std::fs::write(&src_path, "(ns withdep (:require [helper]))\n(+ 1 2)\n").unwrap();
     let out_path = dir.join("withdep.wasm");
 
-    cljrs_compiler::aot::compile_file_to_wasm(&src_path, &out_path, std::slice::from_ref(&dir))
-        .unwrap_or_else(|e| panic!("compile_file_to_wasm failed: {e}"));
+    cljrs_compiler::aot::compile_file_to_wasm(
+        &src_path,
+        &out_path,
+        std::slice::from_ref(&dir),
+        cljrs_compiler::aot::OpacityPolicy::Report,
+    )
+    .unwrap_or_else(|e| panic!("compile_file_to_wasm failed: {e}"));
 
     let bytes = std::fs::read(&out_path).unwrap();
     wasmparser::Validator::new()

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -69,7 +69,7 @@ run to completion. A synchronous `-main` is awaited as a no-op pass-through.
 - `--target <native|wasm>` - code-generation target (default `native`), a closed set validated by clap. `wasm` emits a WebAssembly module via the AOT wasm backend (the entry namespace's functions; the `"rt"` imports are satisfied by the runtime built for `wasm32-unknown-unknown`). `--test` is not yet supported with `wasm`.
 - `--main <NS>` — namespace containing `-main`; overrides `:main` in `cljrs.edn` and auto-detection
 - `--test` — compile a test harness that runs every test in the given file/directory
-- `--require-fully-compiled` - fail the build if the binary would embed readable Clojure source text (interpreted preambles, bundled namespaces).  The audit runs in `compile_file`, so the flag is an error with `--test` and with `--target wasm`, whose paths do not audit; it is rejected there rather than accepted and ignored.
+- `--require-fully-compiled` - fail the build if the artifact would not fully represent the program. On `--target native` that means embedded readable Clojure source (interpreted preambles, bundled namespaces); on `--target wasm`, which embeds no source, it means a namespace or entry form the backend dropped. `--test` cannot satisfy it (the harness bundles every test namespace as source) and is refused.
 
 `ir build` accepts:
 - `-n, --ns <NS>` — repeatable; namespaces to lower (default `clojure.core`)

--- a/crates/cljrs/src/main.rs
+++ b/crates/cljrs/src/main.rs
@@ -625,7 +625,7 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
                     "--test is not supported with --target wasm yet"
                 ));
             }
-            let opacity = resolve_opacity_policy(require_fully_compiled, target, test)
+            let opacity = resolve_opacity_policy(require_fully_compiled, test)
                 .map_err(|e| miette::miette!("{e}"))?;
 
             if test {
@@ -689,8 +689,13 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
                 };
 
                 if target == CompileTarget::Wasm {
-                    cljrs_compiler::aot::compile_file_to_wasm(&entry_file, &out, &all_src_paths)
-                        .map_err(|e| miette::miette!("{e}"))?;
+                    cljrs_compiler::aot::compile_file_to_wasm(
+                        &entry_file,
+                        &out,
+                        &all_src_paths,
+                        opacity,
+                    )
+                    .map_err(|e| miette::miette!("{e}"))?;
                 } else {
                     cljrs_compiler::aot::compile_file(
                         &entry_file,
@@ -771,17 +776,15 @@ fn run_command(command: Commands, versioning: VersioningFlags) -> miette::Result
     }
 }
 
-/// Resolve the opacity policy a `compile` invocation runs under, rejecting the
-/// flag combinations that would not honour it.
+/// Resolve the opacity policy a `compile` invocation runs under.
 ///
-/// The source-embedding audit lives in `compile_file`, the native non-test
-/// path.  `--test` goes through `compile_test_harness` and `--target wasm`
-/// through `compile_file_to_wasm`; neither audits, so accepting
-/// `--require-fully-compiled` there would report success while promising a
-/// guarantee nothing checked.  Reject the combination rather than ignore it.
+/// Both backends audit: `compile_file` for embedded source, and
+/// `compile_file_to_wasm` for units the module would omit.  `--test` does not:
+/// `compile_test_harness` bundles every test namespace as interpreted source
+/// unconditionally, so a strict policy there could never be satisfied and the
+/// combination is refused rather than left to fail confusingly.
 fn resolve_opacity_policy(
     require_fully_compiled: bool,
-    target: CompileTarget,
     test: bool,
 ) -> Result<cljrs_compiler::aot::OpacityPolicy, String> {
     if !require_fully_compiled {
@@ -791,13 +794,6 @@ fn resolve_opacity_policy(
         return Err("--require-fully-compiled is not supported with --test: \
                     the test harness is not audited for embedded source"
             .to_string());
-    }
-    if target == CompileTarget::Wasm {
-        return Err(
-            "--require-fully-compiled is not supported with --target wasm: \
-                    the wasm backend is not audited for embedded source"
-                .to_string(),
-        );
     }
     Ok(cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled)
 }
@@ -1995,53 +1991,36 @@ fn run_repl(globals: Arc<GlobalEnv>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{CompileTarget, resolve_opacity_policy};
+    use super::resolve_opacity_policy;
     use cljrs_compiler::aot::OpacityPolicy;
 
-    /// Without the flag every target/test combination is the reporting default.
+    /// Without the flag the policy is the reporting default.
     #[test]
-    fn absent_flag_reports_under_every_combination() {
-        for target in [CompileTarget::Native, CompileTarget::Wasm] {
-            for test in [false, true] {
-                assert_eq!(
-                    resolve_opacity_policy(false, target, test),
-                    Ok(OpacityPolicy::Report),
-                    "target={target:?} test={test}"
-                );
-            }
+    fn absent_flag_always_reports() {
+        for test in [false, true] {
+            assert_eq!(
+                resolve_opacity_policy(false, test),
+                Ok(OpacityPolicy::Report),
+                "test={test}"
+            );
         }
     }
 
     #[test]
     fn flag_selects_the_strict_policy_on_the_audited_path() {
         assert_eq!(
-            resolve_opacity_policy(true, CompileTarget::Native, false),
+            resolve_opacity_policy(true, false),
             Ok(OpacityPolicy::RequireFullyCompiled)
         );
     }
 
-    /// The unaudited paths reject rather than silently ignore the flag.
+    /// `--test` rejects rather than silently ignoring the flag.
     #[test]
-    fn flag_is_rejected_on_unaudited_paths() {
-        for (target, test) in [
-            (CompileTarget::Native, true),
-            (CompileTarget::Wasm, false),
-            (CompileTarget::Wasm, true),
-        ] {
-            let err = resolve_opacity_policy(true, target, test)
-                .expect_err("target={target:?} test={test} must be rejected");
-            assert!(
-                err.contains("--require-fully-compiled"),
-                "error names the flag: {err}"
-            );
-        }
-    }
-
-    /// `--test` is reported ahead of `--target wasm` when both are given, so the
-    /// message names a flag the caller actually passed.
-    #[test]
-    fn test_combination_is_reported_before_wasm() {
-        let err = resolve_opacity_policy(true, CompileTarget::Wasm, true).expect_err("rejected");
-        assert!(err.contains("--test"), "{err}");
+    fn flag_is_rejected_under_test() {
+        let err = resolve_opacity_policy(true, true).expect_err("--test must be rejected");
+        assert!(
+            err.contains("--require-fully-compiled") && err.contains("--test"),
+            "error names both flags: {err}"
+        );
     }
 }

--- a/crates/cljrs/tests/compile_flag_combinations.rs
+++ b/crates/cljrs/tests/compile_flag_combinations.rs
@@ -1,9 +1,8 @@
 //! CLI-level contract for `cljrs compile --require-fully-compiled`.
 //!
-//! The source-embedding audit only runs on the native, non-test path. These
-//! tests drive the built binary (via `CARGO_BIN_EXE_cljrs`) to pin that the
-//! unaudited combinations are rejected outright rather than accepted and
-//! ignored, and that the audited one is not caught by the same check.
+//! Both backends audit, so both accept `--require-fully-compiled`. `--test`
+//! cannot satisfy it and is refused. These tests drive the built binary via
+//! `CARGO_BIN_EXE_cljrs`.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -35,14 +34,19 @@ fn require_fully_compiled_rejects_test_harness() {
     );
 }
 
+/// wasm audits completeness now, so the flag is accepted there. It must not
+/// be turned away by the combination check before the backend can apply it.
 #[test]
-fn require_fully_compiled_rejects_wasm_target() {
-    let out = compile(&["--target", "wasm", "--require-fully-compiled", "app.cljrs"]);
-    let stderr = stderr_of(&out);
-    assert!(!out.status.success(), "should fail; stderr: {stderr}");
+fn require_fully_compiled_is_accepted_on_the_wasm_path() {
+    let stderr = stderr_of(&compile(&[
+        "--target",
+        "wasm",
+        "--require-fully-compiled",
+        "no-such-file.cljrs",
+    ]));
     assert!(
-        stderr.contains("--require-fully-compiled") && stderr.contains("wasm"),
-        "message names both flags: {stderr}"
+        !stderr.contains("is not supported with"),
+        "wasm must not be refused for the flag: {stderr}"
     );
 }
 


### PR DESCRIPTION
Stacked on #293, which it does not change. This is the other half of your review: "would be good to enforce the flag under those combinations".

## The two backends fall short differently

`compile_file_to_wasm` embeds no source, so `SourceAudit` finds nothing there and #293 refuses the flag as unsupported. But the wasm path does not fully compile the program either. It drops what it cannot lower: a required namespace that fails lowering or codegen is skipped, and an entry form that `needs_interpreter` is filtered out of `__cljrs_main`. Both are left for an IR-interpreter tier that is not wired up yet.

So the module is opaque AND quietly missing behaviour, which is arguably worse than a leaky native binary. Today the only signal is one `eprintln!` per skipped namespace, and none at all for a dropped entry form.

## What this adds

`BundleAudit`, the wasm counterpart of `SourceAudit`, collecting `Omission`s during lowering. `compile_file_to_wasm` takes the SAME `OpacityPolicy` and applies the SAME `OpacityVerdict`, so `--require-fully-compiled` means one thing across backends: the artifact fully represents the program. Each backend reports its own way of falling short.

```
$ cljrs compile omit.cljrs -o omit.wasm --target wasm --require-fully-compiled
Error:   × --require-fully-compiled: 2 unit(s) of the program would be missing
  │ from the wasm module:
  │   • entry form (user): (defmulti route)
  │   • entry form (user): (defmethod route)
  │ The wasm backend drops what it cannot lower, leaving it for an IR-
  │ interpreter tier that is not wired up yet. Move the forms above out of the
  │ compiled unit, or drop --require-fully-compiled.
```

Nothing is written on rejection. `Report` stays the default and adds one summary line, so existing wasm builds are unchanged.

`--test` is untouched and still refused. `compile_test_harness` pushes every test namespace to `interpreted_bundled` unconditionally, so a strict policy there could never be satisfied; that rejection is the terminal answer rather than a placeholder. With wasm now audited, `resolve_opacity_policy` no longer takes a target, since the target stopped changing the decision.

## API

`compile_file_to_wasm` gains an `opacity` parameter. That is the only breaking signature change; the two existing `wasm_compile.rs` call sites pass `OpacityPolicy::Report` and behave as before.

## Tests

4 properties over `BundleAudit` mirroring the `SourceAudit` ones: completeness is exactly "recorded nothing", only the strict policy can reject, the report names every omission (it is the only thing telling a caller what to move), and monotonicity. 17 properties green in `source_leak_audit.rs`.

2 e2e wasm compiles in `aot_e2e.rs`: a `defmulti`/`defmethod` program is rejected and writes nothing, a plain `defn` program is accepted. CLI combination tests updated.

`cargo fmt` and `cargo clippy --tests` clean. Both crate READMEs updated in the same commit.
