### PR TITLE
Fix primitive array GC tracing

### DIFF
--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -1303,14 +1303,14 @@ impl cljrs_gc::Trace for Value {
             Value::Agent(p) => visitor.visit(p),
             Value::TypeInstance(p) => visitor.visit(p),
             Value::ObjectArray(p) => visitor.visit(p),
-            Value::BooleanArray(_)
-            | Value::ByteArray(_)
-            | Value::ShortArray(_)
-            | Value::IntArray(_)
-            | Value::LongArray(_)
-            | Value::FloatArray(_)
-            | Value::DoubleArray(_)
-            | Value::CharArray(_) => {}
+            Value::BooleanArray(p) => visitor.visit(p),
+            Value::ByteArray(p) => visitor.visit(p),
+            Value::ShortArray(p) => visitor.visit(p),
+            Value::IntArray(p) => visitor.visit(p),
+            Value::LongArray(p) => visitor.visit(p),
+            Value::FloatArray(p) => visitor.visit(p),
+            Value::DoubleArray(p) => visitor.visit(p),
+            Value::CharArray(p) => visitor.visit(p),
             Value::NativeObject(p) => visitor.visit(p),
             // Resource, SharedAtom, and ByteBlob are Arc-ref-counted outside the
             // GC heap — nothing to trace through the GC visitor.

--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -1303,6 +1303,8 @@ impl cljrs_gc::Trace for Value {
             Value::Agent(p) => visitor.visit(p),
             Value::TypeInstance(p) => visitor.visit(p),
             Value::ObjectArray(p) => visitor.visit(p),
+            // Primitive arrays have no child Values, but their boxes live on
+            // the GC heap and must themselves be marked.
             Value::BooleanArray(p) => visitor.visit(p),
             Value::ByteArray(p) => visitor.visit(p),
             Value::ShortArray(p) => visitor.visit(p),

--- a/crates/cljrs-value/tests/primitive_array_gc.rs
+++ b/crates/cljrs-value/tests/primitive_array_gc.rs
@@ -7,6 +7,7 @@ use cljrs_value::{PersistentVector, Value};
 
 #[test]
 fn primitive_arrays_reachable_through_a_collection_are_traced() {
+    let _frame = cljrs_gc::push_alloc_frame();
     let heap = GcHeap::new();
     let arrays = [
         Value::BooleanArray(heap.alloc(Mutex::new(vec![true]))),
@@ -20,11 +21,13 @@ fn primitive_arrays_reachable_through_a_collection_are_traced() {
     ];
     let root = heap.alloc(PersistentVector::from_iter(arrays));
 
-    assert_eq!(heap.count(), 9);
+    // This sibling allocation is not stored in the vector. It must be swept,
+    // proving that the collections below reached the free path even if the GC
+    // grace period changes.
+    let _unreachable = Value::DoubleArray(heap.alloc(Mutex::new(vec![7.0])));
 
-    // Unreachable allocations have one collection cycle of grace. Keeping the
-    // vector rooted across two cycles must also keep all array boxes reachable
-    // from its Values.
+    assert_eq!(heap.count(), 10);
+
     for _ in 0..2 {
         heap.collect(|visitor| visitor.visit(&root));
     }
@@ -32,6 +35,41 @@ fn primitive_arrays_reachable_through_a_collection_are_traced() {
     assert_eq!(
         heap.count(),
         9,
-        "the rooted vector and all eight primitive-array boxes must survive"
+        "the rooted vector and all eight primitive-array boxes must survive, \
+         while the unreachable array box must not"
     );
+
+    let vector = root.get();
+    assert_eq!(vector.count(), 8);
+    match (
+        vector.nth(0),
+        vector.nth(1),
+        vector.nth(2),
+        vector.nth(3),
+        vector.nth(4),
+        vector.nth(5),
+        vector.nth(6),
+        vector.nth(7),
+    ) {
+        (
+            Some(Value::BooleanArray(boolean)),
+            Some(Value::ByteArray(byte)),
+            Some(Value::ShortArray(short)),
+            Some(Value::IntArray(int)),
+            Some(Value::LongArray(long)),
+            Some(Value::FloatArray(float)),
+            Some(Value::DoubleArray(double)),
+            Some(Value::CharArray(character)),
+        ) => {
+            assert_eq!(*boolean.get().lock().unwrap(), vec![true]);
+            assert_eq!(*byte.get().lock().unwrap(), vec![1]);
+            assert_eq!(*short.get().lock().unwrap(), vec![2]);
+            assert_eq!(*int.get().lock().unwrap(), vec![3]);
+            assert_eq!(*long.get().lock().unwrap(), vec![4]);
+            assert_eq!(*float.get().lock().unwrap(), vec![5.0]);
+            assert_eq!(*double.get().lock().unwrap(), vec![6.0]);
+            assert_eq!(*character.get().lock().unwrap(), vec!['x']);
+        }
+        other => panic!("unexpected primitive-array values: {other:?}"),
+    }
 }

--- a/crates/cljrs-value/tests/primitive_array_gc.rs
+++ b/crates/cljrs-value/tests/primitive_array_gc.rs
@@ -1,0 +1,37 @@
+#![cfg(not(feature = "no-gc"))]
+
+use std::sync::Mutex;
+
+use cljrs_gc::{GcHeap, GcVisitor as _};
+use cljrs_value::{PersistentVector, Value};
+
+#[test]
+fn primitive_arrays_reachable_through_a_collection_are_traced() {
+    let heap = GcHeap::new();
+    let arrays = [
+        Value::BooleanArray(heap.alloc(Mutex::new(vec![true]))),
+        Value::ByteArray(heap.alloc(Mutex::new(vec![1]))),
+        Value::ShortArray(heap.alloc(Mutex::new(vec![2]))),
+        Value::IntArray(heap.alloc(Mutex::new(vec![3]))),
+        Value::LongArray(heap.alloc(Mutex::new(vec![4]))),
+        Value::FloatArray(heap.alloc(Mutex::new(vec![5.0]))),
+        Value::DoubleArray(heap.alloc(Mutex::new(vec![6.0]))),
+        Value::CharArray(heap.alloc(Mutex::new(vec!['x']))),
+    ];
+    let root = heap.alloc(PersistentVector::from_iter(arrays));
+
+    assert_eq!(heap.count(), 9);
+
+    // Unreachable allocations have one collection cycle of grace. Keeping the
+    // vector rooted across two cycles must also keep all array boxes reachable
+    // from its Values.
+    for _ in 0..2 {
+        heap.collect(|visitor| visitor.visit(&root));
+    }
+
+    assert_eq!(
+        heap.count(),
+        9,
+        "the rooted vector and all eight primitive-array boxes must survive"
+    );
+}


### PR DESCRIPTION
Summary:
- mark primitive-array GcPtr boxes from Value::trace
- add a deterministic regression test covering all eight primitive-array variants
- keep the unrelated cljrs-num changes from the withdrawn PR #369 out of this fix

The regression test confirms that, before the fix, a rooted collection survives while its eight array boxes are swept after two GC cycles. With the fix, all nine allocations survive.

Fixes #370

Testing:
- cargo test --workspace
- cargo test -p cljrs-value --no-default-features --features no-gc,regex-full --test primitive_array_gc
- cargo fmt --all -- --check
- git diff --check