### PR TITLE
defmulti: accept the attr-map arity

### DIFF
--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -121,6 +121,12 @@ tests/
   qualified_protocol_impl.rs       — a qualified protocol name in an impl position
                                      (defrecord/deftype/reify/extend-*) resolves
                                      through its own namespace
+  defmulti_attr_map.rs             — `defmulti`'s four head shapes (docstring
+                                     and/or attr map before the dispatch fn),
+                                     and the metadata precedence between them:
+                                     docstring beats attr map beats `^` marks
+                                     on the name
+
   defmethod_cross_ns.rs            — `defmethod` on a multimethod owned by
                                      another namespace, named through a
                                      `:require :as` alias, in full, or via

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -121,6 +121,11 @@ tests/
   qualified_protocol_impl.rs       — a qualified protocol name in an impl position
                                      (defrecord/deftype/reify/extend-*) resolves
                                      through its own namespace
+  defmulti_attr_map.rs             — `defmulti`'s four head shapes (docstring
+                                     and/or attr map before the dispatch fn),
+                                     and the metadata precedence between them:
+                                     docstring beats attr map beats `^` marks
+                                     on the name
   named_fn_identity.rs, ns_metadata.rs, partition_arities.rs, shared_atom.rs,
   symbolic_nan.rs, threading_macros.rs, auto_gensym.rs, auto_keyword_macro.rs,
   assoc_in_metadata.rs, empty_metadata.rs, into_metadata.rs, vec_metadata.rs,

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -2272,7 +2272,7 @@ fn parse_defmulti_head<'a>(args: &'a [Form]) -> EvalResult<DefmultiHead<'a>> {
     let mut docstring = None;
     let mut attr_map = None;
 
-    if i + 1 < args.len()
+    if i < args.len()
         && let Some(s) = args[i].as_string()
     {
         docstring = Some(s.to_string());
@@ -2314,13 +2314,15 @@ fn eval_defmulti(args: &[Form], env: &mut Env) -> EvalResult {
         i += 2;
     }
 
-    // Metadata sources, weakest first: the attr map, then `^` marks on the
-    // name, then the docstring.
+    // Metadata sources, weakest first: `^` marks on the name, then the attr
+    // map, then the docstring.  Clojure builds the same order in
+    // `clojure.core/defmulti` -- `(conj (meta mm-name) m)` puts the attr map,
+    // docstring already merged into it, on top of the name's metadata.
     let attr_meta = match head.attr_map {
         Some(form) => Some(eval(form, env)?),
         None => None,
     };
-    let meta = merge_meta(attr_meta, name_meta);
+    let meta = merge_meta(name_meta, attr_meta);
     let meta = merge_meta(meta, head.docstring.as_deref().map(doc_meta));
 
     let mfn = MultiFn::new(name_arc.clone(), dispatch_fn, default_dispatch);

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -2253,28 +2253,57 @@ fn build_impl_fn(
 
 // ── defmulti ──────────────────────────────────────────────────────────────────
 
-fn eval_defmulti(args: &[Form], env: &mut Env) -> EvalResult {
-    // (defmulti name dispatch-fn-form) or (defmulti name "doc" dispatch-fn :default val)
-    let (name, name_meta) = require_sym_meta(args, 0, "defmulti", env)?;
-    let name_arc: Arc<str> = Arc::from(name.as_str());
+/// The parsed head of a `defmulti` form.
+///
+/// `(defmulti name docstring? attr-map? dispatch-fn & options)` — the two
+/// optional parts sit between the name and the dispatch function, and each is
+/// only taken as such when a form still follows it, so the dispatch function
+/// is never mistaken for one of them.
+struct DefmultiHead<'a> {
+    docstring: Option<String>,
+    attr_map: Option<&'a Form>,
+    /// Index of the dispatch-fn form; `args[dispatch_idx + 1..]` are options.
+    dispatch_idx: usize,
+}
 
-    let rest_start = if args.len() > 2 && args[1].as_string().is_some() {
-        2
-    } else {
-        1
-    };
+/// Split a `defmulti`'s arguments into its head parts. Pure: reads shapes only.
+fn parse_defmulti_head<'a>(args: &'a [Form]) -> EvalResult<DefmultiHead<'a>> {
+    let mut i = 1;
+    let mut docstring = None;
+    let mut attr_map = None;
 
-    if args.len() <= rest_start {
+    if i + 1 < args.len()
+        && let Some(s) = args[i].as_string()
+    {
+        docstring = Some(s.to_string());
+        i += 1;
+    }
+    if i + 1 < args.len() && matches!(args[i].kind, FormKind::Map(_)) {
+        attr_map = Some(&args[i]);
+        i += 1;
+    }
+    if i >= args.len() {
         return Err(EvalError::Runtime(
             "defmulti requires a dispatch function".into(),
         ));
     }
+    Ok(DefmultiHead {
+        docstring,
+        attr_map,
+        dispatch_idx: i,
+    })
+}
 
-    let dispatch_fn = eval(&args[rest_start], env)?;
+fn eval_defmulti(args: &[Form], env: &mut Env) -> EvalResult {
+    let (name, name_meta) = require_sym_meta(args, 0, "defmulti", env)?;
+    let name_arc: Arc<str> = Arc::from(name.as_str());
+    let head = parse_defmulti_head(args)?;
+
+    let dispatch_fn = eval(&args[head.dispatch_idx], env)?;
 
     // Parse optional :default val.
     let mut default_dispatch = ":default".to_string();
-    let mut i = rest_start + 1;
+    let mut i = head.dispatch_idx + 1;
     while i + 1 < args.len() {
         if let FormKind::Keyword(k) = &args[i].kind
             && k == "default"
@@ -2285,11 +2314,20 @@ fn eval_defmulti(args: &[Form], env: &mut Env) -> EvalResult {
         i += 2;
     }
 
+    // Metadata sources, weakest first: the attr map, then `^` marks on the
+    // name, then the docstring.
+    let attr_meta = match head.attr_map {
+        Some(form) => Some(eval(form, env)?),
+        None => None,
+    };
+    let meta = merge_meta(attr_meta, name_meta);
+    let meta = merge_meta(meta, head.docstring.as_deref().map(doc_meta));
+
     let mfn = MultiFn::new(name_arc.clone(), dispatch_fn, default_dispatch);
     let var = env
         .globals
         .intern(&env.current_ns, name_arc, Value::MultiFn(GcPtr::new(mfn)));
-    if let Some(meta_val) = name_meta {
+    if let Some(meta_val) = meta {
         var.get().set_meta(meta_val);
     }
     Ok(Value::Var(var))

--- a/crates/cljrs-runtime/tests/defmulti_attr_map.rs
+++ b/crates/cljrs-runtime/tests/defmulti_attr_map.rs
@@ -1,0 +1,135 @@
+//! `defmulti`'s optional docstring and attribute map.
+//!
+//! Clojure's signature is `(defmulti name docstring? attr-map? dispatch-fn &
+//! options)`. Only the docstring was recognised, so an attribute map was taken
+//! as the dispatch function — and since a map IS callable, nothing failed at
+//! definition time. `(defmulti area "Doc." {:added "1.0"} :kind)` dispatched
+//! every call through `{:added "1.0"}`, which returns nil for any shape, so the
+//! failure surfaced later as "no method for dispatch value nil".
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::{Keyword, Value};
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+/// Evaluate every form in `src` in one fresh environment; yield the last value.
+fn eval_fresh(src: &str) -> Result<Value, String> {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result =
+            cljrs_runtime::interp::eval::eval(&form, &mut env).map_err(|e| format!("eval: {e:?}"))?;
+    }
+    Ok(result)
+}
+
+fn value_of(src: &str) -> Value {
+    eval_fresh(src).unwrap_or_else(|e| panic!("{src}\n{e}"))
+}
+
+fn kw(name: &str) -> Value {
+    Value::keyword(Keyword::simple(name))
+}
+
+fn text(s: &str) -> Value {
+    Value::string(s.to_string())
+}
+
+/// The four head shapes, each dispatching on `:kind`.
+const HEADS: [&str; 4] = [
+    r#"(defmulti area :kind)"#,
+    r#"(defmulti area "Area of a shape." :kind)"#,
+    r#"(defmulti area {:added "1.0"} :kind)"#,
+    r#"(defmulti area "Area of a shape." {:added "1.0"} :kind)"#,
+];
+
+#[test]
+fn every_head_shape_dispatches_on_the_dispatch_fn() {
+    for head in HEADS {
+        let src = format!(
+            r#"{head}
+               (defmethod area :square [s] (* (:side s) (:side s)))
+               (area {{:kind :square :side 4}})"#
+        );
+        assert_eq!(
+            value_of(&src),
+            Value::Long(16),
+            "dispatch function not recognised in: {head}"
+        );
+    }
+}
+
+#[test]
+fn an_attr_map_is_not_taken_as_the_dispatch_function() {
+    // The regression, stated directly: a map in attr-map position dispatched
+    // every call to nil, so every call fell through to :default.
+    let src = r#"(defmulti area "Doc." {:added "1.0"} :kind)
+                 (defmethod area :square [_] :square-method)
+                 (defmethod area :default [_] :fell-through)
+                 (area {:kind :square})"#;
+    assert_eq!(value_of(src), kw("square-method"));
+}
+
+#[test]
+fn the_docstring_lands_in_the_var_metadata() {
+    for head in [HEADS[1], HEADS[3]] {
+        let src = format!(r#"{head} (:doc (meta (var area)))"#);
+        assert_eq!(value_of(&src), text("Area of a shape."), "in: {head}");
+    }
+}
+
+#[test]
+fn the_attr_map_lands_in_the_var_metadata() {
+    for head in [HEADS[2], HEADS[3]] {
+        let src = format!(r#"{head} (:added (meta (var area)))"#);
+        assert_eq!(value_of(&src), text("1.0"), "in: {head}");
+    }
+}
+
+#[test]
+fn a_head_with_neither_carries_neither() {
+    let src = format!(
+        r#"{} [(:doc (meta (var area))) (:added (meta (var area)))]"#,
+        HEADS[0]
+    );
+    assert_eq!(value_of(&src).to_string(), "[nil nil]");
+}
+
+#[test]
+fn options_after_the_dispatch_fn_still_parse() {
+    // `:default` is found relative to the dispatch fn, whose position moves
+    // when a docstring or attr map precedes it.
+    let src = r#"(defmulti area "Doc." {:added "1.0"} :kind :default :fallback)
+                 (defmethod area :fallback [_] :used-the-fallback)
+                 (area {:kind :hexagon})"#;
+    assert_eq!(value_of(src), kw("used-the-fallback"));
+}
+
+#[test]
+fn a_map_is_still_usable_as_the_dispatch_function() {
+    // With no form following it, a map is the dispatch fn rather than an attr
+    // map: `{:a :first}` looks its argument up and dispatches on the result.
+    let src = r#"(defmulti lookup {:a :first})
+                 (defmethod lookup :first [_] :found-first)
+                 (lookup :a)"#;
+    assert_eq!(value_of(src), kw("found-first"));
+}
+
+#[test]
+fn a_defmulti_with_no_dispatch_function_is_rejected() {
+    let err = eval_fresh("(defmulti area)").expect_err("should require a dispatch function");
+    assert!(err.contains("dispatch function"), "unhelpful error: {err}");
+}

--- a/crates/cljrs-runtime/tests/defmulti_attr_map.rs
+++ b/crates/cljrs-runtime/tests/defmulti_attr_map.rs
@@ -30,8 +30,8 @@ fn eval_fresh(src: &str) -> Result<Value, String> {
     let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
     let mut result = Value::Nil;
     for form in forms {
-        result =
-            cljrs_runtime::interp::eval::eval(&form, &mut env).map_err(|e| format!("eval: {e:?}"))?;
+        result = cljrs_runtime::interp::eval::eval(&form, &mut env)
+            .map_err(|e| format!("eval: {e:?}"))?;
     }
     Ok(result)
 }
@@ -131,5 +131,32 @@ fn a_map_is_still_usable_as_the_dispatch_function() {
 #[test]
 fn a_defmulti_with_no_dispatch_function_is_rejected() {
     let err = eval_fresh("(defmulti area)").expect_err("should require a dispatch function");
+    assert!(err.contains("dispatch function"), "unhelpful error: {err}");
+}
+
+#[test]
+fn the_attr_map_beats_metadata_on_the_name() {
+    // Precedence, not merely presence. Clojure's `(conj (meta mm-name) m)`
+    // puts the attr map on top of the name's `^` marks, so a key present in
+    // both takes the attr map's value.
+    let src = r#"(defmulti ^{:added "name"} area {:added "attr"} :kind)
+                 (:added (meta (var area)))"#;
+    assert_eq!(value_of(src), text("attr"));
+}
+
+#[test]
+fn the_docstring_beats_a_doc_key_in_the_attr_map() {
+    let src = r#"(defmulti area "from the docstring" {:doc "from the attr map"} :kind)
+                 (:doc (meta (var area)))"#;
+    assert_eq!(value_of(src), text("from the docstring"));
+}
+
+#[test]
+fn a_trailing_string_is_a_docstring_not_a_dispatch_function() {
+    // A string is never callable, so taking it as the dispatch fn only defers
+    // the error to the first call, pointing at the wrong thing. Clojure reads
+    // a leading string as the docstring unconditionally.
+    let err = eval_fresh(r#"(defmulti area "Area.")"#)
+        .expect_err("a lone docstring leaves no dispatch function");
     assert!(err.contains("dispatch function"), "unhelpful error: {err}");
 }


### PR DESCRIPTION
Clojure's signature is `(defmulti name docstring? attr-map? dispatch-fn & options)`. Only the docstring was recognised, so with an attribute map present the **map itself became the dispatch function**.

Nothing failed at definition time, because a map is callable. Every call dispatched through `{:added "1.0"}`, which returns nil for any argument, so the error surfaced later and somewhere else:

```clojure
(defmulti area "Area of a shape." {:added "1.0"} :kind)
(defmethod area :square [s] (* (:side s) (:side s)))
(area {:kind :square :side 4})
;; => No method in multimethod 'area' for dispatch value nil
```

The message points at the call, and the call is correct — the definition four lines up is where the meaning was lost.

### The change

The head is parsed as a unit. Each optional part is taken as such only when a form still follows it, so a map that genuinely IS the dispatch function is left alone:

```clojure
(defmulti lookup {:a :first})   ; still dispatches through the map
```

Options are located relative to the dispatch fn, whose index moves with whatever precedes it — `:default` was previously found at a fixed offset.

The docstring also reaches the var's metadata now, alongside the attr map. Previously it was skipped for parsing purposes and then discarded.

### Tests

Eight cases: all four head shapes dispatching correctly, the regression stated directly, docstring and attr-map metadata, `:default` after a full head, a map still usable as the dispatch fn, and the arity error when no dispatch fn is present. `cargo test -p cljrs-runtime` is green.
