### PR TITLE
fix(core): make filter, partition, partition-all and iterate lazy

### DIFF
--- a/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
+++ b/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
@@ -673,7 +673,7 @@
 (defn iterate
   "Returns a lazy sequence of x, (f x), (f (f x)), etc."
   [f x]
-  (cons x (lazy-seq (iterate f (f x)))))
+  (lazy-seq (cons x (lazy-seq (iterate f (f x))))))
 
 (defn repeat
   "Returns a lazy (infinite, or length n if supplied) sequence of xs."

--- a/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
+++ b/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
@@ -142,12 +142,14 @@
           (rf result input)
           result)))))
   ([pred coll]
-   (loop [s (seq coll) acc []]
-     (if s
-       (if (pred (first s))
-         (recur (next s) (conj acc (first s)))
-         (recur (next s) acc))
-       (or (seq acc) '())))))
+   ;; Lazy, as the docstring says: an eager loop here never returns on an
+   ;; infinite coll, so `(take 3 (filter even? (range)))` hangs the process.
+   (lazy-seq
+     (when-let [s (seq coll)]
+       (let [f (first s) r (rest s)]
+         (if (pred f)
+           (cons f (filter pred r))
+           (filter pred r)))))))
 
 (defn remove
   "Returns a lazy sequence of the items in coll for which (pred item)
@@ -754,24 +756,19 @@
   ([n coll]
    (partition n n coll))
   ([n step coll]
-   (loop [s (seq coll) acc []]
-     (if s
-       (let [part (take n s)]
-         (if (= (count part) n)
-           (recur (nthnext s step) (conj acc part))
-           (seq acc)))
-       (seq acc))))
+   ;; Lazy: `(take 4 (partition 2 (range)))` must terminate.
+   (lazy-seq
+     (when-let [s (seq coll)]
+       (let [p (doall (take n s))]
+         (when (= n (count p))
+           (cons p (partition n step (nthnext s step))))))))
   ([n step pad coll]
-   (loop [s (seq coll) acc []]
-     (if s
-       (let [part (take n s)]
-         (if (= (count part) n)
-           (recur (nthnext s step) (conj acc part))
-           (let [padded (take n (concat part pad))]
-             (if (= (count padded) n)
-               (seq (conj acc padded))
-               (seq acc)))))
-       (seq acc)))))
+   (lazy-seq
+     (when-let [s (seq coll)]
+       (let [p (doall (take n s))]
+         (if (= n (count p))
+           (cons p (partition n step pad (nthnext s step)))
+           (list (doall (take n (concat p pad))))))))))
 
 (defn partition-all
   ([n]
@@ -793,11 +790,12 @@
                   (rf result buf))
               result)))))))
   ([n coll]
-   (loop [s (seq coll) acc []]
-     (if s
-       (let [part (take n s)]
-         (recur (nthnext s n) (conj acc part)))
-       (seq acc)))))
+   (partition-all n n coll))
+  ([n step coll]
+   (lazy-seq
+     (when-let [s (seq coll)]
+       (let [p (doall (take n s))]
+         (cons p (partition-all n step (nthnext s step))))))))
 
 (defn flatten
   "Takes any nested combination of sequential things (lists, vectors,

--- a/crates/cljrs-runtime/tests/lazy_producers.rs
+++ b/crates/cljrs-runtime/tests/lazy_producers.rs
@@ -1,0 +1,97 @@
+//! Every lazy producer answers `realized?`.
+//!
+//! `realized?` throws on anything that is not pending, so a producer whose head
+//! is a plain cons rather than a lazy seq is not merely "unrealized" — it is
+//! un-probeable, and the compliance suite's `lazy-seq?` check (a `realized?`
+//! probe in a try/catch) then reports it as not lazy at all.
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .eager_clojure_test(true)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Result<Value, String> {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, &mut env)
+            .map_err(|e| format!("eval: {e:?}"))?;
+    }
+    Ok(result)
+}
+
+fn eval_ok(src: &str) -> Value {
+    eval_fresh(src).unwrap_or_else(|e| panic!("{src}\n{e}"))
+}
+
+/// Producers whose result must be a pending lazy seq, not an already-built cons.
+const LAZY_PRODUCERS: &[&str] = &[
+    "(iterate inc 0)",
+    "(map inc [1 2])",
+    "(range)",
+    "(range 3)",
+    "(repeat :x)",
+    "(repeatedly (fn [] 1))",
+    "(cycle [1 2])",
+    "(filter even? (range))",
+    "(lazy-seq [1])",
+];
+
+#[test]
+fn a_lazy_producer_starts_unrealized_and_ends_realized() {
+    for producer in LAZY_PRODUCERS {
+        assert_eq!(
+            eval_ok(&format!("(realized? {producer})")),
+            Value::Bool(false),
+            "{producer} should be pending before anything is demanded"
+        );
+        assert_eq!(
+            eval_ok(&format!("(let [s {producer}] (first s) (realized? s))")),
+            Value::Bool(true),
+            "{producer} should be realized once its head is demanded"
+        );
+    }
+}
+
+#[test]
+fn iterate_does_not_call_f_before_the_second_element() {
+    let v = eval_ok("(first (iterate (fn [_] (throw (ex-info \"eager!\" {}))) 0))");
+    assert_eq!(v, Value::Long(0));
+}
+
+#[test]
+fn iterate_still_produces_the_right_sequence() {
+    assert_eq!(eval_ok("(nth (iterate inc 0) 4)"), Value::Long(4));
+    assert_eq!(
+        format!("{}", eval_ok("(take 5 (iterate inc 0))")),
+        "(0 1 2 3 4)"
+    );
+    assert_eq!(
+        format!("{}", eval_ok("(take 3 (iterate (fn [x] (* 2 x)) 1))")),
+        "(1 2 4)"
+    );
+}
+
+#[test]
+fn realized_still_rejects_things_that_are_not_pending() {
+    for eager in ["'()", "[]", "{}", "#{}", "1", ":foo"] {
+        assert!(
+            eval_fresh(&format!("(realized? {eager})")).is_err(),
+            "realized? must throw on {eager}"
+        );
+    }
+}


### PR DESCRIPTION
## What

Two commits in one defect family — a core fn documented lazy that was not:

1. **`filter` / `partition` / `partition-all`** were eager, which made
   `clojure.core-test.partition` and `clojure.core-test.remove` hang the runner
   outright rather than fail.
2. **`iterate`** was lazy in its tail but not at its head: it returned a plain
   cons, so `(first (iterate f x))` already called `f`, and `realized?` — which
   throws on anything that is not pending — could not probe it at all.

## Why the second one is subtler than it looks

`realized?` throwing on a non-pending value means the compliance suite's
`lazy-seq?` check (a `realized?` probe in a try/catch) reports such a producer
as *not lazy at all*, not merely as unrealized. Wrapping the cons in `lazy-seq`
fixes the probe and defers one step further.

## Evidence

`crates/cljrs-runtime/tests/lazy_producers.rs` asserts that every lazy producer
answers `realized?`. On the vendored suite, measured when the fix was first
written: 197 → 198 namespaces green, 6288 → 6305 assertions passing, and the two
hangs gone. Those counts are from that run, not re-measured against current
`main`; what I have re-run here is the full workspace suite, green.

---

Applies cleanly to current `main`.
