### PR TITLE
Fix GC trace skipping primitive array boxes (use-after-free)

### DIFF
--- a/crates/cljrs-value/src/value.rs
+++ b/crates/cljrs-value/src/value.rs
@@ -1303,14 +1303,19 @@ impl cljrs_gc::Trace for Value {
             Value::Agent(p) => visitor.visit(p),
             Value::TypeInstance(p) => visitor.visit(p),
             Value::ObjectArray(p) => visitor.visit(p),
-            Value::BooleanArray(_)
-            | Value::ByteArray(_)
-            | Value::ShortArray(_)
-            | Value::IntArray(_)
-            | Value::LongArray(_)
-            | Value::FloatArray(_)
-            | Value::DoubleArray(_)
-            | Value::CharArray(_) => {}
+            // Primitive arrays hold no child Values, but the boxes
+            // themselves live on the GC heap and must be marked — a
+            // primitive array reachable only through a traced collection
+            // (e.g. a map of double-arrays) was previously never visited
+            // and got swept while still referenced (use-after-free).
+            Value::BooleanArray(p) => visitor.visit(p),
+            Value::ByteArray(p) => visitor.visit(p),
+            Value::ShortArray(p) => visitor.visit(p),
+            Value::IntArray(p) => visitor.visit(p),
+            Value::LongArray(p) => visitor.visit(p),
+            Value::FloatArray(p) => visitor.visit(p),
+            Value::DoubleArray(p) => visitor.visit(p),
+            Value::CharArray(p) => visitor.visit(p),
             Value::NativeObject(p) => visitor.visit(p),
             // Resource, SharedAtom, and ByteBlob are Arc-ref-counted outside the
             // GC heap — nothing to trace through the GC visitor.

--- a/crates/cljrs-value/tests/gc_trace_primitive_arrays.rs
+++ b/crates/cljrs-value/tests/gc_trace_primitive_arrays.rs
@@ -1,0 +1,68 @@
+//! Regression: primitive arrays reachable only through a traced collection
+//! must survive garbage collection.
+//!
+//! `Value::trace` used to match every primitive-array variant to `{}` — the
+//! boxes hold no child Values, but they are GcPtr heap objects and must be
+//! marked. An array stored inside a collection (and not also live in a
+//! conservatively scanned stack slot) was swept while still referenced; a
+//! later aget saw a freed Vec (observed as length 0) or panicked locking
+//! the freed Mutex. Arrays held in stack locals survived via conservative
+//! root scanning, which is why this stayed hidden until long-lived arrays
+//! were stored inside collections.
+//!
+//! The test observes the sweep itself (total_freed) rather than reading
+//! back through the pointer, so a regression fails cleanly instead of
+//! exercising use-after-free.
+
+#![cfg(not(feature = "no-gc"))]
+
+use std::sync::Mutex;
+
+use cljrs_gc::{GcPtr, HEAP, Trace, push_alloc_frame};
+use cljrs_value::{PersistentVector, Value};
+
+#[test]
+fn primitive_arrays_inside_collections_survive_collection() {
+    // Flush any pre-existing garbage so total_freed stays flat afterwards.
+    // (Objects get GC_INITIAL_LIVES sweeps of grace, so collect a few times.)
+    for _ in 0..4 {
+        HEAP.collect(|_| {});
+    }
+
+    // One of each primitive-array flavor, reachable only through the vector.
+    // The alloc frame pins fresh allocations as GC roots until it drops;
+    // without dropping it the arrays would be rooted no matter what trace
+    // does, and the test could never fail.
+    let frame = push_alloc_frame();
+    let root = Value::Vector(GcPtr::new(PersistentVector::from_iter(vec![
+        Value::DoubleArray(GcPtr::new(Mutex::new(vec![1.5_f64; 32]))),
+        Value::LongArray(GcPtr::new(Mutex::new(vec![7_i64; 32]))),
+        Value::IntArray(GcPtr::new(Mutex::new(vec![3_i32; 32]))),
+        Value::BooleanArray(GcPtr::new(Mutex::new(vec![true; 32]))),
+    ])));
+
+    drop(frame);
+
+    let freed_before = HEAP.total_freed();
+    for _ in 0..4 {
+        HEAP.collect(|visitor| root.trace(visitor));
+    }
+    let freed_during = HEAP.total_freed() - freed_before;
+    assert_eq!(
+        freed_during, 0,
+        "collection freed {freed_during} object(s) that are reachable through the vector"
+    );
+
+    // The arrays are still intact and usable.
+    if let Value::Vector(v) = &root {
+        let first = v.get().iter().next().cloned();
+        match first {
+            Some(Value::DoubleArray(a)) => {
+                let guard = a.get().lock().unwrap();
+                assert_eq!(guard.len(), 32);
+                assert_eq!(guard[0], 1.5);
+            }
+            other => panic!("expected DoubleArray, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
`Value::trace` matches every primitive-array variant (`BooleanArray` through `CharArray`) to `{}` on the grounds that they hold no child `Value`s — but the boxes themselves are `GcPtr` heap objects and must be marked. A primitive array reachable **only through a traced collection** (e.g. a map of double-arrays) is never visited, so the sweep frees it while still referenced. Observed symptoms: `aget` seeing a dropped `Vec` (length 0) and `pthread_mutex_lock` EINVAL panics, both nondeterministic (objects get `GC_INITIAL_LIVES` sweeps of grace before dying).

Arrays held in stack locals survive via conservative root scanning, which is why this stayed hidden — it needs a long-lived array stored *inside* a collection, across enough collection cycles. We hit it building a market-data generator that keeps per-instrument price series as `double-array`s in a map.

The fix is one hunk: visit each array pointer (the leaf `Trace` impls for `Mutex<Vec<T>>` already exist).

The regression test (`crates/cljrs-value/tests/gc_trace_primitive_arrays.rs`) roots a vector of four primitive arrays, drops the thread's alloc frame so the arrays aren't pinned as allocation roots, runs several collections, and asserts `total_freed` stays flat — observing the sweep itself rather than reading through the pointer, so a regression fails cleanly instead of exercising the use-after-free. Without the fix it fails with exactly the four array boxes freed; with it, it passes.

For what it's worth, this fix has been running in my fork's lineage (which fixed the same bug independently after a 2026-08-27 optimizer-suite panic) and under a heavy array workload since.

https://claude.ai/code/session_01APez7FAHXPfRFtqd478TjG