### PR TITLE
ci: move showcase demos to a manual workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,22 +36,6 @@ jobs:
       - name: Clojure Tests
         run: cargo run -p cljrs compile -o test-suite --test ./clojure-test-suite/test && CLJRS_GC_STATS=- ./test-suite
 
-      - name: Graph sample (region-alloc smoke test)
-        env:
-          CLJRS_GC_STATS: "-"
-        run: cargo run -p cljrs compile -o graph-sample samples/graph.cljrs && ./graph-sample
-
-      - name: Game of Life (bump-allocator showcase)
-        env:
-          CLJRS_GC_STATS: "-"
-        run: cargo run -p cljrs compile -o life-sample samples/life.cljrs && ./life-sample
-
-      - name: core.async sample (CSP showcase)
-        run: cargo run -p cljrs compile -o async-sample samples/core_async.cljrs && ./async-sample
-
-      - name: HTTP GET sample (net + charset showcase)
-        run: cargo run -p cljrs compile -o http-get-sample samples/http_get.cljrs && ./http-get-sample
-
   wasm:
     name: WASM build
     runs-on: ubuntu-latest

--- a/.github/workflows/showcase-demos.yml
+++ b/.github/workflows/showcase-demos.yml
@@ -1,0 +1,45 @@
+name: Showcase Demos
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CLJRS_GC_STATS: "-"
+
+jobs:
+  demo:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Graph sample (region-alloc smoke test)
+            sample: samples/graph.cljrs
+            bin: graph-sample
+          - name: Game of Life (bump-allocator showcase)
+            sample: samples/life.cljrs
+            bin: life-sample
+          - name: core.async sample (CSP showcase)
+            sample: samples/core_async.cljrs
+            bin: async-sample
+          - name: HTTP GET sample (net + charset showcase)
+            sample: samples/http_get.cljrs
+            bin: http-get-sample
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Compile and run ${{ matrix.sample }}
+        run: |
+          cargo run -p cljrs compile -o "${{ matrix.bin }}" "${{ matrix.sample }}"
+          ./"${{ matrix.bin }}"


### PR DESCRIPTION
The four sample demos (graph, Game of Life, core.async, HTTP GET) ran on
every PR, adding compile+run time to the critical path. Move them into a
new workflow_dispatch-only "Showcase Demos" workflow, one matrix job per
sample with fail-fast disabled so each demo reports independently.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pt8nPvBSpgjMbGK5L3D7ZJ