### PR TITLE
Honour `(:refer-clojure ...)` in `ns`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -91,7 +91,7 @@ Implementation roadmap for a Rust-hosted Clojure dialect. Native file extension 
 - [x] Math: `Math/abs`, `Math/pow`, `Math/sqrt`, `Math/floor`, `Math/ceil`, `Math/round`, `Math/log`, `Math/log10`, `Math/exp`, `Math/sin`, `Math/cos`, `Math/tan`, `Math/asin`, `Math/acos`, `Math/atan`, `Math/atan2`, `Math/sinh`, `Math/cosh`, `Math/tanh`, `Math/hypot`, `Math/PI`, `Math/E`
 - [x] Miscellaneous: `apply`, `comp`, `partial`, `juxt`, `memoize`, `constantly`, `identity`, `not`, `complement`, `gensym`, `type`, `class`, `hash`
 - [x] Core macros: `when`, `when-not`, `if-let`, `when-let`, `if-not`, `cond`, `condp`, `case`, `and`, `or`, `->`, `->>`, `as->`, `doto`, `dotimes`, `doseq`, `for`
-- [x] Namespace ops: `in-ns`, `alias`, `refer` (basic); `ns` with `:require`/`:refer-clojure`
+- [x] Namespace ops: `in-ns`, `alias`, `refer` (basic); `ns` with `:require`/`:refer-clojure` (`:exclude`/`:only`/`:rename`)
 - [x] `require` — file-based namespace loading with `:as` alias and `:refer [...]`/`:refer :all`
 - [x] `load-file` — evaluate a source file by absolute path
 - [x] Source-path management — `--src-path DIR` CLI flag; `RuntimeBuilder::source_paths`

--- a/crates/cljrs-async/src/lib.rs
+++ b/crates/cljrs-async/src/lib.rs
@@ -57,7 +57,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
     // clojure.rust.error first — the <? family refers its `throw-err`.
     if !globals.is_loaded("clojure.rust.error") {
         globals.get_or_create_ns("clojure.rust.error");
-        globals.refer_all("clojure.rust.error", "clojure.core");
+        globals.refer_core("clojure.rust.error");
         load_source(globals, "clojure.rust.error", ERROR_SOURCE);
         globals.mark_loaded("clojure.rust.error");
     }
@@ -70,7 +70,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
     // Build the namespace: refer clojure.core so the macro source can use core
     // fns/macros, register the native primitives, then evaluate the source.
     globals.get_or_create_ns(ns);
-    globals.refer_all(ns, "clojure.core");
+    globals.refer_core(ns);
     builtins::register(globals, ns);
     isolate_builtins::register(globals, ns);
     load_source(globals, ns, CORE_ASYNC_SOURCE);

--- a/crates/cljrs-base64/src/lib.rs
+++ b/crates/cljrs-base64/src/lib.rs
@@ -18,7 +18,7 @@ pub fn init(globals: &Arc<GlobalEnv>) {
         return;
     }
     globals.get_or_create_ns(NS);
-    globals.refer_all(NS, "clojure.core");
+    globals.refer_core(NS);
     let mut registry = Registry::for_require(globals.clone());
     register(&mut registry);
 }

--- a/crates/cljrs-charset/src/lib.rs
+++ b/crates/cljrs-charset/src/lib.rs
@@ -61,7 +61,7 @@ pub fn init(globals: &Arc<GlobalEnv>) {
         return;
     }
     globals.get_or_create_ns(NS);
-    globals.refer_all(NS, "clojure.core");
+    globals.refer_core(NS);
     fns::register(globals, NS);
     globals.mark_loaded(NS);
 }
@@ -76,7 +76,7 @@ pub fn init_async(globals: &Arc<GlobalEnv>) {
         return;
     }
     globals.get_or_create_ns(NS_ASYNC);
-    globals.refer_all(NS_ASYNC, "clojure.core");
+    globals.refer_core(NS_ASYNC);
     codec_chan::register(globals, NS_ASYNC);
     globals.mark_loaded(NS_ASYNC);
 }

--- a/crates/cljrs-io/src/lib.rs
+++ b/crates/cljrs-io/src/lib.rs
@@ -58,7 +58,7 @@ pub fn init(globals: &Arc<GlobalEnv>) {
     }
 
     globals.get_or_create_ns(NS);
-    globals.refer_all(NS, "clojure.core");
+    globals.refer_core(NS);
     fs::register(globals, NS);
     load_source(globals, NS, IO_ASYNC_SOURCE);
     globals.mark_loaded(NS);

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -77,7 +77,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_TCP) {
         globals.get_or_create_ns(NS_TCP);
-        globals.refer_all(NS_TCP, "clojure.core");
+        globals.refer_core(NS_TCP);
         tcp::register(globals, NS_TCP);
         load_source(globals, NS_TCP, NET_TCP_SOURCE);
         globals.mark_loaded(NS_TCP);
@@ -85,7 +85,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_FRAME) {
         globals.get_or_create_ns(NS_FRAME);
-        globals.refer_all(NS_FRAME, "clojure.core");
+        globals.refer_core(NS_FRAME);
         frame::register(globals, NS_FRAME);
         load_source(globals, NS_FRAME, NET_FRAME_SOURCE);
         globals.mark_loaded(NS_FRAME);
@@ -93,7 +93,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_UDP) {
         globals.get_or_create_ns(NS_UDP);
-        globals.refer_all(NS_UDP, "clojure.core");
+        globals.refer_core(NS_UDP);
         udp::register(globals, NS_UDP);
         load_source(globals, NS_UDP, NET_UDP_SOURCE);
         globals.mark_loaded(NS_UDP);
@@ -101,7 +101,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_TLS) {
         globals.get_or_create_ns(NS_TLS);
-        globals.refer_all(NS_TLS, "clojure.core");
+        globals.refer_core(NS_TLS);
         tls::register(globals, NS_TLS);
         load_source(globals, NS_TLS, NET_TLS_SOURCE);
         globals.mark_loaded(NS_TLS);
@@ -109,7 +109,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_UNIX) {
         globals.get_or_create_ns(NS_UNIX);
-        globals.refer_all(NS_UNIX, "clojure.core");
+        globals.refer_core(NS_UNIX);
         unix::register(globals, NS_UNIX);
         load_source(globals, NS_UNIX, NET_UNIX_SOURCE);
         globals.mark_loaded(NS_UNIX);
@@ -117,7 +117,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_QUIC) {
         globals.get_or_create_ns(NS_QUIC);
-        globals.refer_all(NS_QUIC, "clojure.core");
+        globals.refer_core(NS_QUIC);
         quic::register(globals, NS_QUIC);
         load_source(globals, NS_QUIC, NET_QUIC_SOURCE);
         globals.mark_loaded(NS_QUIC);
@@ -125,7 +125,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_H3) {
         globals.get_or_create_ns(NS_H3);
-        globals.refer_all(NS_H3, "clojure.core");
+        globals.refer_core(NS_H3);
         h3::register(globals, NS_H3);
         load_source(globals, NS_H3, NET_H3_SOURCE);
         globals.mark_loaded(NS_H3);
@@ -133,7 +133,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS_HTTP2) {
         globals.get_or_create_ns(NS_HTTP2);
-        globals.refer_all(NS_HTTP2, "clojure.core");
+        globals.refer_core(NS_HTTP2);
         h2::register(globals, NS_HTTP2);
         load_source(globals, NS_HTTP2, NET_HTTP2_SOURCE);
         globals.mark_loaded(NS_HTTP2);
@@ -141,7 +141,7 @@ pub fn init(globals: &Arc<cljrs_runtime::env::env::GlobalEnv>) {
 
     if !globals.is_loaded(NS) {
         globals.get_or_create_ns(NS);
-        globals.refer_all(NS, "clojure.core");
+        globals.refer_core(NS);
         load_source(globals, NS, NET_SOURCE);
         globals.mark_loaded(NS);
     }

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -286,18 +286,39 @@ pub fn eval(&self, form: &Form, env: &mut Env) -> EvalResult;
 pub fn call_cljrs_fn(&self, f: &CljxFn, args: &[Value], env: &mut Env) -> EvalResult;
 pub fn on_fn_defined(&self, f: &CljxFn, env: &mut Env);
 
-/// Copy `src_ns`'s interns into `dst_ns` as refers.  When `src_ns` is
-/// `clojure.core`, `dst_ns`'s `ReferClojureFilter` (if any) decides which
-/// names are referred and under what local name.
+/// Copy `src_ns`'s interns into `dst_ns` as refers.  Both are *explicit*
+/// refers (`(:require [x :refer :all])` / `:refer [...]`) and are never
+/// narrowed by `dst_ns`'s `ReferClojureFilter` — matching
+/// `clojure.core/refer`, where naming a namespace explicitly re-maps even
+/// names an earlier `refer-clojure` left out.
 pub fn refer_all(&self, dst_ns: &str, src_ns: &str);
 pub fn refer_named(&self, dst_ns: &str, src_ns: &str, names: &[Arc<str>]);
 
+/// The automatic `clojure.core` refer every namespace starts with, narrowed
+/// by `dst_ns`'s `ReferClojureFilter`.  This — not `refer_all` — is what
+/// runtime init, the loader, `in-ns`, `ns` and versioned-namespace setup use
+/// to seed a namespace with core.
+pub fn refer_core(&self, dst_ns: &str);
+
 /// Install (or, with `None`, remove) the `(:refer-clojure ...)` filter for
 /// `dst_ns` and re-apply the automatic core refer under it.  Refers inherited
-/// from `clojure.core` are dropped first, so a filter installed after the
-/// namespace was pre-referred still takes effect.
-pub fn set_refer_clojure_filter(&self, dst_ns: &str, filter: Option<ReferClojureFilter>);
+/// from `clojure.core` are dropped and re-added under one lock, so a filter
+/// installed after the namespace was pre-referred takes effect without
+/// exposing a half-referred namespace to a concurrent reader.  Errors when
+/// the filter names something `clojure.core` does not define (`:only`,
+/// `:rename`) or would refer two core names under one local name.
+pub fn set_refer_clojure_filter(
+    &self,
+    dst_ns: &str,
+    filter: Option<ReferClojureFilter>,
+) -> Result<(), String>;
 ```
+
+`:exclude` stays permissive where `:only`/`:rename` are validated: it is
+subtractive, so excluding a name core does not define is harmless and keeps a
+file portable across core versions.  The collision check is stricter than Clojure,
+which warns (`Namespace.checkReplacement`) and then lets whichever mapping
+`(keys (ns-publics ...))` yields last win.
 
 ### `depth` submodule
 

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -285,6 +285,18 @@ pub fn ir_cache(&self) -> &Arc<tiered::ir_cache::IrCache>;
 pub fn eval(&self, form: &Form, env: &mut Env) -> EvalResult;
 pub fn call_cljrs_fn(&self, f: &CljxFn, args: &[Value], env: &mut Env) -> EvalResult;
 pub fn on_fn_defined(&self, f: &CljxFn, env: &mut Env);
+
+/// Copy `src_ns`'s interns into `dst_ns` as refers.  When `src_ns` is
+/// `clojure.core`, `dst_ns`'s `ReferClojureFilter` (if any) decides which
+/// names are referred and under what local name.
+pub fn refer_all(&self, dst_ns: &str, src_ns: &str);
+pub fn refer_named(&self, dst_ns: &str, src_ns: &str, names: &[Arc<str>]);
+
+/// Install (or, with `None`, remove) the `(:refer-clojure ...)` filter for
+/// `dst_ns` and re-apply the automatic core refer under it.  Refers inherited
+/// from `clojure.core` are dropped first, so a filter installed after the
+/// namespace was pre-referred still takes effect.
+pub fn set_refer_clojure_filter(&self, dst_ns: &str, filter: Option<ReferClojureFilter>);
 ```
 
 ### `depth` submodule

--- a/crates/cljrs-runtime/src/env/env.rs
+++ b/crates/cljrs-runtime/src/env/env.rs
@@ -408,9 +408,11 @@ impl GlobalEnv {
 
     /// Copy all interns from `src_ns` into `dst_ns` as refers.
     ///
-    /// When `src_ns` is `clojure.core`, `dst_ns`'s `(:refer-clojure ...)`
-    /// filter (if any) decides which names are referred and under what local
-    /// name.
+    /// This is the *explicit* refer — `(:require [x :refer :all])` — so it is
+    /// never narrowed by `dst_ns`'s `(:refer-clojure ...)` filter, matching
+    /// `clojure.core/refer`: naming a namespace explicitly re-maps even names
+    /// an earlier `refer-clojure` left out.  The automatic core refer every
+    /// namespace starts with goes through [`GlobalEnv::refer_core`] instead.
     pub fn refer_all(&self, dst_ns: &str, src_ns: &str) {
         let map = self.namespaces.read().unwrap();
         let src = match map.get(src_ns) {
@@ -421,21 +423,50 @@ impl GlobalEnv {
             Some(ns) => ns.clone(),
             None => return,
         };
-        let filter = if src_ns == "clojure.core" {
-            dst.get().refer_clojure_filter.lock().unwrap().clone()
-        } else {
-            None
-        };
         let src_interns = src.get().interns.lock().unwrap();
         let mut dst_refers = dst.get().refers.lock().unwrap();
         for (name, var) in src_interns.iter() {
-            match &filter {
-                Some(f) => {
+            dst_refers.insert(name.clone(), var.clone());
+        }
+    }
+
+    /// Apply the automatic `clojure.core` refer that every namespace starts
+    /// with, narrowed by `dst_ns`'s `(:refer-clojure ...)` filter.
+    pub fn refer_core(&self, dst_ns: &str) {
+        self.refer_core_impl(dst_ns, false);
+    }
+
+    /// `replace`: drop the refers `dst_ns` already inherited from
+    /// `clojure.core` before re-referring, under the same lock — so installing
+    /// a filter after the namespace was pre-referred neither leaves stale
+    /// names behind nor exposes a window where core is only half-referred.
+    fn refer_core_impl(&self, dst_ns: &str, replace: bool) {
+        let map = self.namespaces.read().unwrap();
+        let src = match map.get("clojure.core") {
+            Some(ns) => ns.clone(),
+            None => return,
+        };
+        let dst = match map.get(dst_ns) {
+            Some(ns) => ns.clone(),
+            None => return,
+        };
+        // Lock order is filter → src interns → dst refers throughout.
+        let filter = dst.get().refer_clojure_filter.lock().unwrap();
+        let src_interns = src.get().interns.lock().unwrap();
+        let mut dst_refers = dst.get().refers.lock().unwrap();
+        if replace {
+            dst_refers.retain(|_, var| var.get().namespace.as_ref() != "clojure.core");
+        }
+        match filter.as_ref() {
+            Some(f) => {
+                for (name, var) in src_interns.iter() {
                     if let Some(local) = f.local_name(name) {
                         dst_refers.insert(local, var.clone());
                     }
                 }
-                None => {
+            }
+            None => {
+                for (name, var) in src_interns.iter() {
                     dst_refers.insert(name.clone(), var.clone());
                 }
             }
@@ -449,21 +480,99 @@ impl GlobalEnv {
     /// filter set after the namespace was pre-referred — the loader refers core
     /// before it reads the file, and `ns` itself refers core before it reaches
     /// the clause — still takes effect.
-    pub fn set_refer_clojure_filter(&self, dst_ns: &str, filter: Option<ReferClojureFilter>) {
+    pub fn set_refer_clojure_filter(
+        &self,
+        dst_ns: &str,
+        filter: Option<ReferClojureFilter>,
+    ) -> Result<(), String> {
+        if let Some(f) = &filter {
+            self.validate_refer_clojure_filter(f)?;
+        }
         let dst = self.get_or_create_ns(dst_ns);
         {
             let mut slot = dst.get().refer_clojure_filter.lock().unwrap();
             // Nothing to install and nothing to undo: leave the refers alone.
             if slot.is_none() && filter.is_none() {
-                return;
+                return Ok(());
             }
             *slot = filter;
         }
-        {
-            let mut refers = dst.get().refers.lock().unwrap();
-            refers.retain(|_, var| var.get().namespace.as_ref() != "clojure.core");
+        self.refer_core_impl(dst_ns, true);
+        Ok(())
+    }
+
+    /// Check a `(:refer-clojure ...)` filter against the names `clojure.core`
+    /// actually publishes, so a typo fails at the `ns` form rather than as an
+    /// unbound symbol somewhere further down the file.
+    ///
+    /// `:only` and `:rename` name specific vars and must resolve; `:exclude` is
+    /// subtractive and stays permissive (excluding a name core does not have is
+    /// harmless, and lets a file stay portable across core versions).  Clojure
+    /// validates `:only` the same way but ignores an unresolvable `:rename`
+    /// key, since it only consults the rename map for names already in its
+    /// to-do list.
+    ///
+    /// Two names landing on the same local name is an error rather than a coin
+    /// flip: with `:rename {inc str}` both `inc` and core's own `str` want the
+    /// name `str`.  Clojure warns and lets whichever one its intern table
+    /// yields last win; picking a winner by hash order here would make the
+    /// choice unstable from run to run.
+    fn validate_refer_clojure_filter(&self, filter: &ReferClojureFilter) -> Result<(), String> {
+        let map = self.namespaces.read().unwrap();
+        let Some(core) = map.get("clojure.core").cloned() else {
+            return Ok(());
+        };
+        drop(map);
+        let interns = core.get().interns.lock().unwrap();
+        // A runtime built without the core bootstrap has nothing to check
+        // against; do not fail every name.
+        if interns.is_empty() {
+            return Ok(());
         }
-        self.refer_all(dst_ns, "clojure.core");
+
+        for (opt, names) in [
+            ("only", filter.only.iter().flatten().collect::<Vec<_>>()),
+            ("rename", filter.rename.keys().collect::<Vec<_>>()),
+        ] {
+            let mut unknown: Vec<&str> = names
+                .into_iter()
+                .filter(|n| !interns.contains_key(*n))
+                .map(|n| n.as_ref())
+                .collect();
+            if !unknown.is_empty() {
+                unknown.sort_unstable();
+                return Err(format!(
+                    ":refer-clojure :{opt} names {}, which clojure.core does not define",
+                    unknown.join(", ")
+                ));
+            }
+        }
+
+        // local name → the core name referred under it.
+        let mut taken: HashMap<Arc<str>, Arc<str>> = HashMap::new();
+        let mut conflicts: Vec<(Arc<str>, Arc<str>, Arc<str>)> = Vec::new();
+        for name in interns.keys() {
+            let Some(local) = filter.local_name(name) else {
+                continue;
+            };
+            if let Some(prev) = taken.insert(local.clone(), name.clone()) {
+                let (a, b) = if prev.as_ref() <= name.as_ref() {
+                    (prev, name.clone())
+                } else {
+                    (name.clone(), prev)
+                };
+                conflicts.push((local, a, b));
+            }
+        }
+        if !conflicts.is_empty() {
+            conflicts.sort_unstable();
+            let (local, a, b) = &conflicts[0];
+            return Err(format!(
+                ":refer-clojure would refer both {a} and {b} as {local}; \
+                 rename or exclude one of them"
+            ));
+        }
+        Ok(())
     }
 
     /// Copy selected interns from `src_ns` into `dst_ns` as refers.

--- a/crates/cljrs-runtime/src/env/env.rs
+++ b/crates/cljrs-runtime/src/env/env.rs
@@ -10,7 +10,7 @@ use crate::env::error::EvalResult;
 use crate::mode::{ExecutionMode, TierState};
 use cljrs_gc::{GcConfig, GcPtr};
 use cljrs_reader::Form;
-use cljrs_value::{CljxFn, Namespace, Value, Var};
+use cljrs_value::{CljxFn, Namespace, ReferClojureFilter, Value, Var};
 // ── RequireSpec / RequireRefer ─────────────────────────────────────────────────
 
 /// How symbols should be referred into the requiring namespace.
@@ -407,6 +407,10 @@ impl GlobalEnv {
     }
 
     /// Copy all interns from `src_ns` into `dst_ns` as refers.
+    ///
+    /// When `src_ns` is `clojure.core`, `dst_ns`'s `(:refer-clojure ...)`
+    /// filter (if any) decides which names are referred and under what local
+    /// name.
     pub fn refer_all(&self, dst_ns: &str, src_ns: &str) {
         let map = self.namespaces.read().unwrap();
         let src = match map.get(src_ns) {
@@ -417,11 +421,49 @@ impl GlobalEnv {
             Some(ns) => ns.clone(),
             None => return,
         };
+        let filter = if src_ns == "clojure.core" {
+            dst.get().refer_clojure_filter.lock().unwrap().clone()
+        } else {
+            None
+        };
         let src_interns = src.get().interns.lock().unwrap();
         let mut dst_refers = dst.get().refers.lock().unwrap();
         for (name, var) in src_interns.iter() {
-            dst_refers.insert(name.clone(), var.clone());
+            match &filter {
+                Some(f) => {
+                    if let Some(local) = f.local_name(name) {
+                        dst_refers.insert(local, var.clone());
+                    }
+                }
+                None => {
+                    dst_refers.insert(name.clone(), var.clone());
+                }
+            }
         }
+    }
+
+    /// Install `dst_ns`'s `(:refer-clojure ...)` filter (`None` removes any
+    /// previous one) and re-apply the automatic `clojure.core` refer under it.
+    ///
+    /// Refers already inherited from `clojure.core` are dropped first, so a
+    /// filter set after the namespace was pre-referred — the loader refers core
+    /// before it reads the file, and `ns` itself refers core before it reaches
+    /// the clause — still takes effect.
+    pub fn set_refer_clojure_filter(&self, dst_ns: &str, filter: Option<ReferClojureFilter>) {
+        let dst = self.get_or_create_ns(dst_ns);
+        {
+            let mut slot = dst.get().refer_clojure_filter.lock().unwrap();
+            // Nothing to install and nothing to undo: leave the refers alone.
+            if slot.is_none() && filter.is_none() {
+                return;
+            }
+            *slot = filter;
+        }
+        {
+            let mut refers = dst.get().refers.lock().unwrap();
+            refers.retain(|_, var| var.get().namespace.as_ref() != "clojure.core");
+        }
+        self.refer_all(dst_ns, "clojure.core");
     }
 
     /// Copy selected interns from `src_ns` into `dst_ns` as refers.

--- a/crates/cljrs-runtime/src/env/loader.rs
+++ b/crates/cljrs-runtime/src/env/loader.rs
@@ -113,7 +113,7 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
         // own `(ns ...)` form (mirrors the source-file path below).
         globals.get_or_create_ns(ns_name);
         if ns_name.as_ref() != "clojure.core" {
-            globals.refer_all(ns_name, "clojure.core");
+            globals.refer_core(ns_name);
         }
         // Save and restore *ns* so the caller's namespace is not disturbed by
         // the `(ns ...)` form in the loaded namespace's preamble.
@@ -168,7 +168,7 @@ fn do_load(globals: &Arc<GlobalEnv>, ns_name: &Arc<str>) -> EvalResult<()> {
 
     // Pre-refer clojure.core so code in the file can use core fns before (ns ...).
     if ns_name.as_ref() != "clojure.core" {
-        globals.refer_all(ns_name, "clojure.core");
+        globals.refer_core(ns_name);
     }
 
     // Evaluate the file in a new Env rooted at the namespace being loaded.

--- a/crates/cljrs-runtime/src/env/versioned.rs
+++ b/crates/cljrs-runtime/src/env/versioned.rs
@@ -258,7 +258,7 @@ fn do_versioned_load(
     }
 
     // Pre-refer clojure.core.
-    globals.refer_all(versioned_ns_name, "clojure.core");
+    globals.refer_core(versioned_ns_name);
 
     // Evaluate all forms with a versioned commit context so that
     // same-namespace calls inside the historical source also resolve at

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -1,6 +1,6 @@
 //! Special form evaluators.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::builtins::form::{
@@ -18,7 +18,7 @@ use cljrs_reader::form::FormKind;
 use cljrs_value::error::ExceptionInfo;
 use cljrs_value::{
     CljxFn, CljxFnArity, FutureState, Keyword, MapValue, MultiFn, Protocol, ProtocolFn,
-    ProtocolMethod, TypeHint, TypeInstance, Value, ValueError,
+    ProtocolMethod, ReferClojureFilter, TypeHint, TypeInstance, Value, ValueError,
 };
 
 /// Dispatch to the right special-form handler.
@@ -1531,6 +1531,66 @@ fn merge_meta(base: Option<Value>, overlay: Option<Value>) -> Option<Value> {
     }
 }
 
+/// Parse the body of a `(:refer-clojure ...)` clause into the filter applied
+/// to the automatic `clojure.core` refer.  Accepts `:exclude`, `:only` and
+/// `:rename`, each once, in any order.
+fn parse_refer_clojure_clause(items: &[Form]) -> Result<ReferClojureFilter, String> {
+    let mut filter = ReferClojureFilter::default();
+    let items = expand_reader_conds(items);
+    let mut i = 0;
+    while i < items.len() {
+        let FormKind::Keyword(k) = &items[i].kind else {
+            return Err(":refer-clojure expects keyword options (:exclude, :only, :rename)".into());
+        };
+        let arg = items
+            .get(i + 1)
+            .ok_or_else(|| format!(":refer-clojure :{k} expects a value"))?;
+        match k.as_str() {
+            "exclude" => filter.exclude = symbol_name_set(arg, "exclude")?,
+            "only" => filter.only = Some(symbol_name_set(arg, "only")?),
+            "rename" => {
+                let FormKind::Map(entries) = &arg.kind else {
+                    return Err(":refer-clojure :rename expects a map".into());
+                };
+                if entries.len() % 2 != 0 {
+                    return Err(":refer-clojure :rename expects an even-sized map".into());
+                }
+                for pair in entries.chunks(2) {
+                    match (&pair[0].kind, &pair[1].kind) {
+                        (FormKind::Symbol(from), FormKind::Symbol(to)) => {
+                            filter
+                                .rename
+                                .insert(Arc::from(from.as_str()), Arc::from(to.as_str()));
+                        }
+                        _ => {
+                            return Err(
+                                ":refer-clojure :rename expects symbol keys and values".into()
+                            );
+                        }
+                    }
+                }
+            }
+            other => return Err(format!(":refer-clojure does not support :{other}")),
+        }
+        i += 2;
+    }
+    Ok(filter)
+}
+
+/// Read a vector of symbols (an `:exclude`/`:only` list) as a set of names.
+fn symbol_name_set(form: &Form, opt: &str) -> Result<HashSet<Arc<str>>, String> {
+    let FormKind::Vector(items) = &form.kind else {
+        return Err(format!(":refer-clojure :{opt} expects a vector of symbols"));
+    };
+    expand_reader_conds(items)
+        .iter()
+        .map(|f| match &f.kind {
+            FormKind::Symbol(sym) => Ok(Arc::from(sym.as_str())),
+            _ => Err(format!(":refer-clojure :{opt} expects symbols")),
+        })
+        .collect()
+}
+
 fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
     let (name, name_meta) = extract_ns_name_form(args.first(), env)?;
     env.globals.get_or_create_ns(&name);
@@ -1557,6 +1617,23 @@ fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
         ns_ptr.get().set_meta(m);
     }
 
+    // `:refer-clojure` first: it narrows the automatic core refer done above,
+    // and an explicit `:require ... :refer` below must be able to override it.
+    // Re-evaluating an `ns` form without the clause clears a filter left by an
+    // earlier evaluation, restoring the full core refer.
+    let mut refer_clojure = None;
+    for clause in rest {
+        if let FormKind::List(items) = &clause.kind
+            && matches!(items.first().map(|f| &f.kind), Some(FormKind::Keyword(k)) if k == "refer-clojure")
+        {
+            refer_clojure =
+                Some(parse_refer_clojure_clause(&items[1..]).map_err(EvalError::Runtime)?);
+        }
+    }
+    if name != "clojure.core" {
+        env.globals.set_refer_clojure_filter(&name, refer_clojure);
+    }
+
     for clause in rest {
         if let FormKind::List(items) = &clause.kind {
             match items.first().map(|f| &f.kind) {
@@ -1569,7 +1646,8 @@ fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
                         load_ns(env.globals.clone(), &spec, &name)?;
                     }
                 }
-                // Other clauses (:refer-clojure, :use, :import) — skip for now.
+                // `:refer-clojure` was handled in the pass above; other clauses
+                // (`:use`, `:import`) — skip for now.
                 _ => {}
             }
         }

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -1597,7 +1597,7 @@ fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
     env.current_ns = Arc::from(name.as_str());
     // Auto-refer clojure.core (Clojure default behaviour).
     if name != "clojure.core" {
-        env.globals.refer_all(&name, "clojure.core");
+        env.globals.refer_core(&name);
     }
     sync_star_ns(env);
 
@@ -1621,6 +1621,12 @@ fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
     // and an explicit `:require ... :refer` below must be able to override it.
     // Re-evaluating an `ns` form without the clause clears a filter left by an
     // earlier evaluation, restoring the full core refer.
+    //
+    // More than one `:refer-clojure` clause is not meaningful, so the last one
+    // wins rather than accumulating.  (Clojure runs each clause as a separate
+    // `refer` call, where a second clause silently *re-adds* what the first
+    // excluded; there is no reading of that under which both clauses do what
+    // they say.)
     let mut refer_clojure = None;
     for clause in rest {
         if let FormKind::List(items) = &clause.kind
@@ -1631,7 +1637,9 @@ fn eval_ns(args: &[Form], env: &mut Env) -> EvalResult {
         }
     }
     if name != "clojure.core" {
-        env.globals.set_refer_clojure_filter(&name, refer_clojure);
+        env.globals
+            .set_refer_clojure_filter(&name, refer_clojure)
+            .map_err(EvalError::Runtime)?;
     }
 
     for clause in rest {
@@ -1744,7 +1752,7 @@ fn eval_in_ns(args: &[Form], env: &mut Env) -> EvalResult {
     let ns_val = eval(&args[0], env)?;
     let ns_name = extract_ns_name(&ns_val)?;
     env.globals.get_or_create_ns(&ns_name);
-    env.globals.refer_all(&ns_name, "clojure.core");
+    env.globals.refer_core(&ns_name);
     env.current_ns = Arc::from(ns_name.as_str());
     sync_star_ns(env);
     let ns_ptr = env.globals.get_or_create_ns(&env.current_ns);

--- a/crates/cljrs-runtime/src/runtime.rs
+++ b/crates/cljrs-runtime/src/runtime.rs
@@ -193,13 +193,13 @@ impl RuntimeBuilder {
         // Native clojure.core, then a `user` namespace referring it.
         builtins::register_all(&globals, "clojure.core");
         globals.get_or_create_ns("user");
-        globals.refer_all("user", "clojure.core");
+        globals.refer_core("user");
 
         // Bootstrap Clojure source (higher-order fns defined in Clojure).
         eval_embedded(&globals, builtins::BOOTSTRAP_SOURCE, "<bootstrap>")?;
 
         // Re-refer clojure.core now that the bootstrap has defined its HOFs.
-        globals.refer_all("user", "clojure.core");
+        globals.refer_core("user");
         globals.mark_loaded("clojure.core");
 
         for (ns, src) in &self.builtin_sources {

--- a/crates/cljrs-runtime/tests/refer_clojure.rs
+++ b/crates/cljrs-runtime/tests/refer_clojure.rs
@@ -1,0 +1,156 @@
+//! `(:refer-clojure ...)` in `ns`: `:exclude`, `:only` and `:rename` narrow the
+//! automatic `clojure.core` refer.
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_runtime::env::error::{EvalError, EvalResult};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .eager_clojure_test(true)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+#[allow(clippy::result_large_err)]
+fn try_eval_all(env: &mut Env, src: &str) -> EvalResult {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, env)?;
+    }
+    Ok(result)
+}
+
+fn eval_all(env: &mut Env, src: &str) -> Value {
+    try_eval_all(env, src).expect("eval error")
+}
+
+/// Assert that evaluating `src` fails because `sym` cannot be resolved.
+fn assert_unbound(env: &mut Env, src: &str, sym: &str) {
+    match try_eval_all(env, src) {
+        Err(EvalError::UnboundSymbol(s)) => assert_eq!(s, sym),
+        other => panic!("expected {sym} to be unresolved, got {other:?}"),
+    }
+}
+
+#[test]
+fn exclude_removes_the_core_refer() {
+    let (_, mut env) = make_env();
+    eval_all(&mut env, "(ns rc.exclude (:refer-clojure :exclude [inc]))");
+    assert_unbound(&mut env, "(inc 1)", "inc");
+    // Only the excluded name is affected; the rest of core is still referred.
+    assert_eq!(eval_all(&mut env, "(dec 1)"), Value::Long(0));
+    // The fully qualified var is still reachable.
+    assert_eq!(eval_all(&mut env, "(clojure.core/inc 1)"), Value::Long(2));
+}
+
+#[test]
+fn excluded_name_can_be_redefined_locally() {
+    let (_, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns rc.redef (:refer-clojure :exclude [inc]))
+         (defn inc [x] (+ x 100))",
+    );
+    assert_eq!(eval_all(&mut env, "(inc 1)"), Value::Long(101));
+    assert_eq!(eval_all(&mut env, "(clojure.core/inc 1)"), Value::Long(2));
+}
+
+#[test]
+fn only_refers_just_the_listed_names() {
+    let (_, mut env) = make_env();
+    eval_all(&mut env, "(ns rc.only (:refer-clojure :only [+ str]))");
+    assert_eq!(eval_all(&mut env, "(+ 1 2)"), Value::Long(3));
+    assert_eq!(
+        eval_all(&mut env, r#"(str "a" "b")"#),
+        Value::string("ab".to_string())
+    );
+    assert_unbound(&mut env, "(inc 1)", "inc");
+}
+
+#[test]
+fn rename_refers_under_the_new_name_only() {
+    let (_, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns rc.rename (:refer-clojure :rename {inc plus1}))",
+    );
+    assert_eq!(eval_all(&mut env, "(plus1 41)"), Value::Long(42));
+    // As in `clojure.core/refer`, the original name is not also referred.
+    assert_unbound(&mut env, "(inc 1)", "inc");
+    assert_eq!(eval_all(&mut env, "(dec 1)"), Value::Long(0));
+}
+
+#[test]
+fn exclude_and_only_combine() {
+    let (_, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns rc.both (:refer-clojure :only [+ inc] :exclude [inc]))",
+    );
+    assert_eq!(eval_all(&mut env, "(+ 1 2)"), Value::Long(3));
+    assert_unbound(&mut env, "(inc 1)", "inc");
+    assert_unbound(&mut env, "(dec 1)", "dec");
+}
+
+#[test]
+fn require_refer_overrides_the_exclusion() {
+    let (_, mut env) = make_env();
+    // An explicit `:refer` names the var directly, so it wins over the
+    // narrowed automatic core refer.
+    eval_all(
+        &mut env,
+        "(ns rc.override
+           (:refer-clojure :exclude [inc])
+           (:require [clojure.core :refer [inc]]))",
+    );
+    assert_eq!(eval_all(&mut env, "(inc 1)"), Value::Long(2));
+}
+
+#[test]
+fn reevaluating_ns_without_the_clause_restores_core() {
+    let (_, mut env) = make_env();
+    eval_all(&mut env, "(ns rc.reload (:refer-clojure :exclude [inc]))");
+    assert_unbound(&mut env, "(inc 1)", "inc");
+    eval_all(&mut env, "(ns rc.reload)");
+    assert_eq!(eval_all(&mut env, "(inc 1)"), Value::Long(2));
+}
+
+#[test]
+fn other_namespaces_are_unaffected() {
+    let (_, mut env) = make_env();
+    eval_all(&mut env, "(ns rc.private (:refer-clojure :exclude [inc]))");
+    eval_all(&mut env, "(ns rc.other)");
+    assert_eq!(eval_all(&mut env, "(inc 1)"), Value::Long(2));
+}
+
+#[test]
+fn unknown_option_is_an_error() {
+    let (_, mut env) = make_env();
+    let err = try_eval_all(&mut env, "(ns rc.bad (:refer-clojure :bogus [inc]))")
+        .expect_err("expected an error");
+    assert!(
+        format!("{err}").contains(":bogus"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn exclude_expects_a_vector_of_symbols() {
+    let (_, mut env) = make_env();
+    let err = try_eval_all(&mut env, "(ns rc.bad2 (:refer-clojure :exclude inc))")
+        .expect_err("expected an error");
+    assert!(
+        format!("{err}").contains(":exclude"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/cljrs-runtime/tests/refer_clojure.rs
+++ b/crates/cljrs-runtime/tests/refer_clojure.rs
@@ -154,3 +154,102 @@ fn exclude_expects_a_vector_of_symbols() {
         "unexpected error: {err}"
     );
 }
+
+#[test]
+fn explicit_refer_all_of_core_overrides_the_exclusion() {
+    let (_, mut env) = make_env();
+    // An explicit `:refer :all` names `clojure.core` directly, so — as with
+    // `clojure.core/refer` — it re-refers everything the clause left out.
+    eval_all(
+        &mut env,
+        "(ns rc.all
+           (:refer-clojure :exclude [inc])
+           (:require [clojure.core :refer :all]))",
+    );
+    assert_eq!(eval_all(&mut env, "(inc 1)"), Value::Long(2));
+}
+
+#[test]
+fn rename_onto_an_existing_core_name_is_an_error() {
+    let (_, mut env) = make_env();
+    // Both `inc` (renamed) and core's own `str` want the name `str`; picking a
+    // winner by hash order would be unstable from run to run.
+    let err = try_eval_all(&mut env, "(ns rc.clash (:refer-clojure :rename {inc str}))")
+        .expect_err("expected an error");
+    let msg = format!("{err}");
+    assert!(msg.contains("inc") && msg.contains("str"), "{msg}");
+}
+
+#[test]
+fn two_renames_onto_one_name_is_an_error() {
+    let (_, mut env) = make_env();
+    let err = try_eval_all(
+        &mut env,
+        "(ns rc.clash2 (:refer-clojure :rename {inc bump dec bump}))",
+    )
+    .expect_err("expected an error");
+    assert!(format!("{err}").contains("bump"), "{err}");
+}
+
+#[test]
+fn renaming_onto_an_excluded_name_is_fine() {
+    let (_, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns rc.clash3 (:refer-clojure :rename {inc str} :exclude [str]))",
+    );
+    assert_eq!(eval_all(&mut env, "(str 1)"), Value::Long(2));
+}
+
+#[test]
+fn only_must_name_vars_core_actually_defines() {
+    let (_, mut env) = make_env();
+    let err = try_eval_all(
+        &mut env,
+        "(ns rc.typo (:refer-clojure :only [inc no-such-fn]))",
+    )
+    .expect_err("expected an error");
+    let msg = format!("{err}");
+    assert!(msg.contains("no-such-fn"), "{msg}");
+    assert!(
+        !msg.contains("inc"),
+        "only the unknown name is reported: {msg}"
+    );
+}
+
+#[test]
+fn rename_must_name_vars_core_actually_defines() {
+    let (_, mut env) = make_env();
+    let err = try_eval_all(
+        &mut env,
+        "(ns rc.typo2 (:refer-clojure :rename {no-such-fn f}))",
+    )
+    .expect_err("expected an error");
+    assert!(format!("{err}").contains("no-such-fn"), "{err}");
+}
+
+#[test]
+fn exclude_of_an_unknown_name_is_allowed() {
+    let (_, mut env) = make_env();
+    // `:exclude` is subtractive: excluding a name core does not define is
+    // harmless, and lets a file stay portable across core versions.
+    eval_all(
+        &mut env,
+        "(ns rc.tolerant (:refer-clojure :exclude [inc no-such-fn]))",
+    );
+    assert_unbound(&mut env, "(inc 1)", "inc");
+    assert_eq!(eval_all(&mut env, "(dec 1)"), Value::Long(0));
+}
+
+#[test]
+fn the_last_refer_clojure_clause_wins() {
+    let (_, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns rc.twice
+           (:refer-clojure :exclude [inc])
+           (:refer-clojure :exclude [dec]))",
+    );
+    assert_eq!(eval_all(&mut env, "(inc 1)"), Value::Long(2));
+    assert_unbound(&mut env, "(dec 1)", "dec");
+}

--- a/crates/cljrs-stdlib/README.md
+++ b/crates/cljrs-stdlib/README.md
@@ -158,8 +158,10 @@ deviations)
   bound.
 - Users must `:require` the namespace with an alias (`:as s`, the universal
   convention anyway). `:refer`ing names like `and`, `or`, or `def` collides
-  with clojurust's special forms, and `:refer-clojure :exclude` is a no-op
-  in this runtime, so it cannot be used to work around the collision.
+  with clojurust's special forms, which are dispatched on the head symbol's
+  text before any var lookup, so `(:refer-clojure :exclude [and or def])` —
+  which does work — is not enough to reach the referred spec vars in call
+  position.
 
 ### clojure.spec.test.alpha functions and macros
 

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -439,6 +439,7 @@ pub struct Namespace {
     pub git_repo_root: Mutex<Option<Arc<str>>>,               // repo root of source_file, if any
     pub is_versioned: bool,                                   // true for `name@commit` namespaces
     pub meta: Mutex<Option<Value>>,                           // from `(ns ^{...} name ...)` / attr-map
+    pub refer_clojure_filter: Mutex<Option<ReferClojureFilter>>, // from `(:refer-clojure ...)`
 }
 
 impl Namespace {
@@ -449,6 +450,30 @@ impl Namespace {
     pub fn set_meta(&self, m: Value);
 }
 ```
+
+### `ReferClojureFilter` (Phase 4)
+
+How much of `clojure.core` a namespace auto-refers, as narrowed by an
+`(:refer-clojure ...)` clause in `ns`.  `None` on the namespace means the
+default: every public core name is referred.  Applied by
+`GlobalEnv::refer_all` whenever the source namespace is `clojure.core`.
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct ReferClojureFilter {
+    pub only: Option<HashSet<Arc<str>>>,     // `:only` — nothing outside this set is referred
+    pub exclude: HashSet<Arc<str>>,          // `:exclude` — never referred
+    pub rename: HashMap<Arc<str>, Arc<str>>, // `:rename` — core name → local name
+}
+
+impl ReferClojureFilter {
+    /// The local name `name` is referred under, or `None` when dropped.
+    pub fn local_name(&self, name: &Arc<str>) -> Option<Arc<str>>;
+}
+```
+
+A renamed name is *not* also referred under its original name, matching
+`clojure.core/refer`.
 
 ### `Thunk` / `LazySeq` / `CljxCons` (Phase 5)
 

--- a/crates/cljrs-value/README.md
+++ b/crates/cljrs-value/README.md
@@ -456,7 +456,8 @@ impl Namespace {
 How much of `clojure.core` a namespace auto-refers, as narrowed by an
 `(:refer-clojure ...)` clause in `ns`.  `None` on the namespace means the
 default: every public core name is referred.  Applied by
-`GlobalEnv::refer_all` whenever the source namespace is `clojure.core`.
+`GlobalEnv::refer_core`, and only there — an explicit refer (`refer_all` /
+`refer_named`) bypasses it.
 
 ```rust
 #[derive(Debug, Clone, Default)]
@@ -473,7 +474,9 @@ impl ReferClojureFilter {
 ```
 
 A renamed name is *not* also referred under its original name, matching
-`clojure.core/refer`.
+`clojure.core/refer`.  `local_name` is a pure lookup: validating the filter
+against what core actually defines, and rejecting two names that collide on
+one local name, happens once in `GlobalEnv::set_refer_clojure_filter`.
 
 ### `Thunk` / `LazySeq` / `CljxCons` (Phase 5)
 

--- a/crates/cljrs-value/src/lib.rs
+++ b/crates/cljrs-value/src/lib.rs
@@ -43,7 +43,7 @@ pub use type_hint::TypeHint;
 pub use types::{
     Agent, Arity, Atom, BoundFn, CljxCons, CljxFn, CljxFnArity, CljxFuture, CljxPromise, Delay,
     DelayState, FutureState, LazySeq, MultiFn, Namespace, NativeFn, NativeFnFunc, NativeFnPtr,
-    Protocol, ProtocolFn, ProtocolMethod, Thunk, Var, Volatile, bump_protocol_generation,
-    protocol_generation,
+    Protocol, ProtocolFn, ProtocolMethod, ReferClojureFilter, Thunk, Var, Volatile,
+    bump_protocol_generation, protocol_generation,
 };
 pub use value::{MapValue, ObjectArray, SetValue, TypeInstance, Value};

--- a/crates/cljrs-value/src/types.rs
+++ b/crates/cljrs-value/src/types.rs
@@ -504,6 +504,42 @@ impl cljrs_gc::Trace for Atom {
 
 // ── Namespace ─────────────────────────────────────────────────────────────────
 
+/// Which `clojure.core` names a namespace auto-refers, as narrowed by an
+/// `(:refer-clojure ...)` clause in `ns`.  An absent filter (the default)
+/// refers every public core name.
+#[derive(Debug, Clone, Default)]
+pub struct ReferClojureFilter {
+    /// `:only` — when set, no core name outside this set is referred.
+    pub only: Option<std::collections::HashSet<Arc<str>>>,
+    /// `:exclude` — core names that are never referred.
+    pub exclude: std::collections::HashSet<Arc<str>>,
+    /// `:rename` — core name → the local name it is referred under.  A renamed
+    /// name is *not* also referred under its original name (matching
+    /// `clojure.core/refer`).
+    pub rename: HashMap<Arc<str>, Arc<str>>,
+}
+
+impl ReferClojureFilter {
+    /// The local name `name` is referred under, or `None` when this filter
+    /// drops it.
+    pub fn local_name(&self, name: &Arc<str>) -> Option<Arc<str>> {
+        if self.exclude.contains(name) {
+            return None;
+        }
+        if let Some(only) = &self.only
+            && !only.contains(name)
+        {
+            return None;
+        }
+        Some(
+            self.rename
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| name.clone()),
+        )
+    }
+}
+
 /// A Clojure namespace with intern table, refers, and aliases.
 #[derive(Debug)]
 pub struct Namespace {
@@ -525,6 +561,9 @@ pub struct Namespace {
     pub is_versioned: bool,
     /// Metadata attached via `(ns ^{...} name ...)` or an `ns` attr-map.
     pub meta: Mutex<Option<Value>>,
+    /// Narrowing applied to the automatic `clojure.core` refer, set by an
+    /// `(:refer-clojure ...)` clause.  `None` refers all of core.
+    pub refer_clojure_filter: Mutex<Option<ReferClojureFilter>>,
 }
 
 impl Namespace {
@@ -538,6 +577,7 @@ impl Namespace {
             git_repo_root: Mutex::new(None),
             is_versioned: false,
             meta: Mutex::new(None),
+            refer_clojure_filter: Mutex::new(None),
         }
     }
 


### PR DESCRIPTION
The clause was parsed off the `ns` form and dropped, so `:exclude` and
`:only` were silent no-ops and every `clojure.core` name stayed referred.
That is a quiet divergence rather than a missing error: after
`(:refer-clojure :exclude [map])`, an unqualified `map` call above the
local `(defn map ...)` resolved to `clojure.core/map` instead of failing,
which is exactly what the exclusion exists to prevent.

Namespaces now carry a `ReferClojureFilter` (`:only`, `:exclude`,
`:rename`) that `GlobalEnv::refer_all` consults whenever it refers from
`clojure.core`.  `ns` parses the clause and installs the filter through
`set_refer_clojure_filter`, which first drops the refers already
inherited from core — both the loader and `ns` itself pre-refer core
before the clause is reached — and then re-refers under the filter.  A
`ns` form re-evaluated without the clause clears the filter, restoring
the full core refer.

`:rename` refers a var under its new name only, matching
`clojure.core/refer`.  An explicit `(:require [clojure.core :refer [x]])`
still wins over the narrowed automatic refer, and `clojure.core/x` stays
reachable qualified.  Unknown options are now an error instead of being
ignored.

Note this is orthogonal to the special-form dispatch gap (#279): `def`,
`and` and `or` are dispatched on the head symbol's text before any var
lookup, so excluding them still does not make a referred macro reachable
in call position.  The stdlib README note is corrected accordingly.

Fixes #281

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qymq9R3MSzCq825XoWgpNF