### PR TITLE
Load a native extension from a working tree (:local/root + :rust/load :dylib)

### DIFF
--- a/crates/cljrs-project/README.md
+++ b/crates/cljrs-project/README.md
@@ -125,7 +125,12 @@ pub struct RustConfig {
 
 pub enum Dependency {
     Git(GitDep),
-    Local { root: PathBuf },
+    Local {
+        root: PathBuf,
+        rust_init:       Option<Arc<str>>,  // :rust/init  — native init fn path
+        rust_crate_dir:  Option<Arc<str>>,  // :rust/crate — Cargo.toml subdir, relative to root
+        rust_load_dylib: bool,              // :rust/load :dylib — build the working tree as a cdylib
+    },
 }
 
 pub struct GitDep {

--- a/crates/cljrs-project/src/config.rs
+++ b/crates/cljrs-project/src/config.rs
@@ -63,6 +63,17 @@ pub enum Dependency {
     /// A local directory on disk, resolved relative to the `cljrs.edn` file.
     Local {
         root: PathBuf,
+        /// `:rust/init` — fully-qualified path to the dep's native init
+        /// function, when the dep ships Rust code.
+        rust_init: Option<Arc<str>>,
+        /// `:rust/crate` — directory of the dep's Cargo.toml relative to
+        /// `root` (defaults to `root` itself).
+        rust_crate_dir: Option<Arc<str>>,
+        /// `:rust/load :dylib` — build the dep's crate from the working tree
+        /// as a cdylib and load it, instead of resolving its natives against
+        /// the current binary. Unlike the git form there is no pinned commit,
+        /// so a local dep serves `require` only, never versioned resolution.
+        rust_load_dylib: bool,
     },
 }
 

--- a/crates/cljrs-project/src/config/parse.rs
+++ b/crates/cljrs-project/src/config/parse.rs
@@ -196,7 +196,12 @@ fn extract_dependency(form: &Form, config_dir: &Path, name: &str) -> Result<Depe
             rust_crate_dir,
             rust_load_dylib,
         })),
-        (_, _, Some(root)) => Ok(Dependency::Local { root }),
+        (_, _, Some(root)) => Ok(Dependency::Local {
+            root,
+            rust_init,
+            rust_crate_dir,
+            rust_load_dylib,
+        }),
         _ => Err(format!(
             "dep {name}: must specify either :git/url + :git/sha or :local/root"
         )),
@@ -390,5 +395,91 @@ mod tests {
     fn no_main_key_is_none() {
         let cfg = parse(r#"{:paths ["src"]}"#).unwrap();
         assert!(cfg.main_ns.is_none());
+    }
+
+    // ── :local/root native deps ───────────────────────────────────────────
+
+    fn only_dep(cfg: &DepsConfig) -> &Dependency {
+        assert_eq!(cfg.deps.len(), 1, "expected exactly one dep");
+        &cfg.deps[0].1
+    }
+
+    #[test]
+    fn local_root_keeps_its_rust_keys() {
+        // The :rust/* keys were parsed but dropped for anything that was not
+        // a git dep, so a local native package could never be loaded.
+        let cfg = parse(
+            r#"{:deps {my.lib {:local/root "../my-lib"
+                               :rust/load :dylib
+                               :rust/init "my_lib::cljrs_init"
+                               :rust/crate "src/crates/thing"}}}"#,
+        )
+        .unwrap();
+        let Dependency::Local {
+            root,
+            rust_init,
+            rust_crate_dir,
+            rust_load_dylib,
+        } = only_dep(&cfg)
+        else {
+            panic!("expected a local dep");
+        };
+        assert_eq!(root, Path::new("/proj/../my-lib"));
+        assert!(rust_load_dylib);
+        assert_eq!(rust_init.as_deref(), Some("my_lib::cljrs_init"));
+        assert_eq!(rust_crate_dir.as_deref(), Some("src/crates/thing"));
+    }
+
+    #[test]
+    fn a_plain_local_root_declares_no_native_code() {
+        let cfg = parse(r#"{:deps {my.lib {:local/root "../my-lib"}}}"#).unwrap();
+        let Dependency::Local {
+            rust_load_dylib,
+            rust_init,
+            ..
+        } = only_dep(&cfg)
+        else {
+            panic!("expected a local dep");
+        };
+        assert!(!rust_load_dylib);
+        assert!(rust_init.is_none());
+    }
+
+    #[test]
+    fn a_git_dep_still_carries_its_rust_keys() {
+        let cfg = parse(
+            r#"{:deps {my.lib {:git/url "https://example.com/l.git"
+                               :git/sha "abc123"
+                               :rust/load :dylib
+                               :rust/init "my_lib::cljrs_init"}}}"#,
+        )
+        .unwrap();
+        let Dependency::Git(git) = only_dep(&cfg) else {
+            panic!("expected a git dep");
+        };
+        assert!(git.rust_load_dylib);
+        assert_eq!(git.rust_init.as_deref(), Some("my_lib::cljrs_init"));
+    }
+
+    #[test]
+    fn git_wins_when_a_dep_names_both_forms() {
+        // Both a pinned commit and a local root: the pin is the stronger
+        // claim, and this ordering is what the loader assumes.
+        let cfg = parse(
+            r#"{:deps {my.lib {:git/url "https://example.com/l.git"
+                               :git/sha "abc123"
+                               :local/root "../my-lib"}}}"#,
+        )
+        .unwrap();
+        assert!(matches!(only_dep(&cfg), Dependency::Git(_)));
+    }
+
+    #[test]
+    fn a_dep_with_neither_form_is_rejected() {
+        let err = parse(r#"{:deps {my.lib {:rust/load :dylib}}}"#).unwrap_err();
+        assert!(
+            err.contains(":local/root"),
+            "error should name the accepted forms: {err}"
+        );
     }
 }

--- a/crates/cljrs/README.md
+++ b/crates/cljrs/README.md
@@ -313,6 +313,27 @@ binding (`:rust/load :dylib` in `cljrs.edn`).  The same machinery also makes a
 namespace, registering the package's exports into the live (unversioned)
 namespace.
 
+Two dependency forms reach it, differing only in where the crate source comes
+from:
+
+- `:git/url` + `:git/sha` — a commit, materialized by `cljrs_project::vcs`.
+  Serves versioned resolution and `require`; its artifact is cached forever.
+- `:local/root` — a working tree, built as it currently stands.  Serves
+  `require` only, since there is no commit to resolve `@<sha>` against, and is
+  declined by versioned resolution before validation so a misconfigured local
+  dependency leaves that path exactly as it was.  Versioned by
+  `digest_source_tree` over the **whole root**, not just the `:rust/crate`
+  subdirectory: the crate being built normally has path dependencies on its
+  siblings, so an edit outside it still changes what cargo produces.
+
+The generated wrapper crate and its cargo target directory are keyed by
+`(dep crate, ABI fingerprint)` and shared across versions, so an edit costs an
+incremental rebuild rather than a fresh one and leaves one target directory
+behind rather than one per edit.  The built cdylib is then copied to a
+version-unique path: `dlopen` keys on the path, so a rebuilt library has to
+arrive somewhere the previous one never occupied.  `CLJRS_DYLIB_OFFLINE=1`
+builds wrappers with `cargo --offline`.
+
 ### Status
 
 Versioned-namespaces plan, Phase 5 (see `docs/archive/versioned-namespaces-plan.md`).
@@ -331,10 +352,20 @@ src/native/pinned.rs — install (both loader hooks), wrapper crate generation,
               Registry init
 build.rs    — captures `rustc -V` for the host side of the ABI fingerprint
 tests/
-  pinned_dylib_e2e.rs — gated end-to-end test (CLJRS_DYLIB_E2E=1): two-commit
-              native crate fixture; pinned (versioned-symbol) resolution loads
-              the v1 dylib while HEAD stays untouched, and a plain `require`
-              loads the v1 dylib into the unversioned namespace
+  pinned_dylib_e2e.rs — gated end-to-end tests (CLJRS_DYLIB_E2E=1), serialized
+              on an env lock because each points HOME at its own cache:
+              `pinned_native_dylib_end_to_end` (versioned-symbol resolution
+              loads the v1 dylib while HEAD stays untouched),
+              `native_dep_loaded_by_plain_require` (a plain `require` loads the
+              v1 dylib into the unversioned namespace),
+              `local_root_native_dep_is_built_from_the_working_tree` (a
+              `:local/root` dep builds the tree as it stands, and an edit
+              rebuilds),
+              `local_root_native_dep_picks_up_a_sibling_crate_edit` (a
+              two-crate tree under `:rust/crate`: editing only the sibling
+              crate must still rebuild), and
+              `local_root_native_dep_does_not_serve_versioned_resolution`
+              (a local dep declines `@<sha>` and the host binding answers)
 ```
 
 ### Public API
@@ -359,17 +390,26 @@ pub const INIT_SYMBOL: &[u8];  // b"cljrs_dylib_init\0"
 1. The versioned resolver (`cljrs_runtime::env::versioned`) calls the installed
    `PinnedNativeLoader` when a pinned lookup is about to fall back to a
    native function.
-2. The loader finds a `:rust/load :dylib` git dep covering the namespace
-   (exact or dotted-prefix match) with a `:rust/init` function.
+2. The loader finds a `:rust/load :dylib` dep covering the namespace
+   (exact or dotted-prefix match) with a `:rust/init` function.  Versioned
+   resolution takes only the git form; a `:local/root` dep is declined here,
+   before the `:rust/init` check, so a misconfigured one cannot turn the
+   fallback into an error.
 3. `cljrs_project::vcs::fetch_remote` + a gitoxide worktree checkout of the pinned
    commit's tree (`~/.cljrs/cache/dylibs/checkouts/<crate>@<commit>`, no
    `.git`; a `.cljrs-checkout-complete` sentinel marks a finished checkout).
-4. A wrapper cdylib crate is generated
-   (`~/.cljrs/cache/dylibs/<crate>@<commit>/fp-<hash>/`), pinning the same
+4. A wrapper cdylib crate is generated in
+   `~/.cljrs/cache/dylibs/build/<crate>-<hash>/`, keyed by `(dep crate, ABI
+   fingerprint)` and so shared across versions, pinning the same
    `cljrs-interop` as the host (local checkout path when found —
    `CLJRS_WORKSPACE_ROOT` override honored — else the published `=version`),
    and built with cargo **in the host's profile** (debug/release —
-   `cljrs-gc` object headers differ between profiles).
+   `cljrs-gc` object headers differ between profiles).  Cargo runs online
+   unless `CLJRS_DYLIB_OFFLINE` is set, since it resolves the dependency's own
+   crates here.  The built library is then copied to the version-unique
+   `~/.cljrs/cache/dylibs/<crate>@<version>/fp-<hash>/`, which is what gets
+   `dlopen`ed: reusing the path an already-loaded library occupies would not
+   pick the rebuild up.
 5. dlopen → `cljrs_dylib_abi()` fingerprint must equal
    `abi_fingerprint()` exactly, else refuse → `cljrs_dylib_init(*mut
    Registry)` registers the package's exports through
@@ -383,7 +423,8 @@ pub const INIT_SYMBOL: &[u8];  // b"cljrs_dylib_init\0"
 When `(require '[my.native.lib :as l])` finds no Clojure source for the
 namespace, `cljrs-runtime`'s unversioned loader consults the installed
 `NativeRequireLoader`.  It runs the same fetch/checkout/wrapper-build pipeline
-(steps 2–4 above), keyed on the dep's pinned `:git/sha`, then runs
+(steps 2–4 above), keyed on the dep's pinned `:git/sha` or, for a
+`:local/root` dep, on a digest of its whole source tree, then runs
 `cljrs_dylib_init` through `Registry::for_require(...)` — an **unversioned**
 view — so the exports land in the live `my.native.lib` namespace.  The loader
 returns and the unversioned loader marks the namespace loaded, so `l/encode`

--- a/crates/cljrs/src/commands/deps.rs
+++ b/crates/cljrs/src/commands/deps.rs
@@ -53,7 +53,7 @@ fn run_deps_fetch(name: Option<String>) -> miette::Result<i32> {
                     }
                 }
             }
-            cljrs_project::config::Dependency::Local { root } => {
+            cljrs_project::config::Dependency::Local { root, .. } => {
                 if root.exists() {
                     eprintln!("{dep_name}: local dep at {} — ok", root.display());
                 } else {
@@ -110,7 +110,7 @@ fn run_deps_status() -> miette::Result<i32> {
                     all_ok = false;
                 }
             }
-            cljrs_project::config::Dependency::Local { root } => {
+            cljrs_project::config::Dependency::Local { root, .. } => {
                 if root.exists() {
                     println!("{dep_name}: local dep at {} — ok", root.display());
                 } else {

--- a/crates/cljrs/src/native/pinned.rs
+++ b/crates/cljrs/src/native/pinned.rs
@@ -1,24 +1,35 @@
-//! Pinned native packages: build a dependency's Rust crate at a pinned git
-//! commit as a cdylib and load it (`:rust/load :dylib` in `cljrs.edn`).
+//! Native packages: build a dependency's Rust crate as a cdylib and load it
+//! (`:rust/load :dylib` in `cljrs.edn`).
+//!
+//! Two dependency forms reach this module, and they differ only in where the
+//! crate's source comes from:
+//!
+//! - `:git/url` + `:git/sha` — an immutable commit. Serves both `require` and
+//!   versioned (`mylib/f@<sha>`) resolution; its artifact is cached forever.
+//! - `:local/root` — a working tree, built as it currently stands. Serves
+//!   `require` only (there is no commit to resolve `@<sha>` against), and is
+//!   rebuilt on every load because the tree changes underfoot.
 //!
 //! By default, a pinned symbol (`mylib/f@<sha>`) that resolves to a native
 //! (Rust-backed) function falls back to the **current binary's**
 //! implementation, with provenance verification (see
-//! `cljrs_runtime::env::versioned`).  This crate provides the opt-in alternative:
-//! true pinned native code.
+//! `cljrs_runtime::env::versioned`).  This module provides the opt-in
+//! alternative: true out-of-binary native code.
 //!
 //! ## Flow
 //!
-//! 1. `install(globals)` registers a [`PinnedNativeLoader`] hook on the
-//!    environment.  The versioned resolver calls it whenever a pinned
-//!    lookup is about to fall back to a native function.
+//! 1. `install(globals)` registers the loader hooks on the environment.  The
+//!    versioned resolver calls one whenever a pinned lookup is about to fall
+//!    back to a native function; `require` calls the other for a namespace no
+//!    source path provides.
 //! 2. The hook checks `cljrs.edn` for a dep covering the namespace with
 //!    `:rust/load :dylib` and a `:rust/init` function.
-//! 3. The dep's repository is fetched (`cljrs_project::vcs::fetch_remote`), checked
-//!    out at the pinned commit, and wrapped in a generated cdylib crate
-//!    that pins the exact same `cljrs-interop` as the host.
-//! 4. `cargo build --release` (cached per `(crate, commit, rustc, cljrs
-//!    version)`), then `dlopen`.
+//! 3. The dep's source is materialized — fetched and checked out at the
+//!    pinned commit (`cljrs_project::vcs`), or taken as-is from
+//!    `:local/root` — and wrapped in a generated cdylib crate that pins the
+//!    exact same `cljrs-interop` as the host.
+//! 4. `cargo build` in the host's profile (cached per `(crate, source, rustc,
+//!    cljrs version)`), then `dlopen`.
 //! 5. **ABI handshake**: the wrapper exports `cljrs_dylib_abi()` returning
 //!    a fingerprint string (cljrs version + `rustc -V`, baked at the
 //!    wrapper's build time).  The host refuses to proceed unless it equals
@@ -44,7 +55,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use cljrs_project::config::{Dependency, GitDep};
+use cljrs_project::config::Dependency;
 use cljrs_runtime::env::error::{EvalError, EvalResult};
 use cljrs_runtime::tiered::GlobalEnv;
 
@@ -92,16 +103,22 @@ fn load_pinned(globals: &Arc<GlobalEnv>, base_ns: &str, commit: &str) -> EvalRes
     let Some(config) = config else {
         return Ok(false);
     };
-    let Some(git) = find_dylib_dep(&config, base_ns) else {
+    let Some(dep) = find_dylib_dep(&config, base_ns) else {
         return Ok(false);
     };
+    let dep = dep.map_err(|e| EvalError::Runtime(format!("pinned native {base_ns}: {e}")))?;
+    // A working tree has no commit, so it cannot answer for `ns/f@sha`.
+    // Decline and let the versioned resolver fall back as it would have.
+    if !dep.is_pinned() {
+        return Ok(false);
+    }
 
     let versioned_ns = format!("{base_ns}@{commit}");
     if globals.is_loaded(&versioned_ns) {
         return Ok(true);
     }
 
-    let lib_path = build_pinned_wrapper(&git, commit)
+    let lib_path = build_wrapper(&dep, Some(commit))
         .map_err(|e| EvalError::Runtime(format!("pinned native {versioned_ns}: {e}")))?;
 
     load_library(globals, &lib_path, Some(commit))
@@ -113,22 +130,26 @@ fn load_pinned(globals: &Arc<GlobalEnv>, base_ns: &str, commit: &str) -> EvalRes
 }
 
 /// The `require`-path loader hook: returns `Ok(true)` when a `:rust/load
-/// :dylib` dep covering `ns` was built at its pinned `:git/sha` and its
-/// exports were registered into the **unversioned** namespace, making a plain
-/// `(require '[ns :as …])` of a pure-native package succeed.
+/// :dylib` dep covering `ns` was built and its exports were registered into
+/// the **unversioned** namespace, making a plain `(require '[ns :as …])` of a
+/// pure-native package succeed.
 ///
 /// Unlike [`load_pinned`] (which serves versioned-symbol resolution and lands
 /// the package in the immutable `"<ns>@<commit>"` namespace), this registers
 /// into the live namespace so unversioned references resolve normally.  The
 /// caller (`cljrs-runtime`'s unversioned loader) marks `ns` loaded on success.
+///
+/// Both dependency forms reach this path: a git dep builds at its pinned
+/// `:git/sha`, a `:local/root` dep builds the working tree as it stands.
 fn load_require(globals: &Arc<GlobalEnv>, ns: &str) -> EvalResult<bool> {
     let config = globals.deps_config.read().unwrap().clone();
     let Some(config) = config else {
         return Ok(false);
     };
-    let Some(git) = find_dylib_dep(&config, ns) else {
+    let Some(dep) = find_dylib_dep(&config, ns) else {
         return Ok(false);
     };
+    let dep = dep.map_err(|e| EvalError::Runtime(format!("native dep {ns}: {e}")))?;
 
     // Already brought in (e.g. an earlier require of a sibling namespace
     // provided by the same dylib loaded the whole package).
@@ -136,62 +157,182 @@ fn load_require(globals: &Arc<GlobalEnv>, ns: &str) -> EvalResult<bool> {
         return Ok(true);
     }
 
-    let commit = git.sha.clone();
-    let lib_path = build_pinned_wrapper(&git, &commit)
+    let lib_path = build_wrapper(&dep, None)
         .map_err(|e| EvalError::Runtime(format!("native dep {ns}: {e}")))?;
 
     load_library(globals, &lib_path, None)
         .map_err(|e| EvalError::Runtime(format!("native dep {ns}: {e}")))?;
 
-    eprintln!("[cljrs] loaded native dep {ns} (pinned {commit})");
+    eprintln!("[cljrs] loaded native dep {ns} ({})", dep.provenance());
     Ok(true)
 }
 
-/// Find a `:rust/load :dylib` git dep whose name covers `base_ns` (exact
-/// match or dotted prefix: dep `my.lib` covers `my.lib.util`).
-fn find_dylib_dep(config: &cljrs_project::config::DepsConfig, base_ns: &str) -> Option<GitDep> {
-    for (name, dep) in &config.deps {
-        if let Dependency::Git(git) = dep
-            && git.rust_load_dylib
-            && (name.as_ref() == base_ns
-                || base_ns
-                    .strip_prefix(name.as_ref())
-                    .is_some_and(|rest| rest.starts_with('.')))
-        {
-            return Some(git.clone());
+// ── Domain: what a native dependency IS ───────────────────────────────────────
+
+/// Where a `:rust/load :dylib` dep's crate source comes from.
+///
+/// A closed set: every source a `cljrs.edn` dep can name is one of these.
+#[derive(Debug, Clone)]
+enum NativeSource {
+    /// A git repository, checked out at a pinned commit.
+    Pinned { url: Arc<str>, sha: Arc<str> },
+    /// A directory on disk, built as it currently stands.
+    WorkingTree(PathBuf),
+}
+
+impl NativeSource {
+    /// The commit this source is fixed at, or `None` for a working tree.
+    fn commit(&self) -> Option<&str> {
+        match self {
+            NativeSource::Pinned { sha, .. } => Some(sha.as_ref()),
+            NativeSource::WorkingTree(_) => None,
         }
     }
-    None
+}
+
+/// What exactly was built — the identity that names one artifact.
+///
+/// A commit names it for a git dep; a working tree has no commit, so its
+/// content does. Either way an artifact under this version is immutable, which
+/// is what lets the cache be trusted and what keeps a rebuilt library from
+/// landing on the path an already-`dlopen`ed one occupies.
+struct SourceVersion {
+    /// The cache-directory suffix, e.g. `@<sha>` or `@local-<hash>`.
+    slug: String,
+    /// The full key mixed into the ABI-fingerprint hash.
+    key: String,
+}
+
+/// A dependency that opts into loading its Rust code as a cdylib.
+///
+/// Constructing one is the validation step: a `NativeDep` always names an
+/// init function, so no later stage has to handle its absence.
+#[derive(Debug, Clone)]
+struct NativeDep {
+    source: NativeSource,
+    init_fn: Arc<str>,
+    crate_subdir: Option<Arc<str>>,
+}
+
+impl NativeDep {
+    /// Build a dep from a declaration, or `Err` when it opted into `:dylib`
+    /// without naming the `:rust/init` function that would load it.
+    fn new(
+        source: NativeSource,
+        rust_init: Option<Arc<str>>,
+        crate_subdir: Option<Arc<str>>,
+    ) -> Result<Self, String> {
+        let init_fn = rust_init.ok_or("dep has :rust/load :dylib but no :rust/init function")?;
+        Ok(NativeDep {
+            source,
+            init_fn,
+            crate_subdir,
+        })
+    }
+
+    /// Whether this dep names an immutable commit, and so can serve versioned
+    /// (`ns/f@sha`) resolution.
+    fn is_pinned(&self) -> bool {
+        self.source.commit().is_some()
+    }
+
+    /// The Cargo package name, as the init path's first segment spells it.
+    fn crate_name(&self) -> &str {
+        self.init_fn.split("::").next().unwrap_or(&self.init_fn)
+    }
+
+    /// The `extern crate` identifier for [`Self::crate_name`].
+    fn pkg_ident(&self) -> String {
+        self.crate_name().replace('-', "_")
+    }
+
+    /// The init path with its crate segment stripped (`a::b::c` -> `b::c`).
+    fn init_tail(&self) -> &str {
+        self.init_fn
+            .split_once("::")
+            .map(|(_, rest)| rest)
+            .unwrap_or(&self.init_fn)
+    }
+
+    /// Human-readable provenance, for the load log line.
+    fn provenance(&self) -> String {
+        match &self.source {
+            NativeSource::Pinned { sha, .. } => format!("pinned {sha}"),
+            NativeSource::WorkingTree(root) => format!("local {}", root.display()),
+        }
+    }
+}
+
+/// Read the `:rust/*` keys of a `:deps` entry as a native dep, or `None` when
+/// the entry did not opt into `:rust/load :dylib`.
+fn as_native_dep(dep: &Dependency) -> Option<Result<NativeDep, String>> {
+    match dep {
+        Dependency::Git(git) if git.rust_load_dylib => Some(NativeDep::new(
+            NativeSource::Pinned {
+                url: git.url.clone(),
+                sha: git.sha.clone(),
+            },
+            git.rust_init.clone(),
+            git.rust_crate_dir.clone(),
+        )),
+        Dependency::Local {
+            root,
+            rust_init,
+            rust_crate_dir,
+            rust_load_dylib: true,
+        } => Some(NativeDep::new(
+            NativeSource::WorkingTree(root.clone()),
+            rust_init.clone(),
+            rust_crate_dir.clone(),
+        )),
+        _ => None,
+    }
+}
+
+/// Whether a dep named `dep_name` provides namespace `ns` — exact match, or a
+/// dotted prefix (dep `my.lib` covers `my.lib.util`).
+fn covers_namespace(dep_name: &str, ns: &str) -> bool {
+    dep_name == ns
+        || ns
+            .strip_prefix(dep_name)
+            .is_some_and(|rest| rest.starts_with('.'))
+}
+
+/// Find the `:rust/load :dylib` dep covering `base_ns`.
+fn find_dylib_dep(
+    config: &cljrs_project::config::DepsConfig,
+    base_ns: &str,
+) -> Option<Result<NativeDep, String>> {
+    config
+        .deps
+        .iter()
+        .filter(|(name, _)| covers_namespace(name, base_ns))
+        .find_map(|(_, dep)| as_native_dep(dep))
 }
 
 // ── Wrapper build ─────────────────────────────────────────────────────────────
 
-/// Build (or reuse from cache) the wrapper cdylib for `git` at `commit`,
-/// returning the path to the built library.
-fn build_pinned_wrapper(git: &GitDep, commit: &str) -> Result<PathBuf, String> {
-    let init_fn = git
-        .rust_init
-        .as_deref()
-        .ok_or("dep has :rust/load :dylib but no :rust/init function")?;
-    let crate_name = init_fn.split("::").next().unwrap_or(init_fn);
-    // Cargo package names use '-', Rust paths use '_': accept either by
-    // depending on the package directory and renaming is unnecessary —
-    // we depend by path, and Cargo reads the real package name from the
-    // checkout's Cargo.toml.  The `extern crate` ident is the init path's
-    // first segment, which must match the package's lib name.
-    let pkg_ident = crate_name.replace('-', "_");
+/// Where the wrapper for one `(dep, version)` is generated and what it produces.
+struct WrapperPlan {
+    /// The dep's own crate, already on disk.
+    crate_dir: PathBuf,
+    /// The generated wrapper crate's directory.
+    wrapper_dir: PathBuf,
+    /// The cdylib `cargo` will produce inside `wrapper_dir`.
+    artifact: PathBuf,
+    /// Cache identity, for log lines.
+    label: String,
+}
 
-    // 1. Fetch + checkout at the pinned commit.  `fetch_remote` populates the
-    //    bare cache (network only if the commit is missing); `worktree_at_commit`
-    //    materializes a files-only checkout from it (shared with the source-path
-    //    materialization used for plain `require` of git deps).
-    cljrs_project::vcs::fetch_remote(&git.url, commit).map_err(|e| e.to_string())?;
-    let checkout =
-        cljrs_project::vcs::worktree_at_commit(&git.url, commit).map_err(|e| e.to_string())?;
-    let crate_dir = match git.rust_crate_dir.as_deref() {
-        Some(sub) => checkout.join(sub),
-        None => checkout.clone(),
-    };
+/// Build (or reuse from cache) the wrapper cdylib for `dep`, returning the
+/// path to the built library.
+///
+/// `commit_override` builds a pinned dep at a commit other than its declared
+/// `:git/sha` — the versioned resolver asks for the commit named in the symbol.
+/// It must be `None` for a working-tree dep, which has no commit at all.
+fn build_wrapper(dep: &NativeDep, commit_override: Option<&str>) -> Result<PathBuf, String> {
+    let source_root = materialize_source(&dep.source, commit_override)?;
+    let crate_dir = crate_dir_of(dep, &source_root);
     if !crate_dir.join("Cargo.toml").exists() {
         return Err(format!(
             "no Cargo.toml at {} (set :rust/crate if the crate lives in a subdirectory)",
@@ -199,53 +340,172 @@ fn build_pinned_wrapper(git: &GitDep, commit: &str) -> Result<PathBuf, String> {
         ));
     }
 
-    // 2. Cache key: same wrapper inputs → same artifact.
-    let fingerprint = abi_fingerprint();
-    let fp_hash = stable_hash(&format!("{fingerprint}|{}|{commit}", git.url));
-    let wrapper_dir = dylib_cache_root()
-        .join(format!("{pkg_ident}@{commit}"))
-        .join(format!("fp-{fp_hash}"));
-    let artifact = wrapper_artifact_path(&wrapper_dir);
-    if artifact.exists() {
-        return Ok(artifact);
+    let version = resolve_version(&dep.source, &crate_dir, commit_override)?;
+    let plan = plan_wrapper(dep, crate_dir, &version);
+    if plan.artifact.exists() {
+        return Ok(plan.artifact);
     }
 
-    // 3. Generate the wrapper crate.
-    write_wrapper_crate(&wrapper_dir, &crate_dir, crate_name, &pkg_ident, init_fn)?;
+    write_wrapper_crate(&plan.wrapper_dir, &plan.crate_dir, dep)?;
+    cargo_build(&plan)?;
 
-    // 4. Build, matching the host's profile (see `abi_fingerprint`).
-    let offline = find_workspace_root().is_some();
+    if !plan.artifact.exists() {
+        return Err(format!(
+            "built wrapper not found at {}",
+            plan.artifact.display()
+        ));
+    }
+    Ok(plan.artifact)
+}
+
+/// Identify what is about to be built.
+///
+/// A pinned dep is named by its commit. A working tree is named by a digest of
+/// its source files, so an edited tree is a different version — which is what
+/// gets it rebuilt, and gets the result its own path to be loaded from.
+fn resolve_version(
+    source: &NativeSource,
+    crate_dir: &Path,
+    commit_override: Option<&str>,
+) -> Result<SourceVersion, String> {
+    match source {
+        NativeSource::Pinned { url, sha } => {
+            let commit = commit_override.unwrap_or(sha.as_ref());
+            Ok(SourceVersion {
+                slug: format!("@{commit}"),
+                key: format!("{url}|{commit}"),
+            })
+        }
+        NativeSource::WorkingTree(root) => {
+            let digest = digest_source_tree(crate_dir)?;
+            Ok(SourceVersion {
+                slug: format!("@local-{digest}"),
+                key: format!("{}|{digest}", root.display()),
+            })
+        }
+    }
+}
+
+/// Digest every source file under `dir`, ignoring build output and VCS data.
+///
+/// Path and contents both feed the hash, so a rename is as much a change as an
+/// edit. Walk order is sorted, making the digest independent of readdir order.
+fn digest_source_tree(dir: &Path) -> Result<String, String> {
+    let mut acc = String::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let mut entries: Vec<_> = std::fs::read_dir(&current)
+            .map_err(|e| format!("reading {}: {e}", current.display()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("reading {}: {e}", current.display()))?;
+        entries.sort_by_key(|e| e.file_name());
+        for entry in entries {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name == "target" || name == ".git" {
+                continue;
+            }
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let rel = path.strip_prefix(dir).unwrap_or(&path);
+            let bytes = std::fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+            acc.push_str(&format!(
+                "{}|{}\n",
+                rel.display(),
+                stable_hash(&String::from_utf8_lossy(&bytes))
+            ));
+        }
+    }
+    Ok(stable_hash(&acc))
+}
+
+/// The dep's crate directory within its materialized source.
+fn crate_dir_of(dep: &NativeDep, source_root: &Path) -> PathBuf {
+    match dep.crate_subdir.as_deref() {
+        Some(sub) => source_root.join(sub),
+        None => source_root.to_path_buf(),
+    }
+}
+
+/// Put the dep's source on disk and return its root.
+///
+/// For a pinned dep this fetches (network only when the commit is missing) and
+/// materializes a files-only checkout; a working tree is already on disk.
+fn materialize_source(
+    source: &NativeSource,
+    commit_override: Option<&str>,
+) -> Result<PathBuf, String> {
+    match source {
+        NativeSource::Pinned { url, sha } => {
+            let commit = commit_override.unwrap_or(sha.as_ref());
+            cljrs_project::vcs::fetch_remote(url, commit).map_err(|e| e.to_string())?;
+            cljrs_project::vcs::worktree_at_commit(url, commit).map_err(|e| e.to_string())
+        }
+        NativeSource::WorkingTree(root) => {
+            if commit_override.is_some() {
+                return Err("a :local/root dep has no commit to build at".into());
+            }
+            if !root.is_dir() {
+                return Err(format!("local dep root not found at {}", root.display()));
+            }
+            Ok(root.canonicalize().unwrap_or_else(|_| root.clone()))
+        }
+    }
+}
+
+/// Derive every path the build needs. Pure: the source is already resolved.
+fn plan_wrapper(dep: &NativeDep, crate_dir: PathBuf, version: &SourceVersion) -> WrapperPlan {
+    let label = format!("{}{}", dep.pkg_ident(), version.slug);
+    let fp_hash = stable_hash(&format!("{}|{}", abi_fingerprint(), version.key));
+    let wrapper_dir = dylib_cache_root()
+        .join(&label)
+        .join(format!("fp-{fp_hash}"));
+    let artifact = wrapper_artifact_path(&wrapper_dir);
+    WrapperPlan {
+        crate_dir,
+        wrapper_dir,
+        artifact,
+        label,
+    }
+}
+
+/// Run `cargo build` on the generated wrapper, matching the host's profile
+/// (see [`abi_fingerprint`]).
+fn cargo_build(plan: &WrapperPlan) -> Result<(), String> {
     let mut cmd = std::process::Command::new("cargo");
-    cmd.arg("build").current_dir(&wrapper_dir);
+    cmd.arg("build").current_dir(&plan.wrapper_dir);
     if host_profile() == "release" {
         cmd.arg("--release");
     }
-    if offline {
+    if find_workspace_root().is_some() {
         cmd.arg("--offline");
     }
-    eprintln!("[cljrs] building pinned native package {pkg_ident}@{commit}…");
+    eprintln!("[cljrs] building native package {}…", plan.label);
     let status = cmd.status().map_err(|e| format!("cargo: {e}"))?;
     if !status.success() {
         return Err(format!(
-            "cargo build of pinned wrapper failed (see output above; wrapper at {})",
-            wrapper_dir.display()
+            "cargo build of native wrapper failed (see output above; wrapper at {})",
+            plan.wrapper_dir.display()
         ));
     }
-
-    if !artifact.exists() {
-        return Err(format!("built wrapper not found at {}", artifact.display()));
-    }
-    Ok(artifact)
+    Ok(())
 }
 
 /// Write the generated wrapper crate (Cargo.toml, build.rs, src/lib.rs).
+///
+/// The wrapper depends on the dep by PATH, so Cargo reads the real package
+/// name from its own Cargo.toml; `crate_name` only has to match the lib name
+/// the `extern crate` ident resolves to.
 fn write_wrapper_crate(
     wrapper_dir: &Path,
     crate_dir: &Path,
-    crate_name: &str,
-    pkg_ident: &str,
-    init_fn: &str,
+    dep: &NativeDep,
 ) -> Result<(), String> {
+    let crate_name = dep.crate_name();
+    let pkg_ident = dep.pkg_ident();
     std::fs::create_dir_all(wrapper_dir.join("src")).map_err(|e| e.to_string())?;
 
     // Pin cljrs-interop exactly like the AOT harness pins runtime crates:
@@ -335,10 +595,7 @@ pub unsafe extern "C" fn cljrs_dylib_init(registry: *mut cljrs_interop::Registry
     {pkg_ident}::{init_tail}(registry);
 }}
 "#,
-        init_tail = init_fn
-            .split_once("::")
-            .map(|(_, rest)| rest)
-            .unwrap_or("cljrs_init"),
+        init_tail = dep.init_tail(),
     );
     std::fs::write(wrapper_dir.join("src/lib.rs"), lib_rs).map_err(|e| e.to_string())?;
     Ok(())

--- a/crates/cljrs/src/native/pinned.rs
+++ b/crates/cljrs/src/native/pinned.rs
@@ -8,7 +8,7 @@
 //!   versioned (`mylib/f@<sha>`) resolution; its artifact is cached forever.
 //! - `:local/root` — a working tree, built as it currently stands. Serves
 //!   `require` only (there is no commit to resolve `@<sha>` against), and is
-//!   rebuilt on every load because the tree changes underfoot.
+//!   versioned by a digest of the tree, so an edit is a different build.
 //!
 //! By default, a pinned symbol (`mylib/f@<sha>`) that resolves to a native
 //! (Rust-backed) function falls back to the **current binary's**
@@ -103,15 +103,18 @@ fn load_pinned(globals: &Arc<GlobalEnv>, base_ns: &str, commit: &str) -> EvalRes
     let Some(config) = config else {
         return Ok(false);
     };
-    let Some(dep) = find_dylib_dep(&config, base_ns) else {
+    let Some(decl) = find_dylib_dep(&config, base_ns) else {
         return Ok(false);
     };
-    let dep = dep.map_err(|e| EvalError::Runtime(format!("pinned native {base_ns}: {e}")))?;
     // A working tree has no commit, so it cannot answer for `ns/f@sha`.
-    // Decline and let the versioned resolver fall back as it would have.
-    if !dep.is_pinned() {
+    // Declined *before* validation: a misconfigured local dep must leave
+    // versioned resolution exactly as it was, not turn it into an error.
+    if !decl.is_pinned() {
         return Ok(false);
     }
+    let dep = decl
+        .validate()
+        .map_err(|e| EvalError::Runtime(format!("pinned native {base_ns}: {e}")))?;
 
     let versioned_ns = format!("{base_ns}@{commit}");
     if globals.is_loaded(&versioned_ns) {
@@ -146,10 +149,12 @@ fn load_require(globals: &Arc<GlobalEnv>, ns: &str) -> EvalResult<bool> {
     let Some(config) = config else {
         return Ok(false);
     };
-    let Some(dep) = find_dylib_dep(&config, ns) else {
+    let Some(decl) = find_dylib_dep(&config, ns) else {
         return Ok(false);
     };
-    let dep = dep.map_err(|e| EvalError::Runtime(format!("native dep {ns}: {e}")))?;
+    let dep = decl
+        .validate()
+        .map_err(|e| EvalError::Runtime(format!("native dep {ns}: {e}")))?;
 
     // Already brought in (e.g. an earlier require of a sibling namespace
     // provided by the same dylib loaded the whole package).
@@ -203,10 +208,43 @@ struct SourceVersion {
     key: String,
 }
 
+/// A `:rust/load :dylib` dependency as `cljrs.edn` declares it, before
+/// validation.
+///
+/// The source alone settles which resolution paths the dep can serve, so that
+/// question is answerable here; only actually building it needs `:rust/init`.
+#[derive(Debug, Clone)]
+struct DylibDecl {
+    source: NativeSource,
+    init_fn: Option<Arc<str>>,
+    crate_subdir: Option<Arc<str>>,
+}
+
+impl DylibDecl {
+    /// Whether this dep names an immutable commit, and so can serve versioned
+    /// (`ns/f@sha`) resolution.
+    fn is_pinned(&self) -> bool {
+        self.source.commit().is_some()
+    }
+
+    /// Into a loadable dep, or `Err` when the dep opted into `:dylib` without
+    /// naming the `:rust/init` function that would load it.
+    fn validate(self) -> Result<NativeDep, String> {
+        let init_fn = self
+            .init_fn
+            .ok_or("dep has :rust/load :dylib but no :rust/init function")?;
+        Ok(NativeDep {
+            source: self.source,
+            init_fn,
+            crate_subdir: self.crate_subdir,
+        })
+    }
+}
+
 /// A dependency that opts into loading its Rust code as a cdylib.
 ///
-/// Constructing one is the validation step: a `NativeDep` always names an
-/// init function, so no later stage has to handle its absence.
+/// Validation happens in [`DylibDecl::validate`]: a `NativeDep` always names
+/// an init function, so no later stage has to handle its absence.
 #[derive(Debug, Clone)]
 struct NativeDep {
     source: NativeSource,
@@ -215,35 +253,12 @@ struct NativeDep {
 }
 
 impl NativeDep {
-    /// Build a dep from a declaration, or `Err` when it opted into `:dylib`
-    /// without naming the `:rust/init` function that would load it.
-    fn new(
-        source: NativeSource,
-        rust_init: Option<Arc<str>>,
-        crate_subdir: Option<Arc<str>>,
-    ) -> Result<Self, String> {
-        let init_fn = rust_init.ok_or("dep has :rust/load :dylib but no :rust/init function")?;
-        Ok(NativeDep {
-            source,
-            init_fn,
-            crate_subdir,
-        })
-    }
-
-    /// Whether this dep names an immutable commit, and so can serve versioned
-    /// (`ns/f@sha`) resolution.
-    fn is_pinned(&self) -> bool {
-        self.source.commit().is_some()
-    }
-
-    /// The Cargo package name, as the init path's first segment spells it.
-    fn crate_name(&self) -> &str {
+    /// The `extern crate` identifier the `:rust/init` path names: its first
+    /// segment.  A Rust identifier, *not* the Cargo package name, which comes
+    /// from [`package_name_of`]; the two differ whenever the package name
+    /// contains `-`, which an identifier cannot.
+    fn pkg_ident(&self) -> &str {
         self.init_fn.split("::").next().unwrap_or(&self.init_fn)
-    }
-
-    /// The `extern crate` identifier for [`Self::crate_name`].
-    fn pkg_ident(&self) -> String {
-        self.crate_name().replace('-', "_")
     }
 
     /// The init path with its crate segment stripped (`a::b::c` -> `b::c`).
@@ -263,28 +278,28 @@ impl NativeDep {
     }
 }
 
-/// Read the `:rust/*` keys of a `:deps` entry as a native dep, or `None` when
-/// the entry did not opt into `:rust/load :dylib`.
-fn as_native_dep(dep: &Dependency) -> Option<Result<NativeDep, String>> {
+/// Read the `:rust/*` keys of a `:deps` entry as a dylib declaration, or
+/// `None` when the entry did not opt into `:rust/load :dylib`.
+fn as_dylib_decl(dep: &Dependency) -> Option<DylibDecl> {
     match dep {
-        Dependency::Git(git) if git.rust_load_dylib => Some(NativeDep::new(
-            NativeSource::Pinned {
+        Dependency::Git(git) if git.rust_load_dylib => Some(DylibDecl {
+            source: NativeSource::Pinned {
                 url: git.url.clone(),
                 sha: git.sha.clone(),
             },
-            git.rust_init.clone(),
-            git.rust_crate_dir.clone(),
-        )),
+            init_fn: git.rust_init.clone(),
+            crate_subdir: git.rust_crate_dir.clone(),
+        }),
         Dependency::Local {
             root,
             rust_init,
             rust_crate_dir,
             rust_load_dylib: true,
-        } => Some(NativeDep::new(
-            NativeSource::WorkingTree(root.clone()),
-            rust_init.clone(),
-            rust_crate_dir.clone(),
-        )),
+        } => Some(DylibDecl {
+            source: NativeSource::WorkingTree(root.clone()),
+            init_fn: rust_init.clone(),
+            crate_subdir: rust_crate_dir.clone(),
+        }),
         _ => None,
     }
 }
@@ -298,16 +313,13 @@ fn covers_namespace(dep_name: &str, ns: &str) -> bool {
             .is_some_and(|rest| rest.starts_with('.'))
 }
 
-/// Find the `:rust/load :dylib` dep covering `base_ns`.
-fn find_dylib_dep(
-    config: &cljrs_project::config::DepsConfig,
-    base_ns: &str,
-) -> Option<Result<NativeDep, String>> {
+/// Find the `:rust/load :dylib` declaration covering `base_ns`.
+fn find_dylib_dep(config: &cljrs_project::config::DepsConfig, base_ns: &str) -> Option<DylibDecl> {
     config
         .deps
         .iter()
         .filter(|(name, _)| covers_namespace(name, base_ns))
-        .find_map(|(_, dep)| as_native_dep(dep))
+        .find_map(|(_, dep)| as_dylib_decl(dep))
 }
 
 // ── Wrapper build ─────────────────────────────────────────────────────────────
@@ -316,9 +328,22 @@ fn find_dylib_dep(
 struct WrapperPlan {
     /// The dep's own crate, already on disk.
     crate_dir: PathBuf,
-    /// The generated wrapper crate's directory.
+    /// The generated wrapper crate's directory.  Deliberately *not* keyed by
+    /// version: cargo tracks the dep's own sources itself, so one wrapper
+    /// crate and one target directory per `(dep crate, ABI)` makes an edit
+    /// cost an incremental rebuild instead of a fresh one, and leaves one
+    /// target directory on disk instead of one per edit.
     wrapper_dir: PathBuf,
-    /// The cdylib `cargo` will produce inside `wrapper_dir`.
+    /// The cargo target directory for `wrapper_dir`, set explicitly so the
+    /// artifact path below is predictable whatever the ambient
+    /// `CARGO_TARGET_DIR` says.
+    target_dir: PathBuf,
+    /// The cdylib cargo produces inside [`Self::target_dir`].
+    build_output: PathBuf,
+    /// The version-unique path the cdylib is published to and `dlopen`ed
+    /// from.  A rebuilt library reusing the path an already-loaded one
+    /// occupies would not be picked up, so this cannot be the shared
+    /// [`Self::build_output`].
     artifact: PathBuf,
     /// Cache identity, for log lines.
     label: String,
@@ -340,7 +365,7 @@ fn build_wrapper(dep: &NativeDep, commit_override: Option<&str>) -> Result<PathB
         ));
     }
 
-    let version = resolve_version(&dep.source, &crate_dir, commit_override)?;
+    let version = version_of(dep, &source_root, commit_override)?;
     let plan = plan_wrapper(dep, crate_dir, &version);
     if plan.artifact.exists() {
         return Ok(plan.artifact);
@@ -349,26 +374,55 @@ fn build_wrapper(dep: &NativeDep, commit_override: Option<&str>) -> Result<PathB
     write_wrapper_crate(&plan.wrapper_dir, &plan.crate_dir, dep)?;
     cargo_build(&plan)?;
 
-    if !plan.artifact.exists() {
+    if !plan.build_output.exists() {
         return Err(format!(
             "built wrapper not found at {}",
-            plan.artifact.display()
+            plan.build_output.display()
         ));
     }
+    publish_artifact(&plan)?;
     Ok(plan.artifact)
 }
 
-/// Identify what is about to be built.
+/// Copy the freshly built cdylib to its version-unique path.
+///
+/// `dlopen` keys on the path, so a rebuilt library has to arrive somewhere the
+/// previous one never occupied; the shared build directory cannot provide
+/// that, and the copy is what buys it back.
+fn publish_artifact(plan: &WrapperPlan) -> Result<(), String> {
+    let dir = plan
+        .artifact
+        .parent()
+        .ok_or("wrapper artifact path has no parent directory")?;
+    std::fs::create_dir_all(dir).map_err(|e| format!("creating {}: {e}", dir.display()))?;
+    std::fs::copy(&plan.build_output, &plan.artifact).map_err(|e| {
+        format!(
+            "copying {} to {}: {e}",
+            plan.build_output.display(),
+            plan.artifact.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Identify what is about to be built, given the dep's materialized
+/// `source_root`.
 ///
 /// A pinned dep is named by its commit. A working tree is named by a digest of
-/// its source files, so an edited tree is a different version — which is what
-/// gets it rebuilt, and gets the result its own path to be loaded from.
-fn resolve_version(
-    source: &NativeSource,
-    crate_dir: &Path,
+/// its source files, so an edited tree is a different version, which is what
+/// gets it rebuilt and gets the result its own path to be loaded from.
+///
+/// The digest covers the whole `source_root`, not just the crate `:rust/crate`
+/// names: a crate in a multi-crate tree normally has path dependencies on its
+/// siblings, so an edit outside it still changes what gets built.  The cost is
+/// a spurious rebuild when something the build ignores changes; the
+/// alternative is loading a stale library, silently.
+fn version_of(
+    dep: &NativeDep,
+    source_root: &Path,
     commit_override: Option<&str>,
 ) -> Result<SourceVersion, String> {
-    match source {
+    match &dep.source {
         NativeSource::Pinned { url, sha } => {
             let commit = commit_override.unwrap_or(sha.as_ref());
             Ok(SourceVersion {
@@ -376,11 +430,11 @@ fn resolve_version(
                 key: format!("{url}|{commit}"),
             })
         }
-        NativeSource::WorkingTree(root) => {
-            let digest = digest_source_tree(crate_dir)?;
+        NativeSource::WorkingTree(_) => {
+            let digest = digest_source_tree(source_root)?;
             Ok(SourceVersion {
                 slug: format!("@local-{digest}"),
-                key: format!("{}|{digest}", root.display()),
+                key: format!("{}|{digest}", source_root.display()),
             })
         }
     }
@@ -411,11 +465,12 @@ fn digest_source_tree(dir: &Path) -> Result<String, String> {
                 continue;
             }
             let rel = path.strip_prefix(dir).unwrap_or(&path);
-            let bytes = std::fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+            let bytes =
+                std::fs::read(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
             acc.push_str(&format!(
                 "{}|{}\n",
                 rel.display(),
-                stable_hash(&String::from_utf8_lossy(&bytes))
+                stable_hash_bytes(&bytes)
             ));
         }
     }
@@ -458,17 +513,56 @@ fn materialize_source(
 
 /// Derive every path the build needs. Pure: the source is already resolved.
 fn plan_wrapper(dep: &NativeDep, crate_dir: PathBuf, version: &SourceVersion) -> WrapperPlan {
+    let abi = abi_fingerprint();
     let label = format!("{}{}", dep.pkg_ident(), version.slug);
-    let fp_hash = stable_hash(&format!("{}|{}", abi_fingerprint(), version.key));
+    let fp_hash = stable_hash(&format!("{abi}|{}", version.key));
+    let build_hash = stable_hash(&format!("{abi}|{}", crate_dir.display()));
     let wrapper_dir = dylib_cache_root()
+        .join("build")
+        .join(format!("{}-{build_hash}", dep.pkg_ident()));
+    let target_dir = wrapper_dir.join("target");
+    let lib_file = wrapper_lib_filename();
+    let build_output = target_dir.join(host_profile()).join(&lib_file);
+    let artifact = dylib_cache_root()
         .join(&label)
-        .join(format!("fp-{fp_hash}"));
-    let artifact = wrapper_artifact_path(&wrapper_dir);
+        .join(format!("fp-{fp_hash}"))
+        .join(&lib_file);
     WrapperPlan {
         crate_dir,
         wrapper_dir,
+        target_dir,
+        build_output,
         artifact,
         label,
+    }
+}
+
+/// Whether a wrapper build may reach the network to resolve dependencies.
+///
+/// Cargo resolves the *dependency's own* crates here, not just the
+/// `cljrs-interop` pin, so online is the default: an extension that pulls an
+/// uncached crates.io crate has to be buildable.  `CLJRS_DYLIB_OFFLINE`
+/// selects `--offline` for a machine that already has everything vendored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NetworkPolicy {
+    Online,
+    Offline,
+}
+
+impl NetworkPolicy {
+    /// Read the policy from a `CLJRS_DYLIB_OFFLINE` value.  Unset, empty and
+    /// `0` mean online; anything else opts into `--offline`.
+    fn from_env_value(value: Option<&str>) -> NetworkPolicy {
+        match value {
+            None => NetworkPolicy::Online,
+            Some(v) if v.is_empty() || v == "0" => NetworkPolicy::Online,
+            Some(_) => NetworkPolicy::Offline,
+        }
+    }
+
+    /// The policy this process runs under.
+    fn from_env() -> NetworkPolicy {
+        NetworkPolicy::from_env_value(std::env::var("CLJRS_DYLIB_OFFLINE").ok().as_deref())
     }
 }
 
@@ -476,11 +570,13 @@ fn plan_wrapper(dep: &NativeDep, crate_dir: PathBuf, version: &SourceVersion) ->
 /// (see [`abi_fingerprint`]).
 fn cargo_build(plan: &WrapperPlan) -> Result<(), String> {
     let mut cmd = std::process::Command::new("cargo");
-    cmd.arg("build").current_dir(&plan.wrapper_dir);
+    cmd.arg("build")
+        .current_dir(&plan.wrapper_dir)
+        .env("CARGO_TARGET_DIR", &plan.target_dir);
     if host_profile() == "release" {
         cmd.arg("--release");
     }
-    if find_workspace_root().is_some() {
+    if NetworkPolicy::from_env() == NetworkPolicy::Offline {
         cmd.arg("--offline");
     }
     eprintln!("[cljrs] building native package {}…", plan.label);
@@ -514,8 +610,9 @@ fn write_wrapper_crate(
         )
     })?;
     let dep_line = format!(
-        r#"{pkg_ident} = {{ path = "{}", package = "{package_name}" }}"#,
-        crate_dir.display()
+        "{pkg_ident} = {{ path = {}, package = {} }}",
+        toml_basic_string(&crate_dir.display().to_string()),
+        toml_basic_string(&package_name),
     );
     std::fs::create_dir_all(wrapper_dir.join("src")).map_err(|e| e.to_string())?;
 
@@ -524,8 +621,8 @@ fn write_wrapper_crate(
     // otherwise.  The handshake catches any residual mismatch.
     let interop_dep = match find_workspace_root() {
         Some(root) => format!(
-            "cljrs-interop = {{ path = \"{}\" }}",
-            root.join("crates/cljrs-interop").display()
+            "cljrs-interop = {{ path = {} }}",
+            toml_basic_string(&root.join("crates/cljrs-interop").display().to_string())
         ),
         None => format!("cljrs-interop = \"={}\"", env!("CARGO_PKG_VERSION")),
     };
@@ -611,6 +708,27 @@ pub unsafe extern "C" fn cljrs_dylib_init(registry: *mut cljrs_interop::Registry
     Ok(())
 }
 
+/// `s` rendered as a TOML basic string, quotes included.
+///
+/// The generated manifest carries filesystem paths: a Windows separator is an
+/// invalid escape inside a basic string, and a `"` would close it early.
+fn toml_basic_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// The `[package] name` declared in a Cargo manifest.
 ///
 /// Only that one key is read, so the full TOML grammar is not needed: track
@@ -640,8 +758,8 @@ fn package_name_of(manifest: &str) -> Option<String> {
     None
 }
 
-/// The built artifact path for a wrapper crate dir (host-profile build).
-fn wrapper_artifact_path(wrapper_dir: &Path) -> PathBuf {
+/// The cdylib file name cargo produces for the generated wrapper crate.
+fn wrapper_lib_filename() -> String {
     let stem = "cljrs_pinned_wrapper";
     #[cfg(target_os = "macos")]
     let file = format!("lib{stem}.dylib");
@@ -649,7 +767,7 @@ fn wrapper_artifact_path(wrapper_dir: &Path) -> PathBuf {
     let file = format!("{stem}.dll");
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let file = format!("lib{stem}.so");
-    wrapper_dir.join("target").join(host_profile()).join(file)
+    file
 }
 
 // ── Loading ───────────────────────────────────────────────────────────────────
@@ -725,15 +843,24 @@ fn find_workspace_root() -> Option<PathBuf> {
 
 /// Short stable hex hash for cache directory names.
 fn stable_hash(s: &str) -> String {
-    use std::hash::{DefaultHasher, Hash as _, Hasher as _};
+    stable_hash_bytes(s.as_bytes())
+}
+
+/// [`stable_hash`] over raw bytes.
+///
+/// File contents are hashed as they lie: a lossy UTF-8 conversion maps every
+/// invalid byte to one replacement character, which would digest two files
+/// that differ only in invalid UTF-8 identically.
+fn stable_hash_bytes(bytes: &[u8]) -> String {
+    use std::hash::{DefaultHasher, Hasher as _};
     let mut h = DefaultHasher::new();
-    s.hash(&mut h);
+    h.write(bytes);
     format!("{:016x}", h.finish())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::package_name_of;
+    use super::*;
 
     #[test]
     fn reads_the_package_name() {
@@ -787,5 +914,192 @@ version.workspace = true
 edition.workspace = true
 "#;
         assert_eq!(package_name_of(manifest).as_deref(), Some("cljrs-ffmpeg"));
+    }
+
+    /// A working-tree dep is versioned by a digest of its whole root, not of
+    /// the crate `:rust/crate` selects: the crate being built normally has
+    /// path dependencies on its siblings, so an edit to one of those changes
+    /// what cargo would produce.  Digesting the crate directory alone leaves
+    /// the version unchanged, and `build_wrapper` then returns the cached
+    /// artifact without ever asking cargo to rebuild.
+    #[test]
+    fn a_working_tree_version_covers_the_whole_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("crates/thing/src")).unwrap();
+        std::fs::create_dir_all(root.join("crates/sibling/src")).unwrap();
+        std::fs::write(
+            root.join("crates/thing/Cargo.toml"),
+            "[package]\nname = \"thing\"\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("crates/thing/src/lib.rs"), "pub fn f() {}\n").unwrap();
+        std::fs::write(
+            root.join("crates/sibling/src/lib.rs"),
+            "pub const N: i64 = 1;\n",
+        )
+        .unwrap();
+
+        let dep = NativeDep {
+            source: NativeSource::WorkingTree(root.to_path_buf()),
+            init_fn: Arc::from("thing::cljrs_init"),
+            crate_subdir: Some(Arc::from("crates/thing")),
+        };
+
+        let before = version_of(&dep, root, None).unwrap();
+        // The edit is outside `:rust/crate`.
+        std::fs::write(
+            root.join("crates/sibling/src/lib.rs"),
+            "pub const N: i64 = 2;\n",
+        )
+        .unwrap();
+        let after = version_of(&dep, root, None).unwrap();
+
+        assert_ne!(
+            before.slug, after.slug,
+            "an edit to a sibling crate must produce a different version"
+        );
+        assert_ne!(before.key, after.key);
+    }
+
+    /// A pinned dep is named by its commit, never by a digest: its checkout is
+    /// immutable, and `commit_override` is what the versioned resolver asks
+    /// for.
+    #[test]
+    fn a_pinned_version_is_the_commit() {
+        let dep = NativeDep {
+            source: NativeSource::Pinned {
+                url: Arc::from("https://example.invalid/lib"),
+                sha: Arc::from("aaaa"),
+            },
+            init_fn: Arc::from("lib::cljrs_init"),
+            crate_subdir: None,
+        };
+        assert_eq!(
+            version_of(&dep, Path::new("/nonexistent"), None)
+                .unwrap()
+                .slug,
+            "@aaaa"
+        );
+        assert_eq!(
+            version_of(&dep, Path::new("/nonexistent"), Some("bbbb"))
+                .unwrap()
+                .slug,
+            "@bbbb"
+        );
+    }
+
+    /// Two files differing only in invalid UTF-8 must not digest identically:
+    /// `String::from_utf8_lossy` collapses every invalid byte onto the same
+    /// replacement character, so the bytes have to be hashed as they lie.
+    #[test]
+    fn a_digest_distinguishes_invalid_utf8() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        std::fs::write(a.path().join("x.bin"), [0xffu8]).unwrap();
+        std::fs::write(b.path().join("x.bin"), [0xfeu8]).unwrap();
+        assert_ne!(
+            digest_source_tree(a.path()).unwrap(),
+            digest_source_tree(b.path()).unwrap()
+        );
+    }
+
+    /// The `:rust/init` path's first segment is a Rust identifier, which is
+    /// what the generated wrapper's `extern crate` reference needs; the Cargo
+    /// package name it renames is `package_name_of`'s job.
+    #[test]
+    fn the_package_identifier_is_the_init_paths_first_segment() {
+        let dep = NativeDep {
+            source: NativeSource::WorkingTree(PathBuf::from("/x")),
+            init_fn: Arc::from("my_lib::deep::cljrs_init"),
+            crate_subdir: None,
+        };
+        assert_eq!(dep.pkg_ident(), "my_lib");
+        assert_eq!(dep.init_tail(), "deep::cljrs_init");
+    }
+
+    /// A `:local/root` dep declines versioned resolution before validation, so
+    /// a missing `:rust/init` cannot turn a fallback into an error.
+    #[test]
+    fn a_working_tree_declaration_is_not_pinned() {
+        let local = DylibDecl {
+            source: NativeSource::WorkingTree(PathBuf::from("/x")),
+            init_fn: None,
+            crate_subdir: None,
+        };
+        assert!(!local.is_pinned());
+        assert!(local.validate().is_err());
+
+        let pinned = DylibDecl {
+            source: NativeSource::Pinned {
+                url: Arc::from("u"),
+                sha: Arc::from("s"),
+            },
+            init_fn: None,
+            crate_subdir: None,
+        };
+        assert!(pinned.is_pinned());
+    }
+
+    /// Paths reach the generated manifest as TOML basic strings: a Windows
+    /// separator is an invalid escape there and a quote would close the string.
+    #[test]
+    fn a_basic_string_escapes_backslashes_and_quotes() {
+        assert_eq!(
+            toml_basic_string(r"C:\src\my crate"),
+            r#""C:\\src\\my crate""#
+        );
+        assert_eq!(toml_basic_string(r#"a"b"#), r#""a\"b""#);
+        assert_eq!(toml_basic_string("plain/path"), r#""plain/path""#);
+    }
+
+    /// `--offline` is a policy the operator sets, not a fact derived from
+    /// whether a cljrs checkout happens to be around: the flag constrains the
+    /// dependency's own resolution, which that checkout says nothing about.
+    #[test]
+    fn the_network_policy_comes_from_its_own_setting() {
+        assert_eq!(NetworkPolicy::from_env_value(None), NetworkPolicy::Online);
+        assert_eq!(
+            NetworkPolicy::from_env_value(Some("")),
+            NetworkPolicy::Online
+        );
+        assert_eq!(
+            NetworkPolicy::from_env_value(Some("0")),
+            NetworkPolicy::Online
+        );
+        assert_eq!(
+            NetworkPolicy::from_env_value(Some("1")),
+            NetworkPolicy::Offline
+        );
+    }
+
+    /// The built cdylib is published to a version-unique path: `dlopen` keys
+    /// on the path, so a rebuild landing where a loaded library already sits
+    /// would not be picked up.  The build directory it comes from is shared
+    /// across versions, which is what keeps rebuilds incremental.
+    #[test]
+    fn the_artifact_path_is_version_unique_but_the_build_dir_is_not() {
+        let dep = NativeDep {
+            source: NativeSource::WorkingTree(PathBuf::from("/x")),
+            init_fn: Arc::from("thing::cljrs_init"),
+            crate_subdir: None,
+        };
+        let crate_dir = PathBuf::from("/x");
+        let v1 = SourceVersion {
+            slug: "@local-1111".into(),
+            key: "/x|1111".into(),
+        };
+        let v2 = SourceVersion {
+            slug: "@local-2222".into(),
+            key: "/x|2222".into(),
+        };
+        let a = plan_wrapper(&dep, crate_dir.clone(), &v1);
+        let b = plan_wrapper(&dep, crate_dir, &v2);
+
+        assert_ne!(a.artifact, b.artifact);
+        assert_eq!(a.wrapper_dir, b.wrapper_dir);
+        assert_eq!(a.target_dir, b.target_dir);
+        assert_eq!(a.build_output, b.build_output);
+        assert!(!a.artifact.starts_with(&a.target_dir));
     }
 }

--- a/crates/cljrs/src/native/pinned.rs
+++ b/crates/cljrs/src/native/pinned.rs
@@ -496,16 +496,27 @@ fn cargo_build(plan: &WrapperPlan) -> Result<(), String> {
 
 /// Write the generated wrapper crate (Cargo.toml, build.rs, src/lib.rs).
 ///
-/// The wrapper depends on the dep by PATH, so Cargo reads the real package
-/// name from its own Cargo.toml; `crate_name` only has to match the lib name
-/// the `extern crate` ident resolves to.
+/// The dependency is declared under the Rust identifier the `:rust/init` path
+/// uses, renamed to the package's real name — those differ whenever a package
+/// name contains `-`, which Rust identifiers cannot.
 fn write_wrapper_crate(
     wrapper_dir: &Path,
     crate_dir: &Path,
     dep: &NativeDep,
 ) -> Result<(), String> {
-    let crate_name = dep.crate_name();
     let pkg_ident = dep.pkg_ident();
+    let manifest = std::fs::read_to_string(crate_dir.join("Cargo.toml"))
+        .map_err(|e| format!("reading {}: {e}", crate_dir.join("Cargo.toml").display()))?;
+    let package_name = package_name_of(&manifest).ok_or_else(|| {
+        format!(
+            "no [package] name in {}",
+            crate_dir.join("Cargo.toml").display()
+        )
+    })?;
+    let dep_line = format!(
+        r#"{pkg_ident} = {{ path = "{}", package = "{package_name}" }}"#,
+        crate_dir.display()
+    );
     std::fs::create_dir_all(wrapper_dir.join("src")).map_err(|e| e.to_string())?;
 
     // Pin cljrs-interop exactly like the AOT harness pins runtime crates:
@@ -532,13 +543,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 {interop_dep}
-{crate_name} = {{ path = "{crate_dir}" }}
+{dep_line}
 
 [profile.release]
 panic = "unwind"
 "#,
         version = env!("CARGO_PKG_VERSION"),
-        crate_dir = crate_dir.display(),
     );
     std::fs::write(wrapper_dir.join("Cargo.toml"), cargo_toml).map_err(|e| e.to_string())?;
 
@@ -599,6 +609,35 @@ pub unsafe extern "C" fn cljrs_dylib_init(registry: *mut cljrs_interop::Registry
     );
     std::fs::write(wrapper_dir.join("src/lib.rs"), lib_rs).map_err(|e| e.to_string())?;
     Ok(())
+}
+
+/// The `[package] name` declared in a Cargo manifest.
+///
+/// Only that one key is read, so the full TOML grammar is not needed: track
+/// which table each line belongs to and take `name` from `[package]`.
+fn package_name_of(manifest: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in manifest.lines() {
+        let line = line.split('#').next().unwrap_or(line).trim();
+        if line.starts_with('[') {
+            in_package = line == "[package]";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "name" {
+            continue;
+        }
+        let value = value.trim().trim_matches(['"', '\''].as_slice());
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
 }
 
 /// The built artifact path for a wrapper crate dir (host-profile build).
@@ -690,4 +729,63 @@ fn stable_hash(s: &str) -> String {
     let mut h = DefaultHasher::new();
     s.hash(&mut h);
     format!("{:016x}", h.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::package_name_of;
+
+    #[test]
+    fn reads_the_package_name() {
+        let manifest = r#"
+[package]
+name = "cljrs-raster"
+version = "0.1.0"
+"#;
+        assert_eq!(package_name_of(manifest).as_deref(), Some("cljrs-raster"));
+    }
+
+    #[test]
+    fn ignores_a_name_in_another_table() {
+        // `[lib] name` and a dependency's `package` key are both `name`-ish
+        // and both wrong; only `[package]` decides.
+        let manifest = r#"
+[lib]
+name = "wrong_lib_name"
+
+[package]
+name = "right-one"
+
+[dependencies.serde]
+name = "also-wrong"
+"#;
+        assert_eq!(package_name_of(manifest).as_deref(), Some("right-one"));
+    }
+
+    #[test]
+    fn tolerates_comments_and_spacing() {
+        let manifest = r#"
+# leading comment
+[package]   # the package table
+   name   =   'spaced-out'   # trailing comment
+"#;
+        assert_eq!(package_name_of(manifest).as_deref(), Some("spaced-out"));
+    }
+
+    #[test]
+    fn a_manifest_without_a_package_name_yields_none() {
+        assert_eq!(package_name_of("[workspace]\nmembers = []\n"), None);
+        assert_eq!(package_name_of(""), None);
+    }
+
+    #[test]
+    fn a_workspace_inherited_version_does_not_confuse_it() {
+        let manifest = r#"
+[package]
+name = "cljrs-ffmpeg"
+version.workspace = true
+edition.workspace = true
+"#;
+        assert_eq!(package_name_of(manifest).as_deref(), Some("cljrs-ffmpeg"));
+    }
 }

--- a/crates/cljrs/src/session.rs
+++ b/crates/cljrs/src/session.rs
@@ -185,7 +185,7 @@ fn apply_deps_config(globals: &Arc<GlobalEnv>, cwd: &Path) {
 fn add_dep_source_paths(globals: &Arc<GlobalEnv>, config: &cljrs_project::config::DepsConfig) {
     for (name, dep) in &config.deps {
         let root = match dep {
-            cljrs_project::config::Dependency::Local { root } => {
+            cljrs_project::config::Dependency::Local { root, .. } => {
                 if root.is_dir() {
                     root.clone()
                 } else {
@@ -227,7 +227,7 @@ pub fn collect_dep_src_paths(config: &cljrs_project::config::DepsConfig) -> Vec<
     let mut paths = Vec::new();
     for (name, dep) in &config.deps {
         let root = match dep {
-            cljrs_project::config::Dependency::Local { root } => {
+            cljrs_project::config::Dependency::Local { root, .. } => {
                 if root.is_dir() {
                     root.clone()
                 } else {

--- a/crates/cljrs/tests/pinned_dylib_e2e.rs
+++ b/crates/cljrs/tests/pinned_dylib_e2e.rs
@@ -8,17 +8,58 @@
 //! CLJRS_DYLIB_E2E=1 cargo test -p cljrs --test pinned_dylib_e2e
 //! ```
 //!
-//! Fixture: a git repository holding a tiny native crate (`pinlib`) whose
-//! `cljrs_init` defines `pinlib/build-tag`.  Commit v1 returns 1; HEAD
-//! returns 2.  The host also registers its own (HEAD) implementation
-//! returning 99.  Resolving `pinlib/build-tag@<sha1>` must load the dylib
-//! built from commit v1 and return 1, leaving the host's binding untouched.
+//! Fixtures, all built around a tiny native crate (`pinlib`) whose
+//! `cljrs_init` defines `pinlib/build-tag`:
+//!
+//! - a git repository where commit v1 returns 1 and HEAD returns 2, for the
+//!   pinned (`@<sha>`) and plain-`require` paths;
+//! - a single-crate working tree, for `:local/root`;
+//! - a two-crate working tree where the tag comes from a *sibling* crate the
+//!   dylib crate depends on by path, for `:local/root` + `:rust/crate`.
+//!
+//! Every test in this binary sets `HOME` and `CLJRS_WORKSPACE_ROOT` for the
+//! whole process, so they are serialized on [`ENV_LOCK`] (see [`TestEnv`]).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use cljrs_value::Value;
+
+/// Serializes the tests in this binary.
+///
+/// Each of them points `HOME` at a private cache directory and pins
+/// `CLJRS_WORKSPACE_ROOT`, and `std::env::set_var` is undefined behaviour
+/// while any other thread may be reading the environment: libtest runs these
+/// tests on parallel threads, and a `Command` spawn reads the environment.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// The process environment for one test: holds [`ENV_LOCK`] for the test's
+/// whole body, points `HOME` at a private cache directory (so the dylib and
+/// git caches are hermetic) and pins the workspace the wrapper's
+/// `cljrs-interop` is taken from.
+struct TestEnv {
+    _guard: MutexGuard<'static, ()>,
+    _home: tempfile::TempDir,
+}
+
+impl TestEnv {
+    fn new(ws_root: &Path) -> TestEnv {
+        let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        // SAFETY: `ENV_LOCK` is held for the rest of the test, and every test
+        // in this binary takes it before touching the environment or spawning
+        // a process, so no other thread reads or writes it concurrently.
+        unsafe {
+            std::env::set_var("HOME", home.path());
+            std::env::set_var("CLJRS_WORKSPACE_ROOT", ws_root);
+        }
+        TestEnv {
+            _guard: guard,
+            _home: home,
+        }
+    }
+}
 
 fn git_ok(dir: &Path, args: &[&str]) {
     let out = Command::new("git")
@@ -122,15 +163,8 @@ fn pinned_native_dylib_end_to_end() {
     }
 
     let ws_root = workspace_root();
+    let _env = TestEnv::new(&ws_root);
     let (repo, sha_v1) = make_pinlib_repo(&ws_root);
-
-    // Hermetic dylib/git caches + a pinned workspace for the wrapper deps.
-    let cache_home = tempfile::tempdir().unwrap();
-    // SAFETY: single gated test in this binary; no concurrent env readers.
-    unsafe {
-        std::env::set_var("HOME", cache_home.path());
-        std::env::set_var("CLJRS_WORKSPACE_ROOT", &ws_root);
-    }
 
     let _mutator = cljrs_gc::register_mutator();
     let globals = cljrs_runtime::Runtime::builder()
@@ -224,15 +258,8 @@ fn native_dep_loaded_by_plain_require() {
     }
 
     let ws_root = workspace_root();
+    let _env = TestEnv::new(&ws_root);
     let (repo, sha_v1) = make_pinlib_repo(&ws_root);
-
-    // Hermetic dylib/git caches + a pinned workspace for the wrapper deps.
-    let cache_home = tempfile::tempdir().unwrap();
-    // SAFETY: single gated test invocation; no concurrent env readers.
-    unsafe {
-        std::env::set_var("HOME", cache_home.path());
-        std::env::set_var("CLJRS_WORKSPACE_ROOT", &ws_root);
-    }
 
     let _mutator = cljrs_gc::register_mutator();
     let globals = cljrs_runtime::Runtime::builder()
@@ -314,8 +341,12 @@ cljrs-interop = {{ path = "{}" }}
     std::fs::write(root.join("src/lib.rs"), pinlib_source(tag)).unwrap();
 }
 
-/// A runtime whose `cljrs.edn` declares `pinlib` as a `:local/root` native dep.
-fn globals_with_local_dep(root: &Path) -> Arc<cljrs_runtime::tiered::GlobalEnv> {
+/// A runtime whose `cljrs.edn` declares `pinlib` as a `:local/root` native
+/// dep, with `crate_subdir` as its `:rust/crate`.
+fn globals_with_local_dep(
+    root: &Path,
+    crate_subdir: Option<&str>,
+) -> Arc<cljrs_runtime::tiered::GlobalEnv> {
     let globals = cljrs_runtime::Runtime::builder()
         .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
         .build()
@@ -328,7 +359,7 @@ fn globals_with_local_dep(root: &Path) -> Arc<cljrs_runtime::tiered::GlobalEnv> 
             cljrs_project::config::Dependency::Local {
                 root: root.to_path_buf(),
                 rust_init: Some(Arc::from("pinlib::cljrs_init")),
-                rust_crate_dir: None,
+                rust_crate_dir: crate_subdir.map(Arc::from),
                 rust_load_dylib: true,
             },
         )],
@@ -378,19 +409,14 @@ fn local_root_native_dep_is_built_from_the_working_tree() {
     }
 
     let ws_root = workspace_root();
+    let _env = TestEnv::new(&ws_root);
     let tree = tempfile::tempdir().unwrap();
     write_pinlib_tree(tree.path(), &ws_root, 7);
 
-    let cache_home = tempfile::tempdir().unwrap();
-    // SAFETY: single gated test invocation; no concurrent env readers.
-    unsafe {
-        std::env::set_var("HOME", cache_home.path());
-        std::env::set_var("CLJRS_WORKSPACE_ROOT", &ws_root);
-    }
     let _mutator = cljrs_gc::register_mutator();
 
     assert_eq!(
-        require_pinlib(&globals_with_local_dep(tree.path())),
+        require_pinlib(&globals_with_local_dep(tree.path(), None)),
         7,
         "the dylib must be built from the working tree as it stands"
     );
@@ -399,10 +425,174 @@ fn local_root_native_dep_is_built_from_the_working_tree() {
     // runtime: the rebuilt dylib must carry the edit.
     std::fs::write(tree.path().join("src/lib.rs"), pinlib_source(8)).unwrap();
     assert_eq!(
-        require_pinlib(&globals_with_local_dep(tree.path())),
+        require_pinlib(&globals_with_local_dep(tree.path(), None)),
         8,
         "an edited working tree must be rebuilt, not served from cache"
     );
+}
+
+/// Write a two-crate working tree: the dylib crate at `crates/pinlib`, and the
+/// sibling `crates/pintag` it takes the build tag from by path dependency.
+/// This is the layout `:rust/crate` exists for.
+fn write_multi_crate_tree(root: &Path, ws_root: &Path, tag: i64) {
+    std::fs::create_dir_all(root.join("crates/pinlib/src")).unwrap();
+    std::fs::create_dir_all(root.join("crates/pintag/src")).unwrap();
+
+    std::fs::write(
+        root.join("crates/pintag/Cargo.toml"),
+        r#"[package]
+name = "pintag"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+"#,
+    )
+    .unwrap();
+    write_pintag_source(root, tag);
+
+    let pinlib_toml = format!(
+        r#"[package]
+name = "pinlib"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+
+[dependencies]
+cljrs-interop = {{ path = "{}" }}
+pintag = {{ path = "../pintag" }}
+"#,
+        ws_root.join("crates/cljrs-interop").display()
+    );
+    std::fs::write(root.join("crates/pinlib/Cargo.toml"), pinlib_toml).unwrap();
+    std::fs::write(
+        root.join("crates/pinlib/src/lib.rs"),
+        r#"use cljrs_interop::{Registry, wrap_fn0};
+
+pub fn cljrs_init(registry: &mut Registry) {
+    registry.define(
+        "pinlib/build-tag",
+        wrap_fn0("build-tag", || Ok::<i64, String>(pintag::TAG)),
+    );
+}
+"#,
+    )
+    .unwrap();
+}
+
+/// Rewrite only the sibling crate's source, leaving `crates/pinlib` untouched.
+fn write_pintag_source(root: &Path, tag: i64) {
+    std::fs::write(
+        root.join("crates/pintag/src/lib.rs"),
+        format!("pub const TAG: i64 = {tag};\n"),
+    )
+    .unwrap();
+}
+
+/// A `:local/root` dep with `:rust/crate` pointing at one crate of a
+/// multi-crate tree is versioned by the whole tree, not by that crate: the
+/// crate's path dependencies are part of what gets built.
+///
+/// Editing only the sibling leaves `crates/pinlib` byte-identical.  Digesting
+/// the `:rust/crate` directory alone therefore yields the same version, the
+/// cached artifact is returned before cargo is ever invoked, and the stale
+/// library is `dlopen`ed.
+#[test]
+fn local_root_native_dep_picks_up_a_sibling_crate_edit() {
+    if std::env::var("CLJRS_DYLIB_E2E").is_err() {
+        eprintln!(
+            "skipping local_root_native_dep_picks_up_a_sibling_crate_edit \
+             (set CLJRS_DYLIB_E2E=1 to run)"
+        );
+        return;
+    }
+
+    let ws_root = workspace_root();
+    let _env = TestEnv::new(&ws_root);
+    let tree = tempfile::tempdir().unwrap();
+    write_multi_crate_tree(tree.path(), &ws_root, 11);
+
+    let _mutator = cljrs_gc::register_mutator();
+    let crate_subdir = Some("crates/pinlib");
+
+    assert_eq!(
+        require_pinlib(&globals_with_local_dep(tree.path(), crate_subdir)),
+        11,
+        "the dylib must be built from the crate :rust/crate names"
+    );
+
+    // The edit is entirely outside `:rust/crate`.
+    write_pintag_source(tree.path(), 12);
+    assert_eq!(
+        require_pinlib(&globals_with_local_dep(tree.path(), crate_subdir)),
+        12,
+        "an edit to a sibling crate must rebuild, not serve the cached artifact"
+    );
+}
+
+/// A `:local/root` dep that opted into `:dylib` but named no `:rust/init` is
+/// still *declined* by versioned resolution, not turned into an error: whether
+/// a dep can answer `ns/f@<sha>` follows from its source having no commit, and
+/// that is settled before `:rust/init` is required.
+///
+/// Not gated on `CLJRS_DYLIB_E2E`: the dep declines before anything is
+/// materialized or built, which is the whole point, so nothing here runs cargo.
+#[test]
+fn a_local_dep_without_rust_init_declines_versioned_resolution() {
+    let ws_root = workspace_root();
+    let _env = TestEnv::new(&ws_root);
+    let _mutator = cljrs_gc::register_mutator();
+
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+
+    // The host's own implementation, which the fallback must reach.
+    let head_fn = cljrs_value::NativeFn {
+        name: Arc::from("build-tag"),
+        arity: cljrs_value::Arity::Fixed(0),
+        func: Arc::new(|_args| Ok(Value::Long(99))),
+    };
+    globals.get_or_create_ns("pinlib");
+    globals.intern(
+        "pinlib",
+        Arc::from("build-tag"),
+        Value::NativeFunction(cljrs_gc::GcPtr::new(head_fn)),
+    );
+
+    // `:rust/load :dylib` with no `:rust/init`, on a root that does not exist:
+    // reaching either the validation error or the filesystem would be a bug.
+    let config = cljrs_project::config::DepsConfig {
+        deps: vec![(
+            Arc::from("pinlib"),
+            cljrs_project::config::Dependency::Local {
+                root: PathBuf::from("/nonexistent/local/root"),
+                rust_init: None,
+                rust_crate_dir: None,
+                rust_load_dylib: true,
+            },
+        )],
+        ..Default::default()
+    };
+    *globals.deps_config.write().unwrap() = Some(Arc::new(config));
+    cljrs::native::pinned::install(&globals);
+
+    let sha = "0123456789abcdef0123456789abcdef01234567";
+    let resolved = cljrs_runtime::env::versioned::resolve_versioned_value(
+        &globals,
+        "user",
+        Some("pinlib"),
+        "build-tag",
+        sha,
+    )
+    .expect("a misconfigured local dep must decline versioned resolution, not error it");
+    let Value::NativeFunction(nf) = &resolved else {
+        panic!("expected a native fn, got {resolved:?}");
+    };
+    assert_eq!((nf.get().func)(&[]).unwrap(), Value::Long(99));
 }
 
 /// A `:local/root` dep has no commit, so it cannot answer a versioned symbol
@@ -419,17 +609,12 @@ fn local_root_native_dep_does_not_serve_versioned_resolution() {
     }
 
     let ws_root = workspace_root();
+    let _env = TestEnv::new(&ws_root);
     let tree = tempfile::tempdir().unwrap();
     write_pinlib_tree(tree.path(), &ws_root, 7);
 
-    let cache_home = tempfile::tempdir().unwrap();
-    // SAFETY: single gated test invocation; no concurrent env readers.
-    unsafe {
-        std::env::set_var("HOME", cache_home.path());
-        std::env::set_var("CLJRS_WORKSPACE_ROOT", &ws_root);
-    }
     let _mutator = cljrs_gc::register_mutator();
-    let globals = globals_with_local_dep(tree.path());
+    let globals = globals_with_local_dep(tree.path(), None);
 
     // The host's own implementation, which the fallback must reach.
     let head_fn = cljrs_value::NativeFn {

--- a/crates/cljrs/tests/pinned_dylib_e2e.rs
+++ b/crates/cljrs/tests/pinned_dylib_e2e.rs
@@ -290,3 +290,179 @@ fn native_dep_loaded_by_plain_require() {
         Some("pinlib")
     );
 }
+
+// ── :local/root native deps ──────────────────────────────────────────────────
+
+/// Write the `pinlib` fixture crate into `root` as a plain directory — no git,
+/// no commit, just a working tree as a developer would have it.
+fn write_pinlib_tree(root: &Path, ws_root: &Path, tag: i64) {
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let cargo_toml = format!(
+        r#"[package]
+name = "pinlib"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+
+[dependencies]
+cljrs-interop = {{ path = "{}" }}
+"#,
+        ws_root.join("crates/cljrs-interop").display()
+    );
+    std::fs::write(root.join("Cargo.toml"), cargo_toml).unwrap();
+    std::fs::write(root.join("src/lib.rs"), pinlib_source(tag)).unwrap();
+}
+
+/// A runtime whose `cljrs.edn` declares `pinlib` as a `:local/root` native dep.
+fn globals_with_local_dep(root: &Path) -> Arc<cljrs_runtime::tiered::GlobalEnv> {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+
+    let config = cljrs_project::config::DepsConfig {
+        deps: vec![(
+            Arc::from("pinlib"),
+            cljrs_project::config::Dependency::Local {
+                root: root.to_path_buf(),
+                rust_init: Some(Arc::from("pinlib::cljrs_init")),
+                rust_crate_dir: None,
+                rust_load_dylib: true,
+            },
+        )],
+        ..Default::default()
+    };
+    *globals.deps_config.write().unwrap() = Some(Arc::new(config));
+    cljrs::native::pinned::install(&globals);
+    globals
+}
+
+fn require_pinlib(globals: &Arc<cljrs_runtime::tiered::GlobalEnv>) -> i64 {
+    let spec = cljrs_runtime::env::env::RequireSpec {
+        ns: Arc::from("pinlib"),
+        version: None,
+        alias: None,
+        refer: cljrs_runtime::env::env::RequireRefer::None,
+    };
+    cljrs_runtime::env::loader::load_ns(globals.clone(), &spec, "user")
+        .expect("require of a :local/root native dep should succeed");
+
+    let f = globals
+        .lookup_in_ns("pinlib", "build-tag")
+        .expect("pinlib/build-tag must be registered by the dylib");
+    let Value::NativeFunction(nf) = &f else {
+        panic!("expected a native fn, got {f:?}");
+    };
+    match (nf.get().func)(&[]).unwrap() {
+        Value::Long(n) => n,
+        other => panic!("expected a long, got {other:?}"),
+    }
+}
+
+/// A `:local/root` dep with `:rust/load :dylib` is built from the working tree
+/// and loaded by a plain `require` — the case a developer hits while writing
+/// the extension, before any of it is committed or pushed anywhere.
+///
+/// Editing the tree and requiring again must pick the edit up: a working tree
+/// has no commit to key a cache on, so its artifact is never assumed fresh.
+#[test]
+fn local_root_native_dep_is_built_from_the_working_tree() {
+    if std::env::var("CLJRS_DYLIB_E2E").is_err() {
+        eprintln!(
+            "skipping local_root_native_dep_is_built_from_the_working_tree \
+             (set CLJRS_DYLIB_E2E=1 to run)"
+        );
+        return;
+    }
+
+    let ws_root = workspace_root();
+    let tree = tempfile::tempdir().unwrap();
+    write_pinlib_tree(tree.path(), &ws_root, 7);
+
+    let cache_home = tempfile::tempdir().unwrap();
+    // SAFETY: single gated test invocation; no concurrent env readers.
+    unsafe {
+        std::env::set_var("HOME", cache_home.path());
+        std::env::set_var("CLJRS_WORKSPACE_ROOT", &ws_root);
+    }
+    let _mutator = cljrs_gc::register_mutator();
+
+    assert_eq!(
+        require_pinlib(&globals_with_local_dep(tree.path())),
+        7,
+        "the dylib must be built from the working tree as it stands"
+    );
+
+    // Edit the tree the way a developer would, and require again in a fresh
+    // runtime: the rebuilt dylib must carry the edit.
+    std::fs::write(tree.path().join("src/lib.rs"), pinlib_source(8)).unwrap();
+    assert_eq!(
+        require_pinlib(&globals_with_local_dep(tree.path())),
+        8,
+        "an edited working tree must be rebuilt, not served from cache"
+    );
+}
+
+/// A `:local/root` dep has no commit, so it cannot answer a versioned symbol
+/// (`pinlib/build-tag@<sha>`). The resolver must fall back to the host's own
+/// native binding rather than erroring or silently serving the local build.
+#[test]
+fn local_root_native_dep_does_not_serve_versioned_resolution() {
+    if std::env::var("CLJRS_DYLIB_E2E").is_err() {
+        eprintln!(
+            "skipping local_root_native_dep_does_not_serve_versioned_resolution \
+             (set CLJRS_DYLIB_E2E=1 to run)"
+        );
+        return;
+    }
+
+    let ws_root = workspace_root();
+    let tree = tempfile::tempdir().unwrap();
+    write_pinlib_tree(tree.path(), &ws_root, 7);
+
+    let cache_home = tempfile::tempdir().unwrap();
+    // SAFETY: single gated test invocation; no concurrent env readers.
+    unsafe {
+        std::env::set_var("HOME", cache_home.path());
+        std::env::set_var("CLJRS_WORKSPACE_ROOT", &ws_root);
+    }
+    let _mutator = cljrs_gc::register_mutator();
+    let globals = globals_with_local_dep(tree.path());
+
+    // The host's own implementation, which the fallback must reach.
+    let head_fn = cljrs_value::NativeFn {
+        name: Arc::from("build-tag"),
+        arity: cljrs_value::Arity::Fixed(0),
+        func: Arc::new(|_args| Ok(Value::Long(99))),
+    };
+    globals.get_or_create_ns("pinlib");
+    globals.intern(
+        "pinlib",
+        Arc::from("build-tag"),
+        Value::NativeFunction(cljrs_gc::GcPtr::new(head_fn)),
+    );
+
+    let sha = "0123456789abcdef0123456789abcdef01234567";
+    let resolved = cljrs_runtime::env::versioned::resolve_versioned_value(
+        &globals,
+        "user",
+        Some("pinlib"),
+        "build-tag",
+        sha,
+    )
+    .expect("versioned resolution should fall back to the host's native fn");
+    let Value::NativeFunction(nf) = &resolved else {
+        panic!("expected a native fn, got {resolved:?}");
+    };
+    assert_eq!(
+        (nf.get().func)(&[]).unwrap(),
+        Value::Long(99),
+        "a local dep must not answer for a commit it does not have"
+    );
+    assert!(
+        !globals.is_loaded(&format!("pinlib@{sha}")),
+        "no versioned namespace should have been created for a local dep"
+    );
+}

--- a/docs/book/src/cli/deps.md
+++ b/docs/book/src/cli/deps.md
@@ -184,7 +184,9 @@ which builds the working tree as it currently stands — no commit, no push:
 
 Edit the crate and the next `require` rebuilds it: a local dependency is
 versioned by a digest of its source files, so a changed tree is a different
-build. This is the loop for writing an extension; pin it with `:git/sha`
+build. The digest covers the whole `:local/root`, not just the `:rust/crate`
+subdirectory, so editing a sibling crate the extension depends on also
+rebuilds. This is the loop for writing an extension; pin it with `:git/sha`
 to ship it.
 
 Two limits apply to a local native dependency, both following from its having
@@ -195,6 +197,13 @@ no commit:
 - It is **not reproducible**. Two machines with different working trees get
   different builds, silently. Only `:git/sha` makes a build repeatable.
 
-Builds are cached under `~/.cljrs/cache/dylib/` per crate, version, compiler
+Builds are cached under `~/.cljrs/cache/dylibs/` per crate, version, compiler
 and cljrs version, and are guarded by an ABI handshake: a wrapper built by a
 different `rustc`, profile, or cljrs version is refused rather than loaded.
+The generated wrapper crate and its cargo target directory are shared by every
+version of one dependency, so an edit costs an incremental rebuild; only the
+built library is copied out to a per-version path, which is what makes a
+rebuilt library load instead of the one already open.
+
+Set `CLJRS_DYLIB_OFFLINE=1` to build wrappers with `cargo --offline`, for a
+machine whose cargo cache already holds everything the dependency needs.

--- a/docs/book/src/cli/deps.md
+++ b/docs/book/src/cli/deps.md
@@ -152,3 +152,49 @@ vendor {:local/root "../vendor/utils"}
 ```
 
 `:local/root` is a path relative to the `cljrs.edn` file's directory.
+
+### Native dependencies
+
+A dependency that ships Rust code can have that code built as a cdylib and
+loaded into the runtime, so `(require '[my.lib])` brings in a namespace no
+Clojure source provides. Opt in with `:rust/load :dylib` and name the crate's
+init function:
+
+```clojure
+{:deps
+ {my.lib {:git/url  "https://github.com/user/my-lib"
+          :git/sha  "abc1234ef"
+          :rust/load :dylib
+          :rust/init "my_lib::cljrs_init"}}}
+```
+
+`:rust/init` is the fully-qualified path to a `pub fn(&mut Registry)`. Add
+`:rust/crate "path/to/crate"` when the crate is not at the dependency's root.
+
+**Developing one locally.** The same keys work on a `:local/root` dependency,
+which builds the working tree as it currently stands — no commit, no push:
+
+```clojure
+{:deps
+ {my.lib {:local/root "../my-lib"
+          :rust/load  :dylib
+          :rust/init  "my_lib::cljrs_init"
+          :rust/crate "src/crates/thing"}}}
+```
+
+Edit the crate and the next `require` rebuilds it: a local dependency is
+versioned by a digest of its source files, so a changed tree is a different
+build. This is the loop for writing an extension; pin it with `:git/sha`
+to ship it.
+
+Two limits apply to a local native dependency, both following from its having
+no commit:
+
+- It cannot serve a **versioned symbol** (`my.lib/f@<sha>`). Those resolve
+  against pinned dependencies only; a local one is skipped.
+- It is **not reproducible**. Two machines with different working trees get
+  different builds, silently. Only `:git/sha` makes a build repeatable.
+
+Builds are cached under `~/.cljrs/cache/dylib/` per crate, version, compiler
+and cljrs version, and are guarded by an ABI handshake: a wrapper built by a
+different `rustc`, profile, or cljrs version is refused rather than loaded.


### PR DESCRIPTION
`:rust/load :dylib` could only name a git dep at a pinned commit, so a Rust extension had to be committed and pushed before the runtime could load it even once. The `:rust/*` keys were already parsed on a `:local/root` dep and then dropped on the floor — `Dependency::Local` had nowhere to put them, and `find_dylib_dep` matched only `Dependency::Git`.

A local root now carries the same keys and builds the working tree as it stands:

```clojure
{:deps {my.lib {:local/root "../my-lib"
                :rust/load  :dylib
                :rust/init  "my_lib::cljrs_init"
                :rust/crate "src/crates/thing"}}}
```

### Shape

The two source forms differ only in where the crate comes from, so they meet at a `NativeDep` and share one build path: materialize the source, identify the version, plan the paths, build, load.

Identifying the version is what makes a working tree safe to cache. A commit names a pinned build; a digest of the crate's source files names a local one. Both are immutable, so the artifact cache is trustworthy in both cases and an edited tree gets its own wrapper directory.

That last part is load-bearing rather than an optimization. A rebuilt library reusing the old path is **not** picked up: the process has already `dlopen`ed that path and gets the existing mapping back. The e2e test caught exactly that — it asserted an edit was visible, and the first implementation returned the stale value.

A local dep is declined for versioned (`ns/f@sha`) resolution: it has no commit, so it cannot answer for one, and the resolver falls back exactly as before.

### Second commit: a naming bug this exposed

The generated wrapper declared its dependency under the first segment of the `:rust/init` path — a Rust *identifier* — with a comment asserting Cargo would read the real package name from the crate's own Cargo.toml. It does not; the key of a path dependency is the package name being looked up. Any package whose name contains `-` failed:

```
error: no matching package named `cljrs_raster` found
help: packages with similar names: cljrs-raster
```

The dependency is now declared under the ident the init path uses and renamed to the real `[package] name`. This affects git deps identically — the existing fixture is called `pinlib`, which has no hyphen, so nothing covered the claim.

### Tests

Five parser cases for the new keys; unit tests for the manifest read (workspace-inherited version, a `name` in another table); two gated e2e cases for build-from-tree, rebuild-after-edit, and the versioned fallback. `CLJRS_DYLIB_E2E=1 cargo test -p cljrs --test pinned_dylib_e2e` passes 4/4; `cargo test -p cljrs -p cljrs-project` is green.

Docs: a "Native dependencies" section in `cli/deps.md`, including the two limits that follow from a local dep having no commit — no versioned symbols, and no reproducibility.
