### PR TITLE
fix(reader): parse special forms through metadata

### DIFF
--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -817,7 +817,7 @@ fn lower_let(ctx: &mut LowerCtx, args: &[Form]) -> R {
             "let requires a binding vector".into(),
         ));
     }
-    let FormKind::Vector(bindings) = &args[0].kind else {
+    let Some(bindings) = args[0].as_vector() else {
         return Err(LowerError::MalformedSpecialForm(
             "let bindings must be a vector".into(),
         ));
@@ -855,7 +855,7 @@ fn lower_loop(ctx: &mut LowerCtx, args: &[Form]) -> R {
             "loop requires a binding vector".into(),
         ));
     }
-    let FormKind::Vector(bindings) = &args[0].kind else {
+    let Some(bindings) = args[0].as_vector() else {
         return Err(LowerError::MalformedSpecialForm(
             "loop bindings must be a vector".into(),
         ));
@@ -963,21 +963,10 @@ fn lower_def(ctx: &mut LowerCtx, args: &[Form]) -> R {
         ));
     }
     // Name may carry metadata: `(def ^:private x 1)`.
-    let name_str: Arc<str> = match &args[0].kind {
-        FormKind::Symbol(s) => Arc::from(s.as_str()),
-        FormKind::Meta(_, inner) => {
-            let FormKind::Symbol(s) = &inner.kind else {
-                return Err(LowerError::MalformedSpecialForm(
-                    "def name must be a symbol".into(),
-                ));
-            };
-            Arc::from(s.as_str())
-        }
-        _ => {
-            return Err(LowerError::MalformedSpecialForm(
-                "def name must be a symbol".into(),
-            ));
-        }
+    let Some(name_str) = args[0].as_symbol().map(Arc::<str>::from) else {
+        return Err(LowerError::MalformedSpecialForm(
+            "def name must be a symbol".into(),
+        ));
     };
     let ns = ctx.ns().clone();
 
@@ -1001,33 +990,20 @@ fn lower_defn(ctx: &mut LowerCtx, args: &[Form]) -> R {
         ));
     }
     // Name may carry `^:async` metadata: `(defn ^:async foo [x] ...)`.
-    let (name_str, is_async) = match &args[0].kind {
-        FormKind::Symbol(s) => (s.clone(), false),
-        FormKind::Meta(meta, inner) => {
-            let FormKind::Symbol(s) = &inner.kind else {
-                return Err(LowerError::MalformedSpecialForm(
-                    "defn name must be a symbol".into(),
-                ));
-            };
-            (s.clone(), is_meta_async(meta))
-        }
-        _ => {
-            return Err(LowerError::MalformedSpecialForm(
-                "defn name must be a symbol".into(),
-            ));
-        }
+    let (name_metas, name_form) = args[0].peel_meta();
+    let Some(name_str) = name_form.as_symbol().map(str::to_string) else {
+        return Err(LowerError::MalformedSpecialForm(
+            "defn name must be a symbol".into(),
+        ));
     };
+    let is_async = name_metas.iter().any(|m| is_meta_async(m));
 
     // Normalise args[0] to a plain symbol (strip metadata for fn name arg).
     let plain_name_form = Form::new(FormKind::Symbol(name_str.clone()), args[0].span.clone());
 
     // Skip optional docstring.
     let rest_start = if args.len() > 2 {
-        if let FormKind::Str(_) = &args[1].kind {
-            2
-        } else {
-            1
-        }
+        if args[1].as_string().is_some() { 2 } else { 1 }
     } else {
         1
     };
@@ -1057,9 +1033,9 @@ fn desugar_pre_post_conditions(body: &[Form]) -> Vec<Form> {
         Some(f) => f,
         None => return body.to_vec(),
     };
-    let entries = match &first.kind {
-        FormKind::Map(entries) => entries,
-        _ => return body.to_vec(),
+    let entries = match first.as_map() {
+        Some(entries) => entries,
+        None => return body.to_vec(),
     };
 
     let mut pre_conds: Vec<Form> = Vec::new();
@@ -1146,9 +1122,7 @@ fn parse_params(params_vec: &[Form]) -> Result<(Vec<Form>, Option<Form>), LowerE
     let mut rest: Option<Form> = None;
     let mut i = 0;
     while i < params_vec.len() {
-        if let FormKind::Symbol(s) = &params_vec[i].kind
-            && s == "&"
-        {
+        if params_vec[i].as_symbol() == Some("&") {
             i += 1;
             if i >= params_vec.len() {
                 return Err(LowerError::MalformedSpecialForm(
@@ -1172,8 +1146,8 @@ struct AritySpec {
 
 fn lower_fn(ctx: &mut LowerCtx, args: &[Form], is_async: bool) -> R {
     // Detect optional name.
-    let (fn_name, body_start) = if let Some(FormKind::Symbol(s)) = args.first().map(|f| &f.kind) {
-        (Some(s.clone()), 1)
+    let (fn_name, body_start) = if let Some(s) = args.first().and_then(|f| f.as_symbol()) {
+        (Some(s.to_string()), 1)
     } else {
         (None, 0)
     };
@@ -1226,12 +1200,9 @@ fn lower_fn(ctx: &mut LowerCtx, args: &[Form], is_async: bool) -> R {
 
     // Parse arities: single [params] body... or multi ([params] body...) ...
     let raw_arities: Vec<AritySpec> = if !rest_args.is_empty() {
-        if let FormKind::Vector(_) = &rest_args[0].kind {
+        if let Some(params_vec) = rest_args[0].as_vector() {
             // Single arity
-            let (fixed, rest) = parse_params(match &rest_args[0].kind {
-                FormKind::Vector(v) => v,
-                _ => unreachable!(),
-            })?;
+            let (fixed, rest) = parse_params(params_vec)?;
             vec![AritySpec {
                 fixed,
                 rest,
@@ -1242,12 +1213,12 @@ fn lower_fn(ctx: &mut LowerCtx, args: &[Form], is_async: bool) -> R {
             rest_args
                 .iter()
                 .map(|arity_form| {
-                    let FormKind::List(arity_parts) = &arity_form.kind else {
+                    let Some(arity_parts) = arity_form.as_list() else {
                         return Err(LowerError::MalformedSpecialForm(
                             "fn* multi-arity: expected list".into(),
                         ));
                     };
-                    let FormKind::Vector(params_vec) = &arity_parts[0].kind else {
+                    let Some(params_vec) = arity_parts[0].as_vector() else {
                         return Err(LowerError::MalformedSpecialForm(
                             "fn* arity: first element must be param vector".into(),
                         ));
@@ -1350,11 +1321,8 @@ fn lower_fn_arity(
         .map(|p| {
             // Peel a `^hint` wrapper, recording the scalar repr seed; the inner
             // form is then handled as a plain symbol or destructuring pattern.
-            let (repr, p) = if let FormKind::Meta(meta, inner) = &p.kind {
-                (meta_tag_repr(meta), inner.as_ref())
-            } else {
-                (None, p)
-            };
+            let (metas, p) = p.peel_meta();
+            let repr = metas.iter().find_map(|m| meta_tag_repr(m));
             if let FormKind::Symbol(s) = &p.kind {
                 ParamInfo {
                     name: Arc::from(s.as_str()),
@@ -1374,11 +1342,7 @@ fn lower_fn_arity(
     let rest_info: Option<ParamInfo> = rest_param.map(|p| {
         // A rest param binds a seq, so any hint carries no scalar repr; just
         // peel it so the inner symbol/pattern is handled correctly.
-        let p = if let FormKind::Meta(_, inner) = &p.kind {
-            inner.as_ref()
-        } else {
-            p
-        };
+        let p = p.unmeta();
         if let FormKind::Symbol(s) = &p.kind {
             ParamInfo {
                 name: Arc::from(s.as_str()),
@@ -1562,19 +1526,17 @@ fn lower_try(ctx: &mut LowerCtx, args: &[Form]) -> R {
         .collect();
 
     let catch_form = args.iter().find(|f| {
-        if let FormKind::List(p) = &f.kind {
-            matches!(p.first().map(|h| &h.kind), Some(FormKind::Symbol(s)) if s == "catch")
-        } else {
-            false
-        }
+        f.as_list()
+            .and_then(|p| p.first())
+            .and_then(|h| h.as_symbol())
+            == Some("catch")
     });
 
     let finally_form = args.iter().find(|f| {
-        if let FormKind::List(p) = &f.kind {
-            matches!(p.first().map(|h| &h.kind), Some(FormKind::Symbol(s)) if s == "finally")
-        } else {
-            false
-        }
+        f.as_list()
+            .and_then(|p| p.first())
+            .and_then(|h| h.as_symbol())
+            == Some("finally")
     });
 
     let ns = ctx.ns().clone();
@@ -1612,16 +1574,12 @@ fn lower_try(ctx: &mut LowerCtx, args: &[Form]) -> R {
 
     // Catch closure.
     let catch_closure = if let Some(cf) = catch_form {
-        if let FormKind::List(cp) = &cf.kind {
-            let catch_sym = if cp.len() > 2 {
-                if let FormKind::Symbol(s) = &cp[2].kind {
-                    s.clone()
-                } else {
-                    "e".to_string()
-                }
-            } else {
-                "e".to_string()
-            };
+        if let Some(cp) = cf.as_list() {
+            let catch_sym = cp
+                .get(2)
+                .and_then(|f| f.as_symbol())
+                .unwrap_or("e")
+                .to_string();
             let catch_body = if cp.len() > 3 {
                 cp[3..].to_vec()
             } else {
@@ -1667,7 +1625,7 @@ fn lower_try(ctx: &mut LowerCtx, args: &[Form]) -> R {
 
     // Finally closure.
     let finally_closure = if let Some(ff) = finally_form {
-        if let FormKind::List(fp) = &ff.kind {
+        if let Some(fp) = ff.as_list() {
             let fin_body = fp[1..].to_vec();
             let fin_name: Arc<str> =
                 Arc::from(format!("__cljrs_try_finally_{}", fresh_global_name_id()).as_str());
@@ -1729,7 +1687,7 @@ fn lower_binding(ctx: &mut LowerCtx, args: &[Form]) -> R {
             "binding requires a binding vector".into(),
         ));
     }
-    let FormKind::Vector(bindings) = &args[0].kind else {
+    let Some(bindings) = args[0].as_vector() else {
         return Err(LowerError::MalformedSpecialForm(
             "binding bindings must be a vector".into(),
         ));
@@ -1744,8 +1702,7 @@ fn lower_binding(ctx: &mut LowerCtx, args: &[Form]) -> R {
     let mut flat_bindings: Vec<VarId> = Vec::new();
     let mut i = 0;
     while i + 1 < bindings.len() {
-        let var_sym = &bindings[i];
-        let FormKind::Symbol(sym_str) = &var_sym.kind else {
+        let Some(sym_str) = bindings[i].as_symbol() else {
             return Err(LowerError::MalformedSpecialForm(
                 "binding var must be a symbol".into(),
             ));
@@ -1811,7 +1768,7 @@ fn lower_letfn(ctx: &mut LowerCtx, args: &[Form]) -> R {
             "letfn requires bindings and body".into(),
         ));
     }
-    let FormKind::Vector(bindings) = &args[0].kind else {
+    let Some(bindings) = args[0].as_vector() else {
         return Err(LowerError::MalformedSpecialForm(
             "letfn bindings must be a vector".into(),
         ));
@@ -1828,12 +1785,12 @@ fn lower_letfn(ctx: &mut LowerCtx, args: &[Form]) -> R {
     let parsed: Vec<LetfnBinding> = bindings
         .iter()
         .map(|b| {
-            let FormKind::List(parts) = &b.kind else {
+            let Some(parts) = b.as_list() else {
                 return Err(LowerError::MalformedSpecialForm(
                     "letfn binding must be a list".into(),
                 ));
             };
-            let FormKind::Symbol(sym) = &parts[0].kind else {
+            let Some(sym) = parts[0].as_symbol() else {
                 return Err(LowerError::MalformedSpecialForm(
                     "letfn binding name must be a symbol".into(),
                 ));
@@ -1844,7 +1801,7 @@ fn lower_letfn(ctx: &mut LowerCtx, args: &[Form]) -> R {
                 ));
             }
             Ok(LetfnBinding {
-                name: Arc::from(sym.as_str()),
+                name: Arc::from(sym),
                 params: parts[1].clone(),
                 body: parts[2..].to_vec(),
             })
@@ -2038,11 +1995,7 @@ fn lower_or(ctx: &mut LowerCtx, args: &[Form]) -> R {
 // ── Call lowering ─────────────────────────────────────────────────────────────
 
 fn lower_call(ctx: &mut LowerCtx, callee_form: &Form, arg_forms: &[Form]) -> R {
-    let sym_name = if let FormKind::Symbol(s) = &callee_form.kind {
-        Some(s.as_str())
-    } else {
-        None
-    };
+    let sym_name = callee_form.as_symbol();
 
     // Try inline expansions first.
     if let Some(name) = sym_name

--- a/crates/cljrs-reader/README.md
+++ b/crates/cljrs-reader/README.md
@@ -139,6 +139,23 @@ impl Form {
     /// Total heap bytes owned by this form tree, excluding the Form struct itself.
     /// Used by GcSize implementations to accurately track memory pressure.
     pub fn heap_size(&self) -> usize
+
+    // ── Metadata ──
+    /// This form with every `^meta` wrapper removed (stacked metadata included).
+    pub fn unmeta(&self) -> &Form
+    /// The `^meta` forms attached here, outermost first, plus the annotated form.
+    pub fn peel_meta(&self) -> (Vec<&Form>, &Form)
+
+    // ── Structural views ──
+    // Each reports the shape of `unmeta()`, so `^m form` has the same shape as
+    // `form`. Special-form parsers ask these instead of matching `FormKind`
+    // directly, which is what keeps a `^hint` from changing how a form parses.
+    pub fn as_symbol(&self) -> Option<&str>
+    pub fn as_keyword(&self) -> Option<&str>
+    pub fn as_string(&self) -> Option<&str>
+    pub fn as_list(&self) -> Option<&[Form]>
+    pub fn as_vector(&self) -> Option<&[Form]>
+    pub fn as_map(&self) -> Option<&[Form]>
 }
 
 impl FormKind {

--- a/crates/cljrs-reader/src/form.rs
+++ b/crates/cljrs-reader/src/form.rs
@@ -21,6 +21,83 @@ impl Form {
     pub fn heap_size(&self) -> usize {
         mem::size_of::<FormKind>() + self.kind.heap_size()
     }
+
+    /// The annotated form with every `^meta` wrapper removed.
+    ///
+    /// Returns `self` when the form carries no metadata. Stacked metadata
+    /// (`^:a ^:b x`) is peeled down to the innermost form.
+    pub fn unmeta(&self) -> &Form {
+        let mut form = self;
+        while let FormKind::Meta(_, inner) = &form.kind {
+            form = inner;
+        }
+        form
+    }
+
+    /// The `^meta` forms attached to this form, outermost first, together with
+    /// the annotated form itself.
+    pub fn peel_meta(&self) -> (Vec<&Form>, &Form) {
+        let mut metas = Vec::new();
+        let mut form = self;
+        while let FormKind::Meta(meta, inner) = &form.kind {
+            metas.push(meta.as_ref());
+            form = inner;
+        }
+        (metas, form)
+    }
+
+    // ── Structural views ──────────────────────────────────────────────────────
+    //
+    // Every accessor below reports the shape of [`Form::unmeta`], so an
+    // annotated form has the same structural shape as the form it annotates.
+
+    /// The symbol name, if this form is a symbol.
+    pub fn as_symbol(&self) -> Option<&str> {
+        match &self.unmeta().kind {
+            FormKind::Symbol(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// The keyword name (without the leading `:`), if this form is a keyword.
+    pub fn as_keyword(&self) -> Option<&str> {
+        match &self.unmeta().kind {
+            FormKind::Keyword(k) => Some(k),
+            _ => None,
+        }
+    }
+
+    /// The string contents, if this form is a string literal.
+    pub fn as_string(&self) -> Option<&str> {
+        match &self.unmeta().kind {
+            FormKind::Str(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// The elements, if this form is a list.
+    pub fn as_list(&self) -> Option<&[Form]> {
+        match &self.unmeta().kind {
+            FormKind::List(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// The elements, if this form is a vector.
+    pub fn as_vector(&self) -> Option<&[Form]> {
+        match &self.unmeta().kind {
+            FormKind::Vector(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// The flat key/value pairs, if this form is a map literal.
+    pub fn as_map(&self) -> Option<&[Form]> {
+        match &self.unmeta().kind {
+            FormKind::Map(v) => Some(v),
+            _ => None,
+        }
+    }
 }
 
 impl FormKind {

--- a/crates/cljrs-runtime/src/interp/eval.rs
+++ b/crates/cljrs-runtime/src/interp/eval.rs
@@ -194,7 +194,7 @@ fn eval_list(forms: &[Form], env: &mut Env) -> EvalResult {
     };
 
     // Check for special form.
-    if let FormKind::Symbol(s) = &forms[0].kind
+    if let Some(s) = forms[0].as_symbol()
         && is_special_form(s)
     {
         return eval_special(s, &forms[1..], env);

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -197,12 +197,9 @@ fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
     let mut is_async = false;
     let peeled: Vec<Form>;
     let args: &[Form] = if matches!(args.first().map(|f| &f.kind), Some(FormKind::Meta(..))) {
-        let mut head = args[0].clone();
-        while let FormKind::Meta(meta, inner) = head.kind {
-            is_async |= meta_form_is_async(&meta);
-            head = *inner;
-        }
-        peeled = std::iter::once(head)
+        let (metas, head) = args[0].peel_meta();
+        is_async |= metas.iter().any(|m| meta_form_is_async(m));
+        peeled = std::iter::once(head.clone())
             .chain(args[1..].iter().cloned())
             .collect();
         &peeled
@@ -226,7 +223,9 @@ fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
         return Err(EvalError::Runtime("fn* requires params and body".into()));
     }
 
-    let arities = match &rest[0].kind {
+    // A `^hint` on the params vector or on an arity clause is advisory — the
+    // structural shape is the form underneath it.
+    let arities = match &rest[0].unmeta().kind {
         FormKind::Vector(_) => {
             // Single arity: (fn* [params] body...)
             vec![parse_arity(&rest[0], &rest[1..])?]
@@ -235,7 +234,7 @@ fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
             // Multi-arity: (fn* ([params] body...) ...)
             rest.iter()
                 .map(|arity_form| {
-                    if let FormKind::List(forms) = &arity_form.kind {
+                    if let Some(forms) = arity_form.as_list() {
                         if forms.is_empty() {
                             return Err(EvalError::Runtime("arity clause requires params".into()));
                         }
@@ -284,13 +283,10 @@ fn eval_fn(args: &[Form], env: &mut Env) -> EvalResult {
 
 /// Parse one arity: params-form and body forms.
 pub fn parse_arity(params_form: &Form, body: &[Form]) -> EvalResult<CljxFnArity> {
-    let param_forms = match &params_form.kind {
-        FormKind::Vector(v) => v,
-        _ => {
-            return Err(EvalError::Runtime(
-                "fn arity params must be a vector".into(),
-            ));
-        }
+    let Some(param_forms) = params_form.as_vector() else {
+        return Err(EvalError::Runtime(
+            "fn arity params must be a vector".into(),
+        ));
     };
 
     let mut params: Vec<Arc<str>> = Vec::new();
@@ -383,9 +379,9 @@ fn desugar_pre_post_conditions(body: &[Form]) -> Vec<Form> {
         None => return body.to_vec(),
     };
 
-    let entries = match &first.kind {
-        FormKind::Map(entries) => entries,
-        _ => return body.to_vec(),
+    let entries = match first.as_map() {
+        Some(entries) => entries,
+        None => return body.to_vec(),
     };
 
     let mut pre_conds: Vec<Form> = Vec::new();
@@ -541,11 +537,11 @@ fn eval_if(args: &[Form], env: &mut Env) -> EvalResult {
 // ── let* ──────────────────────────────────────────────────────────────────────
 
 fn eval_let(args: &[Form], env: &mut Env) -> EvalResult {
-    let bindings = match args.first().map(|f| &f.kind) {
-        Some(FormKind::Vector(v)) => expand_pairs(v)
+    let bindings = match args.first().and_then(|f| f.as_vector()) {
+        Some(v) => expand_pairs(v)
             .map_err(|_| EvalError::Runtime("let* binding vector must have even length".into()))?
             .into_owned(),
-        _ => return Err(EvalError::Runtime("let* requires a binding vector".into())),
+        None => return Err(EvalError::Runtime("let* requires a binding vector".into())),
     };
 
     let body = &args[1..];
@@ -733,11 +729,11 @@ fn eval_chain_normally(
 // ── loop* / recur ─────────────────────────────────────────────────────────────
 
 pub fn eval_loop(args: &[Form], env: &mut Env) -> EvalResult {
-    let bindings = match args.first().map(|f| &f.kind) {
-        Some(FormKind::Vector(v)) => expand_pairs(v)
+    let bindings = match args.first().and_then(|f| f.as_vector()) {
+        Some(v) => expand_pairs(v)
             .map_err(|_| EvalError::Runtime("loop* binding vector must have even length".into()))?
             .into_owned(),
-        _ => return Err(EvalError::Runtime("loop* requires a binding vector".into())),
+        None => return Err(EvalError::Runtime("loop* requires a binding vector".into())),
     };
 
     let body = &args[1..];
@@ -1034,6 +1030,11 @@ fn eval_try(args: &[Form], env: &mut Env) -> EvalResult {
     result
 }
 
+/// The class name or `:default` keyword naming what a `catch` clause catches.
+fn catch_target(f: &Form) -> Option<&str> {
+    f.as_symbol().or_else(|| f.as_keyword())
+}
+
 /// Split try args into (body, catch clauses, finally body).
 ///
 /// Public so the async evaluator can parse `try` forms identically.
@@ -1043,8 +1044,8 @@ pub fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form])
     let mut fin_body: &[Form] = &[];
 
     for (i, form) in args.iter().enumerate() {
-        if let FormKind::List(parts) = &form.kind
-            && let Some(FormKind::Symbol(s)) = parts.first().map(|f| &f.kind)
+        if let Some(parts) = form.as_list()
+            && let Some(s) = parts.first().and_then(|f| f.as_symbol())
         {
             if s == "catch" {
                 if i < body_end {
@@ -1054,22 +1055,25 @@ pub fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form])
                 // the ClojureScript `:default` catch-all keyword, or a reader
                 // conditional `#?(:rust Exception :clj ...)` whose selected branch
                 // resolves to one of those.
-                let type_sym = match parts.get(1).map(|f| &f.kind) {
-                    Some(FormKind::Symbol(s)) => s.as_str(),
-                    Some(FormKind::Keyword(s)) => s.as_str(),
-                    Some(FormKind::ReaderCond {
-                        splicing: false,
-                        clauses,
-                    }) => match select_reader_cond(clauses).map(|f| &f.kind) {
-                        Some(FormKind::Symbol(s)) => s.as_str(),
-                        Some(FormKind::Keyword(s)) => s.as_str(),
-                        _ => continue,
+                let type_sym = match parts.get(1) {
+                    Some(f) => match catch_target(f) {
+                        Some(name) => name,
+                        None => match &f.unmeta().kind {
+                            FormKind::ReaderCond {
+                                splicing: false,
+                                clauses,
+                            } => match select_reader_cond(clauses).and_then(catch_target) {
+                                Some(name) => name,
+                                None => continue,
+                            },
+                            _ => continue,
+                        },
                     },
-                    _ => continue,
+                    None => continue,
                 };
-                let binding = match parts.get(2).map(|f| &f.kind) {
-                    Some(FormKind::Symbol(s)) => s.as_str(),
-                    _ => continue,
+                let binding = match parts.get(2).and_then(|f| f.as_symbol()) {
+                    Some(s) => s,
+                    None => continue,
                 };
                 catches.push(CatchClause {
                     type_sym,
@@ -1095,13 +1099,13 @@ pub fn parse_try_args(args: &[Form]) -> (&[Form], Vec<CatchClause<'_>>, &[Form])
 
 pub fn eval_defn(args: &[Form], env: &mut Env) -> EvalResult {
     // The name may carry reader metadata, e.g. `(defn ^:async fetch ...)`.
-    let (name, mut is_async) = match args.first().map(|f| &f.kind) {
-        Some(FormKind::Symbol(s)) => (s.clone(), false),
-        Some(FormKind::Meta(meta, inner)) => match &inner.kind {
-            FormKind::Symbol(s) => (s.clone(), meta_form_is_async(meta)),
-            _ => return Err(EvalError::Runtime("defn name must be a symbol".into())),
-        },
-        _ => return Err(EvalError::Runtime("defn requires a symbol name".into())),
+    let name_form = args
+        .first()
+        .ok_or_else(|| EvalError::Runtime("defn requires a symbol name".into()))?;
+    let (name_metas, name_sym) = name_form.peel_meta();
+    let (name, mut is_async) = match &name_sym.kind {
+        FormKind::Symbol(s) => (s.clone(), name_metas.iter().any(|m| meta_form_is_async(m))),
+        _ => return Err(EvalError::Runtime("defn name must be a symbol".into())),
     };
     // Optional docstring and/or metadata map after the name.
     // Valid orderings: (defn name body...), (defn name "doc" body...),
@@ -1109,13 +1113,13 @@ pub fn eval_defn(args: &[Form], env: &mut Env) -> EvalResult {
     let mut rest_start = 1;
     let mut docstring: Option<String> = None;
     if rest_start < args.len()
-        && let FormKind::Str(s) = &args[rest_start].kind
+        && let Some(s) = args[rest_start].as_string()
     {
-        docstring = Some(s.clone());
+        docstring = Some(s.to_string());
         rest_start += 1;
     }
     let mut attr_meta: Option<Value> = None;
-    if rest_start < args.len() && matches!(args[rest_start].kind, FormKind::Map(_)) {
+    if rest_start < args.len() && args[rest_start].as_map().is_some() {
         // An attr-map such as `{:async true}` can also request async dispatch.
         is_async |= meta_form_is_async(&args[rest_start]);
         attr_meta = Some(eval(&args[rest_start], env)?);
@@ -1158,7 +1162,7 @@ pub fn eval_defn(args: &[Form], env: &mut Env) -> EvalResult {
 /// - Multi-arity clause list `([params...] body...)` → `([&form &env params...] body...)`
 fn prepend_macro_params(form: &Form) -> Form {
     let span = form.span.clone();
-    match &form.kind {
+    match &form.unmeta().kind {
         FormKind::Vector(params) => {
             let mut new_params = vec![
                 Form::new(FormKind::Symbol("&form".to_string()), span.clone()),
@@ -1701,15 +1705,15 @@ fn eval_load_file(args: &[Form], env: &mut Env) -> EvalResult {
 
 fn eval_letfn(args: &[Form], env: &mut Env) -> EvalResult {
     // (letfn [(f [params] body...) ...] body...)
-    let bindings = match args.first().map(|f| &f.kind) {
-        Some(FormKind::Vector(v)) => expand_reader_conds_cow(v).into_owned(),
-        _ => return Err(EvalError::Runtime("letfn requires a binding vector".into())),
+    let bindings = match args.first().and_then(|f| f.as_vector()) {
+        Some(v) => expand_reader_conds_cow(v).into_owned(),
+        None => return Err(EvalError::Runtime("letfn requires a binding vector".into())),
     };
 
     env.push_frame();
 
     for binding in &bindings {
-        if let FormKind::List(parts) = &binding.kind {
+        if let Some(parts) = binding.as_list() {
             if parts.is_empty() {
                 continue;
             }
@@ -1723,16 +1727,13 @@ fn eval_letfn(args: &[Form], env: &mut Env) -> EvalResult {
                     return Err(e);
                 }
             };
-            let name = match &parts[0].kind {
-                FormKind::Symbol(s) => s.clone(),
-                _ => {
-                    env.pop_frame();
-                    return Err(EvalError::Runtime(
-                        "letfn binding name must be a symbol".into(),
-                    ));
-                }
+            let Some(name) = parts[0].as_symbol() else {
+                env.pop_frame();
+                return Err(EvalError::Runtime(
+                    "letfn binding name must be a symbol".into(),
+                ));
             };
-            env.bind(Arc::from(name.as_str()), fn_val);
+            env.bind(Arc::from(name), fn_val);
         }
     }
 
@@ -1804,7 +1805,7 @@ fn eval_defprotocol(args: &[Form], env: &mut Env) -> EvalResult {
     let proto_name: Arc<str> = Arc::from(name);
 
     // Skip optional docstring.
-    let methods_start = if args.len() > 1 && matches!(args[1].kind, FormKind::Str(_)) {
+    let methods_start = if args.len() > 1 && args[1].as_string().is_some() {
         2
     } else {
         1
@@ -1818,10 +1819,12 @@ fn eval_defprotocol(args: &[Form], env: &mut Env) -> EvalResult {
     while i < rest.len() {
         // Protocol options are flat `:keyword value` pairs interspersed
         // among the method signatures, e.g. `:extend-via-metadata true`.
-        if let FormKind::Keyword(kw) = &rest[i].kind {
+        if let Some(kw) = rest[i].as_keyword() {
             if kw == "extend-via-metadata" {
-                extend_via_metadata =
-                    matches!(rest.get(i + 1).map(|f| &f.kind), Some(FormKind::Bool(true)));
+                extend_via_metadata = matches!(
+                    rest.get(i + 1).map(|f| &f.unmeta().kind),
+                    Some(FormKind::Bool(true))
+                );
             }
             i += 2;
             continue;
@@ -1829,35 +1832,26 @@ fn eval_defprotocol(args: &[Form], env: &mut Env) -> EvalResult {
         let form = &rest[i];
         i += 1;
         // Each method spec is (method-name [params...] "doc"?)
-        let parts = match &form.kind {
-            FormKind::List(parts) => parts,
-            _ => continue, // skip unknown forms
+        let parts = match form.as_list() {
+            Some(parts) => parts,
+            None => continue, // skip unknown forms
         };
         if parts.is_empty() {
             continue;
         }
-        let method_name = match &parts[0].kind {
-            FormKind::Symbol(s) => Arc::from(s.as_str()),
-            _ => continue,
+        let method_name: Arc<str> = match parts[0].as_symbol() {
+            Some(s) => Arc::from(s),
+            None => continue,
         };
         // Find the parameter vector (first vector in parts).
-        let (min_arity, variadic) = if let Some(params_form) =
-            parts.iter().find(|f| matches!(f.kind, FormKind::Vector(_)))
-        {
-            if let FormKind::Vector(param_forms) = &params_form.kind {
-                let variadic = param_forms
-                    .iter()
-                    .any(|p| matches!(&p.kind, FormKind::Symbol(s) if s == "&"));
-                let fixed: usize = param_forms
-                    .iter()
-                    .filter(|p| !matches!(&p.kind, FormKind::Symbol(s) if s == "&"))
-                    .count();
+        let (min_arity, variadic) = match parts.iter().find_map(|f| f.as_vector()) {
+            Some(param_forms) => {
+                let is_amp = |p: &Form| p.as_symbol() == Some("&");
+                let variadic = param_forms.iter().any(is_amp);
+                let fixed = param_forms.iter().filter(|p| !is_amp(p)).count();
                 (fixed, variadic)
-            } else {
-                (1, false)
             }
-        } else {
-            (1, false)
+            None => (1, false),
         };
         methods.push(ProtocolMethod {
             name: method_name,
@@ -1904,20 +1898,17 @@ fn eval_extend_type(args: &[Form], env: &mut Env) -> EvalResult {
             "extend-type requires a type symbol".into(),
         ));
     }
-    let type_sym = match &args[0].kind {
-        FormKind::Symbol(s) => s.clone(),
-        _ => {
-            return Err(EvalError::Runtime(
-                "extend-type: first arg must be a type symbol".into(),
-            ));
-        }
+    let Some(type_sym) = args[0].as_symbol() else {
+        return Err(EvalError::Runtime(
+            "extend-type: first arg must be a type symbol".into(),
+        ));
     };
     let type_tag = crate::interp::apply::resolve_type_tag(&type_sym);
 
     let mut current_proto: Option<GcPtr<Protocol>> = None;
 
     for form in &args[1..] {
-        match &form.kind {
+        match &form.unmeta().kind {
             FormKind::Symbol(s) => {
                 // Look up protocol in env.
                 let val = env.globals.lookup_in_ns(&env.current_ns, s);
@@ -1941,9 +1932,9 @@ fn eval_extend_type(args: &[Form], env: &mut Env) -> EvalResult {
                 if parts.is_empty() {
                     continue;
                 }
-                let method_name = match &parts[0].kind {
-                    FormKind::Symbol(s) => Arc::from(s.as_str()),
-                    _ => continue,
+                let method_name: Arc<str> = match parts[0].as_symbol() {
+                    Some(s) => Arc::from(s),
+                    None => continue,
                 };
                 let fn_val = build_impl_fn(parts, env)?;
                 let mut impls = proto.get().impls.lock().unwrap();
@@ -1970,15 +1961,12 @@ fn eval_extend_protocol(args: &[Form], env: &mut Env) -> EvalResult {
             "extend-protocol requires a protocol".into(),
         ));
     }
-    let proto_sym = match &args[0].kind {
-        FormKind::Symbol(s) => s.clone(),
-        _ => {
-            return Err(EvalError::Runtime(
-                "extend-protocol: first arg must be a protocol symbol".into(),
-            ));
-        }
+    let Some(proto_sym) = args[0].as_symbol() else {
+        return Err(EvalError::Runtime(
+            "extend-protocol: first arg must be a protocol symbol".into(),
+        ));
     };
-    let proto_val = env.globals.lookup_in_ns(&env.current_ns, &proto_sym);
+    let proto_val = env.globals.lookup_in_ns(&env.current_ns, proto_sym);
     let proto_ptr = match proto_val {
         Some(Value::Protocol(p)) => p,
         _ => {
@@ -1992,7 +1980,7 @@ fn eval_extend_protocol(args: &[Form], env: &mut Env) -> EvalResult {
     let mut current_type: Option<Arc<str>> = None;
 
     for form in &args[1..] {
-        match &form.kind {
+        match &form.unmeta().kind {
             FormKind::Symbol(s) => {
                 current_type = Some(crate::interp::apply::resolve_type_tag(s));
             }
@@ -2003,9 +1991,9 @@ fn eval_extend_protocol(args: &[Form], env: &mut Env) -> EvalResult {
                 if parts.is_empty() {
                     continue;
                 }
-                let method_name = match &parts[0].kind {
-                    FormKind::Symbol(s) => Arc::from(s.as_str()),
-                    _ => continue,
+                let method_name: Arc<str> = match parts[0].as_symbol() {
+                    Some(s) => Arc::from(s),
+                    None => continue,
                 };
                 let fn_val = build_impl_fn(parts, env)?;
                 let mut impls = proto_ptr.get().impls.lock().unwrap();
@@ -2038,10 +2026,7 @@ fn build_impl_fn(parts: &[Form], env: &mut Env) -> EvalResult<Value> {
     let body = &parts[2..];
     let arity = parse_arity(params_form, body)?;
     let (closed_over_names, closed_over_vals) = env.all_local_bindings();
-    let fn_name = match &parts[0].kind {
-        FormKind::Symbol(s) => Some(Arc::from(s.as_str())),
-        _ => None,
-    };
+    let fn_name: Option<Arc<str>> = parts[0].as_symbol().map(Arc::from);
     let cljrs_fn = CljxFn::new(
         fn_name,
         vec![arity],
@@ -2060,7 +2045,7 @@ fn eval_defmulti(args: &[Form], env: &mut Env) -> EvalResult {
     let name = require_sym(args, 0, "defmulti")?;
     let name_arc: Arc<str> = Arc::from(name);
 
-    let rest_start = if args.len() > 2 && matches!(args[1].kind, FormKind::Str(_)) {
+    let rest_start = if args.len() > 2 && args[1].as_string().is_some() {
         2
     } else {
         1
@@ -2142,20 +2127,19 @@ fn eval_defmethod(args: &[Form], env: &mut Env) -> EvalResult {
 // ── binding ───────────────────────────────────────────────────────────────────
 
 fn eval_binding(args: &[Form], env: &mut Env) -> EvalResult {
-    let pairs = match args.first().map(|f| &f.kind) {
-        Some(FormKind::Vector(v)) => expand_pairs(v)
+    let pairs = match args.first().and_then(|f| f.as_vector()) {
+        Some(v) => expand_pairs(v)
             .map_err(|_| EvalError::Runtime("binding vector must have even count".into()))?
             .into_owned(),
-        _ => return Err(EvalError::Runtime("binding requires a vector".into())),
+        None => return Err(EvalError::Runtime("binding requires a vector".into())),
     };
 
     let mut frame: HashMap<usize, Value> = HashMap::new();
     for pair in pairs.chunks(2) {
-        let sym_str = match &pair[0].kind {
-            FormKind::Symbol(s) => s.clone(),
-            _ => return Err(EvalError::Runtime("binding targets must be symbols".into())),
+        let Some(sym_str) = pair[0].as_symbol() else {
+            return Err(EvalError::Runtime("binding targets must be symbols".into()));
         };
-        let parsed = cljrs_value::Symbol::parse(&sym_str);
+        let parsed = cljrs_value::Symbol::parse(sym_str);
         let ns_part: Arc<str> = match parsed.namespace.as_deref() {
             // Resolve `alias/*var*` through the current ns's `:require :as`
             // aliases, same as ordinary qualified-symbol lookup (`eval_symbol`)
@@ -2169,7 +2153,7 @@ fn eval_binding(args: &[Form], env: &mut Env) -> EvalResult {
         let var_ptr = env
             .globals
             .lookup_var_in_ns(&ns_part, &parsed.name)
-            .ok_or_else(|| EvalError::UnboundSymbol(sym_str.clone()))?;
+            .ok_or_else(|| EvalError::UnboundSymbol(sym_str.to_string()))?;
         let val = eval(&pair[1], env)?;
         frame.insert(crate::env::dynamics::var_key_of(&var_ptr), val);
     }
@@ -2192,22 +2176,19 @@ fn eval_defrecord(args: &[Form], env: &mut Env) -> EvalResult {
     let type_tag: Arc<str> = Arc::from(type_name);
 
     // Parse field names from the vector.
-    let field_names: Vec<Arc<str>> = match &args[1].kind {
-        FormKind::Vector(fields) => fields
-            .iter()
-            .map(|f| match &f.kind {
-                FormKind::Symbol(s) => Ok(Arc::from(s.as_str())),
-                _ => Err(EvalError::Runtime(
-                    "defrecord field names must be symbols".into(),
-                )),
-            })
-            .collect::<EvalResult<_>>()?,
-        _ => {
-            return Err(EvalError::Runtime(
-                "defrecord requires a field vector as second arg".into(),
-            ));
-        }
+    let Some(fields) = args[1].as_vector() else {
+        return Err(EvalError::Runtime(
+            "defrecord requires a field vector as second arg".into(),
+        ));
     };
+    let field_names: Vec<Arc<str>> = fields
+        .iter()
+        .map(|f| {
+            f.as_symbol()
+                .map(Arc::from)
+                .ok_or_else(|| EvalError::Runtime("defrecord field names must be symbols".into()))
+        })
+        .collect::<EvalResult<_>>()?;
 
     // Register protocol implementations (same as extend-type inner logic).
     register_impls_for_tag(&type_tag, &args[2..], env)?;
@@ -2338,7 +2319,7 @@ fn register_impls_for_tag(type_tag: &Arc<str>, forms: &[Form], env: &mut Env) ->
     let mut current_proto: Option<GcPtr<cljrs_value::Protocol>> = None;
 
     for form in forms {
-        match &form.kind {
+        match &form.unmeta().kind {
             FormKind::Symbol(s) => {
                 let val = env.globals.lookup_in_ns(&env.current_ns, s);
                 match val {
@@ -2360,9 +2341,9 @@ fn register_impls_for_tag(type_tag: &Arc<str>, forms: &[Form], env: &mut Env) ->
                 if parts.is_empty() {
                     continue;
                 }
-                let method_name = match &parts[0].kind {
-                    FormKind::Symbol(s) => Arc::from(s.as_str()),
-                    _ => continue,
+                let method_name: Arc<str> = match parts[0].as_symbol() {
+                    Some(s) => Arc::from(s),
+                    None => continue,
                 };
                 let fn_val = build_impl_fn(parts, env)?;
                 let mut impls = proto.get().impls.lock().unwrap();
@@ -2391,12 +2372,9 @@ pub fn sync_star_ns(env: &mut Env) {
 }
 
 fn require_sym<'a>(args: &'a [Form], idx: usize, form_name: &str) -> EvalResult<&'a str> {
-    match args.get(idx).map(|f| &f.kind) {
-        Some(FormKind::Symbol(s)) => Ok(s.as_str()),
-        _ => Err(EvalError::Runtime(format!(
-            "{form_name} requires a symbol at position {idx}"
-        ))),
-    }
+    args.get(idx).and_then(|f| f.as_symbol()).ok_or_else(|| {
+        EvalError::Runtime(format!("{form_name} requires a symbol at position {idx}"))
+    })
 }
 
 // ── with-out-str ──────────────────────────────────────────────────────────────

--- a/crates/cljrs-runtime/tests/meta_transparency.rs
+++ b/crates/cljrs-runtime/tests/meta_transparency.rs
@@ -1,0 +1,181 @@
+//! Property oracle: for every special form, evaluating `^meta F` agrees with
+//! evaluating `F`.
+//!
+//! Reader metadata is advisory for structural dispatch — a `^hint` in front of
+//! a params vector, a field vector, a binding vector, a name symbol or an arity
+//! clause must not change how the form is parsed.
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .eager_clojure_test(true)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Result<Value, String> {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, &mut env)
+            .map_err(|e| format!("eval: {e:?}"))?;
+    }
+    Ok(result)
+}
+
+/// Every annotation that must be structurally transparent.
+const ANNOTATIONS: &[&str] = &["^:marker ", "^String ", "^{:doc \"d\"} "];
+
+/// `template` contains one `{}` placeholder marking an annotation site.
+fn assert_meta_transparent(template: &str) {
+    let bare = template.replace("{}", "");
+    let expected = eval_fresh(&bare).unwrap_or_else(|e| panic!("bare form failed: {bare}\n{e}"));
+
+    for ann in ANNOTATIONS {
+        let annotated = template.replace("{}", ann);
+        let got = eval_fresh(&annotated)
+            .unwrap_or_else(|e| panic!("annotated form failed: {annotated}\n{e}"));
+        assert_eq!(
+            got, expected,
+            "`{annotated}` disagreed with `{bare}` (annotation `{ann}`)"
+        );
+    }
+}
+
+#[test]
+fn def_name() {
+    assert_meta_transparent("(def {}x 41) (inc x)");
+}
+
+#[test]
+fn defn_name() {
+    assert_meta_transparent("(defn {}f [a] (inc a)) (f 41)");
+}
+
+#[test]
+fn defn_params_vector() {
+    // `(defn f ^String [s] s)` — green on the JVM, previously rejected here
+    // with "fn* expects vector or arity clauses".
+    assert_meta_transparent("(defn f {}[a] (inc a)) (f 41)");
+}
+
+#[test]
+fn defn_docstring_and_body() {
+    assert_meta_transparent("(defn f \"doc\" {}[a] (inc a)) (f 41)");
+}
+
+#[test]
+fn fn_params_vector() {
+    assert_meta_transparent("((fn {}[a] (inc a)) 41)");
+}
+
+#[test]
+fn fn_arity_clause() {
+    assert_meta_transparent("((fn {}([a] (inc a)) ([a b] b)) 41)");
+}
+
+#[test]
+fn fn_param_symbol() {
+    assert_meta_transparent("((fn [{}a] (inc a)) 41)");
+}
+
+#[test]
+fn let_binding_vector() {
+    assert_meta_transparent("(let {}[a 42] a)");
+}
+
+#[test]
+fn loop_binding_vector() {
+    assert_meta_transparent("(loop {}[a 0] (if (< a 42) (recur (inc a)) a))");
+}
+
+#[test]
+fn letfn_binding_vector() {
+    assert_meta_transparent("(letfn {}[(g [x] (inc x))] (g 41))");
+}
+
+#[test]
+fn letfn_binding_name() {
+    assert_meta_transparent("(letfn [({}g [x] (inc x))] (g 41))");
+}
+
+#[test]
+fn binding_vector() {
+    assert_meta_transparent("(def ^:dynamic *v* 1) (binding {}[*v* 42] *v*)");
+}
+
+#[test]
+fn defrecord_field() {
+    // `(defrecord R [^String x])` — the reported repro.
+    assert_meta_transparent("(defrecord R [{}x]) (:x (->R 42))");
+}
+
+#[test]
+fn defrecord_name_and_field_vector() {
+    assert_meta_transparent("(defrecord {}R [x]) (:x (->R 42))");
+    assert_meta_transparent("(defrecord R {}[x]) (:x (->R 42))");
+}
+
+#[test]
+fn defmulti_and_defmethod() {
+    assert_meta_transparent("(defmulti {}m identity) (defmethod m 1 [_] 42) (m 1)");
+    assert_meta_transparent("(defmulti m identity) (defmethod m 1 {}[_] 42) (m 1)");
+}
+
+#[test]
+fn defprotocol_and_extend_type() {
+    assert_meta_transparent(
+        "(defprotocol {}P (pm [this])) (defrecord R [x]) \
+         (extend-type R P (pm [this] (:x this))) (pm (->R 42))",
+    );
+    assert_meta_transparent(
+        "(defprotocol P (pm [this])) (defrecord R [x]) \
+         (extend-type {}R P (pm [this] (:x this))) (pm (->R 42))",
+    );
+    assert_meta_transparent(
+        "(defprotocol P (pm [this])) (defrecord R [x]) \
+         (extend-type R P ({}pm [this] (:x this))) (pm (->R 42))",
+    );
+}
+
+#[test]
+fn extend_protocol() {
+    assert_meta_transparent(
+        "(defprotocol P (pm [this])) (defrecord R [x]) \
+         (extend-protocol {}P R (pm [this] (:x this))) (pm (->R 42))",
+    );
+}
+
+#[test]
+fn defrecord_inline_impl() {
+    assert_meta_transparent(
+        "(defprotocol P (pm [this])) (defrecord R [x] {}P (pm [this] (:x this))) \
+         (pm (->R 42))",
+    );
+}
+
+#[test]
+fn reify_impl() {
+    assert_meta_transparent("(defprotocol P (pm [this])) (pm (reify {}P (pm [this] 42)))");
+}
+
+#[test]
+fn defmacro_params_vector() {
+    assert_meta_transparent("(defmacro m {}[a] `(inc ~a)) (m 41)");
+}
+
+#[test]
+fn pre_post_conditions() {
+    assert_meta_transparent("(defn f [a] {}{:pre [(pos? a)]} (inc a)) (f 41)");
+}


### PR DESCRIPTION
## What

`^m form` now has the structural shape of `form`. `Form` gains `unmeta` /
`peel_meta` plus `as_symbol` / `as_keyword` / `as_string` / `as_list` /
`as_vector` / `as_map` views that report the shape underneath any annotation,
and the interpreter's special forms and the IR lowerer ask those instead of
matching `FormKind` directly.

## Why

An annotation is metadata, not a change of shape — but every site that matched
`FormKind::Vector(..)` directly disagreed. `(defrecord R [^String x])` and
`(defn f ^String [s] s)` failed to parse, both of which are ordinary JVM
Clojure.

## Evidence

`crates/cljrs-runtime/tests/meta_transparency.rs`: each special form asserted
equal with and without an annotation at every structural site.

---

**Ported, not cherry-picked.** The original work predates the four-crate
consolidation into `cljrs-runtime`, and `main` has since added
reader-conditional/pair expansion (`expand_pairs`, `expand_reader_conds_cow`)
inside the very matches this changes. Each of those keeps `main`'s expansion and
only swaps the match for the structural view. One hunk of the original is
dropped entirely: `main`'s own fix for stacked metadata at a `def` name
supersedes it, so `extract_def_name` is left as `main` has it.

Base of a five-PR stack: #344 → #345 → #346 → #347 → #348. Each is cut against `main`, so until this one merges the later PRs' diffs include the commits below them. Merging in that order keeps every diff minimal.
