### PR TITLE
Make the regex engine a build-time choice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,6 @@ dependencies = [
  "bigdecimal",
  "num-bigint",
  "num-rational",
- "regex",
  "system-memory",
  "tracing",
 ]
@@ -1006,7 +1005,6 @@ dependencies = [
  "num-traits",
  "proptest",
  "rand 0.10.2",
- "regex",
  "rpds",
  "tempfile",
  "thiserror",
@@ -1060,6 +1058,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "regex",
+ "regex-lite",
  "rpds",
  "thiserror",
  "uuid",
@@ -5077,6 +5076,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,32 +33,35 @@ repository = "https://github.com/csm/clojurust"
 [workspace.dependencies]
 cljrs-types        = { path = "crates/cljrs-types",        version = "0.1.0" }
 cljrs-gc           = { path = "crates/cljrs-gc",           version = "0.1.0" }
-# Default-off so each member picks a regex engine explicitly: `regex-full`
-# (the `regex` crate) or `small-regex` (`regex-lite`). Every member that
-# depends on cljrs-value re-exports both features and has `regex-full` in its
-# own `default`, so a plain build is unchanged; a size-constrained embedding
-# turns default features off along the whole chain and selects `small-regex`.
+# `default-features = false` on every workspace crate that carries a `default`
+# feature list, so no internal edge silently re-enables one. Cargo unions
+# features across *all* edges to a package, so a single edge left at its
+# defaults turns those features back on for the whole graph — a second, direct
+# dependency declaration cannot switch them off again. Each member therefore
+# re-exports what its dependencies' defaults used to provide (`regex-full`,
+# `deps`, `wasm-aot`) and keeps them in its own `default`, leaving plain builds
+# unchanged while a size-constrained embedding can actually opt out.
 # See crates/cljrs-value/src/regex.rs.
 cljrs-value        = { path = "crates/cljrs-value",        version = "0.1.0", default-features = false }
 cljrs-reader       = { path = "crates/cljrs-reader",       version = "0.1.0" }
-cljrs-stdlib       = { path = "crates/cljrs-stdlib",       version = "0.1.0" }
-cljrs-runtime      = { path = "crates/cljrs-runtime",      version = "0.1.0" }
+cljrs-stdlib       = { path = "crates/cljrs-stdlib",       version = "0.1.0", default-features = false }
+cljrs-runtime      = { path = "crates/cljrs-runtime",      version = "0.1.0", default-features = false }
 cljrs-ir           = { path = "crates/cljrs-ir",           version = "0.1.0" }
-cljrs-compiler     = { path = "crates/cljrs-compiler",     version = "0.1.0" }
-cljrs-interop      = { path = "crates/cljrs-interop",      version = "0.1.0" }
+cljrs-compiler     = { path = "crates/cljrs-compiler",     version = "0.1.0", default-features = false }
+cljrs-interop      = { path = "crates/cljrs-interop",      version = "0.1.0", default-features = false }
 cljrs-export-macro = { path = "crates/cljrs-export-macro", version = "0.1.0" }
 # Default-off so each member opts in to what it needs: the config model alone
 # (nothing extra), `vcs` for local git + signature verification, `vcs-net` for
 # network fetch. See crates/cljrs-project/Cargo.toml.
 cljrs-project      = { path = "crates/cljrs-project",      version = "0.1.0", default-features = false }
-cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0" }
-cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0" }
-cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0" }
-cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0" }
+cljrs-async        = { path = "crates/cljrs-async",        version = "0.1.0", default-features = false }
+cljrs-io           = { path = "crates/cljrs-io",           version = "0.1.0", default-features = false }
+cljrs-net          = { path = "crates/cljrs-net",          version = "0.1.0", default-features = false }
+cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0", default-features = false }
 cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.0" }
-cljrs-nrepl        = { path = "crates/cljrs-nrepl",        version = "0.1.0" }
-cljrs-base64       = { path = "crates/cljrs-base64",       version = "0.1.0" }
-cljrs-tx           = { path = "crates/cljrs-tx",           version = "0.1.0" }
+cljrs-nrepl        = { path = "crates/cljrs-nrepl",        version = "0.1.0", default-features = false }
+cljrs-base64       = { path = "crates/cljrs-base64",       version = "0.1.0", default-features = false }
+cljrs-tx           = { path = "crates/cljrs-tx",           version = "0.1.0", default-features = false }
 
 tracing            = "0.1.44"
 tracing-subscriber = "0.3.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,13 @@ repository = "https://github.com/csm/clojurust"
 [workspace.dependencies]
 cljrs-types        = { path = "crates/cljrs-types",        version = "0.1.0" }
 cljrs-gc           = { path = "crates/cljrs-gc",           version = "0.1.0" }
-cljrs-value        = { path = "crates/cljrs-value",        version = "0.1.0" }
+# Default-off so each member picks a regex engine explicitly: `regex-full`
+# (the `regex` crate) or `small-regex` (`regex-lite`). Every member that
+# depends on cljrs-value re-exports both features and has `regex-full` in its
+# own `default`, so a plain build is unchanged; a size-constrained embedding
+# turns default features off along the whole chain and selects `small-regex`.
+# See crates/cljrs-value/src/regex.rs.
+cljrs-value        = { path = "crates/cljrs-value",        version = "0.1.0", default-features = false }
 cljrs-reader       = { path = "crates/cljrs-reader",       version = "0.1.0" }
 cljrs-stdlib       = { path = "crates/cljrs-stdlib",       version = "0.1.0" }
 cljrs-runtime      = { path = "crates/cljrs-runtime",      version = "0.1.0" }
@@ -71,6 +77,9 @@ tokio        = { version = "1.50.0", features = ["rt", "sync", "time", "macros"]
 futures-util = "0.3"
 encoding_rs  = "0.8"
 regex        = "1.12.3"
+# Alternate engine behind cljrs-value's `small-regex` feature: ~1/10th the code
+# size, no DFA/SIMD, no Unicode character classes.
+regex-lite   = "0.1.9"
 serde        = "1.0.228"
 postcard     = "1.1.3"
 rustyline    = "18.0.0"

--- a/crates/cljrs-async/Cargo.toml
+++ b/crates/cljrs-async/Cargo.toml
@@ -7,6 +7,13 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 # Propagate the no-GC build to every runtime dependency, so a `no-gc` workspace
 # build can include the async extension instead of stopping at the CLI.
 no-gc = [

--- a/crates/cljrs-async/Cargo.toml
+++ b/crates/cljrs-async/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps"]
 
 # Propagate the no-GC build to every runtime dependency, so a `no-gc` workspace
 # build can include the async extension instead of stopping at the CLI.

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -384,12 +384,26 @@ the browser's `setTimeout` is used instead of a non-functional OS-level clock.
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-async = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -377,3 +377,19 @@ own `async` feature pulls this package in.
 **Timer portability:** On `wasm32` the `time` feature of tokio is present but
 `platform_sleep` (used internally by `timeout`) delegates to `gloo-timers` so that
 the browser's `setTimeout` is used instead of a non-functional OS-level clock.
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-base64/Cargo.toml
+++ b/crates/cljrs-base64/Cargo.toml
@@ -10,12 +10,16 @@ repository.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full", "cljrs-interop/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex", "cljrs-interop/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps", "cljrs-interop/deps"]
 
 [dependencies]
 cljrs-runtime = { workspace = true }

--- a/crates/cljrs-base64/Cargo.toml
+++ b/crates/cljrs-base64/Cargo.toml
@@ -9,6 +9,14 @@ repository.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-runtime = { workspace = true }
 cljrs-interop = { workspace = true }

--- a/crates/cljrs-base64/README.md
+++ b/crates/cljrs-base64/README.md
@@ -43,3 +43,19 @@ pub unsafe extern "C" fn cljrs_init(registry: *mut Registry);
 | `cljrs.base64/decode-url` | `(decode-url data)` | URL-safe Base64 decode (no padding); returns a `ByteArray` |
 
 `data` may be a `String`, a `Vector` of integers in `[0, 255]`, a `ByteArray`, or a `ByteBlob`.
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-base64/README.md
+++ b/crates/cljrs-base64/README.md
@@ -50,12 +50,26 @@ pub unsafe extern "C" fn cljrs_init(registry: *mut Registry);
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-base64 = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-blake3/Cargo.toml
+++ b/crates/cljrs-blake3/Cargo.toml
@@ -14,12 +14,16 @@ repository.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-interop/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-interop/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-interop/deps"]
 
 [dependencies]
 cljrs-interop = { workspace = true }

--- a/crates/cljrs-blake3/Cargo.toml
+++ b/crates/cljrs-blake3/Cargo.toml
@@ -13,6 +13,14 @@ repository.workspace = true
 # integration tests and AOT static linking both depend on it.
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-interop = { workspace = true }
 cljrs-gc      = { workspace = true }

--- a/crates/cljrs-blake3/README.md
+++ b/crates/cljrs-blake3/README.md
@@ -125,12 +125,26 @@ pub fn cljrs_init(registry: &mut Registry) {
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-blake3 = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-blake3/README.md
+++ b/crates/cljrs-blake3/README.md
@@ -118,3 +118,19 @@ pub fn cljrs_init(registry: &mut Registry) {
 | `cljrs-interop` (workspace) | `Registry`, `wrap_fn*`, `NativeObject`, marshalling |
 | `cljrs-gc` (workspace) | `GcPtr`, `Trace`, `MarkVisitor` |
 | `cljrs-value` (workspace) | `Value`, `NativeFn`, `Arity` |
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-charset/Cargo.toml
+++ b/crates/cljrs-charset/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full", "cljrs-async/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex", "cljrs-async/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps", "cljrs-async/deps"]
 
 [dependencies]
 cljrs-runtime = { workspace = true }

--- a/crates/cljrs-charset/Cargo.toml
+++ b/crates/cljrs-charset/Cargo.toml
@@ -6,6 +6,14 @@ description = "Charset encoding and decoding with stream support — clojure.rus
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-runtime = { workspace = true }
 cljrs-gc    = { workspace = true }

--- a/crates/cljrs-charset/README.md
+++ b/crates/cljrs-charset/README.md
@@ -97,3 +97,19 @@ HTML numeric character references (e.g. `&#128512;` for 😀).
   ;; out-ch delivers ByteBlob values
   )
 ```
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-charset/README.md
+++ b/crates/cljrs-charset/README.md
@@ -104,12 +104,26 @@ HTML numeric character references (e.g. `&#128512;` for 😀).
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-charset = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -7,7 +7,13 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["wasm-aot"]
+default = ["wasm-aot", "regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 # The WebAssembly AOT backend (`src/wasm/`) and its `compile_file_to_wasm`
 # driver.  On by default so `cljrs compile --target wasm` works out of the box;
 # `--no-default-features` drops the backend and the `wasm-encoder` dependency

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["wasm-aot", "regex-full"]
+default = ["wasm-aot", "regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full", "cljrs-async/regex-full", "cljrs-stdlib/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex", "cljrs-async/small-regex", "cljrs-stdlib/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps", "cljrs-async/deps", "cljrs-stdlib/deps"]
 
 # The WebAssembly AOT backend (`src/wasm/`) and its `compile_file_to_wasm`
 # driver.  On by default so `cljrs compile --target wasm` works out of the box;

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -647,8 +647,15 @@ versioned loader rather than the plain `require` path.
 | `wasm-aot` | on | The WebAssembly backend (`wasm/`), `aot::compile_file_to_wasm`, and the `wasm-encoder` dependency.  `--no-default-features` produces a native-only compiler. |
 | `no-gc` | off | Propagated to `cljrs-gc`/`cljrs-value`/`cljrs-runtime`/`cljrs-stdlib`/`cljrs-async`; enables the `escape.rs` blacklist analysis. |
 | `aot_full_test` | off | Runs the full (~120 test) AOT end-to-end suite instead of its core subset. |
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead; see [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | on | Forwards `regex-full` to `cljrs-value`/`cljrs-runtime`/`cljrs-async`/`cljrs-stdlib` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`; see [cljrs-value's README](../cljrs-value/README.md#features). |
+| `deps` | on | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
+
+All four workspace dependencies above are taken with default features off (see the
+note in the root `Cargo.toml`), so `regex-full` and `deps` are what put back what
+their defaults used to provide; both are in `default`, leaving plain builds
+unchanged. Selecting `small-regex` means `default-features = false` on *this*
+crate — a second direct dependency cannot undo a feature another edge enabled.
 
 ---
 

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -647,6 +647,8 @@ versioned loader rather than the plain `require` path.
 | `wasm-aot` | on | The WebAssembly backend (`wasm/`), `aot::compile_file_to_wasm`, and the `wasm-encoder` dependency.  `--no-default-features` produces a native-only compiler. |
 | `no-gc` | off | Propagated to `cljrs-gc`/`cljrs-value`/`cljrs-runtime`/`cljrs-stdlib`/`cljrs-async`; enables the `escape.rs` blacklist analysis. |
 | `aot_full_test` | off | Runs the full (~120 test) AOT end-to-end suite instead of its core subset. |
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead; see [cljrs-value's README](../cljrs-value/README.md#features). |
 
 ---
 

--- a/crates/cljrs-gc/Cargo.toml
+++ b/crates/cljrs-gc/Cargo.toml
@@ -14,7 +14,6 @@ no-gc = []
 num-bigint   = { workspace = true }
 bigdecimal   = { workspace = true }
 num-rational = { workspace = true }
-regex        = { workspace = true }
 tracing       = { workspace = true }
 
 # Not available on wasm32-unknown-unknown (pulls in errno).  The wasm build

--- a/crates/cljrs-gc/README.md
+++ b/crates/cljrs-gc/README.md
@@ -123,7 +123,12 @@ counted separately when allocated.
 
 Built-in leaf impls: `String` (overrides `gc_size_extra` to return `capacity()`),
 `i64`, `f64`, `bool`, `num_bigint::BigInt`, `bigdecimal::BigDecimal`,
-`num_rational::Ratio<BigInt>`.
+`num_rational::Ratio<BigInt>`, and `Mutex<Vec<T>>` for the primitive array
+element types (`i8`/`i16`/`i32`/`i64`/`f32`/`f64`/`bool`/`char`).
+
+Compiled regular expressions are *not* here: `Trace` for them lives on
+`cljrs-value`'s `Pattern` wrapper, so `cljrs-gc` does not depend on a regex
+engine.
 
 ### `GcPtr<T: Trace + 'static>`
 

--- a/crates/cljrs-gc/src/lib.rs
+++ b/crates/cljrs-gc/src/lib.rs
@@ -100,9 +100,6 @@ impl Trace for bigdecimal::BigDecimal {
 impl Trace for num_rational::Ratio<num_bigint::BigInt> {
     fn trace(&self, _: &mut MarkVisitor) {}
 }
-impl Trace for regex::Regex {
-    fn trace(&self, _: &mut MarkVisitor) {}
-}
 macro_rules! impl_trace_prim_array {
     ($t:ty) => {
         impl Trace for std::sync::Mutex<Vec<$t>> {

--- a/crates/cljrs-interop/Cargo.toml
+++ b/crates/cljrs-interop/Cargo.toml
@@ -6,6 +6,14 @@ description = "Rust<->Clojure FFI, type marshalling, and NativeObject support"
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-types        = { workspace = true }
 cljrs-gc           = { workspace = true }

--- a/crates/cljrs-interop/Cargo.toml
+++ b/crates/cljrs-interop/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps"]
 
 [dependencies]
 cljrs-types        = { workspace = true }

--- a/crates/cljrs-interop/README.md
+++ b/crates/cljrs-interop/README.md
@@ -233,12 +233,26 @@ codepath would replace the HEAD fallback.
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-interop = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-interop/README.md
+++ b/crates/cljrs-interop/README.md
@@ -226,3 +226,19 @@ codepath would replace the HEAD fallback.
 | `cljrs-export-macro` (workspace) | `#[export]` proc-macro |
 | `inventory` (workspace) | Link-time collection of `ExportEntry` items |
 | `num-bigint` (workspace) | `BigInt` marshalling |
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-io/Cargo.toml
+++ b/crates/cljrs-io/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full", "cljrs-async/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex", "cljrs-async/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps", "cljrs-async/deps"]
 
 [dependencies]
 cljrs-runtime = { workspace = true }

--- a/crates/cljrs-io/Cargo.toml
+++ b/crates/cljrs-io/Cargo.toml
@@ -6,6 +6,14 @@ description = "Asynchronous file I/O for clojurust — tokio-backed reads/writes
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-runtime = { workspace = true }
 cljrs-types    = { workspace = true }

--- a/crates/cljrs-io/README.md
+++ b/crates/cljrs-io/README.md
@@ -119,3 +119,19 @@ Helpers: `(error? x)`, `(ok? x)`.
 `cljrs-types`, `cljrs-gc`, `cljrs-value`, `cljrs-runtime` (`env` + `interp`),
 `cljrs-reader`, `cljrs-async` (channels + `spawn_future`), `tokio` (with the
 `fs` and `io-util` features), and `encoding_rs`.
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-io/README.md
+++ b/crates/cljrs-io/README.md
@@ -126,12 +126,26 @@ Helpers: `(error? x)`, `(ok? x)`.
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-io = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -6,6 +6,14 @@ description = "TCP/Unix/TLS networking for clojurust — channel-oriented socket
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-runtime = { workspace = true }
 cljrs-types    = { workspace = true }

--- a/crates/cljrs-net/Cargo.toml
+++ b/crates/cljrs-net/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full", "cljrs-async/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex", "cljrs-async/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps", "cljrs-async/deps"]
 
 [dependencies]
 cljrs-runtime = { workspace = true }

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -448,12 +448,26 @@ in this namespace covers the simple map-over-channel case:
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-net = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-net/README.md
+++ b/crates/cljrs-net/README.md
@@ -441,3 +441,19 @@ in this namespace covers the simple map-over-channel case:
       parsed (frame/pipe-map msgs parse-json)]
   ...)
 ```
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-nrepl/Cargo.toml
+++ b/crates/cljrs-nrepl/Cargo.toml
@@ -6,6 +6,14 @@ description = "nREPL server for clojurust — bencode wire protocol for editor i
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-runtime = { workspace = true }
 cljrs-gc       = { workspace = true }

--- a/crates/cljrs-nrepl/Cargo.toml
+++ b/crates/cljrs-nrepl/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps"]
 
 [dependencies]
 cljrs-runtime = { workspace = true }

--- a/crates/cljrs-nrepl/README.md
+++ b/crates/cljrs-nrepl/README.md
@@ -43,3 +43,19 @@ Each session has its own `Env` (namespace) and its own `*1`/`*2`/`*3`/`*e`, boun
 - `trait EvalForm: FnMut(&Form, &mut Env) -> Result<Value, EvalError>` — evaluator signature for `serve_with`.
 - `mod bencode` — `Bencode`, `encode`, `encode_to_vec`, `decode` (public for tests/clients).
 - `mod protocol` — `Request`, `Response`.
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-nrepl/README.md
+++ b/crates/cljrs-nrepl/README.md
@@ -50,12 +50,26 @@ Each session has its own `Env` (namespace) and its own `*1`/`*2`/`*3`/`*e`, boun
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-nrepl = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-runtime/Cargo.toml
+++ b/crates/cljrs-runtime/Cargo.toml
@@ -7,7 +7,13 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["deps"]
+default = ["deps", "regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc"]
 
 # Git-backed dependency and versioned-var support: installs the
@@ -36,7 +42,6 @@ num-traits   = { workspace = true }
 rand         = { workspace = true }
 rpds         = { workspace = true }
 uuid         = { workspace = true, features = ["v4"] }
-regex        = { workspace = true }
 
 # `logging` installs a subscriber, which is a host-side concern: a wasm32
 # runtime has no stderr to format to and installs none.

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -1124,6 +1124,8 @@ by the lowerer — resolve at Tier 1 exactly as they do tree-walked.
 |---|---|---|
 | `no-gc` | off | Forwards to `cljrs-gc/no-gc` and `cljrs-value/no-gc`; switches `env::gc_roots`, `interp::special`, and `interp::apply` to the region/`StaticArena` allocation protocol |
 | `deps` | **on** | Enables `cljrs-project/vcs` and installs the `cljrs-project`-backed [`VcsProvider`](#vcs-submodule) in `GlobalEnv::new`, so versioned vars (`ns/name@commit`) resolve out of git history and `:verify-commit-signatures` can check signatures |
+| `regex-full` | **on** | Forwards `cljrs-value/regex-full`: `Value::Pattern` uses the `regex` crate |
+| `small-regex` | off | Forwards `cljrs-value/small-regex`: `Value::Pattern` uses `regex-lite` instead, dropping ~277 KB of text at the cost of Unicode character classes. `regex-full` wins if both are on, so this needs `--no-default-features` — and `deps` off as well, since `cljrs-project/vcs` pulls `regex` in through `pgp`. See [cljrs-value's README](../cljrs-value/README.md#features) |
 
 ### Turning `deps` off
 
@@ -1160,11 +1162,11 @@ the default provider at runtime.
 |-------|------|
 | `cljrs-types` | `Span` |
 | `cljrs-gc` | `GcPtr<T>`, alloc frames, safepoints |
-| `cljrs-value` | `Value`, `CljxFn`, persistent collections, `shared` |
+| `cljrs-value` | `Value`, `CljxFn`, persistent collections, `shared`, `regex::Pattern` (the regex engine is selected there, not here) |
 | `cljrs-reader` | `Form` AST and `Parser` |
 | `cljrs-ir` | IR types (`IrFunction`, `Block`, `Inst`, `IrBundle`) and lowering |
 | `tracing` / `tracing-subscriber` (non-WASM) | the `gc`/`env`/`ir`/`jit` diagnostic targets, and the `logging` module that filters and installs them |
 | `cljrs-project` | `config` — project configuration consulted by the namespace loader (always; no external dependencies of its own). `vcs` (non-WASM, `deps` feature) — git history access for versioned namespace resolution. Never `vcs-net`: the interpreter reads local repositories and never fetches, so no HTTP/TLS stack is linked. |
 | `num-bigint`, `num-rational`, `bigdecimal`, `num-traits` | numeric tower |
-| `rand`, `rpds`, `uuid`, `regex` | builtin implementations |
+| `rand`, `rpds`, `uuid` | builtin implementations |
 | `log`, `thiserror` | diagnostics and error derivation |

--- a/crates/cljrs-runtime/src/builtins/form.rs
+++ b/crates/cljrs-runtime/src/builtins/form.rs
@@ -3,11 +3,11 @@
 use crate::env::error::{EvalError, EvalResult};
 use cljrs_gc::GcPtr;
 use cljrs_reader::{Form, FormKind};
+use cljrs_value::regex::Pattern;
 use cljrs_value::value::SetValue;
 use cljrs_value::{
     Keyword, MapValue, PersistentHashSet, PersistentList, PersistentVector, Symbol, Value,
 };
-use regex::Regex;
 
 // ── anon fn expansion ─────────────────────────────────────────────────────────
 
@@ -249,7 +249,7 @@ pub fn form_to_value(form: &Form) -> EvalResult<Value> {
         FormKind::Keyword(s) => Value::keyword(Keyword::parse(s)),
         FormKind::AutoKeyword(s) => Value::keyword(Keyword::simple(s.as_str())),
         FormKind::AutoSymbol(s) => Value::symbol(Symbol::parse(s)),
-        FormKind::Regex(s) => match Regex::new(s.as_str()) {
+        FormKind::Regex(s) => match Pattern::new(s.as_str()) {
             Ok(pattern) => Value::Pattern(GcPtr::new(pattern)),
             Err(_) => Value::Nil, // should already have been caught
         },

--- a/crates/cljrs-runtime/src/builtins/regex.rs
+++ b/crates/cljrs-runtime/src/builtins/regex.rs
@@ -1,5 +1,5 @@
 use cljrs_gc::GcPtr;
-use cljrs_value::regex::{MatchPhase, Matcher};
+use cljrs_value::regex::{MatchPhase, Matcher, Pattern};
 use cljrs_value::{Value, ValueError, ValueResult};
 
 pub fn builtin_re_pattern(args: &[Value]) -> ValueResult<Value> {
@@ -7,7 +7,7 @@ pub fn builtin_re_pattern(args: &[Value]) -> ValueResult<Value> {
         Value::Pattern(pattern) => Ok(Value::Pattern(pattern.clone())),
         Value::Matcher(matcher) => Ok(Value::Pattern(matcher.get().pattern.clone())),
         Value::Str(s) => {
-            let pattern = regex::Regex::new(s.get().as_str());
+            let pattern = Pattern::new(s.get().as_str());
             match pattern {
                 Ok(pattern) => Ok(Value::Pattern(GcPtr::new(pattern))),
                 Err(e) => Err(ValueError::Other(e.to_string())),
@@ -77,7 +77,7 @@ pub fn builtin_re_groups(args: &[Value]) -> ValueResult<Value> {
 fn new_matcher(args: &[Value], match_all: bool) -> ValueResult<Matcher> {
     let pattern = match &args[0] {
         Value::Pattern(p) => Ok(p.get().clone()),
-        Value::Str(s) => regex::Regex::new(s.get()),
+        Value::Str(s) => Pattern::new(s.get()),
         v => {
             return Err(ValueError::WrongType {
                 expected: "str or pattern",

--- a/crates/cljrs-runtime/src/builtins/util.rs
+++ b/crates/cljrs-runtime/src/builtins/util.rs
@@ -3,6 +3,7 @@
 use crate::env::error::{EvalError, EvalResult};
 use bigdecimal::BigDecimal;
 use cljrs_gc::GcPtr;
+use cljrs_value::regex::Pattern;
 use cljrs_value::{Value, ValueError, ValueResult};
 use num_bigint::BigInt;
 use num_traits::{Signed, ToPrimitive};
@@ -112,7 +113,7 @@ pub fn parse_regex(s: &str) -> EvalResult {
     // execution tiers. Tree-walk and compiled tiers currently both compile a
     // regex literal on each evaluation; preserving that behavior keeps this
     // correctness change tier-neutral, but a hot literal still pays Regex::new.
-    regex::Regex::new(s)
+    Pattern::new(s)
         .map(|r| Value::Pattern(GcPtr::new(r)))
         .map_err(|e| EvalError::Runtime(e.to_string()))
 }

--- a/crates/cljrs-runtime/src/interp/eval.rs
+++ b/crates/cljrs-runtime/src/interp/eval.rs
@@ -12,12 +12,12 @@ use crate::interp::syntax_quote::syntax_quote;
 use cljrs_gc::GcPtr;
 use cljrs_reader::Form;
 use cljrs_reader::form::FormKind;
+use cljrs_value::regex::Pattern;
 use cljrs_value::value::SetValue;
 use cljrs_value::{
     FutureState, Keyword, MapValue, PersistentHashSet, PersistentList, PersistentVector, Symbol,
     Value,
 };
-use regex::Regex;
 
 /// Evaluate a `Form` in the given `Env`.
 pub fn eval(form: &Form, env: &mut Env) -> EvalResult {
@@ -37,7 +37,7 @@ pub fn eval(form: &Form, env: &mut Env) -> EvalResult {
         FormKind::BigDecimal(s) => crate::builtins::parse_bigdecimal(s),
         FormKind::Ratio(s) => crate::builtins::parse_ratio(s),
         FormKind::Regex(s) => {
-            let r = Regex::new(s);
+            let r = Pattern::new(s);
             match r {
                 Ok(r) => Ok(Value::Pattern(GcPtr::new(r))),
                 Err(e) => Err(EvalError::Runtime(e.to_string())),

--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -7,13 +7,28 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = []
+default = ["regex-full", "deps"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice) and to
+# cljrs-runtime. `regex-full` is the default engine, `small-regex` swaps in
+# regex-lite. Both are forwarded because cljrs-runtime is depended on with
+# default features off — see the note on `deps` below.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support, on by default
+# so a plain `cljrs-stdlib` build behaves as it always has.
+deps = ["cljrs-runtime/deps"]
+
 no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc", "cljrs-runtime/no-gc"]
 
 [dependencies]
 cljrs-gc      = { workspace = true }
 cljrs-ir      = { workspace = true }
 cljrs-value   = { workspace = true }
-cljrs-runtime = { workspace = true }
+# Not `workspace = true`: an interpreter-plus-clojure.core embedding needs to be
+# able to turn cljrs-runtime's default features off (`deps`, `regex-full`), and
+# Cargo ignores `default-features = false` on an inherited dependency whose
+# workspace entry leaves it on. The features above put both knobs back.
+cljrs-runtime = { path = "../cljrs-runtime", version = "0.1.0", default-features = false }
 cljrs-reader  = { workspace = true }
-

--- a/crates/cljrs-stdlib/Cargo.toml
+++ b/crates/cljrs-stdlib/Cargo.toml
@@ -9,15 +9,13 @@ repository.workspace = true
 [features]
 default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice) and to
-# cljrs-runtime. `regex-full` is the default engine, `small-regex` swaps in
-# regex-lite. Both are forwarded because cljrs-runtime is depended on with
-# default features off — see the note on `deps` below.
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
 regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full"]
 small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex"]
 
-# Pass-through for cljrs-runtime's git-backed dependency support, on by default
-# so a plain `cljrs-stdlib` build behaves as it always has.
+# Pass-through for cljrs-runtime's git-backed dependency support.
 deps = ["cljrs-runtime/deps"]
 
 no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc", "cljrs-runtime/no-gc"]
@@ -26,9 +24,5 @@ no-gc = ["cljrs-gc/no-gc", "cljrs-value/no-gc", "cljrs-runtime/no-gc"]
 cljrs-gc      = { workspace = true }
 cljrs-ir      = { workspace = true }
 cljrs-value   = { workspace = true }
-# Not `workspace = true`: an interpreter-plus-clojure.core embedding needs to be
-# able to turn cljrs-runtime's default features off (`deps`, `regex-full`), and
-# Cargo ignores `default-features = false` on an inherited dependency whose
-# workspace entry leaves it on. The features above put both knobs back.
-cljrs-runtime = { path = "../cljrs-runtime", version = "0.1.0", default-features = false }
+cljrs-runtime = { workspace = true }
 cljrs-reader  = { workspace = true }

--- a/crates/cljrs-stdlib/README.md
+++ b/crates/cljrs-stdlib/README.md
@@ -191,3 +191,26 @@ exists purely so that idiomatic specs which `(:require [clojure.spec.gen.alpha
 - `cljrs-runtime` does **not** depend on `cljrs-stdlib` (no circular dep)
 - The `cljrs` binary depends on both: it builds the runtime and then calls
   `cljrs_stdlib::install()` so stdlib namespaces are available
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` (git-backed dependency and versioned-var support). `cljrs-runtime` is depended on with default features off so this crate does not force the choice on an embedder; leaving `default` alone keeps the historical behaviour. |
+| `regex-full` | **on** | Forwards `cljrs-value/regex-full` and `cljrs-runtime/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` and `cljrs-runtime/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `no-gc` | off | Forwards `no-gc` to `cljrs-gc`, `cljrs-value`, and `cljrs-runtime`. |
+
+`regex-full` wins when both regex features are enabled, so the small engine
+needs `default-features = false`:
+
+```toml
+cljrs-stdlib = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+That combination — interpreter plus `clojure.core`/`clojure.string`, no git
+dependency support, small regex engine — is the profile where the engine swap
+actually removes `regex` from the build. With `deps` on, `cljrs-project/vcs`
+pulls `regex` in through `pgp` anyway.

--- a/crates/cljrs-stdlib/README.md
+++ b/crates/cljrs-stdlib/README.md
@@ -198,7 +198,7 @@ exists purely so that idiomatic specs which `(:require [clojure.spec.gen.alpha
 
 | Feature | Default | Effect |
 |---|---|---|
-| `deps` | **on** | Pass-through for `cljrs-runtime/deps` (git-backed dependency and versioned-var support). `cljrs-runtime` is depended on with default features off so this crate does not force the choice on an embedder; leaving `default` alone keeps the historical behaviour. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 | `regex-full` | **on** | Forwards `cljrs-value/regex-full` and `cljrs-runtime/regex-full` — `Value::Pattern` uses the `regex` crate. |
 | `small-regex` | off | Forwards `cljrs-value/small-regex` and `cljrs-runtime/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
 | `no-gc` | off | Forwards `no-gc` to `cljrs-gc`, `cljrs-value`, and `cljrs-runtime`. |
@@ -214,3 +214,9 @@ That combination — interpreter plus `clojure.core`/`clojure.string`, no git
 dependency support, small regex engine — is the profile where the engine swap
 actually removes `regex` from the build. With `deps` on, `cljrs-project/vcs`
 pulls `regex` in through `pgp` anyway.
+
+`cljrs-runtime` is taken with default features off here (as everywhere in the
+workspace — see the note in the root `Cargo.toml`), which is why `regex-full` and
+`deps` are forwarded rather than inherited. Cargo unions features across every
+edge to a package, so an edge left at its defaults would re-enable them for the
+whole graph and no second, direct dependency could switch them back off.

--- a/crates/cljrs-tx/Cargo.toml
+++ b/crates/cljrs-tx/Cargo.toml
@@ -7,6 +7,13 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 no-gc = [
     "cljrs-gc/no-gc",
     "cljrs-value/no-gc",

--- a/crates/cljrs-tx/Cargo.toml
+++ b/crates/cljrs-tx/Cargo.toml
@@ -7,12 +7,16 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps"]
 
 no-gc = [
     "cljrs-gc/no-gc",

--- a/crates/cljrs-tx/README.md
+++ b/crates/cljrs-tx/README.md
@@ -89,3 +89,19 @@ The memory limit covers arena object boxes and out-of-line memory reported by
 limit: ordinary Rust allocations outside traced values are not fully charged.
 A WASM linear-memory or process sandbox remains necessary when an adversarial
 hard address-space ceiling is required.
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs-tx/README.md
+++ b/crates/cljrs-tx/README.md
@@ -96,12 +96,26 @@ hard address-space ceiling is required.
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-tx = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-value/Cargo.toml
+++ b/crates/cljrs-value/Cargo.toml
@@ -7,7 +7,14 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+default = ["regex-full"]
 no-gc = ["cljrs-gc/no-gc"]
+
+# Regex engine behind `Value::Pattern`. Exactly one is used: `regex-full` wins
+# when both are enabled, so an additive `small-regex` never downgrades a build
+# that also wants full Unicode classes. See src/regex.rs.
+regex-full  = ["dep:regex"]
+small-regex = ["dep:regex-lite"]
 
 [dependencies]
 cljrs-types   = { workspace = true }
@@ -20,5 +27,6 @@ bigdecimal   = { workspace = true }
 thiserror    = { workspace = true }
 rpds         = { workspace = true }
 uuid         = { workspace = true }
-regex        = { workspace = true }
+regex        = { workspace = true, optional = true }
+regex-lite   = { workspace = true, optional = true }
 arc-swap     = { workspace = true }

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -629,8 +629,12 @@ only) and is materially slower on pathological patterns. `re-find`/`re-matches`/
 are unaffected in behaviour.
 
 Because `regex-full` wins ties, selecting the small engine means turning default
-features off on every workspace crate you depend on directly; each of them
-re-exports both features:
+features off on every workspace crate you depend on **directly**. Cargo unions
+features across all edges to a package, so an edge left at its defaults re-enables
+`regex-full` for the whole graph — and a second, direct dependency declaration
+cannot switch it off again. Every workspace crate therefore takes its own internal
+dependencies with default features off and re-exports both features, so one
+`default-features = false` at your edge is enough:
 
 ```toml
 [dependencies]
@@ -642,6 +646,9 @@ One crate left at its defaults anywhere in the graph puts `regex` back — the s
 unification caveat that applies to `cljrs-runtime`'s `deps` feature. And `deps`
 itself has to be off for the swap to pay: `cljrs-project/vcs` pulls `regex` in
 through `pgp`, so an embedding that resolves git-hosted dependencies links the
-full engine no matter what this feature says. `cljrs-stdlib` therefore depends on
-`cljrs-runtime` with default features off and re-exports `deps` alongside the two
-regex features.
+full engine no matter what this feature says. Every crate that re-exports the regex pair also
+re-exports `deps` for that reason.
+
+The one crate where the swap cannot pay is the CLI: `cljrs` depends on
+`cljrs-project` with `vcs`/`vcs-net`/`ssh` unconditionally, so `pgp` — and with it
+`regex` — is always in that binary.

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -28,6 +28,7 @@ src/
   keyword.rs                     — Keyword { namespace, name }
   publish.rs                     — (Phase 10.5, GC builds; identity stub under no-gc) heap-promotion publish barrier: publish_value(Value) -> Value scans for region-allocated boxes, deep-copies them to the GC heap (via clone.rs), or poisons the active regions when the value is opaque to the scan. Called by Var::bind, Atom::new/reset, Volatile::new/reset, CljxPromise::deliver, and cljrs-async channel puts
   shared.rs                      — (Phase B3) SharedValue enum, SharedAtom (Arc<ArcSwap<SharedValue>>), promote/demote; PromoteError. Var roots reuse SharedValue via Var::shared_root (issue #171)
+  regex.rs                       — Pattern (engine-agnostic compiled regex behind Value::Pattern, selected by the regex-full / small-regex features), PatternError, Captures, Matcher (stateful re-find/re-matches driver), MatchPhase, MatchResult
   symbol.rs                      — Symbol { namespace, name }
   type_hint.rs                   — TypeHint enum (^long/^double/^longs/… primitive type tags) + from_tag/is_array/element
   native_object.rs               — NativeObject trait, NativeObjectBox wrapper, gc_native_object helper (Phase 9 interop)
@@ -65,6 +66,9 @@ pub enum Value {
     Ratio(GcPtr<num_rational::Ratio<num_bigint::BigInt>>),
     Char(char),
     Str(GcPtr<String>),
+    // Regexes (engine selected by the regex-full / small-regex features)
+    Pattern(GcPtr<Pattern>),
+    Matcher(GcPtr<Matcher>),
     // Identifiers
     Symbol(GcPtr<Symbol>),
     Keyword(GcPtr<Keyword>),
@@ -124,6 +128,76 @@ Both support `simple(name)`, `qualified(ns, name)`, `parse(str)`, and
 helpers used by all execution tiers to detect versioned names:
 `symbol::is_commit_hash(s) -> bool` and
 `symbol::split_version(name) -> (&str, Option<&str>)`.
+
+### `regex` — `Pattern` / `Captures` / `Matcher`
+
+`Value::Pattern` holds a `GcPtr<Pattern>`, never an engine type directly.
+`Pattern` is the only place in the workspace that names a regex engine, so the
+engine is a build-time choice (see [Features](#features)):
+
+```rust
+pub struct Pattern(/* regex::Regex or regex_lite::Regex */);
+
+impl Pattern {
+    pub fn new(pattern: &str) -> Result<Pattern, PatternError>;
+    pub fn as_str(&self) -> &str;
+    pub fn captures<'h>(&self, haystack: &'h str) -> Option<Captures<'h>>;
+    pub fn captures_at<'h>(&self, haystack: &'h str, start: usize) -> Option<Captures<'h>>;
+    pub fn replace<'h>(&self, haystack: &'h str, replacement: &str) -> Cow<'h, str>;
+    pub fn replace_all<'h>(&self, haystack: &'h str, replacement: &str) -> Cow<'h, str>;
+    pub fn split<'h>(&self, haystack: &'h str) -> impl Iterator<Item = &'h str>;
+    pub fn splitn<'h>(&self, haystack: &'h str, limit: usize) -> impl Iterator<Item = &'h str>;
+}
+
+impl Clone for Pattern {}
+impl fmt::Display for Pattern {}   // the pattern source
+impl Trace for Pattern {}          // leaf: no GcPtr fields
+
+/// Engine-independent compile failure; carries the engine's message.
+pub struct PatternError(/* private */);
+impl fmt::Display for PatternError {}
+impl std::error::Error for PatternError {}
+
+/// A successful match, borrowing the haystack.
+pub struct Captures<'h>(/* private */);
+
+impl<'h> Captures<'h> {
+    pub fn full(&self) -> &'h str;        // group 0
+    pub fn end(&self) -> usize;           // byte offset past group 0
+    pub fn group_count(&self) -> usize;   // groups incl. group 0; ≥ 1
+    pub fn groups(&self) -> impl Iterator<Item = Option<&'h str>> + '_;
+}
+```
+
+`Matcher` is the stateful driver behind `re-find`/`re-matches`/`re-seq`: it
+holds `pattern: GcPtr<Pattern>` plus a haystack and walks matches left to
+right, one per `next()` call.
+
+```rust
+pub enum MatchPhase { New, Matching(usize), Complete }
+
+pub struct Matcher { pub pattern: GcPtr<Pattern>, /* haystack, state, match_all */ }
+
+impl Matcher {
+    pub fn new(pattern: Pattern, source: String, match_all: bool) -> Matcher;
+    pub fn next(&self) -> MatchPhase;            // advance; Complete once exhausted
+    pub fn capture(&self) -> Option<MatchResult>; // last match, owned
+    pub fn phase(&self) -> MatchPhase;
+}
+
+impl Clone for Matcher {}
+impl Trace for Matcher {}
+
+/// Owned form of a match — outlives the haystack borrow.
+pub struct MatchResult { pub full: String, pub groups: Vec<Option<String>> }
+
+impl MatchResult {
+    pub fn new(cap: &Captures<'_>) -> MatchResult;
+    /// Str for a group-less match, Vector of groups otherwise (Clojure's
+    /// re-find return shape).
+    pub fn to_value(&self) -> Value;
+}
+```
 
 ### Phase B3 — Shared static arena
 
@@ -526,3 +600,48 @@ Matcher; Var whose root holds a non-promotable value.
 `cljrs-value` depends on `cljrs-reader` so that `CljxFnArity::body` can store
 `Vec<Form>` (unevaluated source bodies for interpreter evaluation and closure
 capture).
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | yes | `Value::Pattern` uses the `regex` crate: linear-time matching, full Unicode character classes. |
+| `small-regex` | no | `Value::Pattern` uses `regex-lite` instead — roughly a tenth of the code size; `regex-automata`, `regex-syntax` and `aho-corasick` drop out of the build. |
+| `no-gc` | no | Forwards `cljrs-gc/no-gc` (region allocation, no tracing GC). |
+
+Exactly one regex engine is compiled in, and `regex-full` wins when both
+features are enabled. Cargo features are additive, so that ordering is
+deliberate: a build where one dependent asks for `small-regex` and another takes
+the default gets the more capable engine rather than a silent semantic
+downgrade.
+
+Measured on a stripped release build of the interpreter plus
+`clojure.core`/`clojure.string` with `deps` off (`cljrs-stdlib` with
+`default-features = false`), swapping the engine takes `.text` from 3.68 MB to
+2.89 MB and the binary from 5.77 MB to 4.10 MB.
+
+`small-regex` is a **behaviour** change as well as a size one — `regex-lite` has
+no Unicode character classes (`\w`, `\d`, `[[:alpha:]]` and friends are ASCII
+only) and is materially slower on pathological patterns. `re-find`/`re-matches`/
+`re-seq` over short strings, which is what most Clojure code does with regexes,
+are unaffected in behaviour.
+
+Because `regex-full` wins ties, selecting the small engine means turning default
+features off on every workspace crate you depend on directly; each of them
+re-exports both features:
+
+```toml
+[dependencies]
+# interpreter + clojure.core/clojure.string, no git dependency support
+cljrs-stdlib = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+One crate left at its defaults anywhere in the graph puts `regex` back — the same
+unification caveat that applies to `cljrs-runtime`'s `deps` feature. And `deps`
+itself has to be off for the swap to pay: `cljrs-project/vcs` pulls `regex` in
+through `pgp`, so an embedding that resolves git-hosted dependencies links the
+full engine no matter what this feature says. `cljrs-stdlib` therefore depends on
+`cljrs-runtime` with default features off and re-exports `deps` alongside the two
+regex features.

--- a/crates/cljrs-value/src/clone.rs
+++ b/crates/cljrs-value/src/clone.rs
@@ -599,7 +599,7 @@ pub fn deserialize(sv: SerializedValue) -> Value {
         SerializedValue::Ratio(r) => Value::Ratio(GcPtr::new(r)),
         SerializedValue::Str(s) => Value::Str(GcPtr::new(s)),
         SerializedValue::Pattern(src) => Value::Pattern(GcPtr::new(
-            regex::Regex::new(&src).expect("pattern was valid at serialize time"),
+            crate::regex::Pattern::new(&src).expect("pattern was valid at serialize time"),
         )),
 
         SerializedValue::Symbol {

--- a/crates/cljrs-value/src/regex.rs
+++ b/crates/cljrs-value/src/regex.rs
@@ -19,9 +19,13 @@
 //! Features are additive, so `regex-full` wins when both are enabled: a build
 //! that pulls in one dependent asking for the small engine and another taking
 //! the default gets the more capable engine rather than a silent semantic
-//! downgrade. Selecting `small-regex` therefore requires
-//! `default-features = false` on every workspace crate in the graph, which is
-//! why each of them re-exports both features.
+//! downgrade. Cargo also unions features across every edge to a package, so one
+//! internal edge left at its defaults would re-enable `regex-full` for the whole
+//! graph and no second, direct dependency could switch it off again. Every
+//! workspace crate therefore takes its own internal dependencies with default
+//! features off and re-exports both features (along with `deps`, which those
+//! defaults used to carry), so `default-features = false` at the embedder's own
+//! edge is enough to select the small engine.
 
 use crate::{PersistentVector, Value};
 use cljrs_gc::{GcPtr, GcVisitor, MarkVisitor, Trace};

--- a/crates/cljrs-value/src/regex.rs
+++ b/crates/cljrs-value/src/regex.rs
@@ -1,7 +1,160 @@
+//! Regular expressions: the engine wrapper behind `Value::Pattern`, plus the
+//! stateful `Matcher` that `re-find`/`re-matches`/`re-seq` drive.
+//!
+//! Clojure's `#"…"` literal is a first-class value, so whichever engine is
+//! selected is linked into *every* build — there is no way to opt out of regex
+//! support and still read Clojure source. Two engines are selectable, and
+//! `Pattern` is the seam between them:
+//!
+//! - `regex-full` (default) — the `regex` crate. Fast, linear-time, full
+//!   Unicode character classes. Brings `regex-automata`, `regex-syntax`,
+//!   `aho-corasick` and `memchr` with it.
+//! - `small-regex` — the `regex-lite` crate: roughly a tenth of the size, no
+//!   DFA/SIMD machinery. Materially slower on pathological patterns and it has
+//!   **no Unicode character classes**, so this is a behaviour change and not
+//!   only a size one. Measured on a stripped release build of the interpreter
+//!   plus `clojure.core`/`clojure.string` with `deps` off: 3.68 MB of `.text`
+//!   down to 2.89 MB, 5.77 MB of binary down to 4.10 MB.
+//!
+//! Features are additive, so `regex-full` wins when both are enabled: a build
+//! that pulls in one dependent asking for the small engine and another taking
+//! the default gets the more capable engine rather than a silent semantic
+//! downgrade. Selecting `small-regex` therefore requires
+//! `default-features = false` on every workspace crate in the graph, which is
+//! why each of them re-exports both features.
+
 use crate::{PersistentVector, Value};
 use cljrs_gc::{GcPtr, GcVisitor, MarkVisitor, Trace};
-use regex::{Captures, Regex};
+use std::borrow::Cow;
+use std::fmt;
 use std::sync::Mutex;
+
+#[cfg(feature = "regex-full")]
+use regex as engine;
+#[cfg(all(feature = "small-regex", not(feature = "regex-full")))]
+use regex_lite as engine;
+
+#[cfg(not(any(feature = "regex-full", feature = "small-regex")))]
+compile_error!(
+    "cljrs-value needs a regex engine: keep the default `regex-full` feature, \
+     or enable `small-regex` to use regex-lite instead."
+);
+
+/// A compiled regular expression — the payload of `Value::Pattern`.
+///
+/// Every regex operation in the runtime goes through this type, so swapping
+/// engines is confined to this file.
+#[derive(Debug, Clone)]
+pub struct Pattern(engine::Regex);
+
+/// A pattern that failed to compile. Engine-independent so that callers do not
+/// name `regex::Error` or `regex_lite::Error`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatternError(String);
+
+impl fmt::Display for PatternError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for PatternError {}
+
+impl Pattern {
+    /// Compile `pattern`.
+    pub fn new(pattern: &str) -> Result<Pattern, PatternError> {
+        engine::Regex::new(pattern)
+            .map(Pattern)
+            .map_err(|e| PatternError(e.to_string()))
+    }
+
+    /// The pattern source, as written in the `#"…"` literal.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Leftmost match anywhere in `haystack`.
+    pub fn captures<'h>(&self, haystack: &'h str) -> Option<Captures<'h>> {
+        self.0.captures(haystack).map(Captures)
+    }
+
+    /// Leftmost match at or after byte offset `start`. Look-around still sees
+    /// the text before `start`, which is what makes this the right primitive
+    /// for stepping a `Matcher` forward.
+    pub fn captures_at<'h>(&self, haystack: &'h str, start: usize) -> Option<Captures<'h>> {
+        self.0.captures_at(haystack, start).map(Captures)
+    }
+
+    /// Replace the leftmost match in `haystack`; `$1`-style references in
+    /// `replacement` expand to capture groups.
+    pub fn replace<'h>(&self, haystack: &'h str, replacement: &str) -> Cow<'h, str> {
+        self.0.replace(haystack, replacement)
+    }
+
+    /// Replace every non-overlapping match in `haystack`.
+    pub fn replace_all<'h>(&self, haystack: &'h str, replacement: &str) -> Cow<'h, str> {
+        self.0.replace_all(haystack, replacement)
+    }
+
+    /// Split `haystack` around each match.
+    pub fn split<'h>(&self, haystack: &'h str) -> impl Iterator<Item = &'h str> {
+        self.0.split(haystack)
+    }
+
+    /// Split `haystack` around each match, yielding at most `limit` pieces;
+    /// the last piece holds the unsplit remainder.
+    pub fn splitn<'h>(&self, haystack: &'h str, limit: usize) -> impl Iterator<Item = &'h str> {
+        self.0.splitn(haystack, limit)
+    }
+}
+
+impl fmt::Display for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Trace for Pattern {
+    fn trace(&self, _: &mut MarkVisitor) {}
+}
+
+/// A successful match and its capture groups.
+///
+/// Borrows the haystack, so it never escapes the call that produced it —
+/// `MatchResult` is the owned form that outlives a match.
+#[derive(Debug)]
+pub struct Captures<'h>(engine::Captures<'h>);
+
+impl<'h> Captures<'h> {
+    /// Text of the whole match (group 0).
+    pub fn full(&self) -> &'h str {
+        self.whole().as_str()
+    }
+
+    /// Byte offset just past the whole match — where the next search starts.
+    pub fn end(&self) -> usize {
+        self.whole().end()
+    }
+
+    /// Number of groups, group 0 included; always at least 1.
+    pub fn group_count(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Every group in order, starting with group 0. `None` marks a group that
+    /// did not participate in the match.
+    pub fn groups(&self) -> impl Iterator<Item = Option<&'h str>> + '_ {
+        self.0.iter().map(|g| g.map(|m| m.as_str()))
+    }
+
+    /// Group 0, which always participates in a successful match. Not
+    /// `Captures::get_match`, which `regex-lite` does not have.
+    fn whole(&self) -> engine::Match<'h> {
+        self.0
+            .get(0)
+            .expect("group 0 always participates in a successful match")
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum MatchPhase {
@@ -18,7 +171,7 @@ struct MatcherState {
 
 #[derive(Debug)]
 pub struct Matcher {
-    pub pattern: GcPtr<Regex>,
+    pub pattern: GcPtr<Pattern>,
     haystack: GcPtr<String>,
     state: Mutex<MatcherState>,
     match_all: bool,
@@ -50,7 +203,7 @@ impl Trace for Matcher {
 }
 
 impl Matcher {
-    pub fn new(pattern: Regex, source: String, match_all: bool) -> Self {
+    pub fn new(pattern: Pattern, source: String, match_all: bool) -> Self {
         Self {
             pattern: GcPtr::new(pattern),
             haystack: GcPtr::new(source),
@@ -67,11 +220,14 @@ impl Matcher {
         match state.phase {
             MatchPhase::New => match self.pattern.get().captures(self.haystack.get()) {
                 Some(cap) => {
-                    if !self.match_all || cap.len() == self.haystack.get().len() {
-                        let match_ = cap.get_match();
+                    // TODO: the `match_all` (re-matches) guard compares a group
+                    // count against a byte length; anchoring wants
+                    // `cap.end() == haystack.len()` and a start of 0 instead.
+                    // Left as-is here so the engine swap is behaviour-neutral.
+                    if !self.match_all || cap.group_count() == self.haystack.get().len() {
                         *state = MatcherState {
-                            phase: MatchPhase::Matching(match_.end()),
-                            last_match: Some(MatchResult::new(cap)),
+                            phase: MatchPhase::Matching(cap.end()),
+                            last_match: Some(MatchResult::new(&cap)),
                         }
                     }
                 }
@@ -86,8 +242,8 @@ impl Matcher {
                 match self.pattern.get().captures_at(self.haystack.get(), n) {
                     Some(cap) => {
                         *state = MatcherState {
-                            phase: MatchPhase::Matching(cap.get_match().end()),
-                            last_match: Some(MatchResult::new(cap)),
+                            phase: MatchPhase::Matching(cap.end()),
+                            last_match: Some(MatchResult::new(&cap)),
                         }
                     }
                     None => {
@@ -114,13 +270,10 @@ impl Matcher {
 }
 
 impl MatchResult {
-    pub fn new(cap: Captures) -> Self {
+    pub fn new(cap: &Captures<'_>) -> Self {
         Self {
-            full: cap.get_match().as_str().to_string(),
-            groups: cap
-                .iter()
-                .map(|g| g.map(|e| e.as_str().to_string()))
-                .collect(),
+            full: cap.full().to_string(),
+            groups: cap.groups().map(|g| g.map(|e| e.to_string())).collect(),
         }
     }
 
@@ -138,5 +291,78 @@ impl MatchResult {
                 .collect();
             Value::Vector(GcPtr::new(PersistentVector::from_iter(groups)))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Value` is shared across threads, so the engine's `Regex` must be too.
+    #[test]
+    fn pattern_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Pattern>();
+    }
+
+    #[test]
+    fn captures_expose_groups_in_order() {
+        let p = Pattern::new(r"(\d+)-(\d+)").unwrap();
+        let cap = p.captures("x 12-345 y").unwrap();
+        assert_eq!(cap.full(), "12-345");
+        assert_eq!(cap.group_count(), 3);
+        assert_eq!(cap.end(), 8);
+        assert_eq!(
+            cap.groups().collect::<Vec<_>>(),
+            vec![Some("12-345"), Some("12"), Some("345")]
+        );
+    }
+
+    #[test]
+    fn non_participating_group_is_none() {
+        let p = Pattern::new(r"(a)|(b)").unwrap();
+        let cap = p.captures("b").unwrap();
+        assert_eq!(
+            cap.groups().collect::<Vec<_>>(),
+            vec![Some("b"), None, Some("b")]
+        );
+    }
+
+    #[test]
+    fn captures_at_resumes_after_a_match() {
+        let p = Pattern::new(r"\d+").unwrap();
+        let cap = p.captures_at("a1 b22", 2).unwrap();
+        assert_eq!(cap.full(), "22");
+    }
+
+    #[test]
+    fn invalid_pattern_reports_the_engine_message() {
+        let err = Pattern::new(r"(").unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+
+    #[test]
+    fn split_replace_and_display() {
+        let p = Pattern::new(r",\s*").unwrap();
+        assert_eq!(p.split("a, b,c").collect::<Vec<_>>(), vec!["a", "b", "c"]);
+        assert_eq!(p.splitn("a, b,c", 2).collect::<Vec<_>>(), vec!["a", "b,c"]);
+        assert_eq!(p.replace("a, b,c", "|"), "a|b,c");
+        assert_eq!(p.replace_all("a, b,c", "|"), "a|b|c");
+        assert_eq!(p.as_str(), r",\s*");
+        assert_eq!(p.to_string(), r",\s*");
+    }
+
+    #[test]
+    fn matcher_walks_every_match_then_completes() {
+        let p = Pattern::new(r"\d+").unwrap();
+        let m = Matcher::new(p, "a1 b22 c333".to_string(), false);
+
+        let mut found = Vec::new();
+        while let MatchPhase::Matching(_) = m.next() {
+            found.push(m.capture().unwrap().full);
+        }
+        assert_eq!(found, vec!["1", "22", "333"]);
+        assert!(matches!(m.phase(), MatchPhase::Complete));
+        assert!(m.capture().is_none());
     }
 }

--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -11,7 +11,7 @@ use crate::hash::{
     ClojureHash, hash_combine_ordered, hash_combine_unordered, hash_i64, hash_string, hash_u128,
 };
 use crate::keyword::Keyword;
-use crate::regex::Matcher;
+use crate::regex::{Matcher, Pattern};
 use crate::resource::ResourceHandle;
 use crate::shared::SharedAtom;
 use crate::symbol::Symbol;
@@ -22,7 +22,6 @@ use crate::types::{
 use cljrs_gc::{GcPtr, MarkVisitor, Trace};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
-use regex::Regex;
 
 /// A GC-traced mutable array of Values (backs `object-array`).
 #[derive(Debug)]
@@ -67,7 +66,7 @@ pub enum Value {
     Char(char),
     Str(GcPtr<String>),
     Uuid(u128),
-    Pattern(GcPtr<Regex>),
+    Pattern(GcPtr<Pattern>),
     Matcher(GcPtr<Matcher>),
 
     // ── Identifiers ───────────────────────────────────────────────────────────

--- a/crates/cljrs-wasm/Cargo.toml
+++ b/crates/cljrs-wasm/Cargo.toml
@@ -9,6 +9,14 @@ repository.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 [dependencies]
 cljrs-runtime = { workspace = true }
 cljrs-stdlib   = { workspace = true }

--- a/crates/cljrs-wasm/Cargo.toml
+++ b/crates/cljrs-wasm/Cargo.toml
@@ -10,12 +10,16 @@ repository.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["regex-full"]
+default = ["regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+regex-full  = ["cljrs-value/regex-full", "cljrs-runtime/regex-full", "cljrs-stdlib/regex-full", "cljrs-async/regex-full"]
+small-regex = ["cljrs-value/small-regex", "cljrs-runtime/small-regex", "cljrs-stdlib/small-regex", "cljrs-async/small-regex"]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = ["cljrs-runtime/deps", "cljrs-stdlib/deps", "cljrs-async/deps"]
 
 [dependencies]
 cljrs-runtime = { workspace = true }

--- a/crates/cljrs-wasm/README.md
+++ b/crates/cljrs-wasm/README.md
@@ -246,12 +246,26 @@ Event maps delivered to callbacks:
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to this crate's workspace dependencies — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Pass-through for `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+Every workspace dependency of this crate is taken with default features off (see
+the note in the root `Cargo.toml`), so these pass-throughs are what put back what
+those crates' defaults used to provide. `default` enables all of them, so a plain
+build is unchanged.
+
+`regex-full` wins when both regex features are enabled, so selecting the small
+engine means turning default features off **on this crate** and re-adding what
+you want:
+
+```toml
+cljrs-wasm = { version = "0.1", default-features = false, features = ["small-regex"] }
+```
+
+Adding a second, direct dependency on `cljrs-runtime` with
+`default-features = false` would not undo it — Cargo unions features across every
+edge to a package, so one edge left at its defaults re-enables `regex-full` for
+the whole graph. `deps` has to be off as well for the size win to land, since
+`cljrs-project/vcs` pulls `regex` in through `pgp`. See
+[cljrs-value's README](../cljrs-value/README.md#features).

--- a/crates/cljrs-wasm/README.md
+++ b/crates/cljrs-wasm/README.md
@@ -239,3 +239,19 @@ Event maps delivered to callbacks:
 ```
 
 `:style` map values set individual CSS properties. `:on-*` attributes attach event listeners (closure leaked — no handle returned). Children may be strings, nested hiccup vectors, or `DomNode` values.
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -7,7 +7,13 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["async", "net", "charset", "base64"]
+default = ["async", "net", "charset", "base64", "regex-full"]
+
+# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
+# is the default engine, `small-regex` swaps in regex-lite.
+regex-full  = ["cljrs-value/regex-full"]
+small-regex = ["cljrs-value/small-regex"]
+
 # Propagate no-gc to all direct dependencies; transitive deps pick it up through their own feature chains.
 no-gc = [
     "cljrs-gc/no-gc",

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -7,12 +7,53 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["async", "net", "charset", "base64", "regex-full"]
+default = ["async", "net", "charset", "base64", "regex-full", "deps"]
 
-# Regex engine, forwarded to cljrs-value (which owns the choice); `regex-full`
-# is the default engine, `small-regex` swaps in regex-lite.
-regex-full  = ["cljrs-value/regex-full"]
-small-regex = ["cljrs-value/small-regex"]
+# Regex engine and pass-throughs. Every workspace dependency below is taken
+# with default features off (see the note in the root Cargo.toml), so what
+# their defaults used to provide is re-exported here and kept in `default`.
+# The `?/` entries are weak: they only apply when the optional feature that
+# pulls the package in is also enabled.
+regex-full = [
+    "cljrs-value/regex-full",
+    "cljrs-runtime/regex-full",
+    "cljrs-stdlib/regex-full",
+    "cljrs-compiler/regex-full",
+    "cljrs-interop/regex-full",
+    "cljrs-nrepl/regex-full",
+    "cljrs-async?/regex-full",
+    "cljrs-io?/regex-full",
+    "cljrs-net?/regex-full",
+    "cljrs-charset?/regex-full",
+    "cljrs-base64?/regex-full",
+]
+small-regex = [
+    "cljrs-value/small-regex",
+    "cljrs-runtime/small-regex",
+    "cljrs-stdlib/small-regex",
+    "cljrs-compiler/small-regex",
+    "cljrs-interop/small-regex",
+    "cljrs-nrepl/small-regex",
+    "cljrs-async?/small-regex",
+    "cljrs-io?/small-regex",
+    "cljrs-net?/small-regex",
+    "cljrs-charset?/small-regex",
+    "cljrs-base64?/small-regex",
+]
+
+# Pass-through for cljrs-runtime's git-backed dependency support.
+deps = [
+    "cljrs-runtime/deps",
+    "cljrs-stdlib/deps",
+    "cljrs-compiler/deps",
+    "cljrs-interop/deps",
+    "cljrs-nrepl/deps",
+    "cljrs-async?/deps",
+    "cljrs-io?/deps",
+    "cljrs-net?/deps",
+    "cljrs-charset?/deps",
+    "cljrs-base64?/deps",
+]
 
 # Propagate no-gc to all direct dependencies; transitive deps pick it up through their own feature chains.
 no-gc = [
@@ -45,7 +86,9 @@ cljrs-gc       = { workspace = true }
 cljrs-reader   = { workspace = true }
 cljrs-value    = { workspace = true }
 cljrs-stdlib   = { workspace = true }
-cljrs-compiler = { workspace = true }
+# `wasm-aot` is not optional here: `commands::compile` calls
+# `aot::compile_file_to_wasm` unconditionally for `--target wasm`.
+cljrs-compiler = { workspace = true, features = ["wasm-aot"] }
 cljrs-interop  = { workspace = true }
 cljrs-project  = { workspace = true, features = ["vcs", "vcs-net", "ssh"] }
 cljrs-lsp      = { workspace = true }

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -508,3 +508,19 @@ top-level functions.  Subfunction headers therefore show only their
 first `SourceLoc` marker rather than a span range.
 
 ---
+
+---
+
+## Features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+
+`regex-full` wins when both are enabled, so `small-regex` only takes effect with
+`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
+features on, which re-enables `regex-full` — so selecting the small engine here
+also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
+with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
+through `pgp` regardless, so the size win only lands once `deps` is off too.

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -511,16 +511,34 @@ first `SourceLoc` marker rather than a span range.
 
 ---
 
-## Features
+## Regex engine and pass-through features
+
+Beyond `async`/`net`/`charset`/`base64`/`no-gc`/`enable-rustyline`, the CLI
+re-exports what its workspace dependencies' defaults used to provide, because all
+of them are now taken with default features off (see the note in the root
+`Cargo.toml`). All three are in `default`, so a plain `cargo build -p cljrs` is
+unchanged:
 
 | Feature | Default | Effect |
 |---|---|---|
-| `regex-full` | on | Forwards `cljrs-value/regex-full` — `Value::Pattern` uses the `regex` crate. |
-| `small-regex` | off | Forwards `cljrs-value/small-regex` — `regex-lite` instead, trading Unicode character classes for ~277 KB of text. See [cljrs-value's README](../cljrs-value/README.md#features). |
+| `regex-full` | **on** | Forwards `regex-full` to every workspace dependency — `Value::Pattern` uses the `regex` crate. |
+| `small-regex` | off | Forwards `small-regex` instead: `regex-lite`, which trades Unicode character classes for ~277 KB of text. |
+| `deps` | **on** | Forwards `cljrs-runtime/deps` — git-backed dependency and versioned-var support. |
 
-`regex-full` wins when both are enabled, so `small-regex` only takes effect with
-`--no-default-features`. This crate depends on `cljrs-runtime` with *its* default
-features on, which re-enables `regex-full` — so selecting the small engine here
-also means depending on `cljrs-runtime` (and `cljrs-stdlib`, if present) directly
-with default features off. `cljrs-runtime`'s `deps` feature pulls `regex` in
-through `pgp` regardless, so the size win only lands once `deps` is off too.
+The forwards to the optional extension crates use Cargo's weak `?/` syntax, so
+they apply only when the feature that pulls the package in (`async`, `net`,
+`charset`, `base64`) is also enabled.
+
+`cljrs-compiler`'s `wasm-aot` is *not* a pass-through: `commands::compile` calls
+`aot::compile_file_to_wasm` unconditionally for `--target wasm`, so the CLI's
+dependency pins that feature on rather than offering a knob that would fail to
+compile.
+
+One caveat specific to the CLI: `--no-default-features --features small-regex`
+does switch `Value::Pattern` to `regex-lite`, but it does **not** remove the
+`regex` crate from the binary. `cljrs` depends on `cljrs-project` with
+`features = ["vcs", "vcs-net", "ssh"]` unconditionally — `cljrs deps` needs git
+fetch and commit-signature verification — and `pgp` pulls `regex` in. A CLI built
+that way therefore links both engines and is *larger*, not smaller. The engine
+swap only pays off for an embedding that has no `pgp` in its graph; see
+[cljrs-value's README](../cljrs-value/README.md#features).


### PR DESCRIPTION
Clojure's `#"…"` literal is a first-class value, so a regex engine is linked
into every build. `regex` was a required dependency of three crates for an API
surface of eight methods, at ~277 KB of `regex-automata` + `regex-syntax` text
plus `aho-corasick` and `memchr`.

Introduce `cljrs_value::regex::Pattern`, a wrapper that is the only place in the
workspace naming an engine, and select the engine with a feature: `regex-full`
(default, the `regex` crate) or `small-regex` (`regex-lite`). `Value::Pattern`
now holds `GcPtr<Pattern>`, and `Captures`/`PatternError` keep engine types out
of the module's public API — `regex-lite` has no `Captures::get_match`, so group
0 is fetched with `get(0)` instead.

`regex-full` wins when both features are enabled. Cargo features are additive,
so a graph where one dependent asks for the small engine and another takes the
default gets the more capable engine rather than a silent loss of Unicode
character classes.

Consequences:

- `cljrs-gc` no longer depends on `regex`: `Trace` moves from `regex::Regex` to
  the `Pattern` wrapper.
- `cljrs-runtime` no longer depends on `regex` directly; it constructs patterns
  through `Pattern::new`.
- `cljrs-value` is inherited with `default-features = false` so the choice is
  not forced on embedders; every member re-exports both features and keeps
  `regex-full` in its own `default`, leaving default builds unchanged.
- `cljrs-stdlib` depends on `cljrs-runtime` with default features off (Cargo
  ignores `default-features = false` on an inherited dependency) and re-exports
  `deps` alongside the regex pair, so an interpreter-plus-`clojure.string`
  embedding can reach the small engine.

Measured on a stripped release build of that embedding with `deps` off, and
evaluating the same `re-find`/`clojure.string/split` expression to the same
result under either engine: `.text` 3.68 MB → 2.89 MB, binary 5.77 MB → 4.10 MB.
The win needs `deps` off, since `cljrs-project/vcs` pulls `regex` in through
`pgp` regardless.

`Matcher::next`'s `match_all` guard compares a capture-group count against a
byte length, which cannot be what anchoring `re-matches` wants; it is preserved
verbatim here so the engine swap is behaviour-neutral, with a TODO recording it.

Closes #330

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GpG48LLGRALuqnLGhHbx6M