### PR TITLE
fix(interp): resolve a cross-namespace multimethod in `defmethod`

### DIFF
--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -121,6 +121,10 @@ tests/
   qualified_protocol_impl.rs       — a qualified protocol name in an impl position
                                      (defrecord/deftype/reify/extend-*) resolves
                                      through its own namespace
+  defmethod_cross_ns.rs            — `defmethod` on a multimethod owned by
+                                     another namespace, named through a
+                                     `:require :as` alias, in full, or via
+                                     `:refer`; privacy and version pins refused
   named_fn_identity.rs, ns_metadata.rs, partition_arities.rs, shared_atom.rs,
   symbolic_nan.rs, threading_macros.rs, auto_gensym.rs, auto_keyword_macro.rs,
   assoc_in_metadata.rs, empty_metadata.rs, into_metadata.rs, vec_metadata.rs,

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -124,7 +124,10 @@ tests/
   defmethod_cross_ns.rs            — `defmethod` on a multimethod owned by
                                      another namespace, named through a
                                      `:require :as` alias, in full, or via
-                                     `:refer`; privacy and version pins refused
+                                     `:refer`; privacy refused, and version
+                                     pins refused in either half of the name
+                                     (`mylib/render@sha` and an alias pointing
+                                     at the namespace `mylib@sha`)
   named_fn_identity.rs, ns_metadata.rs, partition_arities.rs, shared_atom.rs,
   symbolic_nan.rs, threading_macros.rs, auto_gensym.rs, auto_keyword_macro.rs,
   assoc_in_metadata.rs, empty_metadata.rs, into_metadata.rs, vec_metadata.rs,

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -7,8 +7,7 @@ use crate::builtins::form::{
     expand_pairs, expand_reader_conds, expand_reader_conds_cow, form_to_value, resolve_auto_forms,
     select_reader_cond,
 };
-use crate::env::env::GlobalEnv;
-use crate::env::env::{Env, RequireRefer, RequireSpec};
+use crate::env::env::{Env, GlobalEnv, RequireRefer, RequireSpec};
 use crate::env::error::{EvalError, EvalResult};
 use crate::env::loader::load_ns;
 use crate::interp::destructure::bind_pattern;
@@ -2334,6 +2333,20 @@ fn eval_defmethod(args: &[Form], env: &mut Env) -> EvalResult {
             .unwrap_or_else(|| Arc::from(ns_part)),
         None => env.current_ns.clone(),
     };
+    // A pin can also live in the NAMESPACE half. `(require '[mylib@abc1234 :as
+    // v1])` registers the namespace under its literal versioned name, so the
+    // alias resolves straight to it and `parsed.version` is None; the guard
+    // above never sees it. Gated on the boundary like the privacy check below,
+    // so a versioned namespace's own source can still extend its own
+    // multimethods while it loads.
+    if owner_ns.as_ref() != env.current_ns.as_ref()
+        && cljrs_value::symbol::split_version(&owner_ns).1.is_some()
+    {
+        return Err(EvalError::Runtime(format!(
+            "defmethod: {multi_name} resolves to the versioned namespace {owner_ns}; \
+             extend the multimethod at HEAD"
+        )));
+    }
     // Reaching into another namespace respects privacy the way `eval_symbol`
     // does: refusing to extend a private multimethod from outside is what
     // `^:private` on a `defmulti` is for.

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -7,6 +7,7 @@ use crate::builtins::form::{
     expand_pairs, expand_reader_conds, expand_reader_conds_cow, form_to_value, resolve_auto_forms,
     select_reader_cond,
 };
+use crate::env::env::GlobalEnv;
 use crate::env::env::{Env, RequireRefer, RequireSpec};
 use crate::env::error::{EvalError, EvalResult};
 use crate::env::loader::load_ns;
@@ -2317,6 +2318,15 @@ fn eval_defmethod(args: &[Form], env: &mut Env) -> EvalResult {
     // only in the current ns — otherwise `(defmethod other/render :x ...)`
     // reports that a perfectly good multimethod "is not a multimethod".
     let parsed = cljrs_value::Symbol::parse(multi_name);
+    // A pinned name (`mylib/render@abc1234`) refers to an immutable past
+    // version, which is not a thing a method can be installed into. `parse`
+    // splits the suffix off into `version`, so without this guard the pin is
+    // dropped and HEAD is extended instead.
+    if parsed.version.is_some() {
+        return Err(EvalError::Runtime(format!(
+            "defmethod: {multi_name} is versioned; extend the multimethod at HEAD"
+        )));
+    }
     let owner_ns: Arc<str> = match parsed.namespace.as_deref() {
         Some(ns_part) => env
             .globals
@@ -2324,12 +2334,24 @@ fn eval_defmethod(args: &[Form], env: &mut Env) -> EvalResult {
             .unwrap_or_else(|| Arc::from(ns_part)),
         None => env.current_ns.clone(),
     };
+    // Reaching into another namespace respects privacy the way `eval_symbol`
+    // does: refusing to extend a private multimethod from outside is what
+    // `^:private` on a `defmulti` is for.
+    if owner_ns.as_ref() != env.current_ns.as_ref()
+        && let Some(var) = env.globals.lookup_var(&owner_ns, &parsed.name)
+        && GlobalEnv::var_is_private(var.get())
+    {
+        return Err(EvalError::Runtime(format!(
+            "defmethod: var {owner_ns}/{} is not public",
+            parsed.name
+        )));
+    }
 
     let mf_ptr = match env.globals.lookup_in_ns(&owner_ns, &parsed.name) {
         Some(Value::MultiFn(mf)) => mf,
         Some(other) => {
             return Err(EvalError::Runtime(format!(
-                "defmethod: {multi_name} is a {}, not a multimethod",
+                "defmethod: {multi_name} is bound to a {}, not a multimethod",
                 other.type_name()
             )));
         }

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -2310,12 +2310,32 @@ fn eval_defmethod(args: &[Form], env: &mut Env) -> EvalResult {
     let (multi_name, _) = require_sym_meta(args, 0, "defmethod", env)?;
     let multi_name = multi_name.as_str();
 
-    let mf_ptr = match env.globals.lookup_in_ns(&env.current_ns, multi_name) {
+    // The multimethod may live in another namespace, which is the normal case
+    // for an open dispatch: one namespace owns the `defmulti`, others extend
+    // it. Resolve `alias/name` and `fully.qualified.ns/name` the way ordinary
+    // qualified symbols resolve (`eval_symbol`, `binding`), instead of looking
+    // only in the current ns — otherwise `(defmethod other/render :x ...)`
+    // reports that a perfectly good multimethod "is not a multimethod".
+    let parsed = cljrs_value::Symbol::parse(multi_name);
+    let owner_ns: Arc<str> = match parsed.namespace.as_deref() {
+        Some(ns_part) => env
+            .globals
+            .resolve_alias(&env.current_ns, ns_part)
+            .unwrap_or_else(|| Arc::from(ns_part)),
+        None => env.current_ns.clone(),
+    };
+
+    let mf_ptr = match env.globals.lookup_in_ns(&owner_ns, &parsed.name) {
         Some(Value::MultiFn(mf)) => mf,
-        _ => {
+        Some(other) => {
             return Err(EvalError::Runtime(format!(
-                "defmethod: {} is not a multimethod",
-                multi_name
+                "defmethod: {multi_name} is a {}, not a multimethod",
+                other.type_name()
+            )));
+        }
+        None => {
+            return Err(EvalError::Runtime(format!(
+                "defmethod: {multi_name} is not defined (no multimethod to extend)"
             )));
         }
     };

--- a/crates/cljrs-runtime/tests/defmethod_cross_ns.rs
+++ b/crates/cljrs-runtime/tests/defmethod_cross_ns.rs
@@ -150,3 +150,80 @@ fn extending_something_undefined_says_that_instead() {
     let err = eval_in(&mut env, "(defmethod nope/area :a [_] 1)").expect_err("no such multimethod");
     assert!(err.contains("not defined"), "unhelpful error: {err}");
 }
+
+#[test]
+fn a_multimethod_reached_through_refer_needs_no_qualification() {
+    // The one path where the unqualified branch does real work rather than
+    // just preserving same-ns behaviour: `:refer` puts the name in the
+    // current namespace, so a bare `defmethod` has to find it there.
+    let extender = r#"
+(ns shapes.referred (:require [shapes.core :refer [area]]))
+(defmethod area :triangle [t] (:base t))
+"#;
+    let (_dir, _g, mut env) = env_with_sources(&[
+        ("shapes/core.cljrs", OWNER),
+        ("shapes/referred.cljrs", extender),
+    ]);
+    eval_in(&mut env, "(require 'shapes.referred)").expect("require the extending ns");
+    let v = eval_in(
+        &mut env,
+        "(do (require '[shapes.core :as c]) (c/area {:kind :triangle :base 9}))",
+    )
+    .expect("dispatch");
+    assert_eq!(v, Value::Long(9));
+}
+
+#[test]
+fn a_private_multimethod_cannot_be_extended_from_another_namespace() {
+    // `^:private` is refused here for the same reason `eval_symbol` refuses
+    // it: the owner did not publish this name. Before the cross-ns fix this
+    // failed for the wrong reason ("is not a multimethod"), so widening the
+    // lookup without the check would have quietly opened a hole.
+    let owner = r#"
+(ns shapes.hidden)
+(defmulti ^:private secret :kind)
+(defmethod secret :default [_] :owner-only)
+"#;
+    let extender = r#"
+(ns shapes.intruder (:require [shapes.hidden :as h]))
+(defmethod h/secret :x [_] :extended)
+"#;
+    let (_dir, _g, mut env) = env_with_sources(&[
+        ("shapes/hidden.cljrs", owner),
+        ("shapes/intruder.cljrs", extender),
+    ]);
+    let err = eval_in(&mut env, "(require 'shapes.intruder)")
+        .expect_err("a private multimethod is not extensible from outside");
+    assert!(err.contains("not public"), "unhelpful error: {err}");
+}
+
+#[test]
+fn a_private_multimethod_is_still_extensible_by_its_owner() {
+    // Privacy is about the boundary, not about the var: the owning namespace
+    // extends its own multimethod normally.
+    let owner = r#"
+(ns shapes.own)
+(defmulti ^:private secret :kind)
+(defmethod secret :x [_] :extended)
+(def result (secret {:kind :x}))
+"#;
+    let (_dir, _g, mut env) = env_with_sources(&[("shapes/own.cljrs", owner)]);
+    eval_in(&mut env, "(require 'shapes.own)").expect("own-ns defmethod");
+    assert_eq!(
+        eval_in(&mut env, "shapes.own/result").expect("result"),
+        Value::keyword(cljrs_value::Keyword::simple("extended"))
+    );
+}
+
+#[test]
+fn a_versioned_name_is_refused_rather_than_silently_unpinned() {
+    // `Symbol::parse` splits `@hash` into `version`; reading only `name` would
+    // extend HEAD while the caller believes they pinned a commit.
+    let (_dir, _g, mut env) = env_with_sources(&[]);
+    let err = eval_in(
+        &mut env,
+        "(do (defmulti f :k) (defmethod f@abc1234 :a [_] 1))",
+    )
+    .expect_err("a versioned defmethod target should be refused");
+    assert!(err.contains("versioned"), "unhelpful error: {err}");
+}

--- a/crates/cljrs-runtime/tests/defmethod_cross_ns.rs
+++ b/crates/cljrs-runtime/tests/defmethod_cross_ns.rs
@@ -1,0 +1,152 @@
+//! `defmethod` on a multimethod that lives in another namespace.
+//!
+//! This is the normal shape of an open dispatch: one namespace owns the
+//! `defmulti`, others extend it. `eval_defmethod` looked the name up with
+//! `lookup_in_ns(current_ns, ..)` and nothing else, so a qualified name never
+//! resolved and the error claimed a perfectly good multimethod "is not a
+//! multimethod".
+//!
+//! The name now resolves the way `eval_symbol` and `binding` resolve one:
+//! through the current namespace's `:require :as` aliases, then as a
+//! fully-qualified namespace.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+/// A runtime whose source path is a temp dir holding the given files.
+fn env_with_sources(files: &[(&str, &str)]) -> (tempfile::TempDir, Arc<GlobalEnv>, Env) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (rel, src) in files {
+        let path = dir.path().join(rel);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, src).expect("write");
+    }
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .source_paths(vec![PathBuf::from(dir.path())])
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (dir, globals, env)
+}
+
+fn eval_in(env: &mut Env, src: &str) -> Result<Value, String> {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, env).map_err(|e| format!("{e:?}"))?;
+    }
+    Ok(result)
+}
+
+const OWNER: &str = r#"
+(ns shapes.core)
+(defmulti area "Area of a shape." :kind)
+(defmethod area :default [_] :unknown)
+"#;
+
+#[test]
+fn defmethod_reaches_a_multimethod_through_a_require_alias() {
+    let extender = r#"
+(ns shapes.square (:require [shapes.core :as core]))
+(defmethod core/area :square [s] (* (:side s) (:side s)))
+"#;
+    let (_dir, _g, mut env) = env_with_sources(&[
+        ("shapes/core.cljrs", OWNER),
+        ("shapes/square.cljrs", extender),
+    ]);
+    eval_in(&mut env, "(require 'shapes.square)").expect("require the extending ns");
+    let v = eval_in(
+        &mut env,
+        "(do (require '[shapes.core :as c]) (c/area {:kind :square :side 4}))",
+    )
+    .expect("dispatch");
+    assert_eq!(v, Value::Long(16));
+}
+
+#[test]
+fn defmethod_reaches_a_multimethod_by_its_full_namespace() {
+    let extender = r#"
+(ns shapes.circle (:require [shapes.core]))
+(defmethod shapes.core/area :circle [c] (:r c))
+"#;
+    let (_dir, _g, mut env) = env_with_sources(&[
+        ("shapes/core.cljrs", OWNER),
+        ("shapes/circle.cljrs", extender),
+    ]);
+    eval_in(&mut env, "(require 'shapes.circle)").expect("require the extending ns");
+    let v = eval_in(
+        &mut env,
+        "(do (require '[shapes.core :as c]) (c/area {:kind :circle :r 7}))",
+    )
+    .expect("dispatch");
+    assert_eq!(v, Value::Long(7));
+}
+
+#[test]
+fn several_namespaces_can_extend_the_same_multimethod() {
+    // The point of an open dispatch: the owner does not know its extenders.
+    let square = r#"
+(ns shapes.square (:require [shapes.core :as core]))
+(defmethod core/area :square [s] (* (:side s) (:side s)))
+"#;
+    let circle = r#"
+(ns shapes.circle (:require [shapes.core :as core]))
+(defmethod core/area :circle [c] (:r c))
+"#;
+    let (_dir, _g, mut env) = env_with_sources(&[
+        ("shapes/core.cljrs", OWNER),
+        ("shapes/square.cljrs", square),
+        ("shapes/circle.cljrs", circle),
+    ]);
+    eval_in(&mut env, "(require 'shapes.square)").expect("square");
+    eval_in(&mut env, "(require 'shapes.circle)").expect("circle");
+    eval_in(&mut env, "(require '[shapes.core :as c])").expect("alias");
+
+    assert_eq!(
+        eval_in(&mut env, "(c/area {:kind :square :side 3})").expect("square dispatch"),
+        Value::Long(9)
+    );
+    assert_eq!(
+        eval_in(&mut env, "(c/area {:kind :circle :r 5})").expect("circle dispatch"),
+        Value::Long(5)
+    );
+    assert_eq!(
+        eval_in(&mut env, "(c/area {:kind :hexagon})").expect("default"),
+        Value::keyword(cljrs_value::Keyword::simple("unknown"))
+    );
+}
+
+#[test]
+fn an_unqualified_name_still_resolves_in_the_current_namespace() {
+    let (_dir, _g, mut env) = env_with_sources(&[]);
+    let v = eval_in(
+        &mut env,
+        "(do (defmulti f :k) (defmethod f :a [_] 1) (f {:k :a}))",
+    )
+    .expect("same-ns defmethod");
+    assert_eq!(v, Value::Long(1));
+}
+
+#[test]
+fn extending_something_that_is_not_a_multimethod_says_so() {
+    let (_dir, _g, mut env) = env_with_sources(&[]);
+    let err = eval_in(&mut env, "(do (def g 1) (defmethod g :a [_] 1))")
+        .expect_err("a def is not a multimethod");
+    assert!(err.contains("not a multimethod"), "unhelpful error: {err}");
+}
+
+#[test]
+fn extending_something_undefined_says_that_instead() {
+    // Distinguishable from the above: "not defined" points at a missing
+    // require, "not a multimethod" points at the wrong kind of var.
+    let (_dir, _g, mut env) = env_with_sources(&[]);
+    let err = eval_in(&mut env, "(defmethod nope/area :a [_] 1)").expect_err("no such multimethod");
+    assert!(err.contains("not defined"), "unhelpful error: {err}");
+}

--- a/crates/cljrs-runtime/tests/defmethod_cross_ns.rs
+++ b/crates/cljrs-runtime/tests/defmethod_cross_ns.rs
@@ -227,3 +227,53 @@ fn a_versioned_name_is_refused_rather_than_silently_unpinned() {
     .expect_err("a versioned defmethod target should be refused");
     assert!(err.contains("versioned"), "unhelpful error: {err}");
 }
+
+#[test]
+fn a_pin_carried_in_the_namespace_half_is_refused_too() {
+    // `(require '[mylib@abc1234 :as v1])` registers the namespace under its
+    // literal versioned name and points the alias straight at it, so by the
+    // time the owner ns is known the pin is inside it and `Symbol::parse` saw
+    // no `@` at all. The state below is what that require leaves behind.
+    let (_dir, globals, mut env) = env_with_sources(&[]);
+
+    let mut pinned = Env::new(globals.clone(), "mylib@abc1234");
+    eval_in(
+        &mut pinned,
+        "(defmulti render :kind) (defmethod render :default [_] :from-the-pin)",
+    )
+    .expect("defmulti in the versioned namespace");
+    globals.add_alias("user", "v1", "mylib@abc1234");
+
+    let err = eval_in(&mut env, "(defmethod v1/render :x [_] :extended)")
+        .expect_err("extending a pinned multimethod should be refused");
+    assert!(
+        err.contains("versioned namespace"),
+        "unhelpful error: {err}"
+    );
+
+    // And the pinned multimethod is untouched: the refusal happens before the
+    // method table is reached.
+    assert_eq!(
+        eval_in(&mut env, "(v1/render {:kind :x})").expect("dispatch through the pin"),
+        Value::keyword(cljrs_value::Keyword::simple("from-the-pin"))
+    );
+}
+
+#[test]
+fn a_versioned_namespace_can_still_extend_its_own_multimethods() {
+    // The guard is about the boundary. While `mylib@abc1234` loads, its own
+    // `defmethod`s must install normally -- `Env::new_versioned` sets
+    // `current_ns` to the versioned name, so an unguarded check would break
+    // exactly the loading path the pin exists to serve.
+    let (_dir, globals, _env) = env_with_sources(&[]);
+    let mut pinned = Env::new(globals.clone(), "mylib@abc1234");
+    eval_in(
+        &mut pinned,
+        "(defmulti render :kind) (defmethod render :x [_] :own-method)",
+    )
+    .expect("a versioned namespace extending itself");
+    assert_eq!(
+        eval_in(&mut pinned, "(render {:kind :x})").expect("dispatch"),
+        Value::keyword(cljrs_value::Keyword::simple("own-method"))
+    );
+}


### PR DESCRIPTION
`defmethod` could not extend a multimethod that lives in another namespace.

```clojure
(ns shapes.square (:require [shapes.core :as core]))
(defmethod core/area :square [s] (* (:side s) (:side s)))
;; defmethod: core/area is not a multimethod
```

`eval_defmethod` resolved its name with `lookup_in_ns(&env.current_ns, name)` and nothing else, so `core/area` — or `shapes.core/area` — was looked up verbatim in the *current* namespace and never found.

That forbids exactly the thing an open dispatch is for: the namespace owning the `defmulti` doesn't know its extenders, so the extenders have to name it. The message was misleading too — `shapes.core/area` is a perfectly good multimethod.

## Fix

The name now resolves the way `eval_symbol` and `binding` resolve one:

- `alias/name` through the current namespace's `:require :as` aliases,
- `fully.qualified.ns/name` directly,
- a bare name in the current namespace, as before.

The alias branch is the same three lines `binding` uses a few hundred lines below in the same file, for the same reason.

The failure is also split in two, since the two causes want different fixes:

```
defmethod: g is a Long, not a multimethod          ;; wrong var
defmethod: nope/area is not defined (no multimethod to extend)   ;; usually a missing require
```

## How it was found

Loading a real cross-namespace codebase under cljrs — [plato](https://github.com/BuddhiLW/plato), a presentation framework whose content renderer is a multimethod extended from four namespaces. With this fix its scene graph, timeline and SVG renderer all run on clojurust; before it, the whole tree failed to load.

## Tests

`crates/cljrs-runtime/tests/defmethod_cross_ns.rs`, 6 tests: through an alias, by full namespace, several namespaces extending one multimethod plus its `:default`, an unqualified name still resolving in the current namespace, and each of the two error messages.

`cargo test -p cljrs-runtime -p cljrs-stdlib` is clean.
