### PR TITLE
fix(aot): establish the entry namespace structurally, not as embedded source

### DIFF
--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -638,6 +638,34 @@ Pinned *versioned* sources (`mylib@<sha>`) are the exception — they still embe
 as interpreted builtin source, since they resolve through the separate
 versioned loader rather than the plain `require` path.
 
+**Structural entry namespace:** the *entry* file's own `ns` form is normally an
+interpreted form too, so it ships as readable text and `--require-fully-compiled`
+rejects the program. When that `ns` is the **only** interpreted form and carries
+no clause richer than `:require` — no `:import`, `:gen-class`, docstring or
+`:refer-clojure` — `structural_ns_form` recognises it and the harness establishes
+the namespace directly instead: `get_or_create_ns`, `refer_core`, `sync_star_ns`
+(so `(resolve '-main)` looks in the entry namespace rather than `user`), then one
+`load_ns` call per require. No source text is emitted, so a single-file program
+can pass the opacity gate.
+
+Require specs are parsed by `cljrs_runtime::interp::special::parse_require_spec_form`
+— the same function `eval_ns` uses — and emitted whole, alias and `:refer` and
+`@version` included. This path must not re-derive spec parsing: aliases are
+resolved at compile time by `qualify_aliases`, but `:refer` is not. A bare `f`
+lowers to `LoadGlobal(<entry-ns>, "f")` and is resolved through the namespace's
+refer table at *runtime*, and `rt_call` on a nil callee returns nil rather than
+erroring — so a dropped refer produces a program that runs and prints wrong
+answers. A dropped `@version` likewise routes a pinned require to the plain
+loader instead of the versioned one.
+
+The structural path is taken only when the `ns` is the *first* interpreted form;
+otherwise it is restored at the head of the preamble, which would reorder the
+program if anything interpreted had preceded it. Any other interpreted form
+present at all forces the textual preamble, since that form may depend on the
+aliases and refers the `ns` installs. Required namespaces still ship their own
+`ns`/`require` preambles as text, so multi-file programs remain rejected by
+`--require-fully-compiled` through the `NamespacePreamble` channel.
+
 ---
 
 ## Features

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -816,17 +816,38 @@ pub fn compile_file(src_path: &Path, out_path: &Path, session: &CompileSession) 
     // The rest is AOT-compiled.
     let mut interpreted_source = String::new();
     let mut compilable = Vec::new();
+    // The entry `ns` form, held back: if it is the ONLY interpreted form, the
+    // harness can establish the namespace structurally and ship no text at all.
+    // Held back rather than dropped, because any OTHER interpreted form may
+    // depend on the aliases and refers this form installs.
+    let mut structural_ns: Option<(String, Vec<String>)> = None;
+    let mut ns_form_text = String::new();
     for (i, form) in expanded.iter().enumerate() {
         if needs_interpreter(&forms[i]) || expanded_needs_interpreter(form) {
             // Extract the original source text using span byte offsets.
             let span = &forms[i].span;
             let src_text = &source[span.start..span.end];
-            interpreted_source.push_str(src_text);
-            interpreted_source.push('\n');
+            match structural_ns_form(&forms[i]) {
+                Some(decl) if structural_ns.is_none() && ns_form_text.is_empty() => {
+                    structural_ns = Some(decl);
+                    ns_form_text.push_str(src_text);
+                    ns_form_text.push('\n');
+                }
+                _ => {
+                    interpreted_source.push_str(src_text);
+                    interpreted_source.push('\n');
+                }
+            }
         } else {
             let form = expand_anon_fns(form);
             compilable.push(qualify_aliases(&form, &env.current_ns, &env.globals));
         }
+    }
+    // Another form needs the interpreter, so the ns form must be evaluated the
+    // old way — its aliases have to exist before that form runs.
+    if !interpreted_source.is_empty() && structural_ns.is_some() {
+        structural_ns = None;
+        interpreted_source.insert_str(0, &ns_form_text);
     }
     if !interpreted_source.is_empty() {
         eprintln!(
@@ -946,6 +967,7 @@ pub fn compile_file(src_path: &Path, out_path: &Path, session: &CompileSession) 
         out_path,
         &obj_bytes,
         &interpreted_source,
+        structural_ns.as_ref(),
         &compiled_namespaces,
         &versioned_bundled,
         &async_polls,
@@ -1192,6 +1214,63 @@ pub fn audit_source(
         })
         .collect();
     SourceAudit { leaks }
+}
+
+/// An entry `(ns ...)` form the harness can establish WITHOUT embedding its text.
+///
+/// Returns `(name, required namespaces)` for `(ns NAME)` and for an `ns` whose
+/// only clauses are `(:require ...)`; `None` for anything richer (`:import`,
+/// `:gen-class`, metadata, a docstring), which still goes through the
+/// interpreted preamble.
+///
+/// Why this exists: `needs_interpreter` sends every `ns` form to the preamble
+/// as VERBATIM SOURCE, so the smallest possible program — `(ns m)` — ships 7
+/// bytes of readable Clojure and `--require-fully-compiled` refuses it. The ns
+/// declaration is not program text; it is a fact the compiler already knows.
+fn structural_ns_form(form: &cljrs_reader::Form) -> Option<(String, Vec<String>)> {
+    use cljrs_reader::form::FormKind;
+    let FormKind::List(parts) = &form.kind else {
+        return None;
+    };
+    let (head, rest) = parts.split_first()?;
+    let FormKind::Symbol(h) = &head.kind else {
+        return None;
+    };
+    if h != "ns" {
+        return None;
+    }
+    let (name_form, clauses) = rest.split_first()?;
+    let FormKind::Symbol(name) = &name_form.kind else {
+        return None;
+    };
+    let mut requires = Vec::new();
+    for clause in clauses {
+        let FormKind::List(items) = &clause.kind else {
+            return None;
+        };
+        let Some(kw) = items.first() else {
+            return None;
+        };
+        let FormKind::Keyword(k) = &kw.kind else {
+            return None;
+        };
+        if k != "require" {
+            // :import, :gen-class, :refer-clojure with exclusions — richer than
+            // this path models. Keep the textual preamble; the gate will say so.
+            return None;
+        }
+        for spec in &items[1..] {
+            match &spec.kind {
+                FormKind::Symbol(ns) => requires.push(ns.clone()),
+                FormKind::Vector(v) => match v.first().map(|f| &f.kind) {
+                    Some(FormKind::Symbol(ns)) => requires.push(ns.clone()),
+                    _ => return None,
+                },
+                _ => return None,
+            }
+        }
+    }
+    Some((name.clone(), requires))
 }
 
 /// Check if a top-level form needs the interpreter (can't be AOT-compiled yet).
@@ -1869,6 +1948,8 @@ fn build_harness(
     out_path: &Path,
     obj_bytes: &[u8],
     interpreted_source: &str,
+    // The entry namespace, when it can be established without embedding text.
+    structural_ns: Option<&(String, Vec<String>)>,
     compiled_namespaces: &[CompiledNamespace],
     versioned_bundled: &[(Arc<str>, String)],
     async_polls: &[AsyncPollEntry],
@@ -2027,6 +2108,36 @@ edition = "2024"
     }
 "#;
 
+    // Establish the entry namespace structurally when its `ns` form carried no
+    // program text. Requires are loaded through the same loader `require` uses,
+    // so an AOT-compiled dependency still runs its native initializer. Aliases
+    // and refers are deliberately NOT installed: nothing interpreted remains to
+    // use them, and the compiled body was alias-qualified at compile time.
+    let ns_setup = match structural_ns {
+        Some((ns, requires)) => {
+            let mut code = format!(
+                "    let mut env = cljrs_runtime::tiered::Env::new(globals.clone(), {ns:?});\n\
+                 \x20   globals.get_or_create_ns({ns:?});\n\
+                 \x20   globals.refer_all({ns:?}, \"clojure.core\");\n\
+                 \x20   // Bind *ns* the way `eval_ns` does. Without this the namespace is\n\
+                 \x20   // established but `(resolve '-main)` still looks in `user`, finds\n\
+                 \x20   // nothing, and the program exits 0 having run nothing at all.\n\
+                 \x20   cljrs_runtime::interp::special::sync_star_ns(&mut env);\n"
+            );
+            for req in requires {
+                code.push_str(&format!(
+                    "    cljrs_runtime::env::loader::load_ns(globals.clone(), \
+                     &cljrs_runtime::env::env::RequireSpec {{ ns: std::sync::Arc::from({req:?}), \
+                     version: None, alias: None, \
+                     refer: cljrs_runtime::env::env::RequireRefer::None }}, {ns:?})\n\
+                     \x20       .expect(\"require failed at startup\");\n"
+                ));
+            }
+            code
+        }
+        None => "    let mut env = cljrs_runtime::tiered::Env::new(globals, \"user\");\n\n".to_string(),
+    };
+
     let preamble_code = if has_preamble {
         r#"
     // Evaluate interpreted preamble (ns, require, defn, defmacro, etc.).
@@ -2135,9 +2246,7 @@ async fn run() {{
     // Register AOT-compiled namespace loaders so `require` runs their native
     // initializers instead of interpreting source.
 {compiled_ns}{native_init}
-    let mut env = cljrs_runtime::tiered::Env::new(globals, "user");
-
-    // Push an eval context so rt_call can dispatch through the interpreter.
+{ns_setup}    // Push an eval context so rt_call can dispatch through the interpreter.
     cljrs_runtime::env::callback::push_eval_context(&env);
 {preamble}
     // Call the compiled code.
@@ -2174,6 +2283,7 @@ fn main() {{
 }}
 "#,
         preamble = preamble_code,
+        ns_setup = ns_setup,
         bundled = bundled_registration,
         compiled_ns = compiled_ns_registration,
         ns_init_externs = ns_init_externs,
@@ -3013,6 +3123,52 @@ edition = "2024"
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn parse_one(src: &str) -> cljrs_reader::Form {
+        cljrs_reader::Parser::new(src.to_string(), "<test>".to_string())
+            .parse_all()
+            .expect("parse")
+            .remove(0)
+    }
+
+    #[test]
+    fn a_bare_ns_form_is_structural() {
+        let (name, requires) = structural_ns_form(&parse_one("(ns m)")).expect("recognised");
+        assert_eq!(name, "m");
+        assert!(requires.is_empty());
+    }
+
+    #[test]
+    fn a_require_clause_is_structural_and_its_namespaces_are_collected() {
+        let (name, requires) =
+            structural_ns_form(&parse_one("(ns m (:require [a.b :as b] c.d))")).expect("recognised");
+        assert_eq!(name, "m");
+        assert_eq!(requires, vec!["a.b".to_string(), "c.d".to_string()]);
+    }
+
+    #[test]
+    fn richer_ns_clauses_are_not_structural() {
+        // :import and :gen-class carry behaviour this path does not model, and
+        // a docstring is text. Each must keep the textual preamble — which the
+        // opacity gate will then (correctly) refuse.
+        for src in [
+            "(ns m (:import [java.util List]))",
+            "(ns m (:gen-class))",
+            "(ns m \"a docstring\")",
+            "(ns m (:refer-clojure :exclude [map]))",
+        ] {
+            assert!(
+                structural_ns_form(&parse_one(src)).is_none(),
+                "should not be structural: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_ns_form_is_not_structural() {
+        assert!(structural_ns_form(&parse_one("(defn f [x] x)")).is_none());
+        assert!(structural_ns_form(&parse_one("42")).is_none());
+    }
 
     #[test]
     fn workspace_deps_use_path() {

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -832,18 +832,21 @@ pub fn compile_file(src_path: &Path, out_path: &Path, session: &CompileSession) 
     // harness can establish the namespace structurally and ship no text at all.
     // Held back rather than dropped, because any OTHER interpreted form may
     // depend on the aliases and refers this form installs.
-    let mut structural_ns: Option<(String, Vec<String>)> = None;
-    let mut ns_form_text = String::new();
+    let mut structural_ns: Option<(String, Vec<cljrs_runtime::env::env::RequireSpec>)> = None;
+    let mut ns_form_text: Option<String> = None;
     for (i, form) in expanded.iter().enumerate() {
         if needs_interpreter(&forms[i]) || expanded_needs_interpreter(form) {
             // Extract the original source text using span byte offsets.
             let span = &forms[i].span;
             let src_text = &source[span.start..span.end];
             match structural_ns_form(&forms[i]) {
-                Some(decl) if structural_ns.is_none() && ns_form_text.is_empty() => {
+                // Only when this is the FIRST interpreted form. Holding back an
+                // `ns` that some other interpreted form already preceded would
+                // let the fallback below re-insert it at position 0, silently
+                // reordering the program.
+                Some(decl) if structural_ns.is_none() && interpreted_source.is_empty() => {
                     structural_ns = Some(decl);
-                    ns_form_text.push_str(src_text);
-                    ns_form_text.push('\n');
+                    ns_form_text = Some(format!("{src_text}\n"));
                 }
                 _ => {
                     interpreted_source.push_str(src_text);
@@ -856,10 +859,14 @@ pub fn compile_file(src_path: &Path, out_path: &Path, session: &CompileSession) 
         }
     }
     // Another form needs the interpreter, so the ns form must be evaluated the
-    // old way — its aliases have to exist before that form runs.
-    if !interpreted_source.is_empty() && structural_ns.is_some() {
+    // old way — its aliases have to exist before that form runs. It was the
+    // first interpreted form, so restoring it at position 0 preserves order.
+    if !interpreted_source.is_empty()
+        && structural_ns.is_some()
+        && let Some(text) = ns_form_text.as_deref()
+    {
         structural_ns = None;
-        interpreted_source.insert_str(0, &ns_form_text);
+        interpreted_source.insert_str(0, text);
     }
     if !interpreted_source.is_empty() {
         eprintln!(
@@ -977,12 +984,14 @@ pub fn compile_file(src_path: &Path, out_path: &Path, session: &CompileSession) 
     // ── 5. Generate harness project & build ─────────────────────────────
     let (harness_dir, offline) = build_harness(
         out_path,
-        &obj_bytes,
-        &interpreted_source,
-        structural_ns.as_ref(),
-        &compiled_namespaces,
-        &versioned_bundled,
-        &async_polls,
+        HarnessInputs {
+            obj_bytes: &obj_bytes,
+            interpreted_source: &interpreted_source,
+            structural_ns: structural_ns.as_ref(),
+            compiled_namespaces: &compiled_namespaces,
+            versioned_bundled: &versioned_bundled,
+            async_polls: &async_polls,
+        },
         session,
     )?;
     link_with_cargo(&harness_dir, out_path, offline)?;
@@ -1239,7 +1248,9 @@ pub fn audit_source(
 /// as VERBATIM SOURCE, so the smallest possible program — `(ns m)` — ships 7
 /// bytes of readable Clojure and `--require-fully-compiled` refuses it. The ns
 /// declaration is not program text; it is a fact the compiler already knows.
-fn structural_ns_form(form: &cljrs_reader::Form) -> Option<(String, Vec<String>)> {
+fn structural_ns_form(
+    form: &cljrs_reader::Form,
+) -> Option<(String, Vec<cljrs_runtime::env::env::RequireSpec>)> {
     use cljrs_reader::form::FormKind;
     let FormKind::List(parts) = &form.kind else {
         return None;
@@ -1260,9 +1271,7 @@ fn structural_ns_form(form: &cljrs_reader::Form) -> Option<(String, Vec<String>)
         let FormKind::List(items) = &clause.kind else {
             return None;
         };
-        let Some(kw) = items.first() else {
-            return None;
-        };
+        let kw = items.first()?;
         let FormKind::Keyword(k) = &kw.kind else {
             return None;
         };
@@ -1272,17 +1281,49 @@ fn structural_ns_form(form: &cljrs_reader::Form) -> Option<(String, Vec<String>)
             return None;
         }
         for spec in &items[1..] {
-            match &spec.kind {
-                FormKind::Symbol(ns) => requires.push(ns.clone()),
-                FormKind::Vector(v) => match v.first().map(|f| &f.kind) {
-                    Some(FormKind::Symbol(ns)) => requires.push(ns.clone()),
-                    _ => return None,
-                },
-                _ => return None,
-            }
+            // Parse through the interpreter's own spec parser rather than
+            // re-deriving it here. `:refer` and an `@version` suffix are both
+            // load-bearing at runtime, and a second implementation drops them
+            // silently — the compiled body then resolves referred names to nil.
+            // Anything the parser rejects keeps the textual preamble.
+            requires.push(cljrs_runtime::interp::special::parse_require_spec_form(spec).ok()?);
         }
     }
     Some((name.clone(), requires))
+}
+
+/// Render a `RequireSpec` as the Rust literal the generated harness constructs.
+///
+/// Every field is carried. `version` routes `load_ns` to the versioned loader,
+/// and `refer` installs the names the compiled body loads through
+/// `LoadGlobal(<entry-ns>, name)`; emitting `None` for either produces a
+/// program that runs and answers wrongly rather than one that fails.
+fn render_require_spec(spec: &cljrs_runtime::env::env::RequireSpec) -> String {
+    use cljrs_runtime::env::env::RequireRefer;
+    let opt_arc = |o: &Option<std::sync::Arc<str>>| match o {
+        Some(v) => format!("Some(std::sync::Arc::from({:?}))", v.as_ref()),
+        None => "None".to_string(),
+    };
+    let refer = match &spec.refer {
+        RequireRefer::None => "cljrs_runtime::env::env::RequireRefer::None".to_string(),
+        RequireRefer::All => "cljrs_runtime::env::env::RequireRefer::All".to_string(),
+        RequireRefer::Named(names) => {
+            let items = names
+                .iter()
+                .map(|n| format!("std::sync::Arc::from({:?})", n.as_ref()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("cljrs_runtime::env::env::RequireRefer::Named(vec![{items}])")
+        }
+    };
+    format!(
+        "cljrs_runtime::env::env::RequireSpec {{ ns: std::sync::Arc::from({:?}), \
+         version: {}, alias: {}, refer: {} }}",
+        spec.ns.as_ref(),
+        opt_arc(&spec.version),
+        opt_arc(&spec.alias),
+        refer
+    )
 }
 
 /// Check if a top-level form needs the interpreter (can't be AOT-compiled yet).
@@ -1956,17 +1997,34 @@ fn compile_async_poll_fns(
     Ok(entries)
 }
 
+/// Everything the generated Cargo harness is assembled from.
+///
+/// A parameter object rather than a longer argument list: these all answer one
+/// question — what does the harness contain? — and they are always passed
+/// together, so a caller cannot supply a coherent subset of them.
+struct HarnessInputs<'a> {
+    obj_bytes: &'a [u8],
+    interpreted_source: &'a str,
+    /// The entry namespace, when it can be established without embedding text.
+    structural_ns: Option<&'a (String, Vec<cljrs_runtime::env::env::RequireSpec>)>,
+    compiled_namespaces: &'a [CompiledNamespace],
+    versioned_bundled: &'a [(Arc<str>, String)],
+    async_polls: &'a [AsyncPollEntry],
+}
+
 fn build_harness(
     out_path: &Path,
-    obj_bytes: &[u8],
-    interpreted_source: &str,
-    // The entry namespace, when it can be established without embedding text.
-    structural_ns: Option<&(String, Vec<String>)>,
-    compiled_namespaces: &[CompiledNamespace],
-    versioned_bundled: &[(Arc<str>, String)],
-    async_polls: &[AsyncPollEntry],
+    inputs: HarnessInputs<'_>,
     session: &CompileSession,
 ) -> AotResult<(PathBuf, bool)> {
+    let HarnessInputs {
+        obj_bytes,
+        interpreted_source,
+        structural_ns,
+        compiled_namespaces,
+        versioned_bundled,
+        async_polls,
+    } = inputs;
     let rust_config = session.rust_config_ref();
     let extensions = session.extensions();
     // Place the harness in a temp dir next to the output.
@@ -2122,32 +2180,47 @@ edition = "2024"
 
     // Establish the entry namespace structurally when its `ns` form carried no
     // program text. Requires are loaded through the same loader `require` uses,
-    // so an AOT-compiled dependency still runs its native initializer. Aliases
-    // and refers are deliberately NOT installed: nothing interpreted remains to
-    // use them, and the compiled body was alias-qualified at compile time.
+    // so an AOT-compiled dependency still runs its native initializer, and each
+    // spec is emitted whole — alias and refer included. The compiled body was
+    // alias-qualified at compile time, but `LoadGlobal(<entry-ns>, name)`
+    // resolves referred names through the namespace at RUNTIME, so dropping
+    // them yields nil callees rather than an error.
     let ns_setup = match structural_ns {
         Some((ns, requires)) => {
+            // `refer_core` rather than `refer_all(.., "clojure.core")`: it is the
+            // API that MEANS "the automatic core refer", and it is what `eval_ns`
+            // calls — including skipping itself for `clojure.core`, which is
+            // decided here because the namespace is known at compile time.
+            let core_refer = if ns == "clojure.core" {
+                String::new()
+            } else {
+                format!("    globals.refer_core({ns:?});\n")
+            };
             let mut code = format!(
                 "    let mut env = cljrs_runtime::tiered::Env::new(globals.clone(), {ns:?});\n\
                  \x20   globals.get_or_create_ns({ns:?});\n\
-                 \x20   globals.refer_all({ns:?}, \"clojure.core\");\n\
+                 {core_refer}\
                  \x20   // Bind *ns* the way `eval_ns` does. Without this the namespace is\n\
                  \x20   // established but `(resolve '-main)` still looks in `user`, finds\n\
                  \x20   // nothing, and the program exits 0 having run nothing at all.\n\
                  \x20   cljrs_runtime::interp::special::sync_star_ns(&mut env);\n"
             );
             for req in requires {
+                let spec_src = render_require_spec(req);
                 code.push_str(&format!(
-                    "    cljrs_runtime::env::loader::load_ns(globals.clone(), \
-                     &cljrs_runtime::env::env::RequireSpec {{ ns: std::sync::Arc::from({req:?}), \
-                     version: None, alias: None, \
-                     refer: cljrs_runtime::env::env::RequireRefer::None }}, {ns:?})\n\
-                     \x20       .expect(\"require failed at startup\");\n"
+                    "    if let Err(e) = cljrs_runtime::env::loader::load_ns(\n\
+                     \x20       globals.clone(), &{spec_src}, {ns:?})\n\
+                     \x20   {{\n\
+                     \x20       eprintln!(\"error: require failed at startup: {{e:?}}\");\n\
+                     \x20       std::process::exit(1);\n\
+                     \x20   }}\n"
                 ));
             }
             code
         }
-        None => "    let mut env = cljrs_runtime::tiered::Env::new(globals, \"user\");\n\n".to_string(),
+        None => {
+            "    let mut env = cljrs_runtime::tiered::Env::new(globals, \"user\");\n\n".to_string()
+        }
     };
 
     let preamble_code = if has_preamble {
@@ -3152,10 +3225,38 @@ mod tests {
 
     #[test]
     fn a_require_clause_is_structural_and_its_namespaces_are_collected() {
-        let (name, requires) =
-            structural_ns_form(&parse_one("(ns m (:require [a.b :as b] c.d))")).expect("recognised");
+        let (name, requires) = structural_ns_form(&parse_one("(ns m (:require [a.b :as b] c.d))"))
+            .expect("recognised");
         assert_eq!(name, "m");
-        assert_eq!(requires, vec!["a.b".to_string(), "c.d".to_string()]);
+        let names: Vec<&str> = requires.iter().map(|r| r.ns.as_ref()).collect();
+        assert_eq!(names, vec!["a.b", "c.d"]);
+        assert_eq!(requires[0].alias.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn a_require_spec_keeps_its_refer_and_version() {
+        // Both are load-bearing at RUNTIME: `:refer` installs the names the
+        // compiled body resolves through `LoadGlobal(<entry-ns>, name)`, and a
+        // `@version` pin is what routes `load_ns` to the versioned loader.
+        // Dropping either produced a program that ran and answered wrongly.
+        use cljrs_runtime::env::env::RequireRefer;
+        let (_, requires) = structural_ns_form(&parse_one(
+            "(ns m (:require [a.b :refer [f g]] [c.d :refer :all] e.f@abc1234))",
+        ))
+        .expect("recognised");
+        assert_eq!(requires.len(), 3);
+
+        match &requires[0].refer {
+            RequireRefer::Named(names) => {
+                let names: Vec<&str> = names.iter().map(|n| n.as_ref()).collect();
+                assert_eq!(names, vec!["f", "g"]);
+            }
+            other => panic!("expected Named refer, got {other:?}"),
+        }
+        assert!(matches!(requires[1].refer, RequireRefer::All));
+
+        assert_eq!(requires[2].ns.as_ref(), "e.f");
+        assert_eq!(requires[2].version.as_deref(), Some("abc1234"));
     }
 
     #[test]
@@ -3174,6 +3275,36 @@ mod tests {
                 "should not be structural: {src}"
             );
         }
+    }
+
+    #[test]
+    fn a_rendered_spec_carries_every_field() {
+        // `render_require_spec` is the only place that knows RequireSpec's
+        // shape in generated code. A field it forgets is a field the harness
+        // constructs as None, which is exactly how :refer went missing.
+        let (_, requires) = structural_ns_form(&parse_one(
+            "(ns m (:require [a.b :as b :refer [f g]] c.d@abc1234 [e.f :refer :all]))",
+        ))
+        .expect("recognised");
+
+        let named = render_require_spec(&requires[0]);
+        assert!(named.contains(r#"std::sync::Arc::from("a.b")"#), "{named}");
+        assert!(named.contains(r#"alias: Some("#), "{named}");
+        assert!(named.contains(r#"Arc::from("b")"#), "{named}");
+        assert!(named.contains("RequireRefer::Named"), "{named}");
+        assert!(named.contains(r#"Arc::from("f")"#), "{named}");
+        assert!(named.contains(r#"Arc::from("g")"#), "{named}");
+
+        let pinned = render_require_spec(&requires[1]);
+        assert!(pinned.contains(r#"Arc::from("c.d")"#), "{pinned}");
+        assert!(
+            pinned.contains(r#"version: Some(std::sync::Arc::from("abc1234"))"#),
+            "a dropped version silently skips the versioned loader: {pinned}"
+        );
+
+        let all = render_require_spec(&requires[2]);
+        assert!(all.contains("RequireRefer::All"), "{all}");
+        assert!(all.contains("alias: None"), "{all}");
     }
 
     #[test]

--- a/crates/cljrs-compiler/tests/aot_e2e.rs
+++ b/crates/cljrs-compiler/tests/aot_e2e.rs
@@ -47,7 +47,17 @@ fn compile_and_run(name: &str, source: &str) -> String {
 
     result.unwrap_or_else(|e| panic!("compilation failed for {name}: {e:?}"));
 
-    let output = Command::new(&bin_path)
+    run_binary(name, &bin_path)
+}
+
+/// Run an already-built AOT binary and return its stdout.
+///
+/// Split out so the gated and ungated paths assert program BEHAVIOUR the same
+/// way. A compile that succeeds is not evidence that the program runs: an entry
+/// namespace can be created, pass every gate, and still exit 0 having resolved
+/// nothing.
+fn run_binary(name: &str, bin_path: &std::path::Path) -> String {
+    let output = Command::new(bin_path)
         .output()
         .unwrap_or_else(|e| panic!("failed to run {name} binary: {e}"));
 
@@ -2667,6 +2677,81 @@ fn compile_gated(name: &str, source: &str) -> cljrs_compiler::aot::AotResult<()>
         .unwrap()
         .join()
         .unwrap()
+}
+
+/// Compile under `RequireFullyCompiled` and run the result.
+///
+/// The gate rejects any embedded source text, so a program that reaches a
+/// binary here MUST have taken the structural entry-ns path. Running it then
+/// proves the namespace that path establishes actually resolves.
+#[cfg(feature = "aot_full_test")]
+fn compile_gated_and_run(name: &str, source: &str) -> String {
+    let _guard = AOT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let dir = std::env::temp_dir().join("cljrs_aot_tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let src_path = dir.join(format!("{name}.cljrs"));
+    let bin_path = dir.join(format!("{name}_bin"));
+    std::fs::write(&src_path, source).unwrap();
+
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn({
+            let src = src_path.clone();
+            let bin = bin_path.clone();
+            move || {
+                cljrs_compiler::aot::compile_file(
+                    &src,
+                    &bin,
+                    &common::session(vec![])
+                        .opacity(cljrs_compiler::aot::OpacityPolicy::RequireFullyCompiled),
+                )
+            }
+        })
+        .unwrap()
+        .join()
+        .unwrap()
+        .unwrap_or_else(|e| panic!("gated compilation failed for {name}: {e:?}"));
+
+    run_binary(name, &bin_path)
+}
+
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn structural_entry_ns_compiles_opaquely_and_runs() {
+    // The `ns` form is the only interpreted form, so the entry namespace is
+    // established structurally and no text is embedded — which is what lets the
+    // gate pass at all. The harness then resolves `-main` through `*ns*`, so
+    // this also pins the `sync_star_ns` binding: without it the program exits 0
+    // having run nothing, and a compile-only test would still be green.
+    let out = compile_gated_and_run(
+        "gate_structural_ns",
+        r#"
+(ns my-app)
+(defn weigh [x] (+ (* x 31) 7))
+(defn -main [& _] (println (weigh 10)))
+"#,
+    );
+    assert_eq!(out.trim(), "317");
+}
+
+#[test]
+#[cfg(feature = "aot_full_test")]
+fn structural_entry_ns_keeps_referred_names_resolvable() {
+    // The regression this PR's review caught: `:refer` was dropped from the
+    // structurally emitted spec, so `square` lowered to LoadGlobal(my-app,
+    // "square") and resolved to nil at runtime. `rt_call` on a nil callee
+    // returns nil rather than erroring, so the binary printed "nil" and exited
+    // 0. Only running it and reading stdout catches that.
+    let out = compile_gated_and_run(
+        "gate_structural_ns_refer",
+        r#"
+(ns my-app
+  (:require [clojure.string :refer [upper-case]]))
+(defn -main [& _] (println (upper-case "ok")))
+"#,
+    );
+    assert_eq!(out.trim(), "OK");
 }
 
 #[test]

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -1415,7 +1415,11 @@ fn spec_element(form: &Form) -> Option<&Form> {
 
 /// Parse a `RequireSpec` from a raw `Form` (unevaluated, used in `ns` macro).
 /// Also handles versioned namespace symbols such as `my.ns@abc1234`.
-fn parse_require_spec_form(form: &Form) -> Result<RequireSpec, String> {
+///
+/// Public so the AOT compiler can establish an entry namespace from the same
+/// parse `eval_ns` uses. A second implementation there would drift: it already
+/// did, dropping `:refer` and `@version` from structurally emitted requires.
+pub fn parse_require_spec_form(form: &Form) -> Result<RequireSpec, String> {
     match &form.kind {
         FormKind::Symbol(s) => {
             let sym = cljrs_value::Symbol::parse(s);


### PR DESCRIPTION
## What

The AOT entry namespace was established by embedding a source string into the
generated harness and evaluating it at startup. This replaces that with a
structural declaration: the `ns` form is recognised as data (name + `:require`
clauses), and the harness establishes the namespace directly.

## Why

Embedding source into a compiled artifact is a source leak — the point of AOT is
that the shipped binary does not carry, or need, the text it was built from. It
also means the entry namespace is established by a code path (the reader plus
the evaluator) that the rest of the AOT pipeline has already been careful to
avoid.

## Evidence

`crates/cljrs-compiler/tests/source_leak_audit.rs` and the `aot_e2e` cases
(`require_fully_compiled_rejects_embedded_source`,
`require_fully_compiled_accepts_plain_defn`).

---

Applies cleanly to current `main`.
