### PR TITLE
ci: retry crates.io publish when rate-limited

### DIFF
--- a/.github/scripts/publish-crates.sh
+++ b/.github/scripts/publish-crates.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Publish every publishable workspace crate to crates.io, retrying when
+# crates.io rate-limits us.
+#
+# Why this exists: the workspace has ~33 publishable crates and crates.io
+# throttles publishes (as of writing: new versions of an existing crate are a
+# burst of 30 then 1 per minute; brand-new crates are a burst of 5 then 1 per
+# 10 minutes).  A full workspace publish therefore reliably ends in
+#
+#     the remote server responded with an error (status 429 Too Many Requests):
+#     You have published too many crates ... Please try again after <timestamp>
+#
+# after the burst budget is spent, leaving the tail of the workspace
+# unpublished.  Publishing is idempotent, so the fix is to wait for the bucket
+# to refill and re-run for whatever is still missing.
+#
+# Each attempt recomputes which crates are already live at the target version
+# and excludes them, so no crate is ever published twice and a partial success
+# always makes forward progress.
+#
+# Tunables (environment):
+#   PUBLISH_MAX_ATTEMPTS  attempts before giving up          (default 5)
+#   PUBLISH_BASE_SLEEP    seconds to wait after a rate limit (default 300)
+#   PUBLISH_MAX_SLEEP     cap on any single wait             (default 1800)
+#   PUBLISH_ERROR_SLEEP   wait after a non-rate-limit error  (default 60)
+#   PUBLISH_TIMEOUT       per-crate registry confirmation    (default 600)
+
+set -euo pipefail
+
+MAX_ATTEMPTS="${PUBLISH_MAX_ATTEMPTS:-5}"
+BASE_SLEEP="${PUBLISH_BASE_SLEEP:-300}"
+MAX_SLEEP="${PUBLISH_MAX_SLEEP:-1800}"
+ERROR_SLEEP="${PUBLISH_ERROR_SLEEP:-60}"
+PUBLISH_TIMEOUT="${PUBLISH_TIMEOUT:-600}"
+
+USER_AGENT="clojurust-publish/1.0"
+
+log() { printf '%s\n' "$*"; }
+
+# Is <name>@<version> already on crates.io?
+crate_is_published() {
+  local name="$1" version="$2"
+  curl -sf "https://crates.io/api/v1/crates/${name}/${version}" \
+    -H "User-Agent: ${USER_AGENT}" | grep -q '"num"'
+}
+
+# Every publishable workspace package as "<name> <version>" lines.
+# cargo sets `publish` to [] for `publish = false` packages and null otherwise.
+workspace_packages() {
+  cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[] | select(.publish != []) | "\(.name) \(.version)"'
+}
+
+# Fill the globals REMAINING (names still to publish) and EXCLUDE_ARGS
+# (--exclude flags for the ones already live).
+compute_remaining() {
+  REMAINING=()
+  EXCLUDE_ARGS=()
+  local name version
+  while read -r name version; do
+    if crate_is_published "$name" "$version"; then
+      EXCLUDE_ARGS+=(--exclude "$name")
+    else
+      REMAINING+=("${name}@${version}")
+    fi
+  done < <(workspace_packages)
+}
+
+# Does the cargo output look like a crates.io rate limit rather than a real
+# failure (compile error, bad token, ...)?
+is_rate_limited() {
+  grep -qiE '429|too many requests|published too many' "$1"
+}
+
+# Seconds to wait, preferring the timestamp crates.io hands back:
+#   "Please try again after 2026-08-12T18:12:00Z or email help@crates.io ..."
+# Falls back to attempt-scaled backoff when no timestamp can be parsed.
+rate_limit_sleep() {
+  local log_file="$1" attempt="$2"
+  local stamp delta fallback
+
+  fallback=$((BASE_SLEEP * attempt))
+
+  stamp="$(grep -oiE 'try again after [0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:?[0-9]{2})?' "$log_file" \
+    | tail -n 1 | sed -E 's/^[Tt]ry again after //')"
+
+  if [[ -n "$stamp" ]] && delta="$(date -u -d "$stamp" +%s 2>/dev/null)"; then
+    # +30 s of slack for clock skew between the runner and crates.io.
+    delta=$((delta - $(date -u +%s) + 30))
+    if ((delta > 0)); then
+      clamp "$delta"
+      return
+    fi
+  fi
+
+  clamp "$fallback"
+}
+
+# Echo $1 bounded to [60, MAX_SLEEP].
+clamp() {
+  local seconds="$1"
+  ((seconds < 60)) && seconds=60
+  ((seconds > MAX_SLEEP)) && seconds="$MAX_SLEEP"
+  printf '%s\n' "$seconds"
+}
+
+# `--no-verify` is safe here: the CI job that gates this one already built,
+# clippy'd and tested the workspace.
+# Nightly + `-Zpublish-timeout` extends the per-crate registry confirmation
+# wait; without it a slow crates.io response aborts the run with
+# "no packages ready to publish ... 1 awaiting confirmation"
+# (rust-lang/cargo#17028).
+run_cargo_publish() {
+  local log_file="$1"
+  cargo +nightly publish --workspace \
+    -Zpublish-timeout \
+    --config "publish.timeout=${PUBLISH_TIMEOUT}" \
+    --no-verify \
+    "${EXCLUDE_ARGS[@]}" 2>&1 | tee "$log_file"
+  # tee is last in the pipeline, so consult cargo's status explicitly.
+  return "${PIPESTATUS[0]}"
+}
+
+log_file="$(mktemp)"
+trap 'rm -f "$log_file"' EXIT
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  compute_remaining
+
+  if ((${#REMAINING[@]} == 0)); then
+    log "All workspace crates are published at their target versions."
+    exit 0
+  fi
+
+  if ((${#EXCLUDE_ARGS[@]} > 0)); then
+    log "Already published, skipping: $((${#EXCLUDE_ARGS[@]} / 2)) crate(s)"
+  fi
+  log "Attempt ${attempt}/${MAX_ATTEMPTS}: publishing ${#REMAINING[@]} crate(s): ${REMAINING[*]}"
+
+  if run_cargo_publish "$log_file"; then
+    # The loop head re-checks the registry; give crates.io a moment to make the
+    # just-published versions visible so that check isn't racing the API.
+    log "cargo publish reported success; confirming against the registry."
+    sleep 30
+    continue
+  fi
+
+  if ((attempt == MAX_ATTEMPTS)); then
+    break
+  fi
+
+  if is_rate_limited "$log_file"; then
+    sleep_for="$(rate_limit_sleep "$log_file" "$attempt")"
+    log "::warning::crates.io rate-limited the publish; waiting ${sleep_for}s before retrying"
+  else
+    sleep_for="$(clamp "$ERROR_SLEEP")"
+    log "::warning::cargo publish failed for a non-rate-limit reason; waiting ${sleep_for}s before retrying"
+  fi
+  sleep "$sleep_for"
+done
+
+# cargo can exit non-zero on the last crate while everything actually landed,
+# so the registry — not cargo's exit status — has the final word.
+compute_remaining
+if ((${#REMAINING[@]} == 0)); then
+  log "All workspace crates are published at their target versions."
+  exit 0
+fi
+
+log "::error::Gave up after ${MAX_ATTEMPTS} attempt(s). Still unpublished: ${REMAINING[*]}"
+log "Publishing is idempotent — re-running this workflow will publish only the crates listed above."
+exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,9 @@ jobs:
     name: Publish to crates.io
     needs: ci
     runs-on: ubuntu-latest
+    # Rate-limit waits between publish attempts can add up; keep a bound well
+    # above the worst case (~50 min of backoff) but below the 6 h default.
+    timeout-minutes: 120
     permissions:
       contents: write
     steps:
@@ -85,31 +88,13 @@ jobs:
             git push origin "v$VERSION"
           fi
 
+      # The workspace has more publishable crates than crates.io's publish
+      # burst allowance, so a single `cargo publish --workspace` reliably ends
+      # in a 429 with the tail of the workspace unpublished.  The script skips
+      # crates already live at this version and retries the rest after waiting
+      # for the rate limit to refill (honouring the retry-after timestamp
+      # crates.io returns).  See .github/scripts/publish-crates.sh.
       - name: Publish crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          # Build --exclude list for packages already live at this version.
-          # Makes the step idempotent so a retry after a partial failure is safe.
-          EXCLUDE=()
-          while IFS= read -r pkg; do
-            name="${pkg%%@*}"
-            ver="${pkg##*@}"
-            if curl -sf "https://crates.io/api/v1/crates/${name}/${ver}" \
-                 -H "User-Agent: clojurust-publish/1.0" | grep -q '"num"'; then
-              echo "Already published: ${name}@${ver} — skipping"
-              EXCLUDE+=(--exclude "${name}")
-            fi
-          done < <(cargo metadata --no-deps --format-version 1 \
-                     | jq -r '.packages[] | "\(.name)@\(.version)"')
-
-          # Use nightly cargo for -Zpublish-timeout, which extends the
-          # per-crate registry confirmation wait to 600 s.  Without this,
-          # a slow crates.io response causes "no packages ready to publish
-          # … 1 awaiting confirmation" (rust-lang/cargo#17028).
-          # --no-verify is safe here because CI already ran checks above.
-          cargo +nightly publish --workspace \
-            -Zpublish-timeout \
-            --config 'publish.timeout=600' \
-            --no-verify \
-            "${EXCLUDE[@]}"
+        run: .github/scripts/publish-crates.sh


### PR DESCRIPTION
The workspace has 33 publishable crates, which exceeds crates.io's
publish burst allowance (30 new versions of an existing crate, then 1
per minute; 5 for brand-new crates, then 1 per 10 minutes). A single
`cargo publish --workspace` therefore ends in a 429 almost every run,
with the tail of the workspace unpublished and a manual re-run needed.

Move the publish step into .github/scripts/publish-crates.sh, which
loops up to PUBLISH_MAX_ATTEMPTS (default 5) times:

- Before each attempt it asks crates.io which crates are already live at
  the target version and passes --exclude for them, so a partial
  success always makes forward progress and nothing is published twice.
- On a 429 it waits until the retry-after timestamp in the crates.io
  error message, clamped to [60s, PUBLISH_MAX_SLEEP]; when no timestamp
  can be parsed it falls back to attempt-scaled backoff
  (PUBLISH_BASE_SLEEP * attempt, default 300s, 600s, ...).
- On a non-rate-limit failure it waits only 60s, so a genuine build or
  auth error still fails reasonably quickly.
- The registry, not cargo's exit status, has the final word: if every
  crate is live the step succeeds even when cargo exited non-zero on the
  last one. Otherwise it fails listing exactly what is still missing.

Packages with `publish = false` (examples/rust-interop) are now filtered
out via cargo metadata's `publish` field instead of being probed against
crates.io, so they never count as outstanding work.

The publish job gains timeout-minutes: 120 — comfortably above the
worst-case ~50 minutes of accumulated backoff, well below the 6 h
default.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013YHqTtQdDnj2gYASJy3Kya