### PR TITLE
Enable miette's `fancy` feature in the cljrs binary only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,11 @@ cljrs-tx           = { path = "crates/cljrs-tx",           version = "0.1.0", de
 
 tracing            = "0.1.44"
 tracing-subscriber = "0.3.23"
-miette       = { version = "7", features = ["fancy"] }
+# The library crates use only miette's *type* half (`Diagnostic`, `SourceSpan`,
+# `NamedSource`). The `fancy` feature is the *renderer* — terminal colours,
+# hyperlink/unicode probing, backtraces — and is enabled by the `cljrs` binary
+# alone, so embedders and `cljrs-wasm` do not link a terminal report renderer.
+miette       = { version = "7", default-features = false, features = ["derive"] }
 thiserror    = "2"
 inventory    = "0.3"
 clap         = { version = "4", features = ["derive"] }

--- a/crates/cljrs-reader/README.md
+++ b/crates/cljrs-reader/README.md
@@ -302,4 +302,4 @@ pub use token::Token;
 | Crate | Role |
 |-------|------|
 | `cljrs-types` (workspace) | `Span`, `CljxError`, `CljxResult` |
-| `miette` (workspace) | `NamedSource` used in error construction |
+| `miette` (workspace) | `NamedSource` used in error construction. Types only — the `fancy` renderer is enabled by the `cljrs` binary, not here |

--- a/crates/cljrs-types/README.md
+++ b/crates/cljrs-types/README.md
@@ -50,7 +50,9 @@ impl Span {
 
 Unified error type for all clojurust subsystems. Derives
 [`miette::Diagnostic`](https://docs.rs/miette) so errors render with source
-snippets and labels in the terminal.
+snippets and labels in the terminal. This crate depends on miette's type half
+only; the `fancy` feature that does the rendering is enabled by the `cljrs`
+binary, so embedders and the wasm build do not link a terminal renderer.
 
 ```rust
 pub enum CljxError {

--- a/crates/cljrs/Cargo.toml
+++ b/crates/cljrs/Cargo.toml
@@ -95,7 +95,9 @@ cljrs-lsp      = { workspace = true }
 cljrs-nrepl    = { workspace = true }
 cljrs-ir       = { workspace = true }
 clap          = { workspace = true }
-miette        = { workspace = true }
+# The binary is the only crate that *renders* diagnostics (see `cli::main`'s
+# `MietteHandlerOpts` hook), so `fancy` is enabled here rather than workspace-wide.
+miette        = { workspace = true, features = ["fancy"] }
 tracing            = { workspace = true }
 rustyline   = { workspace = true, optional = true }
 libloading  = { workspace = true }

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -285,7 +285,7 @@ Build with e.g. `cargo build --release --features enable-rustyline,no-gc`.
 | `tracing` (workspace)       | `Level` for the `--debug` / `--trace` default; `--debug` / `--trace` / `-X` all build one `Targets` filter and install the stderr subscriber through `cljrs_runtime::logging`, which owns the `tracing-subscriber` dependency |
 | `cljrs-project` (workspace) | `config` — `cljrs.edn` parser, `DepsConfig` / `Dependency` types; `vcs` — pure-Rust (gitoxide) git helpers: `fetch_remote`, `cache_path_for_url`, native signature verification |
 | `clap` (workspace)          | CLI argument parsing                                              |
-| `miette` (workspace)        | Rich terminal error rendering                                     |
+| `miette` (workspace, `fancy`) | Rich terminal error rendering. `fancy` — the renderer half of miette — is enabled *here only*; the library crates take miette without it |
 | `rustyline` (workspace, optional) | Line-editing REPL when `enable-rustyline` is on              |
 | `libloading` (workspace)    | `dlopen` for the project `:rust` cdylib and pinned native packages |
 | `serde_json`                | Reading `target_directory` out of `cargo metadata` output          |


### PR DESCRIPTION
The workspace pinned `miette = { features = ["fancy"] }`, so every crate
in the graph — and every downstream embedder — linked miette's terminal
report renderer: owo-colors, supports-color/-hyperlinks/-unicode,
terminal_size, rustix, textwrap, unicode-linebreak, both unicode-width
majors, and the backtrace stack (backtrace, backtrace-ext, addr2line,
gimli, object, miniz_oxide).

The library crates only use miette's type half — `Diagnostic`,
`SourceSpan`, `SourceOffset`, `NamedSource`. The only place that actually
renders a report is `cljrs::cli::main`, which installs a
`MietteHandlerOpts` hook.

Take miette with `default-features = false, features = ["derive"]` in the
workspace dependency and enable `fancy` on the `cljrs` binary's edge.
`cargo tree -p cljrs-types` drops from the full renderer stack to
miette + miette-derive + cfg-if + unicode-width; `cljrs-wasm` no longer
pulls supports-color/terminal_size/rustix on wasm32; `cargo tree -p cljrs`
still shows the renderer, and a read error still renders with its source
snippet.

Closes #329

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EoQ5QL8ut3P5y1mcdBruDd