### PR TITLE
fix(core): make `for` a real comprehension; widen `mapv`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -85,12 +85,15 @@ Implementation roadmap for a Rust-hosted Clojure dialect. Native file extension 
 - [x] Collection ops: `conj`, `assoc`, `dissoc`, `get`, `get-in`, `assoc-in`, `update`, `update-in`, `merge`, `into`, `empty`
 - [x] Seq ops: `first`, `rest`, `next`, `cons`, `seq`, `count`, `nth`, `last`, `butlast`, `reverse`, `concat`
 - [x] Higher-order: `map`, `filter`, `reduce`, `keep`, `remove`, `mapcat`, `take`, `drop`, `take-while`, `drop-while`, `partition`, `partition-all`, `group-by`, `sort`, `sort-by`
+  - [x] `mapv` over more than one collection. Only its two-argument arity existed, so `(mapv f xs ys)` was an arity error despite a docstring describing the multi-collection behaviour. Tests: `crates/cljrs-runtime/tests/mapv_arities.rs`
 - [x] Lazy sequences: `lazy-seq`, `range`, `repeat`, `iterate`, `cycle`, `repeatedly` (via `Thunk`/`LazySeq` + `Value::Cons`)
 - [x] String functions: `join`, `split`, `trim`, `upper-case`, `lower-case`, `replace`, `starts-with?`, `ends-with?`
 - [x] I/O: `print`, `println`, `prn`, `pr`, `pr-str`, `str`, `read-string`, `slurp`, `spit`
 - [x] Math: `Math/abs`, `Math/pow`, `Math/sqrt`, `Math/floor`, `Math/ceil`, `Math/round`, `Math/log`, `Math/log10`, `Math/exp`, `Math/sin`, `Math/cos`, `Math/tan`, `Math/asin`, `Math/acos`, `Math/atan`, `Math/atan2`, `Math/sinh`, `Math/cosh`, `Math/tanh`, `Math/hypot`, `Math/PI`, `Math/E`
 - [x] Miscellaneous: `apply`, `comp`, `partial`, `juxt`, `memoize`, `constantly`, `identity`, `not`, `complement`, `gensym`, `type`, `class`, `hash`
 - [x] Core macros: `when`, `when-not`, `if-let`, `when-let`, `if-not`, `cond`, `condp`, `case`, `and`, `or`, `->`, `->>`, `as->`, `doto`, `dotimes`, `doseq`, `for`
+  - [x] `for` as a real list comprehension: multiple binding pairs (rightmost fastest) and the `:let`/`:when`/`:while` modifiers, matching the grammar `doseq` beside it already implemented. It previously read only the **first** binding pair and dropped the rest, so `(for [x xs y ys] ...)` failed with "unbound symbol: y" and no modifier was supported. Tests: `crates/cljrs-runtime/tests/for_comprehension.rs`
+  - [ ] `for`'s `:while` compiles into a `take-while` over its own collection, so it has to follow its binding directly (any number of `:let` modifiers may sit in between). A `:while` after a `:when` in the same binding group is rejected at macroexpansion time rather than silently downgraded to a `:when`; supporting it needs a loop-based expansion like Clojure's chunked one
 - [x] Namespace ops: `in-ns`, `alias`, `refer` (basic); `ns` with `:require`/`:refer-clojure` (`:exclude`/`:only`/`:rename`)
 - [x] `require` — file-based namespace loading with `:as` alias and `:refer [...]`/`:refer :all`
 - [x] `load-file` — evaluate a source file by absolute path

--- a/TODO.md
+++ b/TODO.md
@@ -85,15 +85,15 @@ Implementation roadmap for a Rust-hosted Clojure dialect. Native file extension 
 - [x] Collection ops: `conj`, `assoc`, `dissoc`, `get`, `get-in`, `assoc-in`, `update`, `update-in`, `merge`, `into`, `empty`
 - [x] Seq ops: `first`, `rest`, `next`, `cons`, `seq`, `count`, `nth`, `last`, `butlast`, `reverse`, `concat`
 - [x] Higher-order: `map`, `filter`, `reduce`, `keep`, `remove`, `mapcat`, `take`, `drop`, `take-while`, `drop-while`, `partition`, `partition-all`, `group-by`, `sort`, `sort-by`
-  - [x] `mapv` over more than one collection. Only its two-argument arity existed, so `(mapv f xs ys)` was an arity error despite a docstring describing the multi-collection behaviour. Tests: `crates/cljrs-runtime/tests/mapv_arities.rs`
+  - [x] `mapv` over one or more collections (arities 1-4 and variadic)
 - [x] Lazy sequences: `lazy-seq`, `range`, `repeat`, `iterate`, `cycle`, `repeatedly` (via `Thunk`/`LazySeq` + `Value::Cons`)
 - [x] String functions: `join`, `split`, `trim`, `upper-case`, `lower-case`, `replace`, `starts-with?`, `ends-with?`
 - [x] I/O: `print`, `println`, `prn`, `pr`, `pr-str`, `str`, `read-string`, `slurp`, `spit`
 - [x] Math: `Math/abs`, `Math/pow`, `Math/sqrt`, `Math/floor`, `Math/ceil`, `Math/round`, `Math/log`, `Math/log10`, `Math/exp`, `Math/sin`, `Math/cos`, `Math/tan`, `Math/asin`, `Math/acos`, `Math/atan`, `Math/atan2`, `Math/sinh`, `Math/cosh`, `Math/tanh`, `Math/hypot`, `Math/PI`, `Math/E`
 - [x] Miscellaneous: `apply`, `comp`, `partial`, `juxt`, `memoize`, `constantly`, `identity`, `not`, `complement`, `gensym`, `type`, `class`, `hash`
 - [x] Core macros: `when`, `when-not`, `if-let`, `when-let`, `if-not`, `cond`, `condp`, `case`, `and`, `or`, `->`, `->>`, `as->`, `doto`, `dotimes`, `doseq`, `for`
-  - [x] `for` as a real list comprehension: multiple binding pairs (rightmost fastest) and the `:let`/`:when`/`:while` modifiers, matching the grammar `doseq` beside it already implemented. It previously read only the **first** binding pair and dropped the rest, so `(for [x xs y ys] ...)` failed with "unbound symbol: y" and no modifier was supported. Tests: `crates/cljrs-runtime/tests/for_comprehension.rs`
-  - [ ] `for`'s `:while` compiles into a `take-while` over its own collection, so it has to follow its binding directly (any number of `:let` modifiers may sit in between). A `:while` after a `:when` in the same binding group is rejected at macroexpansion time rather than silently downgraded to a `:when`; supporting it needs a loop-based expansion like Clojure's chunked one
+  - [x] `for` as a real list comprehension: multiple binding pairs (rightmost fastest) and the `:let`/`:when`/`:while` modifiers
+  - [ ] Loop-based `for` expansion, so a `:while` may follow a `:when` in the same binding group
 - [x] Namespace ops: `in-ns`, `alias`, `refer` (basic); `ns` with `:require`/`:refer-clojure` (`:exclude`/`:only`/`:rename`)
 - [x] `require` — file-based namespace loading with `:as` alias and `:refer [...]`/`:refer :all`
 - [x] `load-file` — evaluate a source file by absolute path

--- a/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
+++ b/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
@@ -378,11 +378,7 @@
 (defn mapv
   "Returns a vector consisting of the result of applying f to the set of
   first items of each coll, followed by applying f to the set of second
-  items, until any one coll is exhausted.
-
-  The docstring always described the multi-collection behaviour; only the
-  two-argument arity existed, so `(mapv f xs ys)` was an arity error. `map`
-  already carries every arity, so each one here is a `vec` over it."
+  items, until any one coll is exhausted."
   ([f coll] (vec (map f coll)))
   ([f c1 c2] (vec (map f c1 c2)))
   ([f c1 c2 c3] (vec (map f c1 c2 c3)))
@@ -622,56 +618,80 @@
     ;=> (0 4 16 36 64)
 
   :when skips an element and keeps iterating; :while stops the loop it belongs
-  to. Because :while has to stop rather than skip, it is compiled into a
-  take-while over its own collection, which requires it to follow its binding
-  directly (any number of :let modifiers may sit in between). A :while placed
-  after a :when in the same binding group is rejected at macroexpansion time
-  rather than being silently downgraded to a :when."
+  to. A :while must follow its binding directly, and a binding takes at most
+  one :while; any number of :let modifiers may sit in between.
+
+  The emitted symbols are namespace-qualified, so a binding may be named after
+  a core function without breaking the expansion."
   [bindings & body]
   (letfn [(emit [binds]
             (if (seq binds)
-              (let [tag (first binds)]
-                (cond
-                  (= :let tag)
-                  (list 'let (second binds) (emit (next (next binds))))
+              (if (next binds)
+                (let [tag (first binds)]
+                  (cond
+                    (= :let tag)
+                    (list 'let (second binds) (emit (next (next binds))))
 
-                  (= :when tag)
-                  ;; Skip this element, keep iterating: nil concatenates away.
-                  (list 'if (second binds) (emit (next (next binds))) nil)
+                    (= :when tag)
+                    ;; Skip this element, keep iterating: nil concatenates away.
+                    (list 'if (second binds) (emit (next (next binds))) nil)
 
-                  (= :while tag)
-                  (throw (ex-info
-                          (str "for: :while must follow its binding directly "
-                               "(only :let may come between)")
-                          {:modifier :while :bindings bindings}))
+                    (= :while tag)
+                    (throw (ex-info
+                            (str "for: a :while must follow its binding directly "
+                                 "(only :let may come between) and a binding takes "
+                                 "at most one :while")
+                            {:modifier :while :bindings bindings}))
 
-                  :else
-                  (let [x tag
-                        coll (second binds)
-                        after (next (next binds))]
-                    ;; Gather the :let modifiers sitting between this binding
-                    ;; and a possible :while, so the :while test can see what
-                    ;; they bind.
-                    (loop [lets [] more after]
-                      (cond
-                        (= :let (first more))
-                        (recur (into lets (second more)) (next (next more)))
+                    :else
+                    (let [x tag
+                          coll (second binds)
+                          after (next (next binds))]
+                      ;; Gather the :let modifiers sitting between this binding
+                      ;; and a possible :while, so the :while test can see what
+                      ;; they bind.
+                      (loop [lets [] more after]
+                        (cond
+                          (= :let (first more))
+                          (recur (into lets (second more)) (next (next more)))
 
-                        (= :while (first more))
-                        (let [test (second more)
-                              test (if (seq lets) (list 'let lets test) test)
-                              rest-binds (next (next more))
-                              rest-binds (if (seq lets)
-                                           (cons :let (cons lets rest-binds))
-                                           rest-binds)]
-                          (list 'mapcat
-                                (list 'fn (vector x) (emit rest-binds))
-                                (list 'take-while (list 'fn (vector x) test) coll)))
+                          (= :while (first more))
+                          ;; One frame per element, so a :let init runs exactly
+                          ;; once and both the test and the body read it from
+                          ;; the same scope. A frame is [contribution] while the
+                          ;; test holds and nil once it fails, and that is the
+                          ;; difference that lets :while stop the loop while an
+                          ;; inner :when — whose contribution is an empty seq,
+                          ;; not nil — only skips.
+                          (list 'clojure.core/mapcat 'clojure.core/first
+                                (list 'clojure.core/take-while 'clojure.core/some?
+                                      (list 'clojure.core/map
+                                            (list 'fn (vector x)
+                                                  (list 'let lets
+                                                        (list 'if (second more)
+                                                              (vector (emit (next (next more))))
+                                                              nil)))
+                                            coll)))
 
-                        :else
-                        (list 'mapcat (list 'fn (vector x) (emit after)) coll))))))
+                          (seq after)
+                          (list 'clojure.core/mapcat
+                                (list 'fn (vector x) (emit after))
+                                coll)
+
+                          :else
+                          ;; Innermost binding with no modifiers: exactly one
+                          ;; element per element, which is what map is. Routing
+                          ;; it through mapcat costs a per-element list and
+                          ;; gives up the pinned arity-2 map fast path in the
+                          ;; IR interpreter and in codegen.
+                          (list 'clojure.core/map
+                                (list 'fn (vector x) (cons 'do body))
+                                coll))))))
+                (throw (ex-info
+                        "for requires an even number of forms in the binding vector"
+                        {:bindings bindings})))
               ;; Innermost: one element per surviving binding combination.
-              (list 'list (cons 'do body))))]
+              (list 'clojure.core/list (cons 'do body))))]
     (emit (seq bindings))))
 
 (defn second

--- a/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
+++ b/crates/cljrs-runtime/src/builtins/bootstrap.cljrs
@@ -378,8 +378,15 @@
 (defn mapv
   "Returns a vector consisting of the result of applying f to the set of
   first items of each coll, followed by applying f to the set of second
-  items, until any one coll is exhausted."
-  [f coll] (vec (map f coll)))
+  items, until any one coll is exhausted.
+
+  The docstring always described the multi-collection behaviour; only the
+  two-argument arity existed, so `(mapv f xs ys)` was an arity error. `map`
+  already carries every arity, so each one here is a `vec` over it."
+  ([f coll] (vec (map f coll)))
+  ([f c1 c2] (vec (map f c1 c2)))
+  ([f c1 c2 c3] (vec (map f c1 c2 c3)))
+  ([f c1 c2 c3 & colls] (vec (apply map f c1 c2 c3 colls))))
 
 (defn filterv
   "Returns a vector of the items in coll for which (pred item) returns
@@ -601,13 +608,71 @@
     (emit (seq bindings) nil)))
 
 (defmacro for
-  "List comprehension. binding => [name coll-expr]. Returns a lazy sequence
-  of the results of evaluating body for each name bound to successive
-  elements of coll-expr."
-  [binding & body]
-  (let [x (first binding)
-        coll (second binding)]
-    (list 'map (list 'fn (vector x) (cons 'do body)) coll)))
+  "bindings => binding-form coll-expr [modifier binding-form coll-expr]*
+
+  List comprehension. Takes a vector of one or more binding-form/collection-expr
+  pairs, each followed by zero or more modifiers, and yields a lazy sequence of
+  evaluations of body. Collections are iterated in a nested fashion, rightmost
+  fastest. Supports :let, :when and :while modifiers, like doseq.
+
+    (for [x (range 3) y (range 2)] [x y])
+    ;=> ([0 0] [0 1] [1 0] [1 1] [2 0] [2 1])
+
+    (for [x (range 10) :when (even? x) :let [y (* x x)]] y)
+    ;=> (0 4 16 36 64)
+
+  :when skips an element and keeps iterating; :while stops the loop it belongs
+  to. Because :while has to stop rather than skip, it is compiled into a
+  take-while over its own collection, which requires it to follow its binding
+  directly (any number of :let modifiers may sit in between). A :while placed
+  after a :when in the same binding group is rejected at macroexpansion time
+  rather than being silently downgraded to a :when."
+  [bindings & body]
+  (letfn [(emit [binds]
+            (if (seq binds)
+              (let [tag (first binds)]
+                (cond
+                  (= :let tag)
+                  (list 'let (second binds) (emit (next (next binds))))
+
+                  (= :when tag)
+                  ;; Skip this element, keep iterating: nil concatenates away.
+                  (list 'if (second binds) (emit (next (next binds))) nil)
+
+                  (= :while tag)
+                  (throw (ex-info
+                          (str "for: :while must follow its binding directly "
+                               "(only :let may come between)")
+                          {:modifier :while :bindings bindings}))
+
+                  :else
+                  (let [x tag
+                        coll (second binds)
+                        after (next (next binds))]
+                    ;; Gather the :let modifiers sitting between this binding
+                    ;; and a possible :while, so the :while test can see what
+                    ;; they bind.
+                    (loop [lets [] more after]
+                      (cond
+                        (= :let (first more))
+                        (recur (into lets (second more)) (next (next more)))
+
+                        (= :while (first more))
+                        (let [test (second more)
+                              test (if (seq lets) (list 'let lets test) test)
+                              rest-binds (next (next more))
+                              rest-binds (if (seq lets)
+                                           (cons :let (cons lets rest-binds))
+                                           rest-binds)]
+                          (list 'mapcat
+                                (list 'fn (vector x) (emit rest-binds))
+                                (list 'take-while (list 'fn (vector x) test) coll)))
+
+                        :else
+                        (list 'mapcat (list 'fn (vector x) (emit after)) coll))))))
+              ;; Innermost: one element per surviving binding combination.
+              (list 'list (cons 'do body))))]
+    (emit (seq bindings))))
 
 (defn second
   "Same as (first (rest x))."

--- a/crates/cljrs-runtime/tests/for_comprehension.rs
+++ b/crates/cljrs-runtime/tests/for_comprehension.rs
@@ -213,3 +213,81 @@ fn a_multi_form_body_runs_in_order_and_yields_the_last() {
         "[0 10]"
     );
 }
+
+// ── Review findings (#377) ───────────────────────────────────────────────────
+
+#[test]
+fn a_binding_may_be_named_after_a_core_function() {
+    // The expansion emits `list`, `mapcat`, `take-while` and `map` into the
+    // same scope as the user's bindings, so an unqualified emission is callable
+    // only until someone binds that name.
+    assert_eq!(shows("(for [list [1 2]] list)"), "(1 2)");
+    assert_eq!(shows("(for [x [1 2] :let [list x]] list)"), "(1 2)");
+    assert_eq!(shows("(for [mapcat [[1] [2]] x mapcat] x)"), "(1 2)");
+    assert_eq!(shows("(for [map [[1] [2]] x map] x)"), "(1 2)");
+    assert_eq!(
+        shows("(for [take-while [[1] [2]] x take-while] x)"),
+        "(1 2)"
+    );
+    assert_eq!(shows("(for [some? [1 2] :while (< some? 2)] some?)"), "(1)");
+}
+
+#[test]
+fn a_let_init_runs_once_per_element_under_while() {
+    // The :let inits used to be folded into the take-while predicate AND
+    // re-emitted into the body, so anything side-effecting ran twice.
+    let src = r#"(let [n (atom 0)]
+                   [(vec (for [x (range 4)
+                               :let [y (do (swap! n inc) x)]
+                               :while (< y 3)]
+                           y))
+                    @n])"#;
+    assert_eq!(shows(src), "[[0 1 2] 4]");
+}
+
+#[test]
+fn a_while_still_stops_while_an_inner_when_only_skips() {
+    // Both compile to "produce nothing for this element"; only :while may end
+    // the loop. The frame representation has to keep them distinguishable.
+    assert_eq!(
+        shows("(for [x (range 6) :while (< x 4) y [x] :when (even? y)] y)"),
+        "(0 2)"
+    );
+    assert_eq!(
+        shows("(for [x (range 6) :while (< x 4) :let [y (* x 10)]] y)"),
+        "(0 10 20 30)"
+    );
+}
+
+#[test]
+fn a_malformed_binding_vector_is_rejected() {
+    // Both used to yield an empty seq: `(second binds)` was nil and mapcat over
+    // nil is empty, so a dropped collection expression reported nothing at all.
+    for src in [
+        "(for [x [1 2] y] x)",
+        "(for [x [1 2] :when] x)",
+        "(for [x] x)",
+    ] {
+        let err = eval_fresh(src).expect_err("should reject a malformed binding vector");
+        assert!(
+            err.contains("even number of forms"),
+            "unhelpful error for {src}: {err}"
+        );
+    }
+}
+
+#[test]
+fn the_innermost_simple_binding_is_one_to_one_and_lazy() {
+    // The innermost binding with no modifiers now expands through `map` rather
+    // than `mapcat` plus a per-element `list` — a per-element allocation, and
+    // the pinned arity-2 `map` fast path in the IR interpreter and in codegen.
+    // There is no `macroexpand` in this runtime to assert the shape with, so
+    // pin the two properties the substitution has to preserve.
+    assert_eq!(shows("(count (for [x (range 5)] x))"), "5");
+    assert_eq!(shows("(for [x (range 3)] (inc x))"), "(1 2 3)");
+
+    let src = r#"(let [n (atom 0)]
+                   [(vec (take 2 (for [x (range 100)] (do (swap! n inc) x))))
+                    @n])"#;
+    assert_eq!(shows(src), "[[0 1] 2]", "the body must stay lazy");
+}

--- a/crates/cljrs-runtime/tests/for_comprehension.rs
+++ b/crates/cljrs-runtime/tests/for_comprehension.rs
@@ -1,0 +1,215 @@
+//! `for` as a real list comprehension.
+//!
+//! It used to read only the first binding pair of its vector and drop
+//! everything after it, so `(for [x (range 2) y (range 2)] [x y])` failed with
+//! "unbound symbol: y" and no modifier was supported at all. `doseq` next to it
+//! had handled multiple bindings and `:let`/`:when`/`:while` all along, which
+//! is what made the gap easy to miss: the two macros document the same binding
+//! grammar.
+//!
+//! These tests pin the grammar, the iteration order, the laziness, and the one
+//! placement of `:while` the expansion cannot express.
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Result<Value, String> {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, &mut env)
+            .map_err(|e| format!("eval: {e:?}"))?;
+    }
+    Ok(result)
+}
+
+/// Evaluate and render with `pr-str`, so a whole sequence is one comparison.
+fn shows(src: &str) -> String {
+    let wrapped = format!("(pr-str {src})");
+    match eval_fresh(&wrapped).unwrap_or_else(|e| panic!("{src}\n{e}")) {
+        Value::Str(s) => s.get().clone(),
+        other => panic!("{src}: expected a string, got {other:?}"),
+    }
+}
+
+// ── Bindings ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn one_binding_still_works() {
+    assert_eq!(shows("(vec (for [x (range 3)] x))"), "[0 1 2]");
+    assert_eq!(shows("(vec (for [x [1 2 3]] (* x x)))"), "[1 4 9]");
+}
+
+#[test]
+fn two_bindings_nest() {
+    assert_eq!(
+        shows("(vec (for [x (range 2) y (range 2)] [x y]))"),
+        "[[0 0] [0 1] [1 0] [1 1]]"
+    );
+}
+
+#[test]
+fn the_rightmost_binding_varies_fastest() {
+    assert_eq!(
+        shows("(vec (for [c \"ab\" n (range 2)] (str c n)))"),
+        "[\"a0\" \"a1\" \"b0\" \"b1\"]"
+    );
+}
+
+#[test]
+fn three_bindings_take_the_product() {
+    assert_eq!(
+        shows("(count (for [a (range 2) b (range 3) c (range 4)] [a b c]))"),
+        "24"
+    );
+}
+
+#[test]
+fn an_empty_collection_yields_nothing() {
+    assert_eq!(shows("(vec (for [x [] y (range 3)] x))"), "[]");
+    assert_eq!(shows("(vec (for [x (range 3) y []] x))"), "[]");
+}
+
+#[test]
+fn binding_forms_destructure() {
+    assert_eq!(shows("(vec (for [[a b] [[1 2] [3 4]]] (+ a b)))"), "[3 7]");
+    assert_eq!(
+        shows("(vec (for [{:keys [n]} [{:n 1} {:n 2}]] n))"),
+        "[1 2]"
+    );
+}
+
+#[test]
+fn an_inner_binding_can_use_an_outer_one() {
+    assert_eq!(
+        shows("(vec (for [x (range 4) y (range x)] [x y]))"),
+        "[[1 0] [2 0] [2 1] [3 0] [3 1] [3 2]]"
+    );
+}
+
+// ── Modifiers ────────────────────────────────────────────────────────────────
+
+#[test]
+fn when_skips_and_keeps_going() {
+    assert_eq!(
+        shows("(vec (for [x (range 10) :when (even? x)] x))"),
+        "[0 2 4 6 8]"
+    );
+    assert_eq!(shows("(vec (for [x (range 5) :when false] x))"), "[]");
+}
+
+#[test]
+fn let_binds_inside_the_loop() {
+    assert_eq!(
+        shows("(vec (for [x (range 3) :let [y (* 2 x)]] y))"),
+        "[0 2 4]"
+    );
+}
+
+#[test]
+fn when_and_let_compose() {
+    assert_eq!(
+        shows("(vec (for [x (range 10) :when (even? x) :let [y (* x x)]] y))"),
+        "[0 4 16 36 64]"
+    );
+}
+
+#[test]
+fn while_stops_rather_than_skipping() {
+    // The distinction that matters: 8 is even, but :while has already ended
+    // the loop at 5, so it never appears.
+    assert_eq!(
+        shows("(vec (for [x (range 10) :while (< x 5)] x))"),
+        "[0 1 2 3 4]"
+    );
+    assert_eq!(
+        shows("(vec (for [x [2 4 5 6 8] :while (even? x)] x))"),
+        "[2 4]"
+    );
+}
+
+#[test]
+fn while_stops_only_its_own_loop() {
+    assert_eq!(
+        shows("(vec (for [x (range 2) y (range 5) :while (< y 2)] [x y]))"),
+        "[[0 0] [0 1] [1 0] [1 1]]"
+    );
+}
+
+#[test]
+fn while_sees_the_lets_before_it() {
+    assert_eq!(
+        shows("(vec (for [x (range 10) :let [y (* x x)] :while (< y 9)] x))"),
+        "[0 1 2]"
+    );
+}
+
+#[test]
+fn a_while_that_cannot_be_compiled_is_rejected_loudly() {
+    // `:while` becomes a take-while over its own collection, which it can only
+    // do while it still stands next to that collection. After a `:when` it
+    // would have to stop a loop it can no longer see, so the macro refuses
+    // instead of quietly behaving like `:when`.
+    let err = eval_fresh("(for [x (range 3) :when (even? x) :while (< x 2)] x)")
+        .expect_err("a :while after a :when should not expand");
+    assert!(
+        err.contains(":while must follow its binding"),
+        "unhelpful error: {err}"
+    );
+}
+
+// ── Laziness ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_result_is_lazy() {
+    // Realizing a million elements would not finish; taking three must.
+    assert_eq!(
+        shows("(vec (take 3 (for [x (range 1000000)] x)))"),
+        "[0 1 2]"
+    );
+}
+
+#[test]
+fn laziness_survives_nesting() {
+    assert_eq!(
+        shows("(vec (take 3 (for [x (range 1000000) y (range 2)] [x y])))"),
+        "[[0 0] [0 1] [1 0]]"
+    );
+}
+
+// ── Body ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_nil_body_yields_nils_rather_than_vanishing() {
+    // `for` returns one element per surviving combination; a nil element is
+    // still an element. Dropping them would make `(for [...] (when p x))`
+    // silently behave like a filter.
+    assert_eq!(shows("(vec (for [x (range 2)] nil))"), "[nil nil]");
+    assert_eq!(
+        shows("(vec (for [x (range 3)] (when (even? x) x)))"),
+        "[0 nil 2]"
+    );
+}
+
+#[test]
+fn a_multi_form_body_runs_in_order_and_yields_the_last() {
+    assert_eq!(
+        shows("(vec (for [x (range 2)] (inc x) (* 10 x)))"),
+        "[0 10]"
+    );
+}

--- a/crates/cljrs-runtime/tests/mapv_arities.rs
+++ b/crates/cljrs-runtime/tests/mapv_arities.rs
@@ -1,0 +1,101 @@
+//! `mapv` over more than one collection.
+//!
+//! Its docstring described the multi-collection behaviour ("the set of first
+//! items of each coll") from the start, but only the two-argument arity was
+//! defined, so `(mapv f xs ys)` was an arity error. `map` next to it already
+//! carried every arity, which is what made the gap survive: the obvious
+//! reading of the source says it works.
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Result<Value, String> {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, &mut env)
+            .map_err(|e| format!("eval: {e:?}"))?;
+    }
+    Ok(result)
+}
+
+fn shows(src: &str) -> String {
+    let wrapped = format!("(pr-str {src})");
+    match eval_fresh(&wrapped).unwrap_or_else(|e| panic!("{src}\n{e}")) {
+        Value::Str(s) => s.get().clone(),
+        other => panic!("{src}: expected a string, got {other:?}"),
+    }
+}
+
+#[test]
+fn one_collection_still_works() {
+    assert_eq!(shows("(mapv inc [1 2 3])"), "[2 3 4]");
+}
+
+#[test]
+fn two_collections() {
+    assert_eq!(shows("(mapv + [1 2] [10 20])"), "[11 22]");
+}
+
+#[test]
+fn three_collections() {
+    assert_eq!(
+        shows("(mapv vector [1 2] [3 4] [5 6])"),
+        "[[1 3 5] [2 4 6]]"
+    );
+}
+
+#[test]
+fn four_or_more_collections() {
+    assert_eq!(shows("(mapv + [1] [2] [3] [4])"), "[10]");
+    assert_eq!(shows("(mapv + [1] [2] [3] [4] [5])"), "[15]");
+}
+
+#[test]
+fn it_stops_at_the_shortest_collection() {
+    assert_eq!(shows("(mapv + [1 2 3] [1 2])"), "[2 4]");
+    assert_eq!(shows("(mapv vector [1 2 3] [1] [1 2])"), "[[1 1 1]]");
+}
+
+#[test]
+fn an_empty_collection_yields_an_empty_vector() {
+    assert_eq!(shows("(mapv + [] [1 2])"), "[]");
+}
+
+#[test]
+fn the_result_is_a_vector_not_a_seq() {
+    // The whole point of `mapv` over `map`: it is realized and indexable.
+    assert_eq!(shows("(vector? (mapv + [1 2] [3 4]))"), "true");
+    assert_eq!(shows("(nth (mapv + [1 2] [3 4]) 1)"), "6");
+}
+
+#[test]
+fn it_agrees_with_map_over_the_same_arguments() {
+    for args in [
+        "inc [1 2 3]",
+        "+ [1 2] [10 20]",
+        "vector [1 2] [3 4] [5 6]",
+        "+ [1 2 3] [1 2]",
+    ] {
+        assert_eq!(
+            shows(&format!("(mapv {args})")),
+            shows(&format!("(vec (map {args}))")),
+            "mapv and map disagree for ({args})"
+        );
+    }
+}


### PR DESCRIPTION
Two `clojure.core` gaps with the same shape: the docstring describes the full behaviour while only the simplest case is implemented, so reading the source tells you it works. Both turned up while writing a library against the runtime rather than reading it.

## `for` read only its first binding pair

```clojure
(for [x (range 2) y (range 2)] [x y])
;; before: unbound symbol: y
```

Everything after the first `binding coll` pair was dropped, and no `:let` / `:when` / `:while` modifier was supported. `doseq`, directly above it in `bootstrap.cljrs`, had handled multiple bindings and all three modifiers from the start and documents the same binding grammar — which is what made the gap easy to miss.

It now expands to nested `mapcat`, mirroring `doseq`'s `letfn` emitter:

```clojure
(for [x (range 3) y (range 2)] [x y])
;=> ([0 0] [0 1] [1 0] [1 1] [2 0] [2 1])

(for [x (range 10) :when (even? x) :let [y (* x x)]] y)
;=> (0 4 16 36 64)
```

Rightmost binding varies fastest, and laziness is preserved through the nesting — taking three elements of a comprehension over a million returns.

### One deliberate limitation

`:while` has to *stop* its loop rather than skip an element, so it compiles into a `take-while` over that binding's own collection. That works while it still stands next to the collection, optionally behind `:let` modifiers, whose bindings are folded into the predicate:

```clojure
(for [x (range 10) :let [y (* x x)] :while (< y 9)] x)   ;=> (0 1 2)
```

A `:while` placed after a `:when` in the same binding group would have to stop a loop it can no longer see. The macro **refuses at macroexpansion time** rather than silently behaving like a `:when`; lifting that needs a loop-based expansion like Clojure's chunked one. Noted in `TODO.md`.

## `mapv` defined only its two-argument arity

```clojure
(mapv + [1 2] [10 20])
;; before: arity error
```

…despite a docstring describing "the set of first items of each coll, followed by applying f to the set of second items, until any one coll is exhausted". Each arity is now a `vec` over the matching `map` arity, which already had them.

`KnownFn::Mapv` stays pinned at arity 2 exactly as `KnownFn::Map` does — `map` is already variadic at the Clojure level with the same pinning, so off-arity calls take the fallback path that already exists.

## Tests

26 new tests in `crates/cljrs-runtime/tests/`:

- `for_comprehension.rs` (18) — iteration order, three-deep nesting, an inner binding reading an outer one, destructuring, each modifier, `:when` skipping vs `:while` stopping, laziness through nesting, the rejected `:while` placement, and that a nil body yields nils rather than vanishing.
- `mapv_arities.rs` (8) — 1 to 5 collections, shortest-collection truncation, that the result is a vector rather than a seq, and that `mapv` agrees with `map` over the same arguments.

`cargo test -p cljrs-runtime -p cljrs-stdlib` is clean.
