### PR TITLE
Gate the runtime's git dependency behind a `deps` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,10 @@ cljrs-ir           = { path = "crates/cljrs-ir",           version = "0.1.0" }
 cljrs-compiler     = { path = "crates/cljrs-compiler",     version = "0.1.0" }
 cljrs-interop      = { path = "crates/cljrs-interop",      version = "0.1.0" }
 cljrs-export-macro = { path = "crates/cljrs-export-macro", version = "0.1.0" }
-cljrs-project      = { path = "crates/cljrs-project",      version = "0.1.0" }
+# Default-off so each member opts in to what it needs: the config model alone
+# (nothing extra), `vcs` for local git + signature verification, `vcs-net` for
+# network fetch. See crates/cljrs-project/Cargo.toml.
+cljrs-project      = { path = "crates/cljrs-project",      version = "0.1.0", default-features = false }
 cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0" }
 cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
 cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
@@ -81,10 +84,12 @@ tower-lsp     = "0.20"
 dashmap       = "6"
 
 # Pure-Rust git (gitoxide) + native commit-signature verification
+# The http transport (and with it reqwest/hyper/rustls/aws-lc-rs) is *not*
+# selected here: it comes from cljrs-project's `vcs-net` feature, so consumers
+# that only read local repositories do not link a TLS stack.
 gix      = { version = "0.84", default-features = false, features = [
     "sha1",
     "max-performance-safe",
-    "blocking-http-transport-reqwest-rust-tls",
     "revision",
     "worktree-mutation",
 ] }

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -24,6 +24,8 @@ tracing        = { workspace = true }
 # networking, charset, and Base64 are extensions the *host* selects and are
 # deliberately absent here — see `src/extensions.rs`.
 cljrs-async    = { workspace = true }
+# Only the `cljrs.edn` config model is used here; git operations go through
+# the runtime's `VcsProvider`.
 cljrs-project  = { workspace = true }
 cljrs-types    = { workspace = true }
 cljrs-ir       = { workspace = true }

--- a/crates/cljrs-project/Cargo.toml
+++ b/crates/cljrs-project/Cargo.toml
@@ -7,9 +7,25 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = ["vcs", "vcs-net"]
+
+# The `vcs` module: local git operations (gitoxide) plus commit-signature
+# verification (rPGP / ssh-key). Without it the crate is just the `cljrs.edn`
+# config model and has no dependencies outside the workspace.
+vcs = ["dep:gix", "dep:pgp", "dep:ssh-key"]
+
+# `fetch_remote` and friends: cloning/fetching a remote into the local cache.
+# Selects gix's blocking http transport, which is what pulls
+# reqwest/hyper/rustls/aws-lc-rs/tokio into the build — so consumers that only
+# *read* a local repository (the interpreter's versioned-var resolution, for
+# one) should leave this off. Note that gitoxide routes local-path and file://
+# clones through the same transport layer, so this gates all fetching, not just
+# the https:// case.
+vcs-net = ["vcs", "gix/blocking-http-transport-reqwest-rust-tls"]
+
 # Native pure-Rust SSH transport for ssh:// remotes (host keys verified
 # against ~/.ssh/known_hosts; ssh-agent authentication). Off by default.
-ssh = ["dep:russh", "dep:tokio", "dep:tokio-util"]
+ssh = ["vcs-net", "dep:russh", "dep:tokio", "dep:tokio-util"]
 
 [dependencies]
 cljrs-types  = { workspace = true }
@@ -18,11 +34,13 @@ cljrs-reader = { workspace = true }
 thiserror    = { workspace = true }
 
 # The `vcs` module is native-only: gitoxide and the signature verifiers do not
-# build for wasm32, and no wasm consumer resolves git dependencies.
+# build for wasm32, and no wasm consumer resolves git dependencies. It is also
+# feature-gated (`vcs`), so a consumer of the config model alone links none of
+# this.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gix       = { workspace = true }
-pgp       = { workspace = true }
-ssh-key   = { workspace = true }
+gix       = { workspace = true, optional = true }
+pgp       = { workspace = true, optional = true }
+ssh-key   = { workspace = true, optional = true }
 # Optional native SSH transport (enabled by the `ssh` feature).
 russh      = { workspace = true, optional = true }
 tokio      = { workspace = true, optional = true, features = [

--- a/crates/cljrs-project/README.md
+++ b/crates/cljrs-project/README.md
@@ -18,6 +18,27 @@ API under the new module paths.
 This is the same gating `cljrs-runtime` previously applied to the `cljrs-vcs`
 dependency itself.
 
+`vcs` is also **feature-gated**, in two tiers, so a consumer links only the
+weight it actually uses:
+
+- **`vcs`** — reading a local repository plus signature verification
+  (`find_repo_root`, `get_file_at_commit`, `worktree_at_commit`,
+  `checkout_tree`, `verify_commit_signature`). Pulls gitoxide, rPGP and
+  `ssh-key`, but **no** network stack.
+- **`vcs-net`** — `fetch_remote`, i.e. cloning/fetching a remote into the local
+  cache. This is what selects gix's blocking http transport and with it
+  reqwest/hyper/rustls/aws-lc-rs/tokio. Gitoxide routes *every* clone through
+  that transport layer, so `vcs-net` gates local-path and `file://` fetches
+  too, not only `https://`.
+
+Without either, the crate is just the `cljrs.edn` config model and has no
+dependencies outside the workspace. That is what lets `cljrs-runtime` embed
+the config model — and, under its own default `deps` feature, local git reads —
+without dragging a TLS stack into every embedding of the interpreter.
+
+The workspace dependency entry sets `default-features = false`, so each member
+opts in explicitly; only the `cljrs` binary takes `vcs-net`.
+
 All git operations run in-process via [`gix`] (gitoxide) — no `git` binary is
 required. Commit-signature verification is native: PGP signatures are checked
 with rPGP (`pgp`) and SSH signatures with `ssh-key`, against a caller-supplied
@@ -33,9 +54,15 @@ cache presence without network access.
 
 ## Features
 
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `ssh`   | off     | Native pure-Rust SSH transport (`russh`) for `ssh://`/scp-like remotes. Host keys are verified against `~/.ssh/known_hosts`; authentication is via a running ssh-agent (`$SSH_AUTH_SOCK`). The `cljrs` binary enables this. |
+The crate's own `default` is `["vcs", "vcs-net"]`, but the workspace dependency
+entry sets `default-features = false`, so within this repo every member states
+what it needs.
+
+| Feature | Default | Enabled by | Description |
+|---------|---------|-----------|-------------|
+| `vcs`     | on (crate default) | `cljrs-runtime/deps`, `cljrs` | The `vcs` module: local git reads (gitoxide) and commit-signature verification (rPGP, `ssh-key`). No network stack. |
+| `vcs-net` | on (crate default) | `cljrs` | `fetch_remote`: clone/fetch a remote into the local cache. Selects gix's blocking http transport, and with it reqwest/hyper/rustls/aws-lc-rs/tokio. Implies `vcs`. |
+| `ssh`     | off     | `cljrs` | Native pure-Rust SSH transport (`russh`) for `ssh://`/scp-like remotes. Host keys are verified against `~/.ssh/known_hosts`; authentication is via a running ssh-agent (`$SSH_AUTH_SOCK`). Implies `vcs-net`. |
 
 [`gix`]: https://docs.rs/gix
 
@@ -43,7 +70,7 @@ cache presence without network access.
 
 | File | Description |
 |------|-------------|
-| `src/lib.rs` | Crate root; declares `config` and the native-only `vcs` |
+| `src/lib.rs` | Crate root; declares `config` and the native-only, `vcs`-feature-gated `vcs` |
 | `src/config.rs` | `cljrs.edn` types (`DepsConfig`, `RustConfig`, `Dependency`, `Alias`, `GitDep`, `TrustedSigner`), `find_config_file`, `load_config` |
 | `src/config/parse.rs` | Walk the `cljrs-reader` Form tree from `cljrs.edn` source into `DepsConfig` |
 | `src/vcs.rs` | `VcsError` and the `gix`-backed git operations |
@@ -118,7 +145,7 @@ pub enum DepsError { Io(std::io::Error), Parse(String) }
 pub type DepsResult<T> = Result<T, DepsError>;
 ```
 
-### `cljrs_project::vcs` (native targets only)
+### `cljrs_project::vcs` (native targets, `vcs` feature)
 
 ```rust
 /// True if `s` is 7–40 lowercase or uppercase hex characters.
@@ -139,6 +166,9 @@ pub fn cache_path_for_url(url: &str) -> PathBuf
 
 /// Clone or fetch `url` (https/local/file), ensuring `sha` is present locally.
 /// Returns the path to the bare repo in the cache.
+/// Requires the `vcs-net` feature (gitoxide routes all clones, local ones
+/// included, through its transport layer).
+#[cfg(feature = "vcs-net")]
 pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf>
 
 /// Materialize a files-only working checkout of `sha` for `url` from the local

--- a/crates/cljrs-project/src/lib.rs
+++ b/crates/cljrs-project/src/lib.rs
@@ -10,7 +10,13 @@
 //! The `vcs` module is native-only. Gitoxide and the signature verifiers do not
 //! build for `wasm32`, and a browser runtime has no git dependencies to
 //! resolve, so the module (and its dependencies) are compiled out there.
+//!
+//! It is also gated behind the default-on `vcs` feature, so a consumer that
+//! only needs the config model — the interpreter, an editor plugin, a
+//! sandboxed evaluator — can turn it off and link none of gitoxide, rPGP or
+//! `ssh-key`. Network fetch/clone is a further step up: it needs `vcs-net`,
+//! which is what selects gix's http transport and so the reqwest/rustls stack.
 
 pub mod config;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "vcs", not(target_arch = "wasm32")))]
 pub mod vcs;

--- a/crates/cljrs-project/src/vcs.rs
+++ b/crates/cljrs-project/src/vcs.rs
@@ -11,6 +11,18 @@
 //! `ssh` binary) when the optional `ssh` feature is enabled (see the `ssh`
 //! module); without it they are rejected with a clear error. Other schemes
 //! (`git://`, `http://`) are unsupported.
+//!
+//! ## Feature tiers
+//!
+//! Reading a repository and verifying signatures ([`find_repo_root`],
+//! [`get_file_at_commit`], [`worktree_at_commit`], [`checkout_tree`],
+//! [`verify_commit_signature`]) needs only the `vcs` feature and links no
+//! network stack at all.
+//!
+//! Fetching — `fetch_remote` — additionally needs `vcs-net`, which selects
+//! gix's blocking http transport and with it reqwest/hyper/rustls/aws-lc-rs.
+//! Gitoxide routes every clone through that transport layer, so `vcs-net`
+//! gates local-path and `file://` fetches too, not just `https://`.
 
 use std::path::{Path, PathBuf};
 
@@ -36,7 +48,7 @@ pub enum VcsError {
     #[error("no git repository found at or above {0:?}")]
     NoRepo(PathBuf),
     #[error(
-        "unsupported remote {0:?}: supported are https:// URLs, local paths, and (with the `ssh` feature) ssh:// remotes"
+        "unsupported remote {0:?}: supported are https:// URLs (with the `vcs-net` feature), local paths, and (with the `ssh` feature) ssh:// remotes"
     )]
     UnsupportedRemote(String),
     #[error("git error: {0}")]
@@ -108,7 +120,7 @@ pub fn cache_root() -> PathBuf {
 
 /// Return the local cache path for a given remote URL, without fetching.
 ///
-/// This mirrors the slug derivation inside [`fetch_remote`] so callers can
+/// This mirrors the slug derivation inside `fetch_remote` so callers can
 /// check cache existence without triggering network access.
 pub fn cache_path_for_url(url: &str) -> PathBuf {
     cache_root().join(url_slug(url))
@@ -131,7 +143,7 @@ fn url_slug(url: &str) -> String {
 /// bare cache, returning the worktree root.
 ///
 /// **Network-free**: the bare cache must already contain `sha` (run
-/// [`fetch_remote`] / `cljrs deps fetch` first).  The checkout is the tree of
+/// `fetch_remote` / `cljrs deps fetch` first).  The checkout is the tree of
 /// `sha` with no `.git`, written under
 /// `~/.cljrs/cache/git/worktrees/<slug>@<sha>/`.  Idempotent and cached per
 /// `(url, sha)` via a `.cljrs-worktree-complete` sentinel (the worktree has no
@@ -203,6 +215,11 @@ pub fn checkout_tree(repo: &Path, commit: &str, dest: &Path) -> VcsResult<()> {
 /// `sha`  — the commit SHA that must be reachable after the operation
 ///
 /// Returns the path to the bare repository in the cache.
+///
+/// Requires the `vcs-net` feature. Gitoxide routes *every* clone/fetch through
+/// its transport layer — local paths and `file://` included — so the whole
+/// operation, not just the `https://` case, needs a transport compiled in.
+#[cfg(feature = "vcs-net")]
 pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
     if !is_valid_commit_hash(sha) {
         return Err(VcsError::InvalidCommit(sha.to_string()));
@@ -214,6 +231,12 @@ pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
     // ssh requires the optional `ssh` feature; without it, reject clearly.
     #[cfg(not(feature = "ssh"))]
     if matches!(kind, RemoteKind::Ssh) {
+        return Err(VcsError::UnsupportedRemote(url.to_string()));
+    }
+    // https needs a network transport, which only `vcs-net` links in. Reject
+    // here rather than letting gitoxide fail with "unsupported protocol".
+    #[cfg(not(feature = "vcs-net"))]
+    if matches!(kind, RemoteKind::Https) {
         return Err(VcsError::UnsupportedRemote(url.to_string()));
     }
 
@@ -245,9 +268,14 @@ pub fn fetch_remote(url: &str, sha: &str) -> VcsResult<PathBuf> {
 }
 
 /// How a remote URL is transported.
+#[cfg(feature = "vcs-net")]
 enum RemoteKind {
-    /// `https://` (pure-Rust network) or a local filesystem path / `file://`.
-    Supported,
+    /// `https://` — a pure-Rust network fetch, available only with the
+    /// `vcs-net` feature (which selects gix's http transport).
+    Https,
+    /// A local filesystem path or a `file://` URL. Handled in-process by
+    /// gitoxide with no network transport, so always available.
+    Local,
     /// `ssh://` or scp-like `git@host:path`. Fetched natively only with the
     /// `ssh` feature; otherwise rejected.
     Ssh,
@@ -255,13 +283,17 @@ enum RemoteKind {
     Unsupported,
 }
 
-/// Classify a remote URL. `https://` (network) plus local paths and `file://`
-/// are always supported (gitoxide handles them in-process). `ssh://` and
-/// scp-like `git@host:path` map to [`RemoteKind::Ssh`]. Other network schemes
-/// (`http://`, `git://`, …) are unsupported.
+/// Classify a remote URL. Local paths and `file://` are always supported
+/// (gitoxide handles them in-process); `https://` needs the `vcs-net` feature.
+/// `ssh://` and scp-like `git@host:path` map to [`RemoteKind::Ssh`]. Other
+/// network schemes (`http://`, `git://`, …) are unsupported.
+#[cfg(feature = "vcs-net")]
 fn classify_remote(url: &str) -> RemoteKind {
-    if url.starts_with("https://") || url.starts_with("file://") {
-        return RemoteKind::Supported;
+    if url.starts_with("https://") {
+        return RemoteKind::Https;
+    }
+    if url.starts_with("file://") {
+        return RemoteKind::Local;
     }
     if url.starts_with("ssh://") {
         return RemoteKind::Ssh;
@@ -273,11 +305,12 @@ fn classify_remote(url: &str) -> RemoteKind {
     // No scheme: an scp-like `user@host:path` is SSH; otherwise a local path.
     match url.split_once(':') {
         Some((host, _)) if !host.is_empty() && !host.contains('/') => RemoteKind::Ssh,
-        _ => RemoteKind::Supported,
+        _ => RemoteKind::Local,
     }
 }
 
 /// Clone `url` as a bare repository into `repo_dir`.
+#[cfg(feature = "vcs-net")]
 fn clone_bare(url: &str, repo_dir: &Path) -> VcsResult<()> {
     let mut prepare =
         gix::prepare_clone_bare(url, repo_dir).map_err(|e| VcsError::Git(e.to_string()))?;
@@ -288,6 +321,7 @@ fn clone_bare(url: &str, repo_dir: &Path) -> VcsResult<()> {
 }
 
 /// Fetch updates for an already-cloned bare repository at `repo_dir`.
+#[cfg(feature = "vcs-net")]
 fn fetch_existing(repo_dir: &Path) -> VcsResult<()> {
     let repo = gix::open(repo_dir).map_err(|e| VcsError::Git(e.to_string()))?;
     let remote = repo
@@ -350,16 +384,14 @@ mod tests {
         assert!(!is_valid_commit_hash(""));
     }
 
+    #[cfg(feature = "vcs-net")]
     #[test]
     fn remote_classification() {
         use RemoteKind::*;
-        assert!(matches!(
-            classify_remote("https://github.com/u/r"),
-            Supported
-        ));
-        assert!(matches!(classify_remote("file:///tmp/repo"), Supported));
-        assert!(matches!(classify_remote("/tmp/local/repo"), Supported)); // absolute local path
-        assert!(matches!(classify_remote("../relative/repo"), Supported)); // relative local path
+        assert!(matches!(classify_remote("https://github.com/u/r"), Https));
+        assert!(matches!(classify_remote("file:///tmp/repo"), Local));
+        assert!(matches!(classify_remote("/tmp/local/repo"), Local)); // absolute local path
+        assert!(matches!(classify_remote("../relative/repo"), Local)); // relative local path
         assert!(matches!(classify_remote("ssh://git@github.com/u/r"), Ssh));
         assert!(matches!(classify_remote("git@github.com:u/r.git"), Ssh)); // scp-like
         assert!(matches!(

--- a/crates/cljrs-project/tests/versioning_harness.rs
+++ b/crates/cljrs-project/tests/versioning_harness.rs
@@ -1,5 +1,8 @@
 //! Versioning test harness.
 //!
+//! Exercises the `vcs` feature (local git reads + signature verification);
+//! compiled away when the crate is built without it.
+//!
 //! Two git repositories are created in temporary directories:
 //!
 //! - **library repo** — a minimal Clojure library (`src/mylib.cljc`) with two
@@ -14,6 +17,8 @@
 //! | Tagged version → pinned commit | sha of tag `v1.0.0` returns v1 content |
 //! | Signature positive | `verify_commit_signature` on a GPG-signed commit → Ok |
 //! | Signature negative | `verify_commit_signature` on an unsigned commit → Err |
+
+#![cfg(feature = "vcs")]
 
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crates/cljrs-project/tests/worktree.rs
+++ b/crates/cljrs-project/tests/worktree.rs
@@ -1,6 +1,12 @@
 //! Integration test for `worktree_at_commit`: materializing a files-only
 //! working checkout of a pinned commit from the local bare cache, with no
 //! network access.
+//!
+//! Needs `vcs-net`: the cache is primed with `fetch_remote`, which lives
+//! behind that feature (gitoxide routes even local clones through its
+//! transport layer).
+
+#![cfg(feature = "vcs-net")]
 
 use std::path::Path;
 use std::process::Command;

--- a/crates/cljrs-runtime/Cargo.toml
+++ b/crates/cljrs-runtime/Cargo.toml
@@ -7,13 +7,24 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = ["deps"]
 no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc"]
+
+# Git-backed dependency and versioned-var support: installs the
+# `cljrs-project`-backed `VcsProvider` (gitoxide + rPGP + ssh-key) at
+# `GlobalEnv::new` time. Turning it off drops ~290 transitive crates — the
+# whole gix/pgp/ssh-key tree — from an embedding of the interpreter; versioned
+# resolution then works only against embedded (AOT) sources. `GlobalEnv`'s
+# layout is the same either way, so mixing the two in one build is safe.
+deps = ["cljrs-project/vcs"]
 
 [dependencies]
 cljrs-types   = { workspace = true }
 cljrs-gc      = { workspace = true }
 cljrs-value   = { workspace = true }
 cljrs-reader  = { workspace = true }
+# Config model only by default; the `deps` feature adds `cljrs-project/vcs`.
+# Never `vcs-net` — the interpreter reads local repositories and never fetches.
 cljrs-project = { workspace = true }
 cljrs-ir      = { workspace = true }
 tracing      = { workspace = true }

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -57,6 +57,8 @@ src/
     taps.rs             — tap> / add-tap registry
     async_hook.rs       — AsyncRuntime seam and the async-JIT compile hook
     depth.rs            — call-depth cap for ExecutionMode::NoGcTransaction
+    vcs.rs              — VcsProvider trait (the runtime's git seam) and the
+                          cljrs-project-backed ProjectVcs impl (`deps` feature)
     versioned.rs        — (non-WASM) versioned symbol/namespace resolution
 
   builtins/
@@ -102,6 +104,9 @@ src/
 tests/
   no_gc_eval.rs                    — (no-gc) arithmetic, def provenance, region stack
   versioned_resolution.rs          — versioned resolution against a real git fixture
+  vcs_provider.rs                  — the VcsProvider seam: default provider, degradation
+                                     with none installed, signature-check routing
+                                     (passes with and without the `deps` feature)
   require_spec_reader_conditional.rs — reader conditionals in ns require specs
   declare_macro.rs, doc.rs, gas_meter.rs, into_seq_target.rs, map_entry.rs,
   named_fn_identity.rs, ns_metadata.rs, partition_arities.rs, shared_atom.rs,
@@ -328,6 +333,58 @@ versioned namespace loading, and Rust object construction. `check_native`,
 final dispatch seams. `next_transaction_gensym()` supplies an invocation-local
 deterministic sequence for syntax-quote hygiene. Violations return
 `EvalError::ForbiddenEffect(String)`.
+
+### `vcs` submodule
+
+The runtime's seam to version control. Everywhere the interpreter would touch
+git — locating a source file's repository, reading a file out of history,
+checking a commit signature — it goes through a `VcsProvider` trait object held
+by `GlobalEnv`, rather than calling `cljrs-project::vcs` directly. That is what
+lets the `deps` feature (see [Features](#features)) drop gitoxide, rPGP and
+`ssh-key` from an embedding without the rest of the runtime noticing.
+
+```rust
+pub trait VcsProvider: Send + Sync {
+    /// Walk up from `start` to the enclosing git working-tree root.
+    fn find_repo_root(&self, start: &Path) -> Option<PathBuf>;
+    /// Read `rel_path` (relative to `repo_root`) as of `commit`.
+    fn file_at_commit(&self, repo_root: &Path, rel_path: &str, commit: &str)
+        -> Result<String, String>;
+    /// Ok only when `commit` carries a valid signature by a trusted key.
+    fn verify_commit_signature(&self, repo_root: &Path, commit: &str)
+        -> Result<(), SignatureFailure>;
+    /// Install the trusted-signer key set, replacing any previous one;
+    /// returns the number of keys loaded.
+    fn load_trusted_signers(&self, signers: &[TrustedSigner]) -> usize;
+}
+
+/// Untrusted → EvalError::CommitSignatureVerificationFailed;
+/// Error     → EvalError::Runtime.
+pub enum SignatureFailure {
+    Untrusted { commit: String, reason: String },
+    Error(String),
+}
+
+/// What `GlobalEnv::new` installs: `Some(ProjectVcs)` with the `deps` feature
+/// on a native target, `None` otherwise.
+pub fn default_provider() -> Option<Arc<dyn VcsProvider>>;
+
+/// `cljrs-project`-backed implementation (`deps` feature, non-WASM).  Owns the
+/// trusted-key set, which used to be the `GlobalEnv::trusted_keys` field.
+pub struct ProjectVcs { /* … */ }
+```
+
+On `GlobalEnv`:
+
+- `vcs(&self) -> Option<Arc<dyn VcsProvider>>` — the installed provider.
+  Callers must degrade gracefully: `None` means "this file is not in a git
+  repository".
+- `set_vcs_provider(&self, Option<Arc<dyn VcsProvider>>)` — supply your own
+  implementation, or pass `None` to strip git access from a sandboxed host.
+
+Callers: `loader::do_load` (records a namespace's repo root),
+`versioned::versioned_source_available` and `versioned::fetch_versioned_source`,
+and `GlobalEnv::check_commit_signature` / `load_trusted_signers`.
 
 ### `versioned` submodule (non-WASM)
 
@@ -1056,9 +1113,37 @@ by the lowerer — resolve at Tier 1 exactly as they do tree-walked.
 
 ## Features
 
-| Feature | Effect |
-|---|---|
-| `no-gc` | Forwards to `cljrs-gc/no-gc` and `cljrs-value/no-gc`; switches `env::gc_roots`, `interp::special`, and `interp::apply` to the region/`StaticArena` allocation protocol |
+| Feature | Default | Effect |
+|---|---|---|
+| `no-gc` | off | Forwards to `cljrs-gc/no-gc` and `cljrs-value/no-gc`; switches `env::gc_roots`, `interp::special`, and `interp::apply` to the region/`StaticArena` allocation protocol |
+| `deps` | **on** | Enables `cljrs-project/vcs` and installs the `cljrs-project`-backed [`VcsProvider`](#vcs-submodule) in `GlobalEnv::new`, so versioned vars (`ns/name@commit`) resolve out of git history and `:verify-commit-signatures` can check signatures |
+
+### Turning `deps` off
+
+`--no-default-features` drops the whole gitoxide/rPGP/`ssh-key` tree — roughly
+290 transitive crates, or three quarters of a minimal embedding's build — for
+anything that links the interpreter but never resolves a git-hosted dependency:
+an editor plugin, a sandboxed evaluator, `cljrs-tx`, an embedded host. It is
+also the first prerequisite for any `no_std`/embedded profile, since none of
+those crates build for a bare-metal target.
+
+What changes when it is off:
+
+* `GlobalEnv::vcs()` returns `None`, so every source file is treated as living
+  outside a git repository. Versioned resolution then works only against
+  sources embedded at AOT-compile time; a live fetch reports the existing
+  "not in a git repository" error.
+* `check_commit_signature` **fails** rather than passing when
+  `:verify-commit-signatures` is on — a build that cannot verify must not
+  silently accept.
+* `load_trusted_signers` returns 0.
+
+The `GlobalEnv` field holding the provider is present in either configuration,
+so the struct's layout does not vary with the feature and an embedder cannot be
+caught out by Cargo feature unification. An embedder that wants git without
+`cljrs-project` can implement `VcsProvider` itself and install it with
+`set_vcs_provider`; passing `None` there also lets a sandboxed host *remove*
+the default provider at runtime.
 
 ---
 
@@ -1072,7 +1157,7 @@ by the lowerer — resolve at Tier 1 exactly as they do tree-walked.
 | `cljrs-reader` | `Form` AST and `Parser` |
 | `cljrs-ir` | IR types (`IrFunction`, `Block`, `Inst`, `IrBundle`) and lowering |
 | `tracing` / `tracing-subscriber` (non-WASM) | the `gc`/`env`/`ir`/`jit` diagnostic targets, and the `logging` module that filters and installs them |
-| `cljrs-project` | `config` — project configuration consulted by the namespace loader; `vcs` (non-WASM) — git history access for versioned namespace resolution |
+| `cljrs-project` | `config` — project configuration consulted by the namespace loader (always; no external dependencies of its own). `vcs` (non-WASM, `deps` feature) — git history access for versioned namespace resolution. Never `vcs-net`: the interpreter reads local repositories and never fetches, so no HTTP/TLS stack is linked. |
 | `num-bigint`, `num-rational`, `bigdecimal`, `num-traits` | numeric tower |
 | `rand`, `rpds`, `uuid`, `regex` | builtin implementations |
 | `log`, `thiserror` | diagnostics and error derivation |

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -105,7 +105,8 @@ tests/
   no_gc_eval.rs                    — (no-gc) arithmetic, def provenance, region stack
   versioned_resolution.rs          — versioned resolution against a real git fixture
   vcs_provider.rs                  — the VcsProvider seam: default provider, degradation
-                                     with none installed, signature-check routing
+                                     with none installed, signature-check routing and
+                                     cache invalidation on provider/trust-set change
                                      (passes with and without the `deps` feature)
   require_spec_reader_conditional.rs — reader conditionals in ns require specs
   declare_macro.rs, doc.rs, gas_meter.rs, into_seq_target.rs, map_entry.rs,
@@ -381,6 +382,12 @@ On `GlobalEnv`:
   repository".
 - `set_vcs_provider(&self, Option<Arc<dyn VcsProvider>>)` — supply your own
   implementation, or pass `None` to strip git access from a sandboxed host.
+  Drops every cached signature verdict: those were reached by the outgoing
+  provider under its trust set, so carrying them over would let a permissive
+  provider launder an approval for source a stricter one would reject.
+- `invalidate_signature_cache(&self)` — forget those verdicts explicitly.
+  `load_trusted_signers` calls it too, since a new key set invalidates
+  conclusions drawn under the old one.
 
 Callers: `loader::do_load` (records a namespace's repo root),
 `versioned::versioned_source_available` and `versioned::fetch_versioned_source`,

--- a/crates/cljrs-runtime/src/env/env.rs
+++ b/crates/cljrs-runtime/src/env/env.rs
@@ -684,8 +684,27 @@ impl GlobalEnv {
     /// `deps` feature supply its own git implementation, or a sandboxed host
     /// remove the default one (`None`) so no versioned resolution can reach
     /// the filesystem's git history.
+    ///
+    /// Drops every cached signature verdict: those were reached by the
+    /// outgoing provider, against its trust set and its view of the
+    /// repository, and say nothing about what the incoming one would decide
+    /// for the same `(repo, commit)`.  Keeping them would let a permissive
+    /// provider launder an approval for source a later provider serves.
     pub fn set_vcs_provider(&self, provider: Option<Arc<dyn crate::env::vcs::VcsProvider>>) {
+        // Neither this nor `check_commit_signature` ever holds the `vcs` and
+        // `sig_verify_cache` locks at the same time, and the two reach for
+        // them in opposite orders — keep it that way, or the pair becomes a
+        // lock-order inversion.
         *self.vcs.write().unwrap() = provider;
+        self.invalidate_signature_cache();
+    }
+
+    /// Forget every cached signature verdict, so the next
+    /// [`check_commit_signature`](Self::check_commit_signature) re-asks the
+    /// current provider.  Called whenever the thing that produced those
+    /// verdicts changes: the provider itself, or its trusted-key set.
+    pub fn invalidate_signature_cache(&self) {
+        self.sig_verify_cache.lock().unwrap().clear();
     }
 
     /// If `:verify-commit-signatures` is enabled, verify that `commit` inside
@@ -736,11 +755,18 @@ impl GlobalEnv {
     /// Returns the number of keys loaded; warns (to stderr) on any key that
     /// fails to load rather than aborting.  Returns 0 when this build has no
     /// VCS provider, since there is nothing that could consume the keys.
+    ///
+    /// Replacing the trust set invalidates the signature cache for the same
+    /// reason replacing the provider does: a verdict reached under the old
+    /// keys is not a verdict under the new ones.  (In the normal flow this
+    /// runs at session start, before anything has been verified.)
     pub fn load_trusted_signers(&self, config: &cljrs_project::config::DepsConfig) -> usize {
-        match self.vcs() {
-            Some(vcs) => vcs.load_trusted_signers(&config.trusted_signers),
-            None => 0,
-        }
+        let Some(vcs) = self.vcs() else {
+            return 0;
+        };
+        let loaded = vcs.load_trusted_signers(&config.trusted_signers);
+        self.invalidate_signature_cache();
+        loaded
     }
 }
 

--- a/crates/cljrs-runtime/src/env/env.rs
+++ b/crates/cljrs-runtime/src/env/env.rs
@@ -124,12 +124,12 @@ pub struct GlobalEnv {
     /// `--verify-commit-signatures` CLI flag or `:verify-commit-signatures true`
     /// in `cljrs.edn`.
     pub verify_commit_signatures: AtomicBool,
-    /// Public keys trusted to sign versioned dependency commits, built from
-    /// the `:trusted-signers` config.  Consulted by `check_commit_signature`
-    /// when `verify_commit_signatures` is on.  (Not built on wasm, where
-    /// `cljrs-project::vcs` is unavailable and signature checks are no-ops.)
-    #[cfg(not(target_arch = "wasm32"))]
-    pub trusted_keys: RwLock<Arc<cljrs_project::vcs::TrustedKeys>>,
+    /// The git backend used by versioned resolution and signature checking, or
+    /// `None` in builds that carry no VCS implementation (wasm, or
+    /// `cljrs-runtime` without its default `deps` feature).  With no provider,
+    /// source files are treated as living outside any repository and versioned
+    /// resolution can only use embedded (AOT) sources.  See [`crate::env::vcs`].
+    vcs: RwLock<Option<Arc<dyn crate::env::vcs::VcsProvider>>>,
     /// Session-scoped cache of commits that have already passed signature
     /// verification this run, keyed by `(repo_root, commit_hash)`.
     pub sig_verify_cache: Mutex<HashSet<(Arc<str>, Arc<str>)>>,
@@ -229,8 +229,7 @@ impl GlobalEnv {
             version_cache: Mutex::new(HashMap::new()),
             deps_config: RwLock::new(None),
             verify_commit_signatures: AtomicBool::new(false),
-            #[cfg(not(target_arch = "wasm32"))]
-            trusted_keys: RwLock::new(Arc::new(cljrs_project::vcs::TrustedKeys::new())),
+            vcs: RwLock::new(crate::env::vcs::default_provider()),
             sig_verify_cache: Mutex::new(HashSet::new()),
             versioned_sources: RwLock::new(HashMap::new()),
             versioned_offline: AtomicBool::new(false),
@@ -674,6 +673,21 @@ impl GlobalEnv {
         }
     }
 
+    /// The installed VCS backend, or `None` when this build has none (see
+    /// [`crate::env::vcs`]).  Callers must degrade gracefully: "no provider"
+    /// means "this source file is not in a git repository".
+    pub fn vcs(&self) -> Option<Arc<dyn crate::env::vcs::VcsProvider>> {
+        self.vcs.read().unwrap().clone()
+    }
+
+    /// Replace the VCS backend.  Lets an embedder that built without the
+    /// `deps` feature supply its own git implementation, or a sandboxed host
+    /// remove the default one (`None`) so no versioned resolution can reach
+    /// the filesystem's git history.
+    pub fn set_vcs_provider(&self, provider: Option<Arc<dyn crate::env::vcs::VcsProvider>>) {
+        *self.vcs.write().unwrap() = provider;
+    }
+
     /// If `:verify-commit-signatures` is enabled, verify that `commit` inside
     /// `repo_root` carries a valid GPG or SSH signature.
     ///
@@ -681,34 +695,38 @@ impl GlobalEnv {
     /// path the result is cached per `(repo_root, commit)` so each commit is
     /// only verified once per session.  On failure returns
     /// `EvalError::CommitSignatureVerificationFailed`.
+    ///
+    /// If verification is demanded but this build has no VCS provider, the
+    /// check fails: silently accepting an unverifiable commit would defeat the
+    /// flag the user explicitly turned on.
     pub fn check_commit_signature(&self, repo_root: &str, commit: &str) -> EvalResult<()> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            if !self.verify_commit_signatures.load(Ordering::Relaxed) {
-                return Ok(());
-            }
-            let key = (Arc::<str>::from(repo_root), Arc::<str>::from(commit));
-            if self.sig_verify_cache.lock().unwrap().contains(&key) {
-                return Ok(());
-            }
-            let trusted = self.trusted_keys.read().unwrap().clone();
-            cljrs_project::vcs::verify_commit_signature(
-                std::path::Path::new(repo_root),
-                commit,
-                &trusted,
-            )
+        if !self.verify_commit_signatures.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        let key = (Arc::<str>::from(repo_root), Arc::<str>::from(commit));
+        if self.sig_verify_cache.lock().unwrap().contains(&key) {
+            return Ok(());
+        }
+        let Some(vcs) = self.vcs() else {
+            return Err(crate::env::error::EvalError::Runtime(format!(
+                "commit-signature verification is enabled, but this build has no VCS \
+                 provider to verify commit {commit} with (cljrs-runtime built without \
+                 the `deps` feature)"
+            )));
+        };
+        vcs.verify_commit_signature(std::path::Path::new(repo_root), commit)
             .map_err(|e| match e {
-                cljrs_project::vcs::VcsError::SignatureVerificationFailed { commit: c, reason } => {
+                crate::env::vcs::SignatureFailure::Untrusted { commit, reason } => {
                     crate::env::error::EvalError::CommitSignatureVerificationFailed {
-                        commit: c,
+                        commit,
                         reason,
                     }
                 }
-                other => crate::env::error::EvalError::Runtime(format!("{other}")),
+                crate::env::vcs::SignatureFailure::Error(msg) => {
+                    crate::env::error::EvalError::Runtime(msg)
+                }
             })?;
-            self.sig_verify_cache.lock().unwrap().insert(key);
-        }
-        let _ = (repo_root, commit);
+        self.sig_verify_cache.lock().unwrap().insert(key);
         Ok(())
     }
 
@@ -716,34 +734,13 @@ impl GlobalEnv {
     /// install it, so subsequent `check_commit_signature` calls verify against
     /// it.  Inline keys are parsed directly; `File` entries are read from disk.
     /// Returns the number of keys loaded; warns (to stderr) on any key that
-    /// fails to load rather than aborting.  (Not available on wasm.)
-    #[cfg(not(target_arch = "wasm32"))]
+    /// fails to load rather than aborting.  Returns 0 when this build has no
+    /// VCS provider, since there is nothing that could consume the keys.
     pub fn load_trusted_signers(&self, config: &cljrs_project::config::DepsConfig) -> usize {
-        let mut keys = cljrs_project::vcs::TrustedKeys::new();
-        let mut loaded = 0usize;
-        for signer in &config.trusted_signers {
-            let result = match signer {
-                cljrs_project::config::TrustedSigner::Inline(text) => keys.add_key_text(text),
-                cljrs_project::config::TrustedSigner::File(path) => {
-                    match std::fs::read_to_string(path) {
-                        Ok(text) => keys.add_key_text(&text),
-                        Err(e) => {
-                            eprintln!(
-                                "cljrs: warning: could not read trusted signer key {}: {e}",
-                                path.display()
-                            );
-                            continue;
-                        }
-                    }
-                }
-            };
-            match result {
-                Ok(()) => loaded += 1,
-                Err(e) => eprintln!("cljrs: warning: invalid trusted signer key: {e}"),
-            }
+        match self.vcs() {
+            Some(vcs) => vcs.load_trusted_signers(&config.trusted_signers),
+            None => 0,
         }
-        *self.trusted_keys.write().unwrap() = Arc::new(keys);
-        loaded
     }
 }
 

--- a/crates/cljrs-runtime/src/env/loader.rs
+++ b/crates/cljrs-runtime/src/env/loader.rs
@@ -156,7 +156,9 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
     // Only meaningful for real files (not builtins) and non-WASM targets.
     #[cfg(not(target_arch = "wasm32"))]
     if !file_path.starts_with("<builtin:") {
-        let repo_root = cljrs_project::vcs::find_repo_root(Path::new(&file_path))
+        let repo_root = globals
+            .vcs()
+            .and_then(|vcs| vcs.find_repo_root(Path::new(&file_path)))
             .map(|p| p.display().to_string());
         let ns_ptr = globals.get_or_create_ns(ns_name);
         ns_ptr

--- a/crates/cljrs-runtime/src/env/mod.rs
+++ b/crates/cljrs-runtime/src/env/mod.rs
@@ -16,6 +16,7 @@ pub mod gc_roots;
 pub mod loader;
 pub mod policy;
 pub mod taps;
+pub mod vcs;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod versioned;
 

--- a/crates/cljrs-runtime/src/env/vcs.rs
+++ b/crates/cljrs-runtime/src/env/vcs.rs
@@ -1,0 +1,178 @@
+//! The runtime's interface to version control.
+//!
+//! Versioned symbol resolution (`ns/name@commit`) and commit-signature
+//! verification are the only two places where the interpreter touches git.
+//! Calling `cljrs_project::vcs` directly from here would link gitoxide, rPGP,
+//! `ssh-key` — and, through gix's blocking http transport, reqwest/hyper/rustls
+//! — into *every* embedding of the interpreter, including ones that never
+//! resolve a versioned var.
+//!
+//! So the runtime talks to a [`VcsProvider`] trait object instead:
+//!
+//! * With the default `deps` feature on, [`GlobalEnv::new`] installs
+//!   [`ProjectVcs`] — the `cljrs-project`-backed implementation — so behaviour
+//!   is exactly what it was before the split and no downstream crate changes.
+//! * Built with `--no-default-features`, no provider is installed:
+//!   [`VcsProvider::find_repo_root`] never gets asked, so a source file is
+//!   treated as "not in a git repository", versioned resolution falls back to
+//!   embedded (AOT) sources, and gix/pgp/ssh-key are not compiled at all.
+//!
+//! The `GlobalEnv` field holding the provider exists in both configurations,
+//! so the struct's layout does not change with the feature — an embedder that
+//! links a `deps`-less runtime alongside a `deps`-ful one is not exposed to a
+//! feature-unification surprise.
+//!
+//! [`GlobalEnv::new`]: crate::env::env::GlobalEnv::new
+
+use std::path::{Path, PathBuf};
+
+use cljrs_project::config::TrustedSigner;
+
+/// Why a commit-signature check did not succeed.
+#[derive(Debug)]
+pub enum SignatureFailure {
+    /// The commit is unsigned, its signature is invalid, or the signing key is
+    /// not in the trusted set.  Surfaces to user code as
+    /// `EvalError::CommitSignatureVerificationFailed`.
+    Untrusted { commit: String, reason: String },
+    /// The check could not be carried out at all (malformed hash, unreadable
+    /// repository, …).  Surfaces as a plain runtime error.
+    Error(String),
+}
+
+/// The git operations the runtime needs, as an interface.
+///
+/// Implementations must be cheap to clone-by-`Arc` and safe to call from any
+/// thread: a provider is shared by every thread evaluating in a `GlobalEnv`.
+pub trait VcsProvider: Send + Sync {
+    /// Walk upward from `start` (a file or directory) to the enclosing git
+    /// working-tree root, or `None` when `start` is not inside a repository.
+    fn find_repo_root(&self, start: &Path) -> Option<PathBuf>;
+
+    /// Read `rel_path` (relative to `repo_root`) as it existed at `commit`.
+    fn file_at_commit(
+        &self,
+        repo_root: &Path,
+        rel_path: &str,
+        commit: &str,
+    ) -> Result<String, String>;
+
+    /// Verify that `commit` in `repo_root` carries a cryptographically valid
+    /// signature made by one of the keys installed by
+    /// [`load_trusted_signers`](VcsProvider::load_trusted_signers).
+    fn verify_commit_signature(
+        &self,
+        repo_root: &Path,
+        commit: &str,
+    ) -> Result<(), SignatureFailure>;
+
+    /// Install the set of keys trusted to sign versioned dependency commits,
+    /// replacing any previously installed set.  Returns the number of keys
+    /// successfully loaded; malformed or unreadable keys are warned about
+    /// rather than aborting.
+    fn load_trusted_signers(&self, signers: &[TrustedSigner]) -> usize;
+}
+
+/// The provider installed by [`GlobalEnv::new`], or `None` in builds that
+/// carry no VCS implementation.
+///
+/// [`GlobalEnv::new`]: crate::env::env::GlobalEnv::new
+pub fn default_provider() -> Option<std::sync::Arc<dyn VcsProvider>> {
+    #[cfg(all(feature = "deps", not(target_arch = "wasm32")))]
+    {
+        Some(std::sync::Arc::new(ProjectVcs::new()))
+    }
+    #[cfg(not(all(feature = "deps", not(target_arch = "wasm32"))))]
+    {
+        None
+    }
+}
+
+// ── cljrs-project-backed implementation ───────────────────────────────────────
+
+/// [`VcsProvider`] implemented on top of `cljrs_project::vcs` (gitoxide for the
+/// git side, rPGP / `ssh-key` for signatures).
+#[cfg(all(feature = "deps", not(target_arch = "wasm32")))]
+pub struct ProjectVcs {
+    /// Public keys trusted to sign versioned dependency commits, built from the
+    /// `:trusted-signers` config.  Empty until `load_trusted_signers` runs, in
+    /// which case every signature check fails as untrusted.
+    trusted: std::sync::RwLock<std::sync::Arc<cljrs_project::vcs::TrustedKeys>>,
+}
+
+#[cfg(all(feature = "deps", not(target_arch = "wasm32")))]
+impl Default for ProjectVcs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(feature = "deps", not(target_arch = "wasm32")))]
+impl ProjectVcs {
+    pub fn new() -> Self {
+        Self {
+            trusted: std::sync::RwLock::new(std::sync::Arc::new(
+                cljrs_project::vcs::TrustedKeys::new(),
+            )),
+        }
+    }
+}
+
+#[cfg(all(feature = "deps", not(target_arch = "wasm32")))]
+impl VcsProvider for ProjectVcs {
+    fn find_repo_root(&self, start: &Path) -> Option<PathBuf> {
+        cljrs_project::vcs::find_repo_root(start)
+    }
+
+    fn file_at_commit(
+        &self,
+        repo_root: &Path,
+        rel_path: &str,
+        commit: &str,
+    ) -> Result<String, String> {
+        cljrs_project::vcs::get_file_at_commit(repo_root, rel_path, commit)
+            .map_err(|e| e.to_string())
+    }
+
+    fn verify_commit_signature(
+        &self,
+        repo_root: &Path,
+        commit: &str,
+    ) -> Result<(), SignatureFailure> {
+        let trusted = self.trusted.read().unwrap().clone();
+        cljrs_project::vcs::verify_commit_signature(repo_root, commit, &trusted).map_err(
+            |e| match e {
+                cljrs_project::vcs::VcsError::SignatureVerificationFailed { commit, reason } => {
+                    SignatureFailure::Untrusted { commit, reason }
+                }
+                other => SignatureFailure::Error(other.to_string()),
+            },
+        )
+    }
+
+    fn load_trusted_signers(&self, signers: &[TrustedSigner]) -> usize {
+        let mut keys = cljrs_project::vcs::TrustedKeys::new();
+        let mut loaded = 0usize;
+        for signer in signers {
+            let result = match signer {
+                TrustedSigner::Inline(text) => keys.add_key_text(text),
+                TrustedSigner::File(path) => match std::fs::read_to_string(path) {
+                    Ok(text) => keys.add_key_text(&text),
+                    Err(e) => {
+                        eprintln!(
+                            "cljrs: warning: could not read trusted signer key {}: {e}",
+                            path.display()
+                        );
+                        continue;
+                    }
+                },
+            };
+            match result {
+                Ok(()) => loaded += 1,
+                Err(e) => eprintln!("cljrs: warning: invalid trusted signer key: {e}"),
+            }
+        }
+        *self.trusted.write().unwrap() = std::sync::Arc::new(keys);
+        loaded
+    }
+}

--- a/crates/cljrs-runtime/src/env/versioned.rs
+++ b/crates/cljrs-runtime/src/env/versioned.rs
@@ -173,7 +173,10 @@ fn versioned_source_available(globals: &GlobalEnv, base_ns: &str, versioned_ns: 
     let rel_path = base_ns.replace('.', "/").replace('-', "_");
     let src_paths = globals.source_paths.read().unwrap().clone();
     match crate::env::loader::find_source_file(&rel_path, &src_paths) {
-        Some((_, file_path)) => cljrs_project::vcs::find_repo_root(Path::new(&file_path)).is_some(),
+        Some((_, file_path)) => globals
+            .vcs()
+            .and_then(|vcs| vcs.find_repo_root(Path::new(&file_path)))
+            .is_some(),
         None => false,
     }
 }
@@ -302,13 +305,19 @@ fn fetch_versioned_source(
             ))
         })?;
 
-    // Locate the git repository.
-    let repo_root = cljrs_project::vcs::find_repo_root(Path::new(&file_path)).ok_or_else(|| {
+    // Locate the git repository.  A build with no VCS provider has no git
+    // history to reach for, so it lands in the same "not in a repository" path
+    // as a source tree that genuinely is not checked in.
+    let not_in_repo = || {
         EvalError::Runtime(format!(
             "Namespace {base_ns} (file {file_path}) is not in a git repository; \
              cannot resolve {base_ns}@{commit}"
         ))
-    })?;
+    };
+    let vcs = globals.vcs().ok_or_else(not_in_repo)?;
+    let repo_root = vcs
+        .find_repo_root(Path::new(&file_path))
+        .ok_or_else(not_in_repo)?;
 
     // Verify commit signature before loading any historical code.
     globals.check_commit_signature(&repo_root.to_string_lossy(), commit)?;
@@ -324,8 +333,9 @@ fn fetch_versioned_source(
     let rel_file_str = rel_file.to_string_lossy();
 
     // Fetch the source at the requested commit.
-    let src = cljrs_project::vcs::get_file_at_commit(&repo_root, &rel_file_str, commit)
-        .map_err(|e| EvalError::Runtime(format!("{e}")))?;
+    let src = vcs
+        .file_at_commit(&repo_root, &rel_file_str, commit)
+        .map_err(EvalError::Runtime)?;
 
     // Record for AOT embedding.
     globals.record_versioned_source(&format!("{base_ns}@{commit}"), &src);

--- a/crates/cljrs-runtime/tests/vcs_provider.rs
+++ b/crates/cljrs-runtime/tests/vcs_provider.rs
@@ -1,0 +1,200 @@
+//! The `VcsProvider` seam: what the runtime does with, without, and around a
+//! git backend.
+//!
+//! These are the guarantees the `deps` feature rests on — a build with no
+//! provider must degrade to "not in a git repository" rather than misbehave,
+//! and must *fail* a signature check it cannot perform.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use cljrs_project::config::TrustedSigner;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_runtime::env::vcs::{SignatureFailure, VcsProvider};
+
+fn make_globals() -> Arc<GlobalEnv> {
+    cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals()
+}
+
+/// A provider that claims every path is a repository and answers with canned
+/// content, so the seam can be exercised without a git fixture.
+struct StubVcs {
+    signature_ok: bool,
+}
+
+impl VcsProvider for StubVcs {
+    fn find_repo_root(&self, _start: &Path) -> Option<PathBuf> {
+        Some(PathBuf::from("/stub/repo"))
+    }
+
+    fn file_at_commit(
+        &self,
+        _repo_root: &Path,
+        rel_path: &str,
+        commit: &str,
+    ) -> Result<String, String> {
+        Ok(format!("(def marker \"{rel_path}@{commit}\")"))
+    }
+
+    fn verify_commit_signature(
+        &self,
+        _repo_root: &Path,
+        commit: &str,
+    ) -> Result<(), SignatureFailure> {
+        if self.signature_ok {
+            Ok(())
+        } else {
+            Err(SignatureFailure::Untrusted {
+                commit: commit.to_string(),
+                reason: "stub rejects everything".to_string(),
+            })
+        }
+    }
+
+    fn load_trusted_signers(&self, signers: &[TrustedSigner]) -> usize {
+        signers.len()
+    }
+}
+
+/// With the default `deps` feature a provider is installed; without it, none is.
+#[test]
+fn default_provider_matches_feature() {
+    let globals = make_globals();
+    assert_eq!(globals.vcs().is_some(), cfg!(feature = "deps"));
+}
+
+/// Signature checking stays a no-op while `:verify-commit-signatures` is off,
+/// provider or not.
+#[test]
+fn signature_check_is_noop_when_disabled() {
+    let globals = make_globals();
+    globals.set_vcs_provider(None);
+    assert!(
+        globals
+            .check_commit_signature("/anywhere", "abc1234")
+            .is_ok()
+    );
+}
+
+/// A build that cannot verify must not silently accept: with verification
+/// demanded and no provider, the check fails.
+#[test]
+fn signature_check_fails_without_provider() {
+    let globals = make_globals();
+    globals.set_vcs_provider(None);
+    globals
+        .verify_commit_signatures
+        .store(true, Ordering::Relaxed);
+
+    let err = globals
+        .check_commit_signature("/anywhere", "abc1234")
+        .expect_err("must not pass a check it cannot perform");
+    assert!(
+        format!("{err:?}").contains("no VCS provider"),
+        "unexpected error: {err:?}"
+    );
+}
+
+/// An installed provider is what decides the verdict, and a pass is cached so
+/// the provider is consulted once per (repo, commit).
+#[test]
+fn installed_provider_decides_signature_verdict() {
+    let globals = make_globals();
+    globals
+        .verify_commit_signatures
+        .store(true, Ordering::Relaxed);
+
+    globals.set_vcs_provider(Some(Arc::new(StubVcs {
+        signature_ok: false,
+    })));
+    assert!(
+        globals
+            .check_commit_signature("/stub/repo", "abc1234")
+            .is_err()
+    );
+
+    globals.set_vcs_provider(Some(Arc::new(StubVcs { signature_ok: true })));
+    assert!(
+        globals
+            .check_commit_signature("/stub/repo", "abc1234")
+            .is_ok()
+    );
+
+    // Cached: the rejecting provider is never asked about this commit again.
+    globals.set_vcs_provider(Some(Arc::new(StubVcs {
+        signature_ok: false,
+    })));
+    assert!(
+        globals
+            .check_commit_signature("/stub/repo", "abc1234")
+            .is_ok()
+    );
+    assert!(
+        globals
+            .check_commit_signature("/stub/repo", "def5678")
+            .is_err()
+    );
+}
+
+/// Trusted signers are routed to the provider, and are simply dropped when
+/// there is none to consume them.
+#[test]
+fn trusted_signers_route_through_the_provider() {
+    let globals = make_globals();
+    let config = cljrs_project::config::DepsConfig {
+        trusted_signers: vec![
+            TrustedSigner::Inline("key-a".to_string()),
+            TrustedSigner::Inline("key-b".to_string()),
+        ],
+        ..Default::default()
+    };
+
+    globals.set_vcs_provider(Some(Arc::new(StubVcs { signature_ok: true })));
+    assert_eq!(globals.load_trusted_signers(&config), 2);
+
+    globals.set_vcs_provider(None);
+    assert_eq!(globals.load_trusted_signers(&config), 0);
+}
+
+/// Without a provider, a namespace loaded from disk records no repository —
+/// the same state as a source tree that is genuinely not checked in, which is
+/// what makes versioned resolution degrade rather than break.
+#[test]
+fn no_provider_means_no_repo_root() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("plainns.cljc"), "(def x 1)\n").expect("write source");
+
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .source_paths(vec![dir.path().to_path_buf()])
+        .build()
+        .expect("runtime")
+        .into_globals();
+    globals.set_vcs_provider(None);
+
+    let mut env = Env::new(globals.clone(), "user");
+    let mut parser =
+        cljrs_reader::Parser::new("(require 'plainns)".to_string(), "<test>".to_string());
+    for form in parser.parse_all().expect("parse") {
+        globals.eval(&form, &mut env).expect("require");
+    }
+
+    let ns = globals.get_or_create_ns("plainns");
+    let ns = ns.get();
+    assert!(
+        ns.source_file.lock().unwrap().is_some(),
+        "source file should still be recorded"
+    );
+    let repo_root = ns.git_repo_root.lock().unwrap().clone();
+    assert!(
+        repo_root.is_none(),
+        "no provider must mean no repo root, got {repo_root:?}"
+    );
+}

--- a/crates/cljrs-runtime/tests/vcs_provider.rs
+++ b/crates/cljrs-runtime/tests/vcs_provider.rs
@@ -63,6 +63,47 @@ impl VcsProvider for StubVcs {
     }
 }
 
+/// An always-approving provider that counts how often it is actually asked,
+/// so caching and cache invalidation are observable.
+#[derive(Default)]
+struct CountingVcs {
+    verify_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl CountingVcs {
+    fn calls(&self) -> usize {
+        self.verify_calls.load(Ordering::Relaxed)
+    }
+}
+
+impl VcsProvider for CountingVcs {
+    fn find_repo_root(&self, _start: &Path) -> Option<PathBuf> {
+        Some(PathBuf::from("/stub/repo"))
+    }
+
+    fn file_at_commit(
+        &self,
+        _repo_root: &Path,
+        _rel_path: &str,
+        _commit: &str,
+    ) -> Result<String, String> {
+        Ok(String::new())
+    }
+
+    fn verify_commit_signature(
+        &self,
+        _repo_root: &Path,
+        _commit: &str,
+    ) -> Result<(), SignatureFailure> {
+        self.verify_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn load_trusted_signers(&self, signers: &[TrustedSigner]) -> usize {
+        signers.len()
+    }
+}
+
 /// With the default `deps` feature a provider is installed; without it, none is.
 #[test]
 fn default_provider_matches_feature() {
@@ -102,8 +143,7 @@ fn signature_check_fails_without_provider() {
     );
 }
 
-/// An installed provider is what decides the verdict, and a pass is cached so
-/// the provider is consulted once per (repo, commit).
+/// The installed provider is what decides the verdict.
 #[test]
 fn installed_provider_decides_signature_verdict() {
     let globals = make_globals();
@@ -126,11 +166,21 @@ fn installed_provider_decides_signature_verdict() {
             .check_commit_signature("/stub/repo", "abc1234")
             .is_ok()
     );
+}
 
-    // Cached: the rejecting provider is never asked about this commit again.
-    globals.set_vcs_provider(Some(Arc::new(StubVcs {
-        signature_ok: false,
-    })));
+/// A pass is cached, so a given `(repo, commit)` costs one verification per
+/// session — but the cache belongs to the provider that filled it.  Swapping
+/// the provider must drop those verdicts, or a permissive provider could
+/// launder an approval for source a stricter one would reject.
+#[test]
+fn provider_swap_invalidates_cached_verdicts() {
+    let globals = make_globals();
+    globals
+        .verify_commit_signatures
+        .store(true, Ordering::Relaxed);
+
+    let counting = Arc::new(CountingVcs::default());
+    globals.set_vcs_provider(Some(counting.clone()));
     assert!(
         globals
             .check_commit_signature("/stub/repo", "abc1234")
@@ -138,8 +188,55 @@ fn installed_provider_decides_signature_verdict() {
     );
     assert!(
         globals
-            .check_commit_signature("/stub/repo", "def5678")
-            .is_err()
+            .check_commit_signature("/stub/repo", "abc1234")
+            .is_ok()
+    );
+    assert_eq!(counting.calls(), 1, "a pass should be cached");
+
+    // Swap in a provider that rejects: the earlier approval must not carry
+    // over to it.
+    globals.set_vcs_provider(Some(Arc::new(StubVcs {
+        signature_ok: false,
+    })));
+    assert!(
+        globals
+            .check_commit_signature("/stub/repo", "abc1234")
+            .is_err(),
+        "cached verdict from the previous provider leaked"
+    );
+}
+
+/// Reloading the trusted-key set is the same hazard: the verdicts in the
+/// cache were reached under the old keys.
+#[test]
+fn reloading_trusted_signers_invalidates_cached_verdicts() {
+    let globals = make_globals();
+    globals
+        .verify_commit_signatures
+        .store(true, Ordering::Relaxed);
+
+    let counting = Arc::new(CountingVcs::default());
+    globals.set_vcs_provider(Some(counting.clone()));
+    assert!(
+        globals
+            .check_commit_signature("/stub/repo", "abc1234")
+            .is_ok()
+    );
+    assert_eq!(counting.calls(), 1);
+
+    globals.load_trusted_signers(&cljrs_project::config::DepsConfig {
+        trusted_signers: vec![TrustedSigner::Inline("key-a".to_string())],
+        ..Default::default()
+    });
+    assert!(
+        globals
+            .check_commit_signature("/stub/repo", "abc1234")
+            .is_ok()
+    );
+    assert_eq!(
+        counting.calls(),
+        2,
+        "new trust set must force re-verification"
     );
 }
 

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -41,7 +41,7 @@ cljrs-value    = { workspace = true }
 cljrs-stdlib   = { workspace = true }
 cljrs-compiler = { workspace = true }
 cljrs-interop  = { workspace = true }
-cljrs-project  = { workspace = true, features = ["ssh"] }
+cljrs-project  = { workspace = true, features = ["vcs", "vcs-net", "ssh"] }
 cljrs-lsp      = { workspace = true }
 cljrs-nrepl    = { workspace = true }
 cljrs-ir       = { workspace = true }


### PR DESCRIPTION
`cljrs-runtime` depended on `cljrs-project` unconditionally, and `GlobalEnv`
held `cljrs_project::vcs::TrustedKeys` as a struct field. Because it was a
field rather than an interface, nothing that linked the interpreter could
avoid gitoxide, rPGP and `ssh-key` — nor, through gix's http transport,
reqwest/hyper/rustls/aws-lc-rs/tokio/icu. An editor plugin, a sandboxed
evaluator or `cljrs-tx` linked a TLS stack to run Clojure.

Introduce `env::vcs::VcsProvider`: the four git operations the interpreter
actually needs (find repo root, read a file at a commit, verify a commit
signature, install trusted signers), as a trait object on `GlobalEnv`.

- `cljrs-runtime`'s new default-on `deps` feature installs the
  `cljrs-project`-backed `ProjectVcs` in `GlobalEnv::new`, so behaviour and
  every downstream crate are unchanged.
- With `--no-default-features` no provider is installed: source files are
  treated as living outside a repository, versioned resolution falls back to
  embedded (AOT) sources, and the gix/pgp/ssh-key tree is not compiled.
  303 -> 87 transitive crates for a runtime-only build.
- The provider field exists in both configurations, so `GlobalEnv`'s layout
  does not vary with the feature and feature unification cannot surprise an
  embedder. `set_vcs_provider` lets a host supply its own implementation, or
  pass `None` to strip git access from a sandbox.
- `check_commit_signature` now *fails* when verification is demanded but no
  provider exists, rather than silently accepting. Previously the wasm path
  passed unconditionally.

Split `cljrs-project`'s git support into two feature tiers so the weight
matches the use:

- `vcs` — local repository reads and signature verification. No network stack.
- `vcs-net` — `fetch_remote`, which is what selects gix's blocking http
  transport and with it reqwest/rustls/aws-lc-rs. Gitoxide routes every clone
  through that layer, so this gates local-path and `file://` fetches too.
  Only the `cljrs` binary takes it; the runtime never fetches, so even with
  `deps` on it links no HTTP/TLS stack (previously 0 of these crates were
  avoidable).

The http transport was selected by the workspace `gix` entry rather than by
gix's defaults, so `default-features = false` was already in place; moving
the transport feature to `vcs-net` is what actually drops it.

New `tests/vcs_provider.rs` covers the seam and passes both with and without
`deps`.