### PR TITLE
Lower a call as `clojure.core` only when it resolves there

### DIFF
--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -1,3 +1,10 @@
+// `EvalResult`'s error is `cljrs_runtime`'s `EvalError`, returned by value from
+// every evaluator entry point; the synchronous side allows this lint crate-wide
+// (`cljrs-runtime/src/lib.rs`) and `runtime.rs` allows it per function.  Clippy
+// only began flagging `async fn`s for it in 1.98 — the code below is unchanged
+// from when it passed under 1.94.
+#![allow(clippy::result_large_err)]
+
 //! Asynchronous tree-walking evaluation for `^:async` function bodies.
 //!
 //! [`eval_async`] mirrors the synchronous [`cljrs_runtime::interp::eval::eval`] for the

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -114,11 +114,23 @@ pub fn lower_via_rust(
     ns: &str,
     params: &[Arc<str>],
     compilable_forms: &[cljrs_reader::Form],
-    _env: &mut cljrs_runtime::tiered::Env,
+    env: &mut cljrs_runtime::tiered::Env,
 ) -> AotResult<IrFunction> {
     let ns_arc: Arc<str> = Arc::from(ns);
-    let ir = cljrs_ir::lower::lower_fn_body(name, &ns_arc, params, compilable_forms, false)
-        .map_err(|e| AotError::Eval(format!("lowering: {e:?}")))?;
+    // `ns` has already been evaluated into `env`, so its own `def`s, refers and
+    // `(:refer-clojure ...)` filter are visible: a name it rebinds must not be
+    // compiled as `clojure.core`'s (issue #337).
+    let shadows = cljrs_runtime::tiered::lower::core_shadows_for(&env.globals, ns);
+    let ir = cljrs_ir::lower::lower_fn_body_shadowed(
+        name,
+        &ns_arc,
+        params,
+        &[],
+        compilable_forms,
+        false,
+        &shadows,
+    )
+    .map_err(|e| AotError::Eval(format!("lowering: {e:?}")))?;
     let ir = cljrs_ir::lower::optimize(ir);
 
     #[cfg(feature = "no-gc")]

--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -27,8 +27,8 @@ src/
              live-in values (loop φs + pre-loop defs) arriving as parameters
   lower/
     mod.rs      — re-exports: lower_fn_body, lower_fn_body_destructured,
-                  lower_fn_body_seeded, lower_fn_body_shadowed, CoreShadows,
-                  analyze, inline, optimize, EscapeContext …
+                  lower_fn_body_shadowed, CoreShadows, analyze, inline,
+                  optimize, EscapeContext …
     async_lower.rs — async state-machine lowering (Phase H): rewrites an
                   `^:async` IrFunction into a non-async poll function
                   (is_async_poll_fn) whose control flow is an explicit resumable
@@ -254,7 +254,6 @@ impl CoreShadows {
     pub fn none() -> Self;
     pub fn new(names: impl IntoIterator<Item = Arc<str>>) -> Self;
     pub fn contains(&self, name: &str) -> bool;
-    pub fn is_empty(&self) -> bool;
     pub fn union(&self, extra: impl IntoIterator<Item = Arc<str>>) -> Self;
 }
 
@@ -274,10 +273,10 @@ pub fn lower_fn_body_shadowed(
 
 Lexical bindings are handled by the lowerer itself: `LowerCtx::core_call_name`
 consults `lookup_local` first, so a `let`-bound or parameter `inc` is a call to
-that binding.  `def`s in the unit being lowered are folded into the shadow set
-up front (`collect_defined_names`), because AOT compiles a whole file without
-evaluating its `def`s — the environment cannot report them yet.  See issue
-#337.
+that binding.  Names the unit being lowered binds are folded into the shadow
+set up front (`collect_defined_names`, over `DEF_HEADS` plus `declare`),
+because AOT compiles a whole file without evaluating its `def`s — the
+environment cannot report them yet.  See issue #337.
 
 ### Optimization pipeline (re-exported from `lower::`)
 

--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -27,7 +27,8 @@ src/
              live-in values (loop φs + pre-loop defs) arriving as parameters
   lower/
     mod.rs      — re-exports: lower_fn_body, lower_fn_body_destructured,
-                  lower_fn_body_seeded, analyze, inline, optimize, EscapeContext …
+                  lower_fn_body_seeded, lower_fn_body_shadowed, CoreShadows,
+                  analyze, inline, optimize, EscapeContext …
     async_lower.rs — async state-machine lowering (Phase H): rewrites an
                   `^:async` IrFunction into a non-async poll function
                   (is_async_poll_fn) whose control flow is an explicit resumable
@@ -38,17 +39,24 @@ src/
                   resume blocks are phi-free so the codegen dispatch jump needs
                   no phi args.  Lowers `await` only; channels/spawn return
                   AsyncLowerError::Unsupported (interpreter fallback kept)
-    anf.rs      — ANF lowering: Form AST → IrFunction (pure Rust).  Closures
+    anf.rs      — ANF lowering: Form AST → IrFunction (pure Rust).  Also
+                  `collect_defined_names`, which reads the `def`s out of the
+                  unit being lowered so its own definitions shadow core.
+                  Closures
                   capture only the enclosing locals their (fully macro-expanded)
                   body references (`collect_symbol_names`, a conservative
                   free-variable over-approximation), not every local in scope.
                   `desugar_pre_post_conditions` rewrites `{:pre [...] :post [...]}`
                   maps at the head of a function body into `(assert ...)` forms
                   (binds `%` to the return value in `:post` conditions).
-    context.rs  — LowerCtx builder state used by anf.rs
+    context.rs  — LowerCtx builder state used by anf.rs; also
+                  `core_call_name`, the call-position check that decides
+                  whether a head symbol really is a clojure.core name
     escape.rs   — worklist-based escape analysis; inter-procedural via EscapeContext
     inline.rs   — inlining pass: splices small callees into call sites
-    known.rs    — symbol → KnownFn resolution
+    known.rs    — symbol → KnownFn resolution, the `clojure.core` qualifier
+                  check (core_name) and CoreShadows (what the lowering
+                  namespace binds instead of core)
     optimize.rs — region-allocation promotion; dominator/post-dominator CFG analysis
     regionalize.rs — stage-4 cross-function region promotion: clones callees
                      whose `Returns` allocs are NoEscape at a call site, wraps
@@ -61,7 +69,10 @@ src/
                      passed to an opaque call
 tests/
   capture_minimization.rs — closure-capture set regression tests
+  core_shadowing.rs       — call-position core resolution: locals, namespace
+                            shadows and qualified symbols (issue #337)
   escape_regression.rs    — escape-analysis regression tests
+  numeric_literals.rs     — numeric-literal lowering regression tests
 ```
 
 ---
@@ -221,6 +232,52 @@ bridge clones the value out, so its result does not alias the source.
 ### Closures
 
 `ClosureTemplate`: static description of an `fn*` form (arity info, capture names).
+
+### Core-name resolution
+
+Inlining `(inc x)` into an add — or `(count c)` into `CallKnown(Count, …)` —
+is only correct when that call site actually resolves to `clojure.core`.  Two
+pieces decide that, and a call that fails either one is lowered as an ordinary
+dynamic `Call`, which resolves per call exactly as the tree-walker does:
+
+```rust
+/// The bare clojure.core name `sym` denotes, or None.  Unqualified symbols and
+/// `clojure.core/x` are candidates; `other.ns/count` is not core's `count`.
+pub fn core_name(sym: &str) -> Option<&str>;
+
+/// Names the lowering namespace does *not* resolve to clojure.core: its own
+/// `def`s, names it `:refer`s from elsewhere, and names a `(:refer-clojure
+/// ...)` clause keeps out of the automatic core refer.  Empty means "no
+/// namespace information", i.e. assume core.
+pub struct CoreShadows { /* … */ }
+impl CoreShadows {
+    pub fn none() -> Self;
+    pub fn new(names: impl IntoIterator<Item = Arc<str>>) -> Self;
+    pub fn contains(&self, name: &str) -> bool;
+    pub fn is_empty(&self) -> bool;
+    pub fn union(&self, extra: impl IntoIterator<Item = Arc<str>>) -> Self;
+}
+
+/// Lower with a namespace's shadows supplied.  The other entry points lower
+/// with `CoreShadows::none()`; callers holding an environment should build a
+/// real one (`cljrs_runtime::tiered::lower::core_shadows_for`).
+pub fn lower_fn_body_shadowed(
+    name: Option<&str>,
+    ns: &str,
+    params: &[Arc<str>],
+    destructures: &[(usize, Form)],
+    body: &[Form],
+    is_async: bool,
+    shadows: &CoreShadows,
+) -> Result<IrFunction, LowerError>;
+```
+
+Lexical bindings are handled by the lowerer itself: `LowerCtx::core_call_name`
+consults `lookup_local` first, so a `let`-bound or parameter `inc` is a call to
+that binding.  `def`s in the unit being lowered are folded into the shadow set
+up front (`collect_defined_names`), because AOT compiles a whole file without
+evaluating its `def`s — the environment cannot report them yet.  See issue
+#337.
 
 ### Optimization pipeline (re-exported from `lower::`)
 

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -11,7 +11,7 @@ use cljrs_reader::form::{Form, FormKind};
 use crate::{BlockId, ClosureTemplate, Const, Inst, IrFunction, KnownFn, Terminator, VarId};
 
 use super::context::{LowerCtx, fresh_global_name_id};
-use super::known::{resolve_known_fn, strip_ns_prefix};
+use super::known::{CoreShadows, resolve_known_core_fn};
 
 // ── Free-variable approximation for closure captures ─────────────────────────
 
@@ -57,6 +57,64 @@ fn collect_symbol_names_form<'a>(form: &'a Form, out: &mut HashSet<&'a str>) {
         // Atoms (Nil, Bool, Int, …, Keyword, …) contain no symbol references.
         _ => {}
     }
+}
+
+// ── Namespace-level `def` collection ─────────────────────────────────────────
+
+/// Collect the names the forms being lowered `def` into the lowering
+/// namespace.
+///
+/// Such a name is bound to *this* namespace's var, so an unqualified call to
+/// it is not `clojure.core`'s even when it reuses a core name — the same
+/// shadowing an already-interned var causes, except that the unit's own `def`s
+/// may not have run yet: AOT compiles a whole file without evaluating its
+/// `def`s, so the environment cannot report them (issue #337).
+///
+/// Collected up front, so a call site above the `def` is lowered the same way
+/// as one below it.  Both become dynamic calls that resolve per call, which is
+/// what the tree-walking interpreter does.
+fn collect_defined_names(forms: &[Form], out: &mut HashSet<Arc<str>>) {
+    for form in forms {
+        collect_defined_names_form(form, out);
+    }
+}
+
+fn collect_defined_names_form(form: &Form, out: &mut HashSet<Arc<str>>) {
+    match &form.kind {
+        FormKind::List(parts) => {
+            if let Some(FormKind::Symbol(head)) = parts.first().map(|f| &f.kind)
+                && matches!(head.as_str(), "def" | "defn" | "defn-" | "defonce")
+                && let Some(name) = parts.get(1).and_then(def_name)
+            {
+                out.insert(Arc::from(name));
+            }
+            collect_defined_names(parts, out);
+        }
+        FormKind::Vector(v) | FormKind::Map(v) | FormKind::Set(v) | FormKind::AnonFn(v) => {
+            collect_defined_names(v, out)
+        }
+        FormKind::Meta(_, f) | FormKind::Deref(f) | FormKind::TaggedLiteral(_, f) => {
+            collect_defined_names_form(f, out)
+        }
+        FormKind::ReaderCond { clauses, .. } => collect_defined_names(clauses, out),
+        // A quoted `(def x ...)` is data, not a definition; every other form
+        // kind is an atom.
+        _ => {}
+    }
+}
+
+/// The bare name a `def` form binds — `(def ^:private x 1)` binds `x` — or
+/// `None` when the name position is not a symbol.
+fn def_name(form: &Form) -> Option<&str> {
+    let inner = match &form.kind {
+        FormKind::Meta(_, inner) => inner,
+        _ => form,
+    };
+    let FormKind::Symbol(s) = &inner.kind else {
+        return None;
+    };
+    // `(def my.ns/x ...)` still binds `x` in `my.ns`.
+    Some(split_ns_name(s).1)
 }
 
 // ── Error type ───────────────────────────────────────────────────────────────
@@ -131,6 +189,26 @@ pub fn lower_fn_body(
     lower_fn_body_destructured(name, ns, params, &[], body, is_async)
 }
 
+/// Lower a function arity's body, told what the lowering namespace binds.
+///
+/// The shorter entry points above lower with no namespace information, which
+/// makes every `clojure.core` name resolve to core.  Callers that hold an
+/// environment should build a real [`CoreShadows`] instead
+/// (`cljrs_runtime::tiered::lower::core_shadows_for`), so a namespace that
+/// `def`s, `:refer`s, or `:refer-clojure :exclude`s a core name does not get
+/// core's semantics inlined at its call sites.
+pub fn lower_fn_body_shadowed(
+    name: Option<&str>,
+    ns: &str,
+    params: &[Arc<str>],
+    destructures: &[(usize, Form)],
+    body: &[Form],
+    is_async: bool,
+    shadows: &CoreShadows,
+) -> Result<IrFunction, LowerError> {
+    lower_fn_body_impl(name, ns, params, destructures, body, is_async, shadows)
+}
+
 /// Like [`lower_fn_body_destructured`] but also records static parameter
 /// representation seeds (from `^long`/`^double` type hints) on the resulting
 /// `IrFunction::seed_reprs`.  `seed_reprs` is positional with `params`.
@@ -170,7 +248,39 @@ pub fn lower_fn_body_destructured(
     body: &[Form],
     is_async: bool,
 ) -> Result<IrFunction, LowerError> {
-    let mut ctx = LowerCtx::new(name.map(Arc::from), Arc::from(ns));
+    lower_fn_body_impl(
+        name,
+        ns,
+        params,
+        destructures,
+        body,
+        is_async,
+        &CoreShadows::none(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn lower_fn_body_impl(
+    name: Option<&str>,
+    ns: &str,
+    params: &[Arc<str>],
+    destructures: &[(usize, Form)],
+    body: &[Form],
+    is_async: bool,
+    shadows: &CoreShadows,
+) -> Result<IrFunction, LowerError> {
+    // `clojure.core`'s own `def`s *are* the core names, so only other
+    // namespaces' definitions shadow.
+    let base_ns = versioned_ns_base(ns).unwrap_or(ns);
+    let shadows = if base_ns == "clojure.core" {
+        shadows.clone()
+    } else {
+        let mut defined: HashSet<Arc<str>> = HashSet::new();
+        collect_defined_names(body, &mut defined);
+        shadows.union(defined)
+    };
+
+    let mut ctx = LowerCtx::new(name.map(Arc::from), Arc::from(ns)).with_core_shadows(shadows);
     ctx.is_async = is_async;
 
     // Bind each param to a fresh VarId.
@@ -1327,7 +1437,7 @@ fn lower_fn(ctx: &mut LowerCtx, args: &[Form], is_async: bool) -> R {
 
 #[allow(clippy::too_many_arguments)]
 fn lower_fn_arity(
-    _parent_ctx: &mut LowerCtx,
+    parent_ctx: &mut LowerCtx,
     arity_name: Option<Arc<str>>,
     ns: Arc<str>,
     capture_names: &[Arc<str>],
@@ -1403,7 +1513,9 @@ fn lower_fn_arity(
         all_param_names.push(ri.name.clone());
     }
 
-    let mut sub = LowerCtx::new(arity_name, ns);
+    // A nested `fn*` is lowered in the same namespace as its parent, so it
+    // inherits the parent's view of what that namespace shadows.
+    let mut sub = LowerCtx::new(arity_name, ns).with_core_shadows(parent_ctx.core_shadows.clone());
     sub.is_async = is_async;
 
     // Bind all params.
@@ -2044,18 +2156,28 @@ fn lower_call(ctx: &mut LowerCtx, callee_form: &Form, arg_forms: &[Form]) -> R {
         None
     };
 
+    // Only a symbol that actually resolves to `clojure.core` here may be
+    // inlined or turned into a `CallKnown`: a local, a parameter, a var this
+    // namespace defs or refers from elsewhere, and an explicitly qualified
+    // `other.ns/count` all name something else, and the tree-walker calls that
+    // something else.  Lowering them as core's would make the answer depend on
+    // which tier is running.
+    let core_name = sym_name.and_then(|name| ctx.core_call_name(name));
+
     // Try inline expansions first.
-    if let Some(name) = sym_name
-        && let Some(result) = try_inline_expansion(ctx, name, arg_forms)?
+    if let Some(bare) = core_name
+        && let Some(result) = try_inline_expansion(ctx, bare, arg_forms)?
     {
         return Ok(result);
     }
 
     // Known function?
-    if let Some(name) = sym_name
-        && let Some(known) = resolve_known_fn(name)
+    if let Some(bare) = core_name
+        && let Some(known) = resolve_known_core_fn(bare)
     {
-        return lower_known_call(ctx, known, name, arg_forms);
+        // `lower_known_call` falls back to a dynamic call for unsupported
+        // arities; it needs the symbol as written to resolve the var.
+        return lower_known_call(ctx, known, sym_name.unwrap_or(bare), arg_forms);
     }
 
     // Generic dynamic call.
@@ -2353,12 +2475,15 @@ fn emit_comparison_chain(ctx: &mut LowerCtx, kf: KnownFn, args: Vec<VarId>) -> R
 
 // ── Inline expansions ─────────────────────────────────────────────────────────
 
+/// Expand a `clojure.core` call into IR directly, or `None` when the name has
+/// no inline expansion.  `core_name` is the bare core name the call site
+/// resolves to (see `LowerCtx::core_call_name`), never a raw symbol.
 fn try_inline_expansion(
     ctx: &mut LowerCtx,
-    callee_name: &str,
+    core_name: &str,
     args: &[Form],
 ) -> Result<Option<VarId>, LowerError> {
-    match strip_ns_prefix(callee_name) {
+    match core_name {
         "inc" => {
             let x = lower_form(
                 ctx,

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -61,8 +61,27 @@ fn collect_symbol_names_form<'a>(form: &'a Form, out: &mut HashSet<&'a str>) {
 
 // ── Namespace-level `def` collection ─────────────────────────────────────────
 
-/// Collect the names the forms being lowered `def` into the lowering
-/// namespace.
+/// Heads that bind their first argument as a var in the current namespace.
+///
+/// `def` and `defn` are the ones that reach a successful lowering: the rest
+/// are interpreter-only (`lower_list` rejects them, and AOT evaluates them
+/// instead of compiling them), so a unit containing one falls back to the
+/// tree-walker before shadowing can matter.  They are listed anyway because
+/// each does bind the name — if one ever becomes lowerable, its shadow is
+/// already accounted for rather than silently inlining core's semantics.
+/// `declare` binds every argument, so it is handled separately below.
+const DEF_HEADS: &[&str] = &[
+    "def",
+    "defn",
+    "defn-",
+    "defonce",
+    "defmulti",
+    "defprotocol",
+    "defrecord",
+    "deftype",
+];
+
+/// Collect the names the forms being lowered bind in the lowering namespace.
 ///
 /// Such a name is bound to *this* namespace's var, so an unqualified call to
 /// it is not `clojure.core`'s even when it reuses a core name — the same
@@ -73,6 +92,11 @@ fn collect_symbol_names_form<'a>(form: &'a Form, out: &mut HashSet<&'a str>) {
 /// Collected up front, so a call site above the `def` is lowered the same way
 /// as one below it.  Both become dynamic calls that resolve per call, which is
 /// what the tree-walking interpreter does.
+///
+/// Only the name a form binds directly is collected: a `defprotocol`'s method
+/// names are not walked out of its body.  Over-collecting costs an inline;
+/// under-collecting would inline core's semantics over another binding, so the
+/// walk stays on the conservative side wherever the two differ.
 fn collect_defined_names(forms: &[Form], out: &mut HashSet<Arc<str>>) {
     for form in forms {
         collect_defined_names_form(form, out);
@@ -82,11 +106,26 @@ fn collect_defined_names(forms: &[Form], out: &mut HashSet<Arc<str>>) {
 fn collect_defined_names_form(form: &Form, out: &mut HashSet<Arc<str>>) {
     match &form.kind {
         FormKind::List(parts) => {
-            if let Some(FormKind::Symbol(head)) = parts.first().map(|f| &f.kind)
-                && matches!(head.as_str(), "def" | "defn" | "defn-" | "defonce")
-                && let Some(name) = parts.get(1).and_then(def_name)
-            {
-                out.insert(Arc::from(name));
+            let head = match parts.first().map(|f| &f.kind) {
+                Some(FormKind::Symbol(head)) => Some(head.as_str()),
+                _ => None,
+            };
+            match head {
+                // `(quote (def inc 1))` is data, exactly like `'(def inc 1)`
+                // (which arrives as `FormKind::Quote` and is skipped below).
+                Some("quote") => return,
+                // `(declare a b c)` binds every argument.
+                Some("declare") => {
+                    for name in parts[1..].iter().filter_map(def_name) {
+                        out.insert(Arc::from(name));
+                    }
+                }
+                Some(h) if DEF_HEADS.contains(&h) => {
+                    if let Some(name) = parts.get(1).and_then(def_name) {
+                        out.insert(Arc::from(name));
+                    }
+                }
+                _ => {}
             }
             collect_defined_names(parts, out);
         }
@@ -103,18 +142,24 @@ fn collect_defined_names_form(form: &Form, out: &mut HashSet<Arc<str>>) {
     }
 }
 
-/// The bare name a `def` form binds — `(def ^:private x 1)` binds `x` — or
-/// `None` when the name position is not a symbol.
+/// The bare name a `def`-like form binds — `(def ^:private x 1)` binds `x` —
+/// or `None` when the name position is not a symbol.
 fn def_name(form: &Form) -> Option<&str> {
-    let inner = match &form.kind {
-        FormKind::Meta(_, inner) => inner,
-        _ => form,
-    };
-    let FormKind::Symbol(s) = &inner.kind else {
+    let FormKind::Symbol(s) = &peel_meta(form).kind else {
         return None;
     };
     // `(def my.ns/x ...)` still binds `x` in `my.ns`.
     Some(split_ns_name(s).1)
+}
+
+/// Strip every layer of `^meta` from a form: metadata stacks, so
+/// `^:private ^:dynamic x` reads as `Meta(_, Meta(_, Symbol))`.
+fn peel_meta(form: &Form) -> &Form {
+    let mut inner = form;
+    while let FormKind::Meta(_, next) = &inner.kind {
+        inner = next;
+    }
+    inner
 }
 
 // ── Error type ───────────────────────────────────────────────────────────────
@@ -207,26 +252,6 @@ pub fn lower_fn_body_shadowed(
     shadows: &CoreShadows,
 ) -> Result<IrFunction, LowerError> {
     lower_fn_body_impl(name, ns, params, destructures, body, is_async, shadows)
-}
-
-/// Like [`lower_fn_body_destructured`] but also records static parameter
-/// representation seeds (from `^long`/`^double` type hints) on the resulting
-/// `IrFunction::seed_reprs`.  `seed_reprs` is positional with `params`.
-#[allow(clippy::too_many_arguments)]
-pub fn lower_fn_body_seeded(
-    name: Option<&str>,
-    ns: &str,
-    params: &[Arc<str>],
-    destructures: &[(usize, Form)],
-    body: &[Form],
-    is_async: bool,
-    seed_reprs: &[crate::Repr],
-) -> Result<IrFunction, LowerError> {
-    let mut ir = lower_fn_body_destructured(name, ns, params, destructures, body, is_async)?;
-    if seed_reprs.iter().any(|r| *r != crate::Repr::Boxed) {
-        ir.seed_reprs = seed_reprs.to_vec();
-    }
-    Ok(ir)
 }
 
 /// Like [`lower_fn_body`], but expands destructuring patterns on the parameters
@@ -1072,23 +1097,13 @@ fn lower_def(ctx: &mut LowerCtx, args: &[Form]) -> R {
             "def requires a name".into(),
         ));
     }
-    // Name may carry metadata: `(def ^:private x 1)`.
-    let name_str: Arc<str> = match &args[0].kind {
-        FormKind::Symbol(s) => Arc::from(s.as_str()),
-        FormKind::Meta(_, inner) => {
-            let FormKind::Symbol(s) = &inner.kind else {
-                return Err(LowerError::MalformedSpecialForm(
-                    "def name must be a symbol".into(),
-                ));
-            };
-            Arc::from(s.as_str())
-        }
-        _ => {
-            return Err(LowerError::MalformedSpecialForm(
-                "def name must be a symbol".into(),
-            ));
-        }
+    // Name may carry metadata, possibly stacked: `(def ^:private ^:dynamic x 1)`.
+    let FormKind::Symbol(s) = &peel_meta(&args[0]).kind else {
+        return Err(LowerError::MalformedSpecialForm(
+            "def name must be a symbol".into(),
+        ));
     };
+    let name_str: Arc<str> = Arc::from(s.as_str());
     let ns = ctx.ns().clone();
 
     let val = if args.len() >= 2 {
@@ -2172,12 +2187,13 @@ fn lower_call(ctx: &mut LowerCtx, callee_form: &Form, arg_forms: &[Form]) -> R {
     }
 
     // Known function?
-    if let Some(bare) = core_name
+    if let Some(name) = sym_name
+        && let Some(bare) = core_name
         && let Some(known) = resolve_known_core_fn(bare)
     {
         // `lower_known_call` falls back to a dynamic call for unsupported
         // arities; it needs the symbol as written to resolve the var.
-        return lower_known_call(ctx, known, sym_name.unwrap_or(bare), arg_forms);
+        return lower_known_call(ctx, known, name, arg_forms);
     }
 
     // Generic dynamic call.

--- a/crates/cljrs-ir/src/lower/context.rs
+++ b/crates/cljrs-ir/src/lower/context.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use cljrs_types::span::Span;
 
+use crate::lower::known::{CoreShadows, core_name};
 use crate::{Block, BlockId, Inst, IrFunction, Terminator, VarId};
 
 // ── Global name counter (shared across all lowering calls in the process) ────
@@ -64,6 +65,10 @@ pub struct LowerCtx {
     /// Static representation seeds for `let`/`loop`-bound locals, keyed by the
     /// local's `VarId`.  Propagated to `IrFunction::local_seed_reprs`.
     pub(crate) local_seed_reprs: Vec<(VarId, crate::Repr)>,
+
+    /// Names `ns` does not resolve to `clojure.core` — see [`CoreShadows`].
+    /// Cheap to clone (shared set) so nested `fn*` contexts inherit it.
+    pub(crate) core_shadows: CoreShadows,
 }
 
 impl LowerCtx {
@@ -86,7 +91,34 @@ impl LowerCtx {
             is_async: false,
             seed_reprs: Vec::new(),
             local_seed_reprs: Vec::new(),
+            core_shadows: CoreShadows::none(),
         }
+    }
+
+    /// Record what the lowering namespace binds, so call-position symbols that
+    /// name a shadowing var are not lowered as `clojure.core` builtins.
+    pub fn with_core_shadows(mut self, shadows: CoreShadows) -> Self {
+        self.core_shadows = shadows;
+        self
+    }
+
+    /// The bare `clojure.core` name a call-position symbol denotes, or `None`
+    /// when it names something else and must be lowered as a dynamic call.
+    ///
+    /// An unqualified symbol loses to a lexical binding (`(let [inc ...] (inc
+    /// x))`, a parameter named `inc`) and to a namespace-level shadow (a local
+    /// `def`, a `:refer` of that name, a `(:refer-clojure :exclude [inc])`).
+    /// An explicit `clojure.core/inc` bypasses both — that is what it is for.
+    pub fn core_call_name<'a>(&self, sym: &'a str) -> Option<&'a str> {
+        let bare = core_name(sym)?;
+        // `core_name` returns a suffix of `sym`, so equal lengths mean the
+        // symbol was written unqualified.
+        if bare.len() == sym.len()
+            && (self.lookup_local(sym).is_some() || self.core_shadows.contains(sym))
+        {
+            return None;
+        }
+        Some(bare)
     }
 
     // ── ID allocation ────────────────────────────────────────────────────────

--- a/crates/cljrs-ir/src/lower/known.rs
+++ b/crates/cljrs-ir/src/lower/known.rs
@@ -1,26 +1,107 @@
 //! Known-function name → KnownFn dispatch table.
 //!
-//! Maps Clojure symbol names (possibly namespace-qualified) to `KnownFn`
-//! variants.
+//! Maps `clojure.core` symbol names to `KnownFn` variants, plus the two pieces
+//! that decide whether a symbol names core at all: [`core_name`] (qualifier
+//! check) and [`CoreShadows`] (what the lowering namespace binds).
+
+use std::collections::HashSet;
+use std::sync::Arc;
 
 use crate::KnownFn;
 
-/// Strip a namespace prefix from a symbol/function name.
-/// `"clojure.core/+"` → `"+"`, `"+"` → `"+"`, `"/"` → `"/"`.
-pub fn strip_ns_prefix(s: &str) -> &str {
-    if s == "/" {
-        return s;
+/// The bare `clojure.core` name `sym` denotes, or `None` when it names
+/// something else.
+///
+/// An unqualified symbol is a candidate (the caller still has to rule out a
+/// local or a namespace-level shadow — see [`CoreShadows`]), and an explicit
+/// `clojure.core/x` always is one.  Any other qualifier names a different
+/// namespace's var: `my.ns/count` is not core's `count`, so it must not be
+/// lowered as one.
+pub fn core_name(sym: &str) -> Option<&str> {
+    // `/` is division, not a namespace separator; `clojure.core//` is that
+    // same var written qualified.
+    if sym == "/" {
+        return Some(sym);
     }
-    match s.rfind('/') {
-        Some(pos) => &s[pos + 1..],
-        None => s,
+    if let Some(ns) = sym.strip_suffix("//") {
+        return (ns == "clojure.core").then(|| &sym[sym.len() - 1..]);
+    }
+    match sym.rfind('/') {
+        None => Some(sym),
+        Some(pos) => {
+            let (ns, name) = (&sym[..pos], &sym[pos + 1..]);
+            (ns == "clojure.core" && !name.is_empty()).then_some(name)
+        }
+    }
+}
+
+/// Names the namespace being lowered does *not* resolve to `clojure.core`.
+///
+/// A `def` in the namespace itself, a `:refer` of the same name from another
+/// namespace, and a `(:refer-clojure :exclude [...])` clause all mean an
+/// unqualified call to that name is not core's — so the lowerer must leave it
+/// as a dynamic call instead of inlining core's semantics (which is what the
+/// tree-walking interpreter does, and the two tiers have to agree).
+///
+/// The empty set means "no namespace information available": every core name
+/// is assumed to resolve to core, which is what lowering did before shadows
+/// were threaded through.  Callers that hold an environment
+/// (`cljrs_runtime::tiered::lower::core_shadows_for`) should always build a
+/// real one.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CoreShadows {
+    names: Arc<HashSet<Arc<str>>>,
+}
+
+impl CoreShadows {
+    /// No shadowing information — every core name resolves to core.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    pub fn new(names: impl IntoIterator<Item = Arc<str>>) -> Self {
+        Self {
+            names: Arc::new(names.into_iter().collect()),
+        }
+    }
+
+    /// Does the lowering namespace resolve `name` to something other than
+    /// `clojure.core/name`?
+    pub fn contains(&self, name: &str) -> bool {
+        self.names.contains(name)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+
+    /// This set plus `extra` — used to fold in shadows only the forms being
+    /// lowered know about (see `anf::collect_defined_names`).
+    pub fn union(&self, extra: impl IntoIterator<Item = Arc<str>>) -> Self {
+        let mut names: HashSet<Arc<str>> = extra.into_iter().collect();
+        if names.is_empty() {
+            return self.clone();
+        }
+        names.extend(self.names.iter().cloned());
+        Self {
+            names: Arc::new(names),
+        }
     }
 }
 
 /// Resolve a symbol name to a `KnownFn`, or `None` if not recognized.
-/// Strips namespace prefix so `"clojure.core/+"` and `"+"` both resolve.
+///
+/// Only unqualified names and explicit `clojure.core/…` ones resolve; a symbol
+/// qualified with any other namespace names a different var.  Callers in call
+/// position must additionally rule out locals and namespace-level shadowing —
+/// see `LowerCtx::core_call_name`.
 pub fn resolve_known_fn(sym_name: &str) -> Option<KnownFn> {
-    match strip_ns_prefix(sym_name) {
+    resolve_known_core_fn(core_name(sym_name)?)
+}
+
+/// Resolve an already-unqualified `clojure.core` name to a `KnownFn`.
+pub fn resolve_known_core_fn(bare_name: &str) -> Option<KnownFn> {
+    match bare_name {
         "vector" => Some(KnownFn::Vector),
         "hash-map" => Some(KnownFn::HashMap),
         "hash-set" => Some(KnownFn::HashSet),

--- a/crates/cljrs-ir/src/lower/known.rs
+++ b/crates/cljrs-ir/src/lower/known.rs
@@ -71,10 +71,6 @@ impl CoreShadows {
         self.names.contains(name)
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.names.is_empty()
-    }
-
     /// This set plus `extra` — used to fold in shadows only the forms being
     /// lowered know about (see `anf::collect_defined_names`).
     pub fn union(&self, extra: impl IntoIterator<Item = Arc<str>>) -> Self {
@@ -89,17 +85,11 @@ impl CoreShadows {
     }
 }
 
-/// Resolve a symbol name to a `KnownFn`, or `None` if not recognized.
+/// Resolve a `clojure.core` name to a `KnownFn`, or `None` if not recognized.
 ///
-/// Only unqualified names and explicit `clojure.core/…` ones resolve; a symbol
-/// qualified with any other namespace names a different var.  Callers in call
-/// position must additionally rule out locals and namespace-level shadowing —
-/// see `LowerCtx::core_call_name`.
-pub fn resolve_known_fn(sym_name: &str) -> Option<KnownFn> {
-    resolve_known_core_fn(core_name(sym_name)?)
-}
-
-/// Resolve an already-unqualified `clojure.core` name to a `KnownFn`.
+/// The name must already be unqualified — [`core_name`] establishes that a
+/// symbol names core at all, and callers in call position must additionally
+/// rule out locals and namespace-level shadowing (`LowerCtx::core_call_name`).
 pub fn resolve_known_core_fn(bare_name: &str) -> Option<KnownFn> {
     match bare_name {
         "vector" => Some(KnownFn::Vector),

--- a/crates/cljrs-ir/src/lower/mod.rs
+++ b/crates/cljrs-ir/src/lower/mod.rs
@@ -12,10 +12,7 @@ pub mod known;
 pub mod optimize;
 pub mod regionalize;
 
-pub use anf::{
-    LowerError, lower_fn_body, lower_fn_body_destructured, lower_fn_body_seeded,
-    lower_fn_body_shadowed,
-};
+pub use anf::{LowerError, lower_fn_body, lower_fn_body_destructured, lower_fn_body_shadowed};
 pub use async_lower::{AsyncLowerError, AsyncLowering, lower_async};
 pub use escape::{
     AnalysisResult, EscapeContext, EscapeState, ExternalDefn, UseInfo, UseKind, analyze,

--- a/crates/cljrs-ir/src/lower/mod.rs
+++ b/crates/cljrs-ir/src/lower/mod.rs
@@ -12,12 +12,16 @@ pub mod known;
 pub mod optimize;
 pub mod regionalize;
 
-pub use anf::{LowerError, lower_fn_body, lower_fn_body_destructured, lower_fn_body_seeded};
+pub use anf::{
+    LowerError, lower_fn_body, lower_fn_body_destructured, lower_fn_body_seeded,
+    lower_fn_body_shadowed,
+};
 pub use async_lower::{AsyncLowerError, AsyncLowering, lower_async};
 pub use escape::{
     AnalysisResult, EscapeContext, EscapeState, ExternalDefn, UseInfo, UseKind, analyze,
 };
 pub use inline::inline;
+pub use known::CoreShadows;
 pub use optimize::{optimize, optimize_with_externals};
 
 /// Build an inter-procedural escape-analysis context for the entire IR tree

--- a/crates/cljrs-ir/tests/core_shadowing.rs
+++ b/crates/cljrs-ir/tests/core_shadowing.rs
@@ -193,6 +193,68 @@ fn a_def_in_the_lowered_unit_shadows_core() {
 }
 
 #[test]
+fn every_lowerable_def_head_shadows() {
+    // The interpreter-only heads (`defn-`, `defonce`, `defmulti`, …) are
+    // rejected outright by `lower_list`, so a unit containing one never
+    // lowers; these are the def-like heads a successful lowering can contain.
+    for form in [
+        "(def count 1)",
+        "(defn count [c] 1)",
+        "(declare other count)",
+        // Nested inside a form that is itself lowered.
+        "(when true (def count 1))",
+    ] {
+        let ir = lower_fn_body(
+            Some("__cljrs_main"),
+            "x",
+            &["coll".into()],
+            &parse(&format!("{form} (count coll)")),
+            false,
+        )
+        .expect("lower");
+        assert!(
+            !uses_known(&ir, KnownFn::Count),
+            "`{form}` did not shadow core's `count`"
+        );
+    }
+}
+
+#[test]
+fn stacked_metadata_on_a_def_name_still_shadows() {
+    // `^:private ^:dynamic x` nests as Meta(_, Meta(_, Symbol)); peeling only
+    // one layer would drop the shadow and inline core's `count`.
+    let ir = lower_fn_body(
+        Some("__cljrs_main"),
+        "x",
+        &["coll".into()],
+        &parse("(def ^:private ^:dynamic count (fn [c] 1)) (count coll)"),
+        false,
+    )
+    .expect("lower");
+    assert!(!uses_known(&ir, KnownFn::Count));
+    assert!(has_dynamic_call(&ir));
+}
+
+#[test]
+fn a_quoted_def_is_data_not_a_definition() {
+    // Both spellings of quote: the reader form and the explicit head.
+    for form in ["'(def count 1)", "(quote (def count 1))"] {
+        let ir = lower_fn_body(
+            Some("__cljrs_main"),
+            "x",
+            &["coll".into()],
+            &parse(&format!("{form} (count coll)")),
+            false,
+        )
+        .expect("lower");
+        assert!(
+            uses_known(&ir, KnownFn::Count),
+            "`{form}` is data; it must not shadow core's `count`"
+        );
+    }
+}
+
+#[test]
 fn clojure_cores_own_defs_are_still_core() {
     // Core defining `inc` *is* core's `inc`; lowering must keep inlining it.
     let ir = lower_fn_body(

--- a/crates/cljrs-ir/tests/core_shadowing.rs
+++ b/crates/cljrs-ir/tests/core_shadowing.rs
@@ -1,0 +1,231 @@
+//! Regression tests for issue #337: a call-position symbol is lowered as a
+//! `clojure.core` builtin only when it actually resolves to core.
+//!
+//! Before the fix `lower_call` matched on the head symbol's *text*, so a
+//! `let`-bound `inc`, a parameter named `inc`, a locally-`def`ed `inc` and even
+//! an explicitly qualified `other.ns/count` were inlined (or turned into
+//! `CallKnown`) with core's semantics — while the tree-walking interpreter
+//! called the real binding.  The answer then depended on which tier was
+//! running, changing mid-run at the promotion boundary.
+
+use std::sync::Arc;
+
+use cljrs_ir::lower::{CoreShadows, lower_fn_body, lower_fn_body_shadowed};
+use cljrs_ir::{Inst, IrFunction, KnownFn};
+use cljrs_reader::Parser;
+
+fn parse(source: &str) -> Vec<cljrs_reader::Form> {
+    let mut parser = Parser::new(source.to_string(), "<test>".to_string());
+    parser.parse_all().expect("parse")
+}
+
+fn lower(source: &str) -> IrFunction {
+    lower_fn_body(Some("test"), "user", &[], &parse(source), false).expect("lower")
+}
+
+fn lower_in(ns: &str, params: &[&str], source: &str, shadows: &CoreShadows) -> IrFunction {
+    let params: Vec<Arc<str>> = params.iter().map(|p| Arc::from(*p)).collect();
+    lower_fn_body_shadowed(
+        Some("test"),
+        ns,
+        &params,
+        &[],
+        &parse(source),
+        false,
+        shadows,
+    )
+    .expect("lower")
+}
+
+/// Every instruction in `ir` and its subfunctions.
+fn insts(ir: &IrFunction) -> Vec<Inst> {
+    let mut out = Vec::new();
+    for block in &ir.blocks {
+        out.extend(block.phis.iter().cloned());
+        out.extend(block.insts.iter().cloned());
+    }
+    for sub in &ir.subfunctions {
+        out.extend(insts(sub));
+    }
+    out
+}
+
+fn uses_known(ir: &IrFunction, kf: KnownFn) -> bool {
+    insts(ir)
+        .iter()
+        .any(|i| matches!(i, Inst::CallKnown(_, k, _) if *k == kf))
+}
+
+/// Like [`uses_known`], but only in `ir`'s own blocks — a call inside a nested
+/// `fn*` body lives in a subfunction.
+fn body_uses_known(ir: &IrFunction, kf: KnownFn) -> bool {
+    ir.blocks
+        .iter()
+        .flat_map(|b| b.insts.iter())
+        .any(|i| matches!(i, Inst::CallKnown(_, k, _) if *k == kf))
+}
+
+fn has_dynamic_call(ir: &IrFunction) -> bool {
+    insts(ir).iter().any(|i| matches!(i, Inst::Call(..)))
+}
+
+// ── Locals ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn let_bound_name_is_not_core() {
+    // Repro 1: `(let [inc (fn [x] (* x 100))] (inc n))` must call the local.
+    let ir = lower_in(
+        "shadow.test",
+        &["n"],
+        "(let [inc (fn [x] (* x 100))] (inc n))",
+        &CoreShadows::none(),
+    );
+    assert!(
+        !uses_known(&ir, KnownFn::Add),
+        "the let-bound `inc` was inlined as core's `inc`"
+    );
+    assert!(
+        has_dynamic_call(&ir),
+        "expected a dynamic call to the local"
+    );
+}
+
+#[test]
+fn parameter_name_is_not_core() {
+    // Repro 2: `inc` is just a parameter here.
+    let ir = lower_in(
+        "shadow.two",
+        &["inc", "n"],
+        "(inc (inc n))",
+        &CoreShadows::none(),
+    );
+    assert!(
+        !uses_known(&ir, KnownFn::Add),
+        "the parameter `inc` was inlined as core's `inc`"
+    );
+    assert!(has_dynamic_call(&ir));
+}
+
+#[test]
+fn known_fn_name_bound_as_a_local_is_not_core() {
+    // The same for a `KnownFn` (rather than an inline expansion).
+    let ir = lower_in(
+        "shadow.known",
+        &["coll"],
+        "(let [count (fn [c] :local)] (count coll))",
+        &CoreShadows::none(),
+    );
+    assert!(!uses_known(&ir, KnownFn::Count));
+    assert!(has_dynamic_call(&ir));
+}
+
+#[test]
+fn a_local_does_not_shadow_an_explicitly_qualified_core_call() {
+    let ir = lower_in(
+        "shadow.test",
+        &["n"],
+        "(let [inc (fn [x] (* x 100))] (clojure.core/inc n))",
+        &CoreShadows::none(),
+    );
+    assert!(
+        uses_known(&ir, KnownFn::Add),
+        "`clojure.core/inc` is core's"
+    );
+}
+
+#[test]
+fn locals_only_shadow_inside_their_scope() {
+    let ir = lower_in(
+        "shadow.test",
+        &["n"],
+        "(do (let [inc (fn [x] x)] (inc n)) (inc n))",
+        &CoreShadows::none(),
+    );
+    // The second `(inc n)` is outside the `let`, so it is core's.
+    assert!(uses_known(&ir, KnownFn::Add));
+    assert!(has_dynamic_call(&ir));
+}
+
+// ── Namespace-level shadowing ───────────────────────────────────────────────
+
+#[test]
+fn namespace_shadow_is_not_core() {
+    let shadows = CoreShadows::new([Arc::from("count")]);
+    let ir = lower_in("my.ns", &["coll"], "(count coll)", &shadows);
+    assert!(
+        !uses_known(&ir, KnownFn::Count),
+        "a name the namespace binds elsewhere was lowered as core's"
+    );
+    assert!(has_dynamic_call(&ir));
+    // Unshadowed names in the same namespace are unaffected.
+    let ir = lower_in("my.ns", &["coll"], "(first coll)", &shadows);
+    assert!(uses_known(&ir, KnownFn::First));
+}
+
+#[test]
+fn a_namespace_shadow_does_not_reach_a_qualified_core_call() {
+    let shadows = CoreShadows::new([Arc::from("count")]);
+    let ir = lower_in("my.ns", &["coll"], "(clojure.core/count coll)", &shadows);
+    assert!(uses_known(&ir, KnownFn::Count));
+}
+
+#[test]
+fn a_def_in_the_lowered_unit_shadows_core() {
+    // Repro 3: AOT compiles the whole file without evaluating its `def`s, so
+    // the shadow has to be read off the forms themselves.
+    let ir = lower_fn_body(
+        Some("__cljrs_main"),
+        "x",
+        &[],
+        &parse("(def inc (fn [n] (+ n 7))) (inc 1)"),
+        false,
+    )
+    .expect("lower");
+    // `(+ n 7)` lives in the defined function; `(inc 1)` is in the body here.
+    assert!(
+        !body_uses_known(&ir, KnownFn::Add),
+        "the locally-defined `inc` was inlined as core's"
+    );
+    assert!(
+        has_dynamic_call(&ir),
+        "expected `(inc 1)` to become a dynamic call to x/inc"
+    );
+}
+
+#[test]
+fn clojure_cores_own_defs_are_still_core() {
+    // Core defining `inc` *is* core's `inc`; lowering must keep inlining it.
+    let ir = lower_fn_body(
+        Some("__cljrs_main"),
+        "clojure.core",
+        &[],
+        &parse("(def inc (fn [n] (+ n 1))) (inc 1)"),
+        false,
+    )
+    .expect("lower");
+    assert!(body_uses_known(&ir, KnownFn::Add));
+}
+
+// ── Qualified symbols ───────────────────────────────────────────────────────
+
+#[test]
+fn another_namespaces_var_is_not_core() {
+    let ir = lower("(my.ns/count [1 2 3])");
+    assert!(
+        !uses_known(&ir, KnownFn::Count),
+        "`my.ns/count` is not `clojure.core/count`"
+    );
+    assert!(has_dynamic_call(&ir));
+}
+
+#[test]
+fn qualified_core_names_still_lower_as_core() {
+    assert!(uses_known(
+        &lower("(clojure.core/count [1 2 3])"),
+        KnownFn::Count
+    ));
+    assert!(uses_known(&lower("(clojure.core/inc 1)"), KnownFn::Add));
+    // `clojure.core//` is division written qualified.
+    assert!(uses_known(&lower("(clojure.core// 6 2)"), KnownFn::Div));
+    assert!(uses_known(&lower("(/ 6 2)"), KnownFn::Div));
+}

--- a/crates/cljrs-net/src/lib.rs
+++ b/crates/cljrs-net/src/lib.rs
@@ -1,3 +1,9 @@
+// Every `do_*` connect/response driver returns `cljrs_runtime`'s `EvalError` by
+// value, as the rest of the workspace does (`cljrs-runtime/src/lib.rs` allows
+// this lint crate-wide).  Clippy only began flagging `async fn`s for it in 1.98
+// — the seven sites here are unchanged from when they passed under 1.94.
+#![allow(clippy::result_large_err)]
+
 //! Networking for clojurust — TCP, Unix, UDP, TLS over core.async channels.
 //!
 //! # Usage

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -109,6 +109,9 @@ tests/
                                      cache invalidation on provider/trust-set change
                                      (passes with and without the `deps` feature)
   require_spec_reader_conditional.rs — reader conditionals in ns require specs
+  refer_clojure.rs                 — `(:refer-clojure ...)` narrowing of the core refer
+  core_shadows.rs                  — core_shadowed_names: what a namespace binds
+                                     instead of clojure.core (issue #337)
   declare_macro.rs, doc.rs, gas_meter.rs, into_seq_target.rs, map_entry.rs,
   named_fn_identity.rs, ns_metadata.rs, partition_arities.rs, shared_atom.rs,
   symbolic_nan.rs, threading_macros.rs, auto_gensym.rs, auto_keyword_macro.rs,
@@ -312,6 +315,13 @@ pub fn set_refer_clojure_filter(
     dst_ns: &str,
     filter: Option<ReferClojureFilter>,
 ) -> Result<(), String>;
+
+/// Names `ns_name` resolves to something other than `clojure.core`'s var of
+/// the same name: its own interns, refers from other namespaces (or of a
+/// renamed core var), and names a `(:refer-clojure ...)` filter keeps out of
+/// the automatic core refer.  The IR lowerer must not inline these as core
+/// builtins — see `tiered::lower::core_shadows_for` and issue #337.
+pub fn core_shadowed_names(&self, ns_name: &str) -> HashSet<Arc<str>>;
 ```
 
 `:exclude` stays permissive where `:only`/`:rename` are validated: it is
@@ -854,9 +864,17 @@ pub mod lower {
     /// dependent recording, required off the mutator thread); `None` uses the
     /// legacy externals_for (synchronous callers record dependents themselves).
     pub fn lower_expanded_arity(name, params, rest, destructure_params,
-        destructure_rest, expanded_body, ns, globals_id: u64,
-        arity_id: Option<u64>, do_optimize: bool, is_async: bool)
+        destructure_rest, expanded_body, ns, shadows: &CoreShadows,
+        globals_id: u64, arity_id: Option<u64>, do_optimize: bool,
+        is_async: bool)
         -> Result<(IrFunction, Vec<(Arc<str>, Arc<str>)>), LowerError>;
+
+    /// What `ns` binds that `clojure.core` also publishes, for the lowerer's
+    /// call-position core check (issue #337).  Reads the namespace tables, so
+    /// it must be sampled on the mutator thread — `lower_arity` does it for
+    /// its callers, and `tiered::apply` does it before enqueueing a background
+    /// lowering request.
+    pub fn core_shadows_for(globals: &GlobalEnv, ns: &str) -> CoreShadows;
 }
 
 /// Cross-defn IR registry (in submodule `defn_registry`, Phase 10.5):

--- a/crates/cljrs-runtime/src/builtins/form.rs
+++ b/crates/cljrs-runtime/src/builtins/form.rs
@@ -265,8 +265,8 @@ pub fn form_to_value(form: &Form) -> EvalResult<Value> {
         FormKind::Map(forms) => {
             let forms = expand_pairs(forms).map_err(|_| map_literal_arity_error())?;
             let mut m = MapValue::empty();
-            for pair in forms.chunks_exact(2) {
-                m = m.assoc(form_to_value(&pair[0])?, form_to_value(&pair[1])?);
+            for [k, v] in forms.as_chunks::<2>().0 {
+                m = m.assoc(form_to_value(k)?, form_to_value(v)?);
             }
             Value::Map(m)
         }
@@ -341,8 +341,7 @@ fn map_literal_arity_error() -> EvalError {
 /// `None` if no `:rust` or `:default` clause is present.
 pub fn select_reader_cond(clauses: &[Form]) -> Option<&Form> {
     let mut default: Option<&Form> = None;
-    for pair in clauses.chunks_exact(2) {
-        let (feature, branch) = (&pair[0], &pair[1]);
+    for [feature, branch] in clauses.as_chunks::<2>().0 {
         match &feature.kind {
             FormKind::Keyword(k) if k == "rust" => return Some(branch),
             FormKind::Keyword(k) if k == "default" => default = Some(branch),

--- a/crates/cljrs-runtime/src/env/env.rs
+++ b/crates/cljrs-runtime/src/env/env.rs
@@ -575,6 +575,63 @@ impl GlobalEnv {
         Ok(())
     }
 
+    /// Names `ns_name` resolves to something other than `clojure.core`'s var
+    /// of the same name — what the IR lowerer must not inline as a builtin.
+    ///
+    /// Three things put a name in here: a `def` in `ns_name` itself, a refer
+    /// of that name from another namespace (or of a *different* core name
+    /// under it, via `:rename`), and a `(:refer-clojure ...)` filter that
+    /// leaves the name out of the automatic core refer.  In each case an
+    /// unqualified call resolves to something that is not `clojure.core/name`
+    /// — or to nothing at all — and the tree-walking interpreter calls that,
+    /// so the lowered call site has to as well (issue #337).
+    ///
+    /// A name absent from the namespace's tables is *not* reported: with no
+    /// evidence to the contrary the lowerer keeps assuming core, which is what
+    /// the automatic core refer makes true for the overwhelming majority of
+    /// call sites (and keeps the lowerer's synthetic names, e.g. `case=`,
+    /// working in namespaces whose refers are not populated yet).
+    pub fn core_shadowed_names(&self, ns_name: &str) -> HashSet<Arc<str>> {
+        let mut out: HashSet<Arc<str>> = HashSet::new();
+        let (ns, core) = {
+            let map = self.namespaces.read().unwrap();
+            match map.get(ns_name) {
+                Some(ns) => (ns.clone(), map.get("clojure.core").cloned()),
+                None => return out,
+            }
+        };
+        let ns_ref = ns.get();
+
+        // A var bound here is core's only if it *is* core's var under its own
+        // name; core's own namespace passes this trivially for its interns.
+        let shadows = |name: &Arc<str>, var: &GcPtr<Var>| {
+            let v = var.get();
+            v.namespace.as_ref() != "clojure.core" || v.name != *name
+        };
+        for table in [&ns_ref.interns, &ns_ref.refers] {
+            let entries = table.lock().unwrap();
+            for (name, var) in entries.iter() {
+                if shadows(name, var) {
+                    out.insert(name.clone());
+                }
+            }
+        }
+
+        // Names the `(:refer-clojure ...)` filter kept out of the automatic
+        // refer: nothing binds them here, so they are not core's either.
+        // Lock order is filter → core interns, as in `refer_core_impl`.
+        let filter = ns_ref.refer_clojure_filter.lock().unwrap();
+        if let (Some(filter), Some(core)) = (filter.as_ref(), core) {
+            let interns = core.get().interns.lock().unwrap();
+            for name in interns.keys() {
+                if filter.local_name(name).as_ref() != Some(name) {
+                    out.insert(name.clone());
+                }
+            }
+        }
+        out
+    }
+
     /// Copy selected interns from `src_ns` into `dst_ns` as refers.
     pub fn refer_named(&self, dst_ns: &str, src_ns: &str, names: &[Arc<str>]) {
         let map = self.namespaces.read().unwrap();

--- a/crates/cljrs-runtime/src/tiered/apply.rs
+++ b/crates/cljrs-runtime/src/tiered/apply.rs
@@ -225,6 +225,10 @@ fn request_background_lower(f: &CljxFn, caller_env: &mut Env) {
         })
         .collect();
 
+    // The defining namespace's bindings are read here, on the mutator thread:
+    // the worker sees only plain data.
+    let core_shadows = crate::tiered::lower::core_shadows_for(&caller_env.globals, &f.defining_ns);
+
     caller_env.current_ns = saved_ns;
     let arity_ids: Vec<u64> = arities.iter().map(|a| a.arity_id).collect();
 
@@ -234,6 +238,7 @@ fn request_background_lower(f: &CljxFn, caller_env: &mut Env) {
             name: f.name.clone(),
             ns: f.defining_ns.clone(),
             is_async: f.is_async,
+            core_shadows,
             arities,
         });
     if accepted {

--- a/crates/cljrs-runtime/src/tiered/lower.rs
+++ b/crates/cljrs-runtime/src/tiered/lower.rs
@@ -6,12 +6,13 @@
 
 use std::sync::Arc;
 
+use cljrs_ir::lower::CoreShadows;
 use cljrs_ir::{IrFunction, Repr};
 use cljrs_reader::Form;
 use cljrs_value::TypeHint;
 
 use crate::builtins::form::resolve_auto_forms;
-use crate::env::env::Env;
+use crate::env::env::{Env, GlobalEnv};
 
 /// Map per-parameter primitive type hints onto representation seeds for type
 /// inference, positional with the function's fixed parameters.  `^long`/`^int`
@@ -50,6 +51,15 @@ pub fn seed_reprs_from_hints(param_hints: &[Option<TypeHint>]) -> Vec<Repr> {
             _ => Repr::Boxed,
         })
         .collect()
+}
+
+/// What `ns` binds that `clojure.core` also publishes, for the lowerer's
+/// call-position core check (see [`cljrs_ir::lower::CoreShadows`]).
+///
+/// Must be sampled on the mutator thread: it reads the namespace tables, which
+/// the background lowering worker may not touch.
+pub fn core_shadows_for(globals: &GlobalEnv, ns: &str) -> CoreShadows {
+    CoreShadows::new(globals.core_shadowed_names(ns))
 }
 
 // ── Error type ──────────────────────────────────────────────────────────────
@@ -186,6 +196,7 @@ fn lower_arity_inner(
         .collect();
     let expanded_body = resolved.unwrap_or(expanded_body);
     env.current_ns = prev_ns;
+    let shadows = core_shadows_for(&env.globals, ns);
     lower_expanded_arity(
         name,
         params,
@@ -194,6 +205,7 @@ fn lower_arity_inner(
         destructure_rest,
         &expanded_body,
         ns,
+        &shadows,
         env.globals.id(),
         None,
         do_optimize,
@@ -225,7 +237,9 @@ pub fn macroexpand_body(body: &[Form], env: &mut Env) -> Vec<Form> {
 /// Lower an already macro-expanded arity body to (optionally optimized) IR.
 ///
 /// Env-free and callable from the background lowering worker (Phase 10.7):
-/// everything below operates on plain `Form`/IR data.  `globals_id` is
+/// everything below operates on plain `Form`/IR data.  `shadows` is the one
+/// piece that has to be sampled from the environment first — see
+/// [`core_shadows_for`].  `globals_id` is
 /// `GlobalEnv::id`, scoping the cross-defn registry lookups to one runtime.
 ///
 /// `arity_id` selects the externals protocol:
@@ -245,6 +259,7 @@ pub fn lower_expanded_arity(
     destructure_rest: Option<&Form>,
     expanded_body: &[Form],
     ns: &Arc<str>,
+    shadows: &CoreShadows,
     globals_id: u64,
     arity_id: Option<u64>,
     do_optimize: bool,
@@ -272,13 +287,14 @@ pub fn lower_expanded_arity(
         destructures.push((params.len(), rest_pat.clone()));
     }
 
-    let ir = cljrs_ir::lower::lower_fn_body_destructured(
+    let ir = cljrs_ir::lower::lower_fn_body_shadowed(
         name,
         ns,
         &all_params,
         &destructures,
         expanded_body,
         is_async,
+        shadows,
     )
     .map_err(|e| LowerError::LowerFailed(format!("{e:?}")))?;
 

--- a/crates/cljrs-runtime/src/tiered/lower_worker.rs
+++ b/crates/cljrs-runtime/src/tiered/lower_worker.rs
@@ -59,6 +59,9 @@ pub(crate) struct LowerRequest {
     pub name: Option<Arc<str>>,
     pub ns: Arc<str>,
     pub is_async: bool,
+    /// What `ns` binds that would otherwise be lowered as `clojure.core`,
+    /// sampled on the mutator thread (the worker has no `GlobalEnv`).
+    pub core_shadows: cljrs_ir::lower::CoreShadows,
     pub arities: Vec<LowerArityRequest>,
 }
 
@@ -155,6 +158,7 @@ fn process_request(req: &LowerRequest) {
                 arity.destructure_rest.as_ref(),
                 &arity.expanded_body,
                 &req.ns,
+                &req.core_shadows,
                 globals_id,
                 Some(id),
                 true,
@@ -247,6 +251,7 @@ mod tests {
             name: Some(Arc::from(fn_name)),
             ns: Arc::from(ns),
             is_async: false,
+            core_shadows: cljrs_ir::lower::CoreShadows::none(),
             arities: vec![LowerArityRequest {
                 arity_id,
                 params: vec![Arc::from("x")],

--- a/crates/cljrs-runtime/tests/core_shadows.rs
+++ b/crates/cljrs-runtime/tests/core_shadows.rs
@@ -1,0 +1,94 @@
+//! `GlobalEnv::core_shadowed_names` — what a namespace binds that the IR
+//! lowerer must not treat as `clojure.core` (issue #337).
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_all(env: &mut Env, src: &str) -> Value {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse error");
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, env).expect("eval error");
+    }
+    result
+}
+
+#[test]
+fn a_plain_namespace_shadows_nothing() {
+    let (globals, mut env) = make_env();
+    eval_all(&mut env, "(ns shadow.plain)");
+    let shadows = globals.core_shadowed_names("shadow.plain");
+    assert!(!shadows.contains("inc"), "{shadows:?}");
+    assert!(!shadows.contains("count"), "{shadows:?}");
+}
+
+#[test]
+fn a_local_def_shadows_the_core_name() {
+    let (globals, mut env) = make_env();
+    eval_all(&mut env, "(ns shadow.def) (defn inc [n] (+ n 7))");
+    let shadows = globals.core_shadowed_names("shadow.def");
+    assert!(shadows.contains("inc"), "{shadows:?}");
+    assert!(!shadows.contains("dec"), "{shadows:?}");
+}
+
+#[test]
+fn clojure_core_does_not_shadow_itself() {
+    let (globals, _env) = make_env();
+    let shadows = globals.core_shadowed_names("clojure.core");
+    assert!(!shadows.contains("inc"), "{shadows:?}");
+    assert!(!shadows.contains("count"), "{shadows:?}");
+}
+
+#[test]
+fn refer_clojure_exclude_shadows_the_excluded_name() {
+    let (globals, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns shadow.exclude (:refer-clojure :exclude [inc]))",
+    );
+    let shadows = globals.core_shadowed_names("shadow.exclude");
+    // Nothing binds `inc` here at all — so it is certainly not core's.
+    assert!(shadows.contains("inc"), "{shadows:?}");
+    assert!(!shadows.contains("dec"), "{shadows:?}");
+}
+
+#[test]
+fn refer_clojure_rename_shadows_both_names() {
+    let (globals, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns shadow.rename (:refer-clojure :rename {inc bump}))",
+    );
+    let shadows = globals.core_shadowed_names("shadow.rename");
+    // `inc` is no longer referred, and `bump` names a var whose name is `inc`.
+    assert!(shadows.contains("inc"), "{shadows:?}");
+    assert!(shadows.contains("bump"), "{shadows:?}");
+    assert!(!shadows.contains("count"), "{shadows:?}");
+}
+
+#[test]
+fn a_refer_from_another_namespace_shadows_the_core_name() {
+    let (globals, mut env) = make_env();
+    eval_all(&mut env, "(ns shadow.src) (defn count [c] :mine)");
+    eval_all(&mut env, "(ns shadow.dst)");
+    // What `(:require [shadow.src :refer [count]])` installs, without needing
+    // the namespace to live on a source path.
+    globals.refer_named("shadow.dst", "shadow.src", &[Arc::from("count")]);
+    let shadows = globals.core_shadowed_names("shadow.dst");
+    assert!(shadows.contains("count"), "{shadows:?}");
+    assert!(!shadows.contains("first"), "{shadows:?}");
+}

--- a/crates/cljrs-runtime/tests/core_shadows.rs
+++ b/crates/cljrs-runtime/tests/core_shadows.rs
@@ -67,6 +67,27 @@ fn refer_clojure_exclude_shadows_the_excluded_name() {
 }
 
 #[test]
+fn refer_clojure_only_shadows_everything_it_leaves_out() {
+    let (globals, mut env) = make_env();
+    eval_all(
+        &mut env,
+        "(ns shadow.only (:refer-clojure :only [inc dec]))",
+    );
+    let shadows = globals.core_shadowed_names("shadow.only");
+    // The two names the clause keeps are core's; every other core name is not
+    // referred here at all, so this is the one filter that makes the shadow
+    // set roughly the size of `clojure.core`.
+    assert!(!shadows.contains("inc"), "{shadows:?}");
+    assert!(!shadows.contains("dec"), "{shadows:?}");
+    assert!(shadows.contains("count"), "{shadows:?}");
+    assert!(shadows.contains("first"), "{shadows:?}");
+    assert!(
+        shadows.len() > 100,
+        "expected most of core, got {shadows:?}"
+    );
+}
+
+#[test]
 fn refer_clojure_rename_shadows_both_names() {
     let (globals, mut env) = make_env();
     eval_all(

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -54,6 +54,10 @@ tests/
                       documented host API cannot drift
   pinned_dylib_e2e.rs — gated (`CLJRS_DYLIB_E2E=1`) pinned-native end-to-end
                       test; described under Pinned native packages below
+  core_shadowing_tiers.rs — shadowed `clojure.core` names (a `let`-bound `inc`,
+                      a parameter named `inc`, a redefined var, an excluded
+                      name) must answer the same before and after a function
+                      crosses the IR promotion threshold (issue #337)
 ```
 
 ---

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -57,7 +57,8 @@ tests/
   core_shadowing_tiers.rs — shadowed `clojure.core` names (a `let`-bound `inc`,
                       a parameter named `inc`, a redefined var, an excluded
                       name) must answer the same before and after a function
-                      crosses the IR promotion threshold (issue #337)
+                      crosses the IR promotion threshold, and once more when
+                      the file is AOT-compiled (issue #337)
 ```
 
 ---

--- a/crates/cljrs/tests/core_shadowing_tiers.rs
+++ b/crates/cljrs/tests/core_shadowing_tiers.rs
@@ -8,26 +8,16 @@
 //! the promotion boundary; these run each program well past the threshold and
 //! require every line to agree.
 
+use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Run `source` through `cljrs run` with a warm threshold of 5, so the driving
 /// loop crosses into IR partway through.  Returns stdout.
 fn run_tiered(source: &str) -> String {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!(
-        "cljrs_core_shadowing_{}_{nanos}_{seq}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("create dir");
-    let file = dir.join("shadow.cljrs");
-    std::fs::write(&file, source).expect("write source");
+    let (dir, file) = write_program(source);
 
     let output = Command::new(env!("CARGO_BIN_EXE_cljrs"))
         .arg("run")
@@ -46,6 +36,24 @@ fn run_tiered(source: &str) -> String {
         String::from_utf8_lossy(&output.stdout),
     );
     String::from_utf8(output.stdout).expect("utf8 stdout")
+}
+
+/// Write `source` into a fresh temp directory; returns `(dir, file)`.
+fn write_program(source: &str) -> (PathBuf, PathBuf) {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "cljrs_core_shadowing_{}_{nanos}_{seq}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let file = dir.join("shadow.cljrs");
+    std::fs::write(&file, source).expect("write source");
+    (dir, file)
 }
 
 /// Assert every line of `stdout` is `expected` — i.e. the answer did not
@@ -185,4 +193,61 @@ fn unshadowed_core_calls_still_work() {
 "#,
     );
     assert_all_lines(&stdout, "3", 20);
+}
+
+// ── AOT ─────────────────────────────────────────────────────────────────────
+
+/// Repro 3 of #337 is AOT-specific: `cljrs compile` lowers a whole file
+/// without evaluating its `def`s, so the shadow has to come off the forms
+/// themselves.  This guards the wiring in `aot.rs` (`core_shadows_for` +
+/// `lower_fn_body_shadowed`), which no unit test reaches.
+#[test]
+fn redefined_var_survives_aot_compilation() {
+    let (dir, file) = write_program(
+        r#"
+(ns aot.redef)
+
+(defn inc [n] (+ n 7))
+
+(println (inc 1))
+"#,
+    );
+    let binary = dir.join("shadow.bin");
+
+    // AOT compilation recurses deeply enough to want a bigger stack, as
+    // `execution_tier_parity` does.
+    let (src, bin) = (file.clone(), binary.clone());
+    thread::Builder::new()
+        .name("core-shadowing-aot-build".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            // The error type is large; carry it as text so the closure's
+            // Result stays small.
+            cljrs_compiler::aot::compile_file(
+                &src,
+                &bin,
+                &cljrs_compiler::extensions::CompileSession::default(),
+            )
+            .map_err(|e| e.to_string())
+        })
+        .expect("spawn AOT compiler")
+        .join()
+        .expect("AOT compiler panicked")
+        .expect("AOT compilation failed");
+
+    let output = Command::new(&binary).output().expect("run AOT binary");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        output.status.success(),
+        "AOT binary failed with {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    assert_eq!(
+        stdout.trim(),
+        "8",
+        "the compiled call used core's `inc` instead of aot.redef/inc"
+    );
 }

--- a/crates/cljrs/tests/core_shadowing_tiers.rs
+++ b/crates/cljrs/tests/core_shadowing_tiers.rs
@@ -1,0 +1,188 @@
+//! Regression tests for issue #337: shadowed `clojure.core` names must mean
+//! the same thing in every tier.
+//!
+//! IR lowering used to decide "is this a core builtin?" from the head symbol's
+//! text alone, so a `let`-bound `inc`, a parameter named `inc` or a
+//! locally-`def`ed `inc` was inlined as core's — while the tree-walker called
+//! the real binding.  With a low warm threshold the answer flipped mid-run, at
+//! the promotion boundary; these run each program well past the threshold and
+//! require every line to agree.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Run `source` through `cljrs run` with a warm threshold of 5, so the driving
+/// loop crosses into IR partway through.  Returns stdout.
+fn run_tiered(source: &str) -> String {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "cljrs_core_shadowing_{}_{nanos}_{seq}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let file = dir.join("shadow.cljrs");
+    std::fs::write(&file, source).expect("write source");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cljrs"))
+        .arg("run")
+        .arg(&file)
+        .env("CLJRS_IR_THRESHOLD", "5")
+        .output()
+        .expect("spawn cljrs");
+
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        output.status.success(),
+        "cljrs exited with {:?}\nstderr:\n{}\nstdout:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+    String::from_utf8(output.stdout).expect("utf8 stdout")
+}
+
+/// Assert every line of `stdout` is `expected` — i.e. the answer did not
+/// change when the driving loop was promoted to IR.
+fn assert_all_lines(stdout: &str, expected: &str, count: usize) {
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), count, "unexpected line count:\n{stdout}");
+    for (i, line) in lines.iter().enumerate() {
+        assert_eq!(
+            *line, expected,
+            "line {i} disagrees with the interpreted answer:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn let_bound_shadow_survives_promotion() {
+    let stdout = run_tiered(
+        r#"
+(ns shadow.test)
+
+(defn shadowed [n]
+  (let [inc (fn [x] (* x 100))]
+    (inc n)))
+
+(defn run []
+  (loop [i 0]
+    (when (< i 20)
+      (println (shadowed 1))
+      (recur (clojure.core/inc i)))))
+
+(run)
+"#,
+    );
+    assert_all_lines(&stdout, "100", 20);
+}
+
+#[test]
+fn parameter_shadow_survives_promotion() {
+    let stdout = run_tiered(
+        r#"
+(ns shadow.two)
+
+;; `inc` here is just a parameter name.
+(defn apply-twice [inc n]
+  (inc (inc n)))
+
+(defn run []
+  (loop [i 0]
+    (when (< i 20)
+      (println (apply-twice (fn [x] (* x 10)) 1))
+      (recur (clojure.core/inc i)))))
+
+(run)
+"#,
+    );
+    assert_all_lines(&stdout, "100", 20);
+}
+
+#[test]
+fn redefined_var_survives_promotion() {
+    let stdout = run_tiered(
+        r#"
+(ns shadow.redef)
+
+(defn inc [n] (+ n 7))
+
+(defn run []
+  (loop [i 0]
+    (when (< i 20)
+      (println (inc 1))
+      (recur (clojure.core/inc i)))))
+
+(run)
+"#,
+    );
+    assert_all_lines(&stdout, "8", 20);
+}
+
+#[test]
+fn refer_clojure_exclude_survives_promotion() {
+    let stdout = run_tiered(
+        r#"
+(ns shadow.excluded
+  (:refer-clojure :exclude [count]))
+
+(defn count [coll] :not-cores)
+
+(defn run []
+  (loop [i 0]
+    (when (clojure.core/< i 20)
+      (println (count [1 2 3]))
+      (recur (clojure.core/inc i)))))
+
+(run)
+"#,
+    );
+    assert_all_lines(&stdout, ":not-cores", 20);
+}
+
+#[test]
+fn another_namespaces_var_is_not_core() {
+    let stdout = run_tiered(
+        r#"
+(ns shadow.other)
+
+(defn count [coll] :other-count)
+
+(ns shadow.caller)
+
+(defn run []
+  (loop [i 0]
+    (when (< i 20)
+      (println (shadow.other/count [1 2 3]))
+      (recur (inc i)))))
+
+(run)
+"#,
+    );
+    assert_all_lines(&stdout, ":other-count", 20);
+}
+
+#[test]
+fn unshadowed_core_calls_still_work() {
+    // The fix must not disturb the ordinary case: these all stay core's.
+    let stdout = run_tiered(
+        r#"
+(ns shadow.plain)
+
+(defn run []
+  (loop [i 0]
+    (when (< i 20)
+      (println (inc (count [1 2])))
+      (recur (inc i)))))
+
+(run)
+"#,
+    );
+    assert_all_lines(&stdout, "3", 20);
+}


### PR DESCRIPTION
`lower_call` decided whether a call was a core builtin from the head
symbol's text, so anything spelled `inc`, `count`, `first`, … was inlined
or turned into a `CallKnown` regardless of what the name was bound to.
The tree-walker resolved these correctly, so the answer depended on which
tier was executing — and under the tiered runtime it changed mid-run, at
the promotion boundary.

Three things now have to hold before a call site is lowered as core's:

* The symbol is unqualified or explicitly `clojure.core/x`.  A qualifier
  naming any other namespace means another var (`strip_ns_prefix` used to
  make `other.ns/count` match core's `count`); `core_name` replaces it.
* No lexical binding claims the name.  `LowerCtx::core_call_name` consults
  `lookup_local` first, so a `let`-bound `inc` or a parameter named `inc`
  is a call to that binding.
* The lowering namespace does not bind the name itself.  `CoreShadows`
  carries what it binds instead of core — its own interns, refers from
  elsewhere (including a `:rename`d core var), and names a
  `(:refer-clojure ...)` filter keeps out of the automatic core refer.
  `GlobalEnv::core_shadowed_names` computes it; `core_shadows_for` samples
  it on the mutator thread, for the synchronous path, the background
  lowering worker (which has no `GlobalEnv`), and AOT alike.

`def`s in the unit being lowered are folded into the shadow set from the
forms themselves: AOT compiles a whole file without evaluating its `def`s,
so the environment cannot report them yet.  `clojure.core`'s own `def`s
are exempt — those *are* the core names.

A call that fails any of these becomes an ordinary dynamic call, which
resolves per call exactly as the tree-walker does.

Tests cover the lowering decision directly (locals, namespace shadows,
qualified symbols), `core_shadowed_names` against a live environment, and
end-to-end tier parity: each program runs well past a low warm threshold
and every line must match the interpreted answer.

Known remaining gap, unchanged by this commit and worth its own issue: an
arity lowered *before* a shadowing `def` is evaluated keeps its inlined
core semantics, because nothing invalidates IR when a var is interned for
the first time (the existing rebind hook only fires for redefinitions).

Fixes #337

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XNyohMQGAw3dvVC3tXzrEq