### PR TITLE
docs(book): add an Embedding chapter for hosting a runtime in a Rust program

### DIFF
--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -48,6 +48,12 @@ build.rs            — captures `rustc -V` for the pinned-package ABI fingerpri
     build_native.rs — `build-native`: cargo-build the project's `:rust` crate
     lsp.rs          — `lsp`: run the language server over stdio
     nrepl.rs        — `nrepl`: serve an nREPL session
+tests/
+  embedding_book_examples.rs — the snippets from the book's Embedding chapter
+                      (`docs/book/src/embedding/`), compiled and run so the
+                      documented host API cannot drift
+  pinned_dylib_e2e.rs — gated (`CLJRS_DYLIB_E2E=1`) pinned-native end-to-end
+                      test; described under Pinned native packages below
 ```
 
 ---

--- a/crates/cljrs/tests/embedding_book_examples.rs
+++ b/crates/cljrs/tests/embedding_book_examples.rs
@@ -1,0 +1,219 @@
+//! The embedding chapter of the book, compiled and run.
+//!
+//! Every snippet in `docs/book/src/embedding/` that is meant to be real code
+//! has a counterpart here, so a change to the runtime's construction, tier,
+//! evaluation, or metering API breaks the build rather than silently making
+//! the documentation wrong. Keep the two in step: when a test here changes,
+//! change the page it mirrors.
+
+// EvalError::Thrown wraps a full Value; the book's snippets return it as-is.
+#![allow(clippy::result_large_err)]
+
+use std::sync::Arc;
+
+use cljrs_gc::{GcConfig, GcPtr};
+use cljrs_reader::Parser;
+use cljrs_runtime::env::apply::apply_value;
+use cljrs_runtime::env::gas::{GasGuard, GasMeter};
+use cljrs_runtime::env::gc_roots::root_value;
+use cljrs_runtime::tiered::{Env, EvalError, eval};
+use cljrs_runtime::{ExecutionMode, Runtime, TierState};
+use cljrs_value::Value;
+
+/// `embedding/evaluating.md` — the parse-and-evaluate loop, one allocation
+/// frame per top-level form.
+fn eval_str(env: &mut Env, src: &str, origin: &str) -> Result<Value, EvalError> {
+    let mut parser = Parser::new(src.to_string(), origin.to_string());
+    let forms = parser.parse_all().map_err(EvalError::Read)?;
+
+    let mut result = Value::Nil;
+    for form in &forms {
+        let _frame = cljrs_gc::push_alloc_frame();
+        result = eval(form, env)?;
+    }
+    Ok(result)
+}
+
+/// `embedding/index.md` — the minimal host.
+#[test]
+fn minimal_host() {
+    let runtime = Runtime::builder()
+        .execution_mode(ExecutionMode::Tiered)
+        .source_paths(vec!["src".into()])
+        .build()
+        .expect("bootstrap clojure.core");
+
+    cljrs_stdlib::install(&runtime);
+
+    let mut env = runtime.env("user");
+    let value = eval_str(&mut env, "(+ 1 2)", "<host>").expect("eval");
+    assert_eq!(value.to_string(), "3");
+}
+
+/// `embedding/runtime-builder.md` — every builder option, and the handle.
+#[test]
+fn builder_options() {
+    let runtime = Runtime::builder()
+        .execution_mode(ExecutionMode::TreeWalk)
+        .source_paths(vec!["src".into(), "resources".into()])
+        .gc_config_from_env(false)
+        .gc_config(Arc::new(GcConfig::with_limits(32 << 20, 64 << 20)))
+        .register_gc_roots(true)
+        .builtin_source("acme.rules", "(ns acme.rules) (defn allow? [_] true)")
+        .eager_clojure_test(false)
+        .build()
+        .expect("bootstrap");
+
+    assert_eq!(runtime.execution_mode(), ExecutionMode::TreeWalk);
+    assert_eq!(runtime.tier_state(), TierState::TreeWalk);
+
+    // An embedded source resolves through `require` with no file on disk.
+    let mut env = runtime.env("user");
+    eval_str(&mut env, "(require '[acme.rules :as rules])", "<host>").expect("require");
+    assert_eq!(
+        eval_str(&mut env, "(rules/allow? :anything)", "<host>")
+            .unwrap()
+            .to_string(),
+        "true"
+    );
+
+    // The handle round-trips through the environment it wraps.
+    let adopted = Runtime::from_globals(runtime.globals().clone());
+    assert_eq!(adopted.execution_mode(), ExecutionMode::TreeWalk);
+    let _globals: Arc<cljrs_runtime::env::env::GlobalEnv> = adopted.into_globals();
+}
+
+/// `embedding/execution-modes.md` — a tiered runtime lands on `Ir` without a
+/// JIT backend and on `Jit` with one, and the thresholds are settable.
+#[test]
+fn execution_modes() {
+    let no_jit = Runtime::builder()
+        .execution_mode(ExecutionMode::TieredNoJit)
+        .build()
+        .expect("bootstrap");
+    assert_eq!(no_jit.tier_state(), TierState::Ir);
+
+    cljrs_runtime::tiered::set_ir_threshold(10);
+    cljrs_runtime::tiered::set_jit_threshold(500);
+    cljrs_runtime::tiered::set_osr_threshold(5_000);
+
+    let jitted = Runtime::builder()
+        .execution_mode(ExecutionMode::Tiered)
+        .build()
+        .expect("bootstrap");
+    cljrs_compiler::jit::install(&jitted); // before any guest code runs
+    cljrs_stdlib::install(&jitted);
+    assert_eq!(jitted.tier_state(), TierState::Jit);
+}
+
+/// `embedding/execution-modes.md` — the depth cap of `NoGcTransaction`.
+#[test]
+fn depth_cap() {
+    let runtime = Runtime::builder()
+        .execution_mode(ExecutionMode::NoGcTransaction)
+        .build()
+        .expect("bootstrap");
+    let mut env = runtime.env("user");
+    eval_str(
+        &mut env,
+        "(defn down [n] (if (zero? n) 0 (down (dec n))))",
+        "<t>",
+    )
+    .unwrap();
+
+    let _depth = cljrs_runtime::env::depth::DepthGuard::install(8);
+    let err = eval_str(&mut env, "(down 100)", "<t>").unwrap_err();
+    assert!(matches!(err, EvalError::Runtime(_)), "got {err:?}");
+}
+
+/// `embedding/evaluating.md` — calling a Clojure function from Rust, and the
+/// three ways of reading a `Value` back.
+#[test]
+fn call_clojure_from_rust() {
+    let runtime = Runtime::builder().build().expect("bootstrap");
+    cljrs_stdlib::install(&runtime);
+    let mut env = runtime.env("user");
+    eval_str(
+        &mut env,
+        "(defn greet [who] (str \"hello, \" who))",
+        "<host>",
+    )
+    .unwrap();
+
+    let f = runtime
+        .globals()
+        .lookup_in_ns("user", "greet")
+        .expect("greet is defined");
+    let _root = root_value(&f);
+
+    let arg = Value::Str(GcPtr::new("world".to_string()));
+    let out = apply_value(&f, vec![arg], &mut env).expect("call");
+
+    // 1. Display prints readably — a string keeps its quotes.
+    assert_eq!(out.to_string(), "\"hello, world\"");
+    // 2. Marshalling.
+    use cljrs_interop::FromValue;
+    assert_eq!(String::from_value(&out).unwrap(), "hello, world");
+    // 3. Matching.
+    match &out {
+        Value::Str(s) => assert_eq!(s.get().as_str(), "hello, world"),
+        other => panic!("expected a string, got {other}"),
+    }
+}
+
+/// `embedding/sandboxing.md` — a gas meter bounds a runaway loop.
+#[test]
+fn gas_metering() {
+    let runtime = Runtime::builder().build().expect("bootstrap");
+    let mut env = runtime.env("user");
+
+    let meter = GasMeter::new(10_000);
+    let guard = GasGuard::install(meter.clone());
+    let result = eval_str(
+        &mut env,
+        "(loop [i 0] (if (< i 100000000) (recur (inc i)) i))",
+        "<guest>",
+    );
+    drop(guard);
+
+    assert!(
+        matches!(result, Err(EvalError::GasExhausted)),
+        "expected the budget to run out"
+    );
+}
+
+/// `embedding/extensions.md` — extensions install into a finished runtime, and
+/// a host registers its own native functions through a `Registry`.
+#[test]
+fn extensions_and_native_functions() {
+    let runtime = Runtime::builder().build().expect("bootstrap");
+    cljrs_stdlib::install(&runtime);
+    let globals = runtime.globals();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, async {
+        cljrs_async::init(globals);
+        cljrs_io::init(globals);
+        cljrs_net::init(globals);
+        cljrs_charset::init(globals);
+    });
+    cljrs_base64::init(globals);
+
+    let registry = cljrs_interop::Registry::new(globals.clone());
+    registry.define(
+        "acme.native/add",
+        cljrs_interop::wrap_fn2("add", |a: i64, b: i64| Ok::<i64, String>(a + b)),
+    );
+
+    let mut env = runtime.env("user");
+    assert_eq!(
+        eval_str(&mut env, "(acme.native/add 3 4)", "<host>")
+            .unwrap()
+            .to_string(),
+        "7"
+    );
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -40,6 +40,15 @@
 - [Interpreter mode](rust-interop/interpreter.md)
 - [AOT mode](rust-interop/aot.md)
 
+# Embedding
+
+- [Embedding clojurust](embedding/index.md)
+- [The runtime builder](embedding/runtime-builder.md)
+- [Execution modes](embedding/execution-modes.md)
+- [Extensions & native code](embedding/extensions.md)
+- [Evaluating code](embedding/evaluating.md)
+- [Limits & sandboxing](embedding/sandboxing.md)
+
 # Memory Management
 
 - [Overview](memory/index.md)

--- a/docs/book/src/embedding/evaluating.md
+++ b/docs/book/src/embedding/evaluating.md
@@ -1,0 +1,189 @@
+# Evaluating code
+
+Evaluation is two steps the host drives itself: parse source text into forms,
+then evaluate each form in an `Env`. There is no single `eval_string` entry
+point, because hosts differ in how they want to handle allocation frames,
+errors, and partial results — but the loop is a dozen lines.
+
+## Parse and evaluate
+
+```rust
+use cljrs_reader::Parser;
+use cljrs_runtime::tiered::{Env, EvalError, eval};
+use cljrs_value::Value;
+
+fn eval_str(env: &mut Env, src: &str, origin: &str) -> Result<Value, EvalError> {
+    let mut parser = Parser::new(src.to_string(), origin.to_string());
+    let forms = parser.parse_all().map_err(EvalError::Read)?;
+
+    let mut result = Value::Nil;
+    for form in &forms {
+        let _frame = cljrs_gc::push_alloc_frame();
+        result = eval(form, env)?;
+    }
+    Ok(result)
+}
+```
+
+`origin` is the filename the reader attaches to source spans — it shows up in
+error messages, so give it something meaningful (`"<config>"`, the real path, a
+REPL input counter).
+
+`parse_all` reads **every** form up front, so a syntax error anywhere means
+nothing is evaluated. To get REPL-style behaviour (evaluate what parses, report
+the rest), parse and evaluate one form at a time.
+
+An `Env` is a lexical scope chained to the shared `GlobalEnv`. Make one with
+`runtime.env("user")` or `Env::new(globals.clone(), "user")`. It is cheap: one
+per request, per session, or per task is normal. Re-using an `Env` across calls
+preserves whatever `def`s the guest code made — those live in the namespace, not
+the `Env` — while giving you a fresh set of local bindings.
+
+## Getting values out
+
+`Value` is the runtime's tagged union. Three ways to read one:
+
+```rust
+// 1. Display — prints readably, the way `pr-str` does.
+assert_eq!(value.to_string(), "\"hello, world\"");   // note the quotes
+
+// 2. Marshalling, for the common scalar types.
+use cljrs_interop::FromValue;
+let s = String::from_value(&value)?;                  // "hello, world"
+let n = i64::from_value(&count)?;
+
+// 3. Matching, when you need the exact shape.
+match &value {
+    Value::Str(s) => println!("{}", s.get()),
+    Value::Long(n) => println!("{n}"),
+    Value::Nil => println!("nothing"),
+    other => return Err(format!("unexpected: {other}")),
+}
+```
+
+`FromValue`/`IntoValue` are implemented for `()`, `bool`, `i64`, `f64`,
+`String`, `&str`, `BigInt`, `Option<T>`, `Vec<Value>`, and `Value`. Collections
+come back as `Value::Vector` / `Value::Map` / `Value::Set` and are read through
+their persistent-collection APIs.
+
+Remember that `Display` is the *readable* representation: strings keep their
+quotes, characters print as `\a`. Use `FromValue` or a match when you want the
+underlying data rather than something to show a user.
+
+## Calling Clojure from Rust
+
+Look the function up in its namespace, then apply it:
+
+```rust
+use cljrs_runtime::env::apply::apply_value;
+use cljrs_runtime::env::gc_roots::root_value;
+
+eval_str(&mut env, "(defn greet [who] (str \"hello, \" who))", "<host>")?;
+
+let f = globals.lookup_in_ns("user", "greet").expect("greet is defined");
+let _root = root_value(&f);                    // f is on the Rust stack — root it
+
+let arg = Value::Str(cljrs_gc::GcPtr::new("world".to_string()));
+let out = apply_value(&f, vec![arg], &mut env)?;
+```
+
+`apply_value` handles every callee shape Clojure allows — functions, keywords,
+maps, sets, vars, protocol methods, multimethods — and roots the callee and
+arguments across the safepoint it takes on entry.
+
+Inside a **native function** you usually do not have an `Env` in hand. Use
+`invoke` instead, which picks up the eval context that the interpreter pushes
+around every native call:
+
+```rust
+use cljrs_runtime::tiered::invoke;
+
+// e.g. a comparator handed to your native sort
+let ordering = invoke(&user_fn, vec![a.clone(), b.clone()])?;
+```
+
+`invoke` fails with "invoke called outside eval context" if there is no active
+evaluation on the thread. If you spawn a thread and want to call Clojure from
+it — which only makes sense for a runtime confined to that thread — install a
+context first with
+`cljrs_runtime::env::callback::install_eval_context_guard(globals, ns)`.
+
+## Errors
+
+```rust
+pub enum EvalError {
+    Thrown(Value),               // (throw ...) — the thrown value, often an error map
+    UnboundSymbol(String),
+    Arity { name: String, expected: String, got: usize },
+    NotCallable(String),
+    Runtime(String),
+    Read(CljxError),             // reader/parse failure, carries file/line/col
+    GasExhausted,                // the execution-credit budget ran out
+    ForbiddenEffect(String),     // a capability denied by the transaction policy
+    Recur(Vec<Value>),           // `recur` outside a loop — never escapes normal code
+    CommitSignatureVerificationFailed { commit: String, reason: String },
+}
+```
+
+Guest exceptions arrive as `Thrown`, carrying the thrown value; the rest are the
+evaluator's own failures. A host that reports to users will want to map these to
+its own error type — `EvalError::to_error_value` converts one into a Clojure
+error *value* if you would rather hand the failure back to guest code than
+propagate it into Rust.
+
+Reader errors keep their source spans, so `miette` renders them with the
+offending line highlighted if your host uses it.
+
+## GC discipline
+
+The collector traces from a fixed set of roots. Three cases cover a host:
+
+**Values reachable from a namespace are safe.** Anything `def`'d, and anything
+you intern yourself, is traced through the namespace table (assuming
+[`register_gc_roots`](runtime-builder.md#register_gc_roots) is on, which is the
+default). This is the right home for anything the host holds for a long time:
+
+```rust
+globals.intern("acme.host", "session-id".into(), session_id_value);
+```
+
+**Values you allocate while evaluating need an allocation frame.** That is what
+`push_alloc_frame()` in the eval loop is for: everything allocated inside the
+frame is rooted until the returned guard drops. One frame per top-level form is
+the convention the CLI and the bootstrap both use — it keeps a long-running
+session from accumulating roots while still protecting the form being evaluated.
+
+**Values living on the Rust stack across a safepoint need an explicit root.**
+
+```rust
+use cljrs_runtime::env::gc_roots::{root_value, root_values};
+
+let _r1 = root_value(&callee);     // one Value
+let _r2 = root_values(&args);      // a slice
+```
+
+Both return RAII guards that unregister on drop. Forgetting one is the classic
+embedding bug: it works until a collection happens to land inside the call.
+
+`cljrs_runtime::tiered::force_collect(&env)` triggers an immediate collection,
+which is worth doing after you tear down namespaces so their closures and form
+trees are released before the next load.
+
+## Threads and runtimes
+
+`Runtime`, `GlobalEnv`, `Env`, and `Value` are all `!Send`, and the compiler
+enforces it. The rules that fall out:
+
+- **Build the runtime on the thread that will use it**, and evaluate only on
+  that thread. Each such thread owns an independent GC heap.
+- **To use several cores, run several runtimes** — one per thread — and move
+  data between them with isolate channels (a deep copy) or `shared-atom` (a
+  refcounted shared cell). Closures and stateful objects cannot cross. See
+  [Worker isolation](../async-io/isolation.md).
+- **Send work to the interpreter thread as plain data.** This is exactly what
+  the nREPL server does: its network thread packages each request as `Send`
+  strings plus a reply channel and hands it to the interpreter thread over an
+  mpsc channel.
+- **Byte-level work does not need a runtime.** Compression, hashing, TLS, socket
+  traffic — anything touching no Clojure values — can run on an ordinary thread
+  pool and hand results back as `Vec<u8>`.

--- a/docs/book/src/embedding/execution-modes.md
+++ b/docs/book/src/embedding/execution-modes.md
@@ -1,0 +1,162 @@
+# Execution modes
+
+An `ExecutionMode` is chosen once, when the runtime is built, and never changes.
+It selects which path a Clojure function call takes:
+
+```rust
+pub enum ExecutionMode {
+    TreeWalk,
+    Tiered,          // default
+    TieredNoJit,
+    NoGcTransaction,
+}
+```
+
+| Mode | Calls dispatch through | Promoted to | Use it for |
+|---|---|---|---|
+| `TreeWalk` | the tree-walking interpreter | `TreeWalk` | short-lived runtimes: one-shot evaluation, tests, config loading, per-request sandboxes |
+| `Tiered` | the IR-aware dispatcher | `Jit` | long-running hosts — the default, and what `cljrs run`/`repl` use |
+| `TieredNoJit` | the IR-aware dispatcher | `Ir` | long-running hosts that must not generate native code, or that want reproducible timing |
+| `NoGcTransaction` | the tree walker, behind a call-depth cap | `TreeWalk` | bounded evaluation of untrusted pure functions (this is what `cljrs-tx` builds) |
+
+## Tier state: what is live right now
+
+`ExecutionMode` is the *target*; `TierState` is the current reality.
+
+```rust
+pub enum TierState { TreeWalk = 0, Ir = 1, Jit = 2 }
+```
+
+Every runtime starts at `TreeWalk` — nothing can be lowered to IR before
+`clojure.core` exists — and `build()` raises it once, at the very end of
+bootstrap, to the mode's target tier. It only ever moves up, and only that
+once; `runtime.tier_state()` reports where it landed.
+
+The distinction matters because "not tree-walking" is not one thing:
+`TieredNoJit` stops at Tier 1 and stays there **even if a JIT backend is linked
+into your binary**, which a single "compiler ready" flag could not express.
+
+```rust
+let runtime = Runtime::builder()
+    .execution_mode(ExecutionMode::TieredNoJit)
+    .build()?;
+assert_eq!(runtime.tier_state(), TierState::Ir);   // after bootstrap
+```
+
+## How a function heats up in `Tiered` mode
+
+1. **Tree walk.** Every function starts here. Calls are counted.
+2. **Tier 1 — IR.** After roughly 50 calls the arity is queued for background
+   lowering on the `cljrs-ir-lower` worker thread; once its IR is published,
+   calls run on the register-based IR interpreter instead.
+3. **Tier 2 — native.** After roughly 1,000 calls the arity is queued for JIT
+   compilation, and subsequent calls jump straight to native code. Long-running
+   loops can transfer mid-execution through on-stack replacement.
+
+Lowering and compilation happen off the evaluation thread, so a call that is
+"hot enough" does not block while its faster version is built — it keeps running
+at the current tier until the new one is published.
+
+## Attaching the JIT
+
+`Tiered` mode only *targets* native dispatch. Tier 2 requires a JIT backend,
+which lives in `cljrs-compiler` and is not linked in unless you install it:
+
+```rust
+let runtime = Runtime::builder()
+    .execution_mode(ExecutionMode::Tiered)
+    .build()?;
+
+cljrs_compiler::jit::install(&runtime);   // install BEFORE any guest code runs
+cljrs_stdlib::install(&runtime);
+```
+
+Without that call, `Tiered` behaves like `TieredNoJit`.
+
+**Install it before evaluating anything.** An arity that reaches the JIT
+threshold with no backend attached is marked as queued and never re-enqueued —
+that flag is what stops hot dispatch from re-queueing the same arity on every
+call — so a host that evaluates first and installs afterwards silently gets no
+JIT for whatever ran in between. `cljrs_compiler::jit::install_on(&globals)` is
+the same call for a host holding the `Arc<GlobalEnv>` rather than the `Runtime`.
+
+## Tuning
+
+Thresholds are **process-global**, not per runtime. Set them before building:
+
+```rust
+use cljrs_runtime::tiered::{set_ir_threshold, set_jit_threshold, set_osr_threshold};
+
+set_ir_threshold(10);      // bring IR lowering in sooner
+set_jit_threshold(500);    // and native compilation with it
+set_osr_threshold(5_000);  // loop iterations before on-stack replacement
+```
+
+| Variable | Effect |
+|---|---|
+| `CLJRS_NO_IR` | Pins any runtime built afterwards at `TierState::TreeWalk`. The escape hatch when you suspect a lowering bug. |
+| `CLJRS_IR_THRESHOLD` | Calls before background IR lowering (default 50). `u32::MAX` disables lowering. |
+| `CLJRS_JIT_THRESHOLD` | Calls before JIT compilation (default 1,000). |
+| `CLJRS_OSR_THRESHOLD` | Loop iterations before on-stack replacement. |
+| `CLJRS_EAGER_LOWER=1` | Lower every function at definition time instead of when it gets hot. Expensive; useful for reproducing lowering bugs. |
+| `CLJRS_IR_CACHE_TTL` | Seconds an idle lowered arity survives before the cold-IR sweep drops it (default 600). |
+| `CLJRS_NO_ASYNC_JIT` | Disables JIT compilation of `^:async` function bodies. |
+
+The programmatic setters take precedence over the environment variables, which
+in turn override the defaults. Note that `CLJRS_NO_JIT` is read by the **CLI**,
+not by the runtime: in a host program, whether a JIT is attached is decided by
+whether you call `jit::install`, so check the variable yourself if you want to
+honour it.
+
+## Pre-lowered IR
+
+`cljrs ir build` can serialise lowered IR to a bundle, and a host can replay it
+into a runtime's cache:
+
+```rust
+let loaded = cljrs_runtime::tiered::load_prebuilt_ir(&globals, &bundle);
+```
+
+It walks the namespaces, matches each function arity against a bundle key, and
+returns how many arities it installed — skipping the warm-up for those
+functions. No `cljrs` runtime path loads a bundle today; the command exists as a
+lowerer diagnostic, and this entry point is what an embedding host would use if
+it wanted to ship one.
+
+## `NoGcTransaction` and the depth cap
+
+`NoGcTransaction` routes calls through a depth-capped tree walker. Interpreted
+recursion consumes real Rust stack, so an unbounded recursion in guest code
+would overflow the host thread's stack and abort the *process* — not something a
+host can catch. The cap turns that into an ordinary evaluation error.
+
+```rust
+use cljrs_runtime::env::depth::DepthGuard;
+
+let runtime = Runtime::builder()
+    .execution_mode(ExecutionMode::NoGcTransaction)
+    .build()?;
+
+let _depth = DepthGuard::install(1_000);   // scoped to this invocation
+let result = eval(&form, &mut env);        // deeper nesting → EvalError::Runtime
+```
+
+The budget is thread-local and clears when the guard drops, including on
+unwind. With no guard installed the mode is exactly the plain tree walker.
+
+The name comes from its other half: built with the workspace's `no-gc` feature,
+this mode runs inside a region-allocated arena that is discarded wholesale when
+the invocation ends, with no collector and no write barriers. `cljrs-tx` packages
+that whole profile — see [Limits & sandboxing](sandboxing.md#running-untrusted-code).
+
+## Choosing
+
+- **Long-running host, trusted code** → `Tiered` plus `cljrs_compiler::jit::install`.
+  Pay the warm-up once, run fast forever.
+- **Long-running host, no native codegen** (a policy forbidding W^X pages, a
+  platform without a JIT, or a need for predictable timing) → `TieredNoJit`.
+- **Short-lived or one-shot** (evaluate a config file, run a test, handle one
+  request and drop the runtime) → `TreeWalk`. Populating an IR cache you will
+  throw away is pure overhead.
+- **Untrusted input** → `NoGcTransaction` with a depth cap and a gas meter, or
+  `cljrs-tx` for the packaged version.

--- a/docs/book/src/embedding/extensions.md
+++ b/docs/book/src/embedding/extensions.md
@@ -1,0 +1,165 @@
+# Extensions & native code
+
+A freshly built runtime knows `clojure.core` and nothing else. Everything
+beyond it — the standard library, `core.async`, file I/O, sockets, codecs, your
+own Rust functions — installs itself into the finished runtime. Nothing is
+implicit, so a host that only wants pure data transformation never links a
+socket API into its binary.
+
+```rust
+let runtime = Runtime::builder().build()?;
+
+cljrs_compiler::jit::install(&runtime);   // Tier 2 (before any guest code)
+cljrs_stdlib::install(&runtime);          // clojure.string, clojure.set, …
+```
+
+Every `install`/`init` in this chapter is idempotent, so calling one twice is
+harmless.
+
+## The standard library
+
+`cljrs_stdlib::install(&runtime)` registers these namespaces:
+
+| Namespace | Notes |
+|---|---|
+| `clojure.string` | native helpers plus Clojure source |
+| `clojure.set` | native helpers plus Clojure source |
+| `clojure.walk`, `clojure.data`, `clojure.zip`, `clojure.template` | pure Clojure |
+| `clojure.test` | pure Clojure |
+| `clojure.spec.alpha`, `clojure.spec.gen.alpha`, `clojure.spec.test.alpha` | generators are throwing stubs |
+| `clojure.edn` | not available on `wasm32` (uses `std::fs`) |
+| `clojure.rust.io` | synchronous file I/O; not available on `wasm32` |
+
+They are registered as **embedded sources**, so each is parsed and evaluated on
+its first `require` rather than at install time. Installing the whole stdlib
+therefore costs almost nothing until guest code asks for a namespace.
+
+`cljrs_stdlib::register(&globals)` is the same call for a host holding the
+`Arc<GlobalEnv>`.
+
+Note that this is all-or-nothing: there is no "stdlib without `clojure.rust.io`"
+switch. If your concern is what guest code can reach, see [Limits &
+sandboxing](sandboxing.md) — the answer is not to skip the stdlib, because
+`clojure.core` itself has `slurp` and `spit`.
+
+## Async, I/O, and networking
+
+These extensions need a Tokio `LocalSet` — they spawn tasks with `spawn_local`,
+and `cljrs_async::init` starts a background GC-service task immediately. Two
+consequences for a host:
+
+1. Call `init` **from inside** the `LocalSet`, not before it.
+2. Drive each top-level form on that same `LocalSet`, or spawned tasks (channel
+   producers, `^:async` bodies, I/O readers) never make progress.
+
+```rust
+let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+let local = tokio::task::LocalSet::new();
+
+let globals = runtime.globals();
+local.block_on(&rt, async {
+    cljrs_async::init(globals);     // clojure.core.async, clojure.rust.error
+    cljrs_io::init(globals);        // clojure.rust.io.async
+    cljrs_net::init(globals);       // clojure.rust.net.* (calls cljrs_async::init itself)
+    cljrs_charset::init(globals);   // clojure.rust.charset
+});
+cljrs_base64::init(globals);        // cljrs.base64 — no async requirement
+```
+
+| Crate | Namespaces | Requires |
+|---|---|---|
+| `cljrs-async` | `clojure.core.async`, `clojure.rust.error` | a `LocalSet` |
+| `cljrs-io` | `clojure.rust.io.async` | `cljrs_async::init` + a `LocalSet` |
+| `cljrs-net` | `clojure.rust.net`, `.tcp`, `.udp`, `.tls`, `.unix`, `.frame`, `.quic`, `.h3`, `.http2` | a `LocalSet` (initialises async itself) |
+| `cljrs-charset` | `clojure.rust.charset`; `init_async` adds `clojure.rust.charset.async` | `init` is synchronous; `init_async` needs async + a `LocalSet` |
+| `cljrs-base64` | `cljrs.base64` | nothing |
+
+The CLI's own evaluation loop is the reference implementation: it builds the
+runtime and the `LocalSet` once, then drives every top-level form with
+`LocalSet::block_on`, so tasks that outlive one form stay queued and continue on
+the next form's drive. Deliberately, it does **not** wrap the whole session in a
+single outer `block_on` — that would panic when a per-form `block_on` nests
+inside it.
+
+Without a driver installed, evaluation still works; it is simply synchronous,
+and anything that depends on a spawned task will not complete.
+
+## Exposing your own Rust functions
+
+The `Registry` is the same object described in [Rust
+interop](../rust-interop/registry.md), but an embedding host constructs it
+directly rather than exporting a `cljrs_init` symbol for a dylib to be loaded
+through:
+
+```rust
+use cljrs_interop::{Registry, wrap_fn1, wrap_fn2};
+
+let registry = Registry::new(runtime.globals().clone());
+
+registry.define(
+    "acme.native/add",
+    wrap_fn2("add", |a: i64, b: i64| Ok::<i64, String>(a + b)),
+);
+registry.define(
+    "acme.native/config-value",
+    wrap_fn1("config-value", move |key: String| {
+        host_config.get(&key).cloned().ok_or_else(|| format!("no such key: {key}"))
+    }),
+);
+```
+
+Guest code then calls `(acme.native/add 3 4)`. Constructing a `Registry` also
+registers every `#[export]`-annotated function in the binary via `inventory`, so
+the [`#[export]` macro](../rust-interop/export-macro.md) works in a host program
+exactly as it does in a dylib.
+
+The wrappers marshal arguments and return values automatically for the types
+implementing `FromValue`/`IntoValue` — `bool`, `i64`, `f64`, `String`, `BigInt`,
+`Option<T>`, `Vec<Value>`, and `Value` itself. Anything else crosses as an
+opaque `NativeObject`. A closure passed to `wrap_fn*` may capture host state, as
+above; that is the usual way to give guest code a keyhole onto the host rather
+than a general capability.
+
+A native function that needs to call *back* into Clojure — a comparator, a
+callback, a hook — uses `cljrs_runtime::tiered::invoke`, which is covered in
+[Evaluating code](evaluating.md#calling-clojure-from-rust).
+
+## Making namespaces resolvable
+
+Guest code reaches a namespace through `require`, which resolves in this order:
+
+1. **Already loaded** — anything an extension registered, or a previous
+   `require` evaluated.
+2. **A registered compiled-namespace loader** — how an AOT-produced binary
+   supplies its own namespaces.
+3. **Embedded sources** — namespaces registered with
+   [`builtin_source`](runtime-builder.md#builtin_source), evaluated on first use.
+4. **Source paths** — the first `<path>/<rel>.cljrs` or `<path>/<rel>.cljc` that
+   exists, where `<rel>` is the namespace with dots turned into slashes and
+   dashes into underscores, searched across the configured
+   [source paths](runtime-builder.md#source_paths) in order.
+5. **A native-require hook**, if the host installed one (the CLI does, for
+   `:rust/load :dylib` dependencies).
+
+A host that ships its Clojure inside the binary uses (3) and can leave the
+source paths empty; a host that wants operators to drop `.cljc` files into a
+plugins directory uses (4). A namespace found nowhere raises
+`Could not find namespace <ns> on source path`.
+
+## Serving an editor
+
+An embedded runtime can expose the same tooling surface the CLI does. The nREPL
+server takes the `Arc<GlobalEnv>` and runs its network side on its own thread,
+handing jobs back to your interpreter thread as plain `Send` data:
+
+```rust
+let server = cljrs_nrepl::start(cljrs_nrepl::Config::default(), globals.clone())?;
+println!("nREPL listening on port {}", server.port());
+server.serve()?;   // blocks this thread, processing evals
+```
+
+That gives editors (CIDER, Calva, Conjure) a live connection into your running
+application — the same runtime, the same namespaces, your native functions
+included. `cljrs-lsp` is a separate, purely syntactic server (parse diagnostics
+and a document-symbol outline); it never invokes the evaluator, so it does not
+need your runtime at all.

--- a/docs/book/src/embedding/index.md
+++ b/docs/book/src/embedding/index.md
@@ -1,0 +1,111 @@
+# Embedding clojurust
+
+Everything the `cljrs` CLI does — `run`, `repl`, `eval`, `test`, `nrepl` — it
+does through a public Rust API that your own program can call. Embedding means
+building a clojurust runtime inside a larger Rust application and evaluating
+Clojure in it: a scripting layer for a game or an editor, a rules engine whose
+policies ship separately from the binary, a plugin host, or a service that
+exposes an nREPL port so operators can inspect it live.
+
+The API is small. Four steps cover every embedding:
+
+1. **Build** a runtime with [`Runtime::builder()`](runtime-builder.md) — this is
+   where you pick the [execution mode](execution-modes.md), source paths, and GC
+   limits.
+2. **Attach** the tiers and [extensions](extensions.md) you want: the JIT, the
+   standard library, async/IO/networking, your own native functions.
+3. **Evaluate** Clojure forms in an `Env` and [move values across the
+   boundary](evaluating.md).
+4. **Bound** what the guest code may do, if it is not fully trusted — see
+   [Limits & sandboxing](sandboxing.md).
+
+## A minimal host
+
+```rust
+use cljrs_reader::Parser;
+use cljrs_runtime::tiered::{Env, EvalError, eval};
+use cljrs_runtime::{ExecutionMode, Runtime};
+use cljrs_value::Value;
+
+fn main() {
+    // 1. Build.
+    let runtime = Runtime::builder()
+        .execution_mode(ExecutionMode::Tiered)
+        .source_paths(vec!["src".into()])
+        .build()
+        .expect("bootstrap clojure.core");
+
+    // 2. Attach the standard library.
+    cljrs_stdlib::install(&runtime);
+
+    // 3. Evaluate.
+    let mut env = runtime.env("user");
+    let value = eval_str(&mut env, "(+ 1 2)").expect("eval");
+    println!("{value}");   // => 3
+}
+
+/// Parse `src` and evaluate every form in it, returning the last value.
+fn eval_str(env: &mut Env, src: &str) -> Result<Value, EvalError> {
+    let mut parser = Parser::new(src.to_string(), "<host>".to_string());
+    let forms = parser.parse_all().map_err(EvalError::Read)?;
+    let mut result = Value::Nil;
+    for form in &forms {
+        // One allocation frame per top-level form: it roots everything the
+        // form allocates, and releases it when the form is done.
+        let _frame = cljrs_gc::push_alloc_frame();
+        result = eval(form, env)?;
+    }
+    Ok(result)
+}
+```
+
+That is a complete embedding. `build()` registers native `clojure.core`,
+evaluates the Clojure bootstrap, creates a `user` namespace that refers it, and
+raises the runtime to its target tier; `install` adds `clojure.string`,
+`clojure.set`, `clojure.test`, and the rest.
+
+## Which crates you depend on
+
+| Crate | You need it for |
+|---|---|
+| `cljrs-runtime` | `Runtime`, `RuntimeBuilder`, `Env`, `eval` — always |
+| `cljrs-value` | the `Value` enum you pass in and get back — always |
+| `cljrs-reader` | `Parser`, turning source text into forms — always |
+| `cljrs-gc` | `GcConfig`, `push_alloc_frame` — almost always |
+| `cljrs-stdlib` | `clojure.string`, `clojure.set`, `clojure.edn`, `clojure.test`, … |
+| `cljrs-compiler` | the JIT tier (`jit::install`), and AOT compilation |
+| `cljrs-async`, `cljrs-io`, `cljrs-net`, `cljrs-charset`, `cljrs-base64` | `core.async`, file I/O, sockets, codecs |
+| `cljrs-interop` | exposing your Rust functions to Clojure |
+| `cljrs-nrepl` | letting editors connect to your embedded runtime (`cljrs-lsp` is syntactic only and needs no runtime) |
+| `cljrs-tx` | running untrusted pure functions under hard limits |
+
+None of these pull in `clap`, `rustyline`, or the rest of the CLI — the `cljrs`
+binary crate is one consumer of this API, not a layer under it.
+
+## Two rules that shape every embedding
+
+**A runtime is confined to one thread.** `GcPtr` — and therefore `Value`, `Env`,
+`GlobalEnv`, and `Runtime` — is `!Send`. This is enforced by the compiler, not by
+convention: `fn assert_send<T: Send>()` fails to compile for `Runtime`. Build
+the runtime on the thread that will evaluate in it, and keep it there. Each
+thread that hosts a runtime gets its own GC heap and collects independently, so
+several runtimes on several threads scale without coordinating; values move
+between them by copying, never by aliasing. See [Worker
+isolation](../async-io/isolation.md) for that boundary, and
+[Evaluating](evaluating.md#threads-and-runtimes) for the host-side rules.
+
+**Values are garbage-collected, and the collector needs to see yours.** A
+`Value` sitting in a host struct is not a root by itself. Anything reachable
+from a namespace is safe; anything else needs an allocation frame or an explicit
+root guard for as long as you hold it. [Evaluating](evaluating.md#gc-discipline)
+spells out the three cases.
+
+## Chapter overview
+
+| Page | Contents |
+|---|---|
+| [The runtime builder](runtime-builder.md) | Every builder option, what `build()` does, the `Runtime` handle |
+| [Execution modes](execution-modes.md) | `TreeWalk`, `Tiered`, `TieredNoJit`, `NoGcTransaction`; tier promotion; JIT thresholds |
+| [Extensions & native code](extensions.md) | Installing the stdlib, async/IO/net, and your own Rust functions |
+| [Evaluating code](evaluating.md) | Parsing, `Env`, calling Clojure from Rust, marshalling, errors, GC discipline |
+| [Limits & sandboxing](sandboxing.md) | Memory limits, gas metering, depth caps, and what is *not* sandboxed |

--- a/docs/book/src/embedding/runtime-builder.md
+++ b/docs/book/src/embedding/runtime-builder.md
@@ -1,0 +1,205 @@
+# The runtime builder
+
+`Runtime::builder()` is the **only** way to construct a runtime. There is no
+`standard_env`, no `minimal_env`, no `_with_paths` variant: execution mode,
+source paths, GC configuration, embedded sources, and tier enablement are all
+inputs to one builder, and extensions install themselves into the finished
+runtime afterwards.
+
+```rust
+use cljrs_runtime::{ExecutionMode, Runtime};
+
+let runtime = Runtime::builder()
+    .execution_mode(ExecutionMode::Tiered)
+    .source_paths(vec!["src".into(), "resources".into()])
+    .gc_config(config)
+    .build()?;
+```
+
+Every option has a default, so `Runtime::builder().build()?` is a valid runtime:
+tiered execution, no source paths, GC limits taken from the environment,
+namespace roots registered.
+
+## Options
+
+| Method | Default | Effect |
+|---|---|---|
+| `execution_mode(ExecutionMode)` | `Tiered` | Which call path the runtime uses, and which tier it is promoted to. See [Execution modes](execution-modes.md). |
+| `source_paths(Vec<PathBuf>)` | empty | Directories searched when `require` resolves a namespace to a file on disk. |
+| `gc_config(Arc<GcConfig>)` | none | Explicit soft/hard heap limits. Applied *after* the environment defaults, so it wins. |
+| `gc_config_from_env(bool)` | `true` | Whether to apply `CLJRS_GC_SOFT_LIMIT_MB` / `CLJRS_GC_HARD_LIMIT_MB` (and their system-derived defaults) to the heap. |
+| `register_gc_roots(bool)` | `true` | Whether this runtime's namespace table is registered as a GC root set. |
+| `builtin_source(ns, &'static str)` | none | Embed a namespace's Clojure source in the binary so `require` resolves it without a file. Repeatable. |
+| `eager_clojure_test(bool)` | `false` | Evaluate `clojure.test` during construction instead of on first `require`. |
+| `build()` | — | Bootstrap and return `Result<Runtime, BuildError>`. |
+
+### `execution_mode`
+
+The one option worth deciding deliberately. It fixes how function calls
+dispatch for the life of the runtime and cannot be changed afterwards —
+[Execution modes](execution-modes.md) covers the four choices and when each one
+is right.
+
+### `source_paths`
+
+These are the roots `require` searches, in order, when a namespace is not
+already loaded and is not registered as an embedded source. A host that never
+wants guest code reading from disk can leave them empty — though note that an
+empty source path is not by itself a sandbox, since `clojure.core` still has
+`slurp` and `spit`. See [Limits & sandboxing](sandboxing.md).
+
+Paths can also be appended after construction through
+`globals.source_paths` (an `RwLock<Vec<PathBuf>>`); that is how the CLI merges
+`:paths` from `cljrs.edn` on top of its command-line flags.
+
+### `gc_config` and `gc_config_from_env`
+
+`GcConfig` carries two numbers: a **soft limit** that triggers a collection when
+exceeded, and a **hard limit** that forces one.
+
+```rust
+use std::sync::Arc;
+use cljrs_gc::GcConfig;
+
+let runtime = Runtime::builder()
+    .gc_config_from_env(false)                       // ignore CLJRS_GC_* entirely
+    .gc_config(Arc::new(GcConfig::with_limits(
+        64 * 1024 * 1024,                            // soft: 64 MB
+        128 * 1024 * 1024,                           // hard: 128 MB
+    )))
+    .build()?;
+```
+
+Constructors: `GcConfig::new()` (hard limit derived from system memory, soft at
+75% of it), `GcConfig::with_hard_limit(bytes)` (soft at 75% of it), and
+`GcConfig::with_limits(soft, hard)`.
+
+The two options compose in a fixed order: environment settings are applied
+first, then any explicit `gc_config` overwrites them. Leave
+`gc_config_from_env` on if you want operators to be able to tune the heap
+without a rebuild; turn it off if your host must be the only thing that decides
+its own memory budget.
+
+The heap those limits configure is **per thread**, not per process — each
+thread that runs a runtime owns an independent heap and collects it
+independently.
+
+### `register_gc_roots`
+
+On by default, and you almost certainly want it: it registers the runtime's
+namespace table with the collector, so vars, their values, and everything
+reachable from them stay alive. The tracer holds a **weak** handle to the
+environment, so dropping the last `Runtime` handle stops it from being a root
+rather than pinning it forever through the heap's tracer list — which is what
+makes several sequential runtimes in one process safe.
+
+Turn it off only if you are constructing an environment you will root yourself.
+
+### `builtin_source`
+
+Embeds Clojure source in your binary and makes it resolvable by name:
+
+```rust
+const RULES: &str = include_str!("../clj/acme/rules.cljc");
+
+let runtime = Runtime::builder()
+    .builtin_source("acme.rules", RULES)
+    .build()?;
+```
+
+Guest code can now `(require '[acme.rules :as rules])` with no file on disk.
+Sources registered this way are parsed and evaluated on their **first
+`require`**, not at build time, so registering a dozen namespaces costs nothing
+until they are used. This is exactly how `cljrs-stdlib` ships `clojure.string`
+and friends.
+
+### `eager_clojure_test`
+
+Evaluates the embedded `clojure.test` during construction. Only useful when you
+are *not* installing an extension that already registers it lazily
+(`cljrs-stdlib` does), so most hosts leave it alone.
+
+## What `build()` does, in order
+
+1. Creates a `GlobalEnv` carrying the chosen execution mode.
+2. Registers the native `clojure.core` functions.
+3. Creates the `user` namespace and refers `clojure.core` into it.
+4. Parses and evaluates the Clojure bootstrap source (the higher-order
+   functions that are defined in Clojure rather than Rust), then re-refers
+   `clojure.core` so the new definitions are visible, and marks it loaded.
+5. Registers any `builtin_source` namespaces, and evaluates `clojure.test` if
+   `eager_clojure_test` was set.
+6. Applies source paths, then GC configuration (environment first, explicit
+   config second), then registers namespace GC roots.
+7. Resynchronises `*ns*` to `user`.
+8. Raises the tier state to what the execution mode targets.
+
+Step 8 is last for a reason: the bootstrap itself always tree-walks, because
+nothing can be lowered to IR before `clojure.core` exists. Functions defined
+before that point are marked as bootstrap and stay excluded from background
+lowering.
+
+### `BuildError`
+
+```rust
+pub enum BuildError {
+    EmbeddedSource { origin: String, message: String },
+}
+```
+
+The only failure mode, and it means the *binary's own* embedded text failed to
+parse — a broken bootstrap or a malformed `builtin_source`, not anything a user
+did. An individual bootstrap form that fails to *evaluate* is reported on stderr
+and skipped rather than failing the build.
+
+## The `Runtime` handle
+
+```rust
+impl Runtime {
+    pub fn builder() -> RuntimeBuilder;
+    pub fn from_globals(globals: Arc<GlobalEnv>) -> Runtime;
+    pub fn globals(&self) -> &Arc<GlobalEnv>;
+    pub fn into_globals(self) -> Arc<GlobalEnv>;
+    pub fn env(&self, ns: &str) -> Env;
+    pub fn execution_mode(&self) -> ExecutionMode;
+    pub fn tier_state(&self) -> TierState;
+}
+```
+
+`Runtime` is a cheap, cloneable handle: all state lives in the shared
+`GlobalEnv`, so a clone **names the same runtime** rather than creating a new
+one. Clone it freely to hand to extension `install` functions.
+
+- `env(ns)` gives you a fresh evaluation context in namespace `ns` — this is
+  what you evaluate against. Creating one is cheap; make one per request, per
+  REPL session, or per task as suits your host.
+- `globals()` / `into_globals()` reach the `Arc<GlobalEnv>` underneath, which is
+  what extension `init` functions and the nREPL/LSP servers take.
+- `from_globals(...)` goes the other way, for code that is handed an
+  `Arc<GlobalEnv>` (a native package loader, an AOT harness) and needs a
+  `Runtime` to pass to an `install`.
+
+## Environment variables that affect construction
+
+| Variable | Read by | Effect |
+|---|---|---|
+| `CLJRS_GC_SOFT_LIMIT_MB` | `build()`, when `gc_config_from_env` is on | Soft heap limit in MB (default: a third of system memory). |
+| `CLJRS_GC_HARD_LIMIT_MB` | same | Hard heap limit in MB (defaults to the soft limit). |
+| `CLJRS_NO_IR` | `build()` | Pins the runtime at `TierState::TreeWalk` regardless of the execution mode. |
+| `CLJRS_GC_STATS` | `cljrs_gc::dump_stats_from_env()` | Where to write a `GC_STATS` snapshot — unset does nothing, empty or `-` means stdout, anything else is a file path. Nothing reads it on its own; call `dump_stats_from_env()` at exit if you want the behaviour the CLI's `--gc-stats` flag gives. |
+
+Runtime-tuning variables that are read later (IR/JIT thresholds, eager
+lowering) are listed under [Execution modes](execution-modes.md#tuning).
+
+## Several runtimes in one process
+
+Two situations, with different answers:
+
+- **Sequentially on one thread** — build, use, drop, build again. Runtime
+  identity is a counter-allocated `GlobalEnv::id`, not a memory address, so a
+  fresh runtime can never inherit a dropped one's IR cache. Combined with the
+  weak root tracer, dropping a runtime really does release it.
+- **Concurrently** — one runtime per thread, each built on the thread that uses
+  it. Since `Runtime` is `!Send` there is no other option, and the heaps stay
+  independent. Move data between them with isolate channels or `shared-atom`;
+  see [Worker isolation](../async-io/isolation.md).

--- a/docs/book/src/embedding/sandboxing.md
+++ b/docs/book/src/embedding/sandboxing.md
@@ -1,0 +1,185 @@
+# Limits & sandboxing
+
+An embedded interpreter runs code that came from somewhere else. How much you
+need to bound it depends on where that code came from — a config file in your
+own repository is not the same problem as a rule a customer typed into a form.
+
+This page covers the three resource bounds a host can apply to an ordinary
+runtime, then the capability question, which is where the honest answer matters
+most: **an ordinary clojurust runtime is not a security sandbox.** Bounding it
+takes a different execution profile.
+
+## Memory
+
+Each thread's heap is bounded by a [`GcConfig`](runtime-builder.md#gc_config-and-gc_config_from_env):
+a soft limit that triggers collection and a hard limit that forces one.
+
+```rust
+use cljrs_gc::GcConfig;
+
+Runtime::builder()
+    .gc_config_from_env(false)                    // operators can't widen it
+    .gc_config(Arc::new(GcConfig::with_limits(32 << 20, 64 << 20)))
+    .build()?
+```
+
+This bounds the *managed* heap — GC-allocated Clojure values. It is not an RSS
+ceiling: ordinary Rust allocations made by native functions are not charged
+against it. If you need a hard address-space limit against adversarial code, it
+has to come from outside the process (a container limit, `setrlimit`, a WASM
+linear-memory bound).
+
+## CPU: gas metering
+
+A gas meter is a cooperative execution-credit budget. Every tier charges
+against it — the tree walker at each evaluation step, the IR interpreter per
+basic block, and JIT-compiled native code through the runtime ABI — so a hot
+loop cannot outrun its budget by getting compiled.
+
+```rust
+use cljrs_runtime::env::gas::{GasGuard, GasMeter};
+
+let meter = GasMeter::new(10_000);
+let guard = GasGuard::install(meter.clone());
+let result = eval_str(&mut env, untrusted_src, "<guest>");
+drop(guard);
+
+match result {
+    Err(EvalError::GasExhausted) => { /* over budget — meter.remaining() == 0-ish */ }
+    other => other?,
+}
+```
+
+`cljrs_runtime::tiered::eval_with_gas(&form, &mut env, credits)` is the
+one-liner version: it installs a fresh meter for one form and drops it
+afterwards.
+
+Properties worth knowing:
+
+- **Installation is thread-local and scoped.** The guard uninstalls on drop,
+  including on unwind.
+- **Nested meters are charged together**, so an inner evaluation cannot escape an
+  outer budget by installing a smaller one of its own.
+- **Exhaustion does not poison an outer scope.** An inner budget running out
+  leaves the enclosing evaluation able to continue.
+- **Async tasks carry the meter with them** — compiled state machines capture the
+  active meter stack when spawned and reinstall it when polled.
+- **Unmetered code is free.** With no meter installed, `charge` always succeeds;
+  metering costs a thread-local check.
+
+Because charging is per evaluation step rather than per wall-clock tick, a
+budget is reproducible across machines — but it is not a timeout. A native
+function that blocks (a slow syscall in a host-provided builtin) consumes no
+gas. Keep host builtins non-blocking, or enforce time separately.
+
+## Stack: the call-depth cap
+
+Interpreted recursion consumes real Rust stack, and an overflow aborts the
+process rather than raising an error your host can catch. A runtime built in
+[`ExecutionMode::NoGcTransaction`](execution-modes.md#nogctransaction-and-the-depth-cap)
+routes calls through a depth-capped path:
+
+```rust
+use cljrs_runtime::env::depth::DepthGuard;
+
+let _depth = DepthGuard::install(1_000);
+```
+
+Exceeding it returns `EvalError::Runtime` with the depth-exceeded message. Size
+the evaluating thread's stack to comfortably cover the cap you set —
+interpreted frames can run to a few kilobytes each. (`cljrs --stack-size-mb` is
+the CLI's version of that decision; a host does it with
+`std::thread::Builder::stack_size`.)
+
+## Capabilities: what guest code can reach
+
+`clojure.core` — which every runtime has, before any extension is installed —
+includes `slurp`, `spit`, `println`, `rand`, clock access, and `new` for Rust
+object construction. So:
+
+- Leaving `source_paths` empty does not prevent file access.
+- Skipping `cljrs_stdlib::install` does not prevent file access either. It only
+  removes `clojure.string`, `clojure.set`, `clojure.edn`, `clojure.rust.io`, and
+  friends.
+- Not installing `cljrs-net`/`cljrs-io` *does* keep sockets and async file I/O
+  out of the binary — extensions are genuinely opt-in, and that is a real
+  reduction in reachable surface.
+
+For code you wrote or reviewed, that is usually fine: resource limits are the
+thing you actually want, and the guest is not adversarial. For code you did not
+write, it is not enough.
+
+## Running untrusted code
+
+The isolation boundary that does exist is the **transaction profile**: a fresh
+environment, in a bounded arena, tree-walking only, under a capability denylist,
+with pure data crossing in and out. `cljrs-tx` packages it:
+
+```rust
+use cljrs_tx::{TxLimits, TxProgram, execute};
+
+let program = TxProgram::parse("(fn [x] (* x 2))")?;
+let result = execute(
+    &program,
+    vec![arg],                                   // SerializedValue in
+    TxLimits { memory_bytes: 8 << 20, gas: 100_000, call_depth: 256 },
+)?;                                              // SerializedValue out
+```
+
+`execute` builds and bootstraps a new interpreter environment inside one bounded
+arena, structure-clones the arguments in, invokes the function under a gas meter
+and the transaction capability policy, clones a pure-data result out, and
+destroys the whole environment. Nothing survives the call.
+
+The policy that makes it a boundary is `TransactionPolicyGuard`, in
+`cljrs_runtime::env::policy`. While it is active, a denylist is enforced at the
+final call boundary of every native builtin and special form:
+
+| Denied | Examples |
+|---|---|
+| Filesystem | `slurp`, `spit`, `close` |
+| Output | `print`, `println`, `pr`, `prn`, `printf`, `newline`, `flush` |
+| Clocks & randomness | `nanotime`, `sleep`, `rand`, `rand-int`, `random-sample`, `shuffle`, `random-uuid` |
+| Process-global state | `gensym`, `add-tap`, `remove-tap`, `tap>`, `shared-atom` |
+| Concurrency | `promise`, `deliver`, `send`, `send-off` |
+| Rust interop | `new`, `Exception.` |
+| Loading & namespaces | `.`, `ns`, `require`, `in-ns`, `alias`, `load-file`, `with-out-str`, `await` |
+| Versioned lookup | resolution of `sym@commit` |
+
+Violations surface as `EvalError::ForbiddenEffect(operation)`, naming what was
+attempted. A host can install the guard directly around its own evaluation if it
+wants that denylist without the rest of the `cljrs-tx` profile — but note that
+the guard alone is one layer, not the whole boundary; the fresh environment and
+the arena are the other two.
+
+Where guest code genuinely needs to read host state, `execute_with_host` interns
+each `HostApi` entry as a namespaced native function (`my.host/lookup`). That is
+the *only* seam through the boundary: arguments are serialized out and validated
+as pure data, results are validated and cloned back in, and no live handle ever
+enters the arena. Keep those functions deterministic, side-effect-free reads.
+
+Build `cljrs-tx` with its `no-gc` feature (`cargo test -p cljrs-tx --features
+no-gc`); it is off by default so a normal workspace build does not unify every
+dependency into arena mode.
+
+### What the transaction profile still does not give you
+
+- **Not a hard RSS limit.** `memory_bytes` covers arena object boxes and
+  out-of-line memory reported by `Trace::gc_size_extra`. Ordinary Rust
+  allocations outside traced values are not fully charged. An adversarial
+  address-space ceiling still needs a process or WASM sandbox around it.
+- **Not a wall-clock timeout.** Gas bounds work, not time.
+- **Not a stack guarantee by itself.** `call_depth` caps interpreted frames; the
+  thread's stack still has to be big enough for the depth you allow.
+- **No I/O, no async, no JIT, no Rust interop** inside it, by construction — that
+  is the point, but it means transaction functions are pure computations over
+  data, not general programs.
+
+## A checklist
+
+| Guest code is… | Do this |
+|---|---|
+| Yours, in your repo | `Tiered` + JIT, GC limits from the environment. Nothing else. |
+| Yours, but a runaway loop would be embarrassing | Add a gas meter around each top-level evaluation. |
+| Written by users who can already run code on the box | Gas meter, explicit `GcConfig`, empty source paths, install only the extensions you need. |
+| Genuinely untrusted | `cljrs-tx` with `TxLimits`, host reads through `HostApi`, and an OS-level limit around the process. |

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -12,6 +12,7 @@ can AOT-compile programs to standalone native binaries.
 - **Garbage collector** — a tracing GC manages all Clojure values; an optional region-based allocator is available for allocation-heavy code paths.
 - **AOT compilation** — `cljrs compile` produces a standalone native binary via Cranelift, or a WebAssembly module with `--target wasm`. See the [WebAssembly](wasm/index.md) chapter.
 - **Async & I/O** — `clojure.core.async` channels and non-blocking file I/O ship as optional crates layered over the interpreter. See the [Async & I/O](async-io/index.md) chapter.
+- **Embeddable** — the same runtime the CLI drives can be built inside your own Rust program as a scripting, rules, or plugin layer. See the [Embedding](embedding/index.md) chapter.
 
 ## Source file extensions
 

--- a/docs/book/src/rust-interop/index.md
+++ b/docs/book/src/rust-interop/index.md
@@ -13,6 +13,11 @@ integration. The interop layer has two modes that work together:
 Both modes use the same API: a `Registry` object that maps Clojure-visible
 names to Rust functions.
 
+A third arrangement inverts the relationship: instead of `cljrs` loading your
+Rust, *your* program builds a runtime and registers its own functions into it.
+That is the [Embedding](../embedding/index.md) chapter, and it uses the same
+`Registry` described here.
+
 ## When to use Rust interop
 
 - Wrapping an existing Rust library (e.g. a database driver, image codec, or


### PR DESCRIPTION
The runtime has had one public construction path since the crate
consolidation, but the book only documented driving it from the CLI or
loading Rust into it as a dylib. Nothing described the inverse — a Rust
program that builds a runtime and evaluates Clojure inside itself — even
though the CLI is just one consumer of that API.

Six pages under docs/book/src/embedding:

- index: what embedding is, the four-step lifecycle, which crates a host
  depends on, and the two constraints that shape everything (the runtime
  is !Send and thread-confined; the collector has to be able to see the
  host's values)
- runtime-builder: every RuntimeBuilder option with its default, the
  ordered account of what build() does, BuildError, the Runtime handle,
  the environment variables read during construction, and how several
  runtimes coexist in one process
- execution-modes: TreeWalk / Tiered / TieredNoJit / NoGcTransaction,
  TierState promotion and why the bootstrap always tree-walks, attaching
  the JIT (and why it must happen before any guest code runs), the
  threshold knobs, pre-lowered IR bundles, and guidance on choosing
- extensions: what the stdlib install registers, the LocalSet contract
  for async/io/net/charset, registering native functions through a
  Registry, how require resolves a namespace, and serving nREPL
- evaluating: the parse-and-eval loop, reading values back three ways,
  calling Clojure from Rust via apply_value and invoke, the EvalError
  variants, GC discipline (namespace roots, alloc frames, root guards),
  and the threading rules
- sandboxing: memory limits, gas metering across all three tiers, the
  depth cap, and an explicit statement that an ordinary runtime is not a
  security boundary — clojure.core has slurp/spit regardless of what the
  host installs — with cljrs-tx as the profile that is one, including
  what it still does not give you

Every snippet meant as real code has a counterpart in
crates/cljrs/tests/embedding_book_examples.rs, so the documented host API
breaks the build rather than drifting silently.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0115uhUteTY21RvkwVbzfdAF