### PR TITLE
One namespace-resolution rule, not seven copies

### DIFF
--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -1468,10 +1468,7 @@ fn pin_versioned_references(
     for (ns_part, commit) in pins {
         let base: Arc<str> = match &ns_part {
             Some(p) => {
-                let resolved = env
-                    .globals
-                    .resolve_alias(&env.current_ns, p)
-                    .unwrap_or_else(|| Arc::from(p.as_str()));
+                let resolved = env.globals.resolve_ns_part_in(&env.current_ns, p);
                 Arc::from(cljrs_runtime::env::versioned::base_ns_name(&resolved))
             }
             None => Arc::from(cljrs_runtime::env::versioned::base_ns_name(&env.current_ns)),

--- a/crates/cljrs-nrepl/src/engine.rs
+++ b/crates/cljrs-nrepl/src/engine.rs
@@ -386,10 +386,7 @@ impl Engine {
 
         if let Some((alias, name_prefix)) = prefix.split_once('/') {
             // Qualified prefix: complete interns of the aliased/named namespace.
-            let full = self
-                .globals
-                .resolve_alias(&context_ns, alias)
-                .unwrap_or_else(|| Arc::from(alias));
+            let full = self.globals.resolve_ns_part_in(&context_ns, alias);
             if let Some(ns) = namespaces.get(&full) {
                 for (name, var) in ns.get().interns.lock().unwrap().iter() {
                     if name.starts_with(name_prefix) {
@@ -461,10 +458,7 @@ impl Engine {
         let sym = req.sym.clone().unwrap_or_default();
         let var = match sym.split_once('/') {
             Some((ns_part, name)) => {
-                let full = self
-                    .globals
-                    .resolve_alias(&context_ns, ns_part)
-                    .unwrap_or_else(|| Arc::from(ns_part));
+                let full = self.globals.resolve_ns_part_in(&context_ns, ns_part);
                 self.globals.lookup_var_in_ns(&full, name)
             }
             None => self.globals.lookup_var_in_ns(&context_ns, &sym),

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -118,10 +118,12 @@ tests/
                                      protocol method body; params shadow them
   deftype_types.rs                 — deftype: positional ctor, `.-field`, protocol
                                      impls, and mutable fields written with `set!`
-  ns_part_resolution.rs            — one namespace-resolution rule: an alias and
+  ns_part_resolution.rs            — one alias-resolution rule: an alias and
                                      a full namespace name agree for symbols,
                                      `var`, macros, syntax-quote, `binding`
-                                     and protocol names
+                                     and protocol names, and an absent ns part
+                                     means the current namespace (each test
+                                     fails when the arm it names is stubbed)
   qualified_protocol_impl.rs       — a qualified protocol name in an impl position
                                      (defrecord/deftype/reify/extend-*) resolves
                                      through its own namespace
@@ -309,6 +311,19 @@ pub fn ir_cache(&self) -> &Arc<tiered::ir_cache::IrCache>;
 pub fn eval(&self, form: &Form, env: &mut Env) -> EvalResult;
 pub fn call_cljrs_fn(&self, f: &CljxFn, args: &[Value], env: &mut Env) -> EvalResult;
 pub fn on_fn_defined(&self, f: &CljxFn, env: &mut Env);
+
+/// The namespace a qualified symbol's `ns` part names: a `:require … :as`
+/// alias wins, anything else is taken literally.  This is the ONE definition
+/// of that rule; every construct that resolves a qualified name reads it.
+/// `Env::resolve_ns_part` is the same rule relative to that env's
+/// `current_ns`, and `Env::resolve_ns_or_current` adds the absent-ns-part
+/// case.  Callers relative to something else — `resolve`, which follows the
+/// `*ns*` dynamic var, and versioned resolution, which follows a defining
+/// namespace — name it here instead of open-coding the lookup.
+///
+/// Note what this is NOT: `eval_symbol`'s privacy check and versioned-symbol
+/// routing sit *after* its call to this, and remain its own.
+pub fn resolve_ns_part_in(&self, current_ns: &str, ns_part: &str) -> Arc<str>;
 
 /// Copy `src_ns`'s interns into `dst_ns` as refers.  Both are *explicit*
 /// refers (`(:require [x :refer :all])` / `:refer [...]`) and are never

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -118,6 +118,10 @@ tests/
                                      protocol method body; params shadow them
   deftype_types.rs                 — deftype: positional ctor, `.-field`, protocol
                                      impls, and mutable fields written with `set!`
+  ns_part_resolution.rs            — one namespace-resolution rule: an alias and
+                                     a full namespace name agree for symbols,
+                                     `var`, macros, syntax-quote, `binding`
+                                     and protocol names
   qualified_protocol_impl.rs       — a qualified protocol name in an impl position
                                      (defrecord/deftype/reify/extend-*) resolves
                                      through its own namespace

--- a/crates/cljrs-runtime/src/env/env.rs
+++ b/crates/cljrs-runtime/src/env/env.rs
@@ -313,6 +313,20 @@ impl GlobalEnv {
         aliases.get(alias).cloned()
     }
 
+    /// The namespace a qualified symbol's `ns` part names, read from
+    /// `current_ns`'s alias table.
+    ///
+    /// A `:require … :as` alias wins; anything else is taken literally. This
+    /// is the whole rule, and the only place it is written: callers that
+    /// resolve relative to something other than an `Env`'s `current_ns` —
+    /// `resolve`, which is relative to the `*ns*` dynamic var, and versioned
+    /// resolution, which is relative to a defining namespace — name that
+    /// namespace here rather than open-coding the lookup.
+    pub fn resolve_ns_part_in(&self, current_ns: &str, ns_part: &str) -> Arc<str> {
+        self.resolve_alias(current_ns, ns_part)
+            .unwrap_or_else(|| Arc::from(ns_part))
+    }
+
     /// Resolve an auto-resolved keyword name (the text after `::`) to its
     /// fully-qualified `ns/name` form.
     ///
@@ -1037,10 +1051,12 @@ impl Env {
     /// wins, and anything else is taken literally. This is what makes
     /// `(m/f x)` and `(my.lib/f x)` mean the same thing after
     /// `(:require [my.lib :as m])`.
+    ///
+    /// Relative to THIS env's `current_ns`. A caller resolving relative to
+    /// some other namespace wants [`GlobalEnv::resolve_ns_part_in`], which
+    /// this delegates to.
     pub fn resolve_ns_part(&self, ns_part: &str) -> Arc<str> {
-        self.globals
-            .resolve_alias(&self.current_ns, ns_part)
-            .unwrap_or_else(|| Arc::from(ns_part))
+        self.globals.resolve_ns_part_in(&self.current_ns, ns_part)
     }
 
     /// The namespace a symbol belongs to: [`Self::resolve_ns_part`] when it

--- a/crates/cljrs-runtime/src/env/env.rs
+++ b/crates/cljrs-runtime/src/env/env.rs
@@ -1031,6 +1031,27 @@ impl Env {
         }
     }
 
+    /// The namespace a qualified symbol's `ns` part names, here.
+    ///
+    /// `ns_part` may be a `:require … :as` alias or a namespace name; an alias
+    /// wins, and anything else is taken literally. This is what makes
+    /// `(m/f x)` and `(my.lib/f x)` mean the same thing after
+    /// `(:require [my.lib :as m])`.
+    pub fn resolve_ns_part(&self, ns_part: &str) -> Arc<str> {
+        self.globals
+            .resolve_alias(&self.current_ns, ns_part)
+            .unwrap_or_else(|| Arc::from(ns_part))
+    }
+
+    /// The namespace a symbol belongs to: [`Self::resolve_ns_part`] when it
+    /// carries one, and the current namespace when it does not.
+    pub fn resolve_ns_or_current(&self, ns_part: Option<&str>) -> Arc<str> {
+        match ns_part {
+            Some(ns_part) => self.resolve_ns_part(ns_part),
+            None => self.current_ns.clone(),
+        }
+    }
+
     /// Create an Env for evaluating source at a specific commit.
     pub fn new_versioned(globals: Arc<GlobalEnv>, ns: &str, commit: &str) -> Self {
         Self {

--- a/crates/cljrs-runtime/src/env/versioned.rs
+++ b/crates/cljrs-runtime/src/env/versioned.rs
@@ -60,9 +60,9 @@ pub fn resolve_versioned_value(
     //    a qualified self-reference inside an already-versioned namespace).
     let base_ns: Arc<str> = match ns_part {
         Some(p) => {
-            let resolved = globals
-                .resolve_alias(defining_ns, p)
-                .unwrap_or_else(|| Arc::from(p));
+            // Relative to the DEFINING namespace, which is what a versioned
+            // source's own aliases are registered against.
+            let resolved = globals.resolve_ns_part_in(defining_ns, p);
             Arc::from(base_ns_name(&resolved))
         }
         None => Arc::from(base_ns_name(defining_ns)),

--- a/crates/cljrs-runtime/src/interp/apply.rs
+++ b/crates/cljrs-runtime/src/interp/apply.rs
@@ -1879,10 +1879,9 @@ fn handle_resolve(arg_forms: &[Form], env: &mut Env) -> EvalResult {
             let sym = s.get();
             // If qualified (ns/name), use the given ns; otherwise current ns.
             if let Some(ns) = &sym.namespace {
-                let full_ns = env
-                    .globals
-                    .resolve_alias(&resolve_ns, ns.as_ref())
-                    .unwrap_or_else(|| ns.clone());
+                // Relative to `*ns*`, not to `env.current_ns` — `resolve` is
+                // defined in terms of the dynamic var.
+                let full_ns = env.globals.resolve_ns_part_in(&resolve_ns, ns.as_ref());
                 return Ok(
                     match env.globals.lookup_var_in_ns(&full_ns, sym.name.as_ref()) {
                         Some(var_ptr) => Value::Var(var_ptr),

--- a/crates/cljrs-runtime/src/interp/eval.rs
+++ b/crates/cljrs-runtime/src/interp/eval.rs
@@ -127,13 +127,7 @@ pub fn eval(form: &Form, env: &mut Env) -> EvalResult {
         FormKind::Var(inner) => {
             if let FormKind::Symbol(s) = &inner.kind {
                 let parsed = Symbol::parse(s);
-                let ns: Arc<str> = match parsed.namespace.as_deref() {
-                    Some(ns_part) => env
-                        .globals
-                        .resolve_alias(&env.current_ns, ns_part)
-                        .unwrap_or_else(|| Arc::from(ns_part)),
-                    None => env.current_ns.clone(),
-                };
+                let ns: Arc<str> = env.resolve_ns_or_current(parsed.namespace.as_deref());
                 env.globals
                     .lookup_var_in_ns(&ns, &parsed.name)
                     .map(Value::Var)
@@ -264,10 +258,7 @@ fn eval_symbol(s: &str, env: &mut Env) -> EvalResult {
         && !s.starts_with('/')
         && let Some(ns_part) = &sym.namespace
     {
-        let resolved: Arc<str> = env
-            .globals
-            .resolve_alias(&env.current_ns, ns_part)
-            .unwrap_or_else(|| Arc::from(ns_part.as_ref()));
+        let resolved: Arc<str> = env.resolve_ns_part(ns_part);
         // Qualified self-reference inside a versioned namespace: `mylib/x`
         // written in `mylib@hash`'s own source resolves at the pinned commit,
         // i.e. inside the versioned namespace itself.

--- a/crates/cljrs-runtime/src/interp/macros.rs
+++ b/crates/cljrs-runtime/src/interp/macros.rs
@@ -198,16 +198,7 @@ pub fn macroexpand_all(form: &Form, env: &mut Env) -> EvalResult<Form> {
 /// If `sym` resolves to a macro in the current env, return its CljxFn.
 fn resolve_macro(sym: &str, env: &Env) -> Option<cljrs_value::CljxFn> {
     let parsed = Symbol::parse(sym);
-    // A namespace part may be an alias (`:require [... :as m]`), not a real
-    // namespace name — resolve it the same way `eval_symbol`/`(var ...)` do,
-    // falling back to the literal text only if it isn't a known alias.
-    let ns: Arc<str> = match parsed.namespace.as_deref() {
-        Some(ns_part) => env
-            .globals
-            .resolve_alias(&env.current_ns, ns_part)
-            .unwrap_or_else(|| Arc::from(ns_part)),
-        None => env.current_ns.clone(),
-    };
+    let ns: Arc<str> = env.resolve_ns_or_current(parsed.namespace.as_deref());
     let name = parsed.name.as_ref();
 
     let v = env.globals.lookup_in_ns(&ns, name)?;

--- a/crates/cljrs-runtime/src/interp/special.rs
+++ b/crates/cljrs-runtime/src/interp/special.rs
@@ -869,13 +869,7 @@ fn eval_var(args: &[Form], env: &mut Env) -> EvalResult {
         _ => return Err(EvalError::Runtime("var requires a symbol".into())),
     };
     let parsed = cljrs_value::Symbol::parse(&sym);
-    let ns: Arc<str> = match parsed.namespace.as_deref() {
-        Some(ns_part) => env
-            .globals
-            .resolve_alias(&env.current_ns, ns_part)
-            .unwrap_or_else(|| Arc::from(ns_part)),
-        None => env.current_ns.clone(),
-    };
+    let ns: Arc<str> = env.resolve_ns_or_current(parsed.namespace.as_deref());
     let name = parsed.name.as_ref();
     env.globals
         .lookup_var_in_ns(&ns, name)
@@ -2372,16 +2366,7 @@ fn eval_binding(args: &[Form], env: &mut Env) -> EvalResult {
             return Err(EvalError::Runtime("binding targets must be symbols".into()));
         };
         let parsed = cljrs_value::Symbol::parse(sym_str);
-        let ns_part: Arc<str> = match parsed.namespace.as_deref() {
-            // Resolve `alias/*var*` through the current ns's `:require :as`
-            // aliases, same as ordinary qualified-symbol lookup (`eval_symbol`)
-            // — otherwise `(binding [alias/*x* v] ...)` never finds the var.
-            Some(ns_part) => env
-                .globals
-                .resolve_alias(&env.current_ns, ns_part)
-                .unwrap_or_else(|| Arc::from(ns_part)),
-            None => env.current_ns.clone(),
-        };
+        let ns_part: Arc<str> = env.resolve_ns_or_current(parsed.namespace.as_deref());
         let var_ptr = env
             .globals
             .lookup_var_in_ns(&ns_part, &parsed.name)
@@ -2675,10 +2660,7 @@ fn resolve_protocol_sym(env: &Env, s: &str) -> Option<GcPtr<Protocol>> {
     let parsed = cljrs_value::Symbol::parse(s);
     let val = match parsed.namespace.as_deref() {
         Some(ns_part) => {
-            let ns = env
-                .globals
-                .resolve_alias(&env.current_ns, ns_part)
-                .unwrap_or_else(|| Arc::from(ns_part));
+            let ns = env.resolve_ns_part(ns_part);
             env.globals.lookup_in_ns(&ns, &parsed.name)
         }
         None => env.globals.lookup_in_ns(&env.current_ns, s),

--- a/crates/cljrs-runtime/src/interp/syntax_quote.rs
+++ b/crates/cljrs-runtime/src/interp/syntax_quote.rs
@@ -231,10 +231,7 @@ fn qualify_symbol(
     if let Some(idx) = s.find('/') {
         if idx > 0 && idx < s.len() - 1 {
             let (ns_part, name_part) = (&s[..idx], &s[idx + 1..]);
-            let resolved_ns = env
-                .globals
-                .resolve_alias(&env.current_ns, ns_part)
-                .unwrap_or_else(|| Arc::from(ns_part));
+            let resolved_ns = env.resolve_ns_part(ns_part);
             return format!("{resolved_ns}/{name_part}");
         }
         return s.to_string();

--- a/crates/cljrs-runtime/src/tiered/ir_interp.rs
+++ b/crates/cljrs-runtime/src/tiered/ir_interp.rs
@@ -536,9 +536,7 @@ fn execute_inst(
         }
 
         Inst::LoadVar(dst, gns, name) => {
-            let resolved_ns = globals
-                .resolve_alias(ns, gns)
-                .unwrap_or_else(|| Arc::from(&**gns));
+            let resolved_ns = globals.resolve_ns_part_in(ns, gns);
             let var = globals
                 .lookup_var_in_ns(&resolved_ns, name)
                 .ok_or_else(|| {
@@ -841,10 +839,9 @@ fn load_global_value(
         );
     }
 
-    // Try direct namespace lookup first, then resolve as alias.
-    let resolved_ns = globals
-        .resolve_alias(defining_ns, ns)
-        .unwrap_or_else(|| Arc::from(ns));
+    // Relative to the defining namespace, whose alias table a lowered
+    // function's qualified names were written against.
+    let resolved_ns = globals.resolve_ns_part_in(defining_ns, ns);
 
     if let Some(var) = globals.lookup_var_in_ns(&resolved_ns, name) {
         if let Some(val) = crate::env::dynamics::deref_var(&var) {

--- a/crates/cljrs-runtime/tests/ns_part_resolution.rs
+++ b/crates/cljrs-runtime/tests/ns_part_resolution.rs
@@ -1,24 +1,30 @@
-//! One namespace-resolution rule, shared by every construct that needs it.
+//! One alias-resolution rule, shared by every construct that needs it.
 //!
 //! `alias/name` and `fully.qualified.ns/name` must mean the same thing to a
-//! symbol, a `var` form, a macro call, a syntax-quote, a `binding` target, a
-//! protocol name and a `defmethod` target. The rule had been open-coded at
-//! each of those sites, so "the same thing" was a coincidence maintained by
-//! hand rather than a property — and a site added later (or a rule extended
-//! later, as privacy and version pins were) simply missed whichever copies
-//! nobody remembered.
+//! symbol, a `var` form, a macro call, a syntax-quote, a `binding` target and
+//! a protocol name. That lookup had been open-coded at each of those sites,
+//! so "the same thing" was a coincidence maintained by hand rather than a
+//! property, and a site added later simply started from whichever copy got
+//! pasted.
 //!
-//! These pin the agreement itself: every construct below goes through
-//! `Env::resolve_ns_part` / `Env::resolve_ns_or_current`.
+//! What the seam covers is exactly that lookup: an alias wins, anything else
+//! is literal, an absent ns part means the current namespace. It is NOT the
+//! whole of `eval_symbol`'s rule — the privacy check and versioned-symbol
+//! routing sit after the alias call there and still exist only there. Those
+//! are a separate divergence, and moving them is a behaviour change at every
+//! other site rather than a refactor.
+//!
+//! Each test below drives one construct through the seam. The two unqualified
+//! cases are the `None` arm; the six agreement cases are the alias arm, and
+//! each fails when the arm it names is stubbed out.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use cljrs_reader::Parser;
-use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_runtime::env::env::Env;
 use cljrs_value::Value;
 
-fn env_with_sources(files: &[(&str, &str)]) -> (tempfile::TempDir, Arc<GlobalEnv>, Env) {
+fn env_with_sources(files: &[(&str, &str)]) -> (tempfile::TempDir, Env) {
     let dir = tempfile::tempdir().expect("tempdir");
     for (rel, src) in files {
         let path = dir.path().join(rel);
@@ -31,8 +37,8 @@ fn env_with_sources(files: &[(&str, &str)]) -> (tempfile::TempDir, Arc<GlobalEnv
         .build()
         .expect("runtime")
         .into_globals();
-    let env = Env::new(globals.clone(), "user");
-    (dir, globals, env)
+    let env = Env::new(globals, "user");
+    (dir, env)
 }
 
 fn eval_in(env: &mut Env, src: &str) -> Result<Value, String> {
@@ -52,14 +58,12 @@ const LIB: &str = r#"
 (def ^:dynamic *knob* :default-knob)
 (defmacro twice [x] (list 'clojure.core/+ x x))
 (defprotocol Shaped (area [s]))
-(defmulti describe :kind)
-(defmethod describe :default [_] :unknown)
 "#;
 
 /// Evaluate `expr` twice — through an alias and through the full name — and
 /// require the two to agree. `{ns}` is replaced by each spelling in turn.
 fn agrees(expr_template: &str) -> Value {
-    let (_dir, _g, mut env) = env_with_sources(&[("some/lib.cljrs", LIB)]);
+    let (_dir, mut env) = env_with_sources(&[("some/lib.cljrs", LIB)]);
     eval_in(&mut env, "(require '[some.lib :as l])").expect("require with an alias");
 
     let via_alias = eval_in(&mut env, &expr_template.replace("{ns}", "l"))
@@ -116,8 +120,8 @@ fn a_protocol_name_resolves_the_same_either_way() {
 #[test]
 fn an_unknown_namespace_part_is_taken_literally() {
     // The fallback the seam has to preserve: a ns part that is not a known
-    // alias names a namespace directly, whether or not it is loaded yet.
-    let (_dir, _g, mut env) = env_with_sources(&[("some/lib.cljrs", LIB)]);
+    // alias names a namespace directly.
+    let (_dir, mut env) = env_with_sources(&[("some/lib.cljrs", LIB)]);
     eval_in(&mut env, "(require 'some.lib)").expect("require without an alias");
     assert_eq!(
         eval_in(&mut env, "some.lib/value").expect("full name with no alias in scope"),
@@ -127,9 +131,13 @@ fn an_unknown_namespace_part_is_taken_literally() {
 
 #[test]
 fn an_unqualified_name_means_the_current_namespace() {
-    let (_dir, _g, mut env) = env_with_sources(&[]);
+    // `eval_symbol` answers a bare symbol from `lookup_in_ns(current_ns, ..)`
+    // before it reaches the qualified branch, so `here` alone would pin a
+    // different code path than the one named here. A `var` form has no such
+    // short-circuit: it goes through `resolve_ns_or_current` with `None`.
+    let (_dir, mut env) = env_with_sources(&[]);
     assert_eq!(
-        eval_in(&mut env, "(do (def here 7) here)").expect("current-ns lookup"),
+        eval_in(&mut env, "(do (def here 7) @(var here))").expect("current-ns lookup"),
         Value::Long(7)
     );
 }

--- a/crates/cljrs-runtime/tests/ns_part_resolution.rs
+++ b/crates/cljrs-runtime/tests/ns_part_resolution.rs
@@ -1,0 +1,135 @@
+//! One namespace-resolution rule, shared by every construct that needs it.
+//!
+//! `alias/name` and `fully.qualified.ns/name` must mean the same thing to a
+//! symbol, a `var` form, a macro call, a syntax-quote, a `binding` target, a
+//! protocol name and a `defmethod` target. The rule had been open-coded at
+//! each of those sites, so "the same thing" was a coincidence maintained by
+//! hand rather than a property — and a site added later (or a rule extended
+//! later, as privacy and version pins were) simply missed whichever copies
+//! nobody remembered.
+//!
+//! These pin the agreement itself: every construct below goes through
+//! `Env::resolve_ns_part` / `Env::resolve_ns_or_current`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn env_with_sources(files: &[(&str, &str)]) -> (tempfile::TempDir, Arc<GlobalEnv>, Env) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (rel, src) in files {
+        let path = dir.path().join(rel);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, src).expect("write");
+    }
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .source_paths(vec![PathBuf::from(dir.path())])
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (dir, globals, env)
+}
+
+fn eval_in(env: &mut Env, src: &str) -> Result<Value, String> {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, env).map_err(|e| format!("{e:?}"))?;
+    }
+    Ok(result)
+}
+
+/// One namespace, exercising every construct whose ns part must resolve.
+const LIB: &str = r#"
+(ns some.lib)
+(def value 41)
+(def ^:dynamic *knob* :default-knob)
+(defmacro twice [x] (list 'clojure.core/+ x x))
+(defprotocol Shaped (area [s]))
+(defmulti describe :kind)
+(defmethod describe :default [_] :unknown)
+"#;
+
+/// Evaluate `expr` twice — through an alias and through the full name — and
+/// require the two to agree. `{ns}` is replaced by each spelling in turn.
+fn agrees(expr_template: &str) -> Value {
+    let (_dir, _g, mut env) = env_with_sources(&[("some/lib.cljrs", LIB)]);
+    eval_in(&mut env, "(require '[some.lib :as l])").expect("require with an alias");
+
+    let via_alias = eval_in(&mut env, &expr_template.replace("{ns}", "l"))
+        .unwrap_or_else(|e| panic!("through the alias: {expr_template}\n{e}"));
+    let via_full = eval_in(&mut env, &expr_template.replace("{ns}", "some.lib"))
+        .unwrap_or_else(|e| panic!("through the full name: {expr_template}\n{e}"));
+
+    assert_eq!(
+        via_alias, via_full,
+        "an alias and the full namespace name disagreed for: {expr_template}"
+    );
+    via_alias
+}
+
+#[test]
+fn a_qualified_symbol_resolves_the_same_either_way() {
+    assert_eq!(agrees("{ns}/value"), Value::Long(41));
+}
+
+#[test]
+fn a_var_form_resolves_the_same_either_way() {
+    assert_eq!(agrees("@(var {ns}/value)"), Value::Long(41));
+}
+
+#[test]
+fn a_macro_call_resolves_the_same_either_way() {
+    assert_eq!(agrees("({ns}/twice 21)"), Value::Long(42));
+}
+
+#[test]
+fn a_syntax_quoted_symbol_resolves_the_same_either_way() {
+    assert_eq!(
+        agrees("(str `{ns}/value)"),
+        Value::string("some.lib/value".to_string())
+    );
+}
+
+#[test]
+fn a_binding_target_resolves_the_same_either_way() {
+    assert_eq!(
+        agrees("(binding [{ns}/*knob* :bound] {ns}/*knob*)"),
+        Value::keyword(cljrs_value::Keyword::simple("bound"))
+    );
+}
+
+#[test]
+fn a_protocol_name_resolves_the_same_either_way() {
+    assert_eq!(
+        agrees("(do (extend-protocol {ns}/Shaped Long (area [s] (* s 2))) (some.lib/area 5))"),
+        Value::Long(10)
+    );
+}
+
+#[test]
+fn an_unknown_namespace_part_is_taken_literally() {
+    // The fallback the seam has to preserve: a ns part that is not a known
+    // alias names a namespace directly, whether or not it is loaded yet.
+    let (_dir, _g, mut env) = env_with_sources(&[("some/lib.cljrs", LIB)]);
+    eval_in(&mut env, "(require 'some.lib)").expect("require without an alias");
+    assert_eq!(
+        eval_in(&mut env, "some.lib/value").expect("full name with no alias in scope"),
+        Value::Long(41)
+    );
+}
+
+#[test]
+fn an_unqualified_name_means_the_current_namespace() {
+    let (_dir, _g, mut env) = env_with_sources(&[]);
+    assert_eq!(
+        eval_in(&mut env, "(do (def here 7) here)").expect("current-ns lookup"),
+        Value::Long(7)
+    );
+}


### PR DESCRIPTION
Follow-up to the note on #378 ("the three-line alias resolution is now in its sixth copy").

"Resolve a symbol's namespace part: a `:require :as` alias wins, anything else is taken literally, and an absent one means the current namespace" was open-coded at **seven** sites — `eval_symbol`, the `var` form, macro resolution, syntax-quote, `binding`, protocol names, and `eval_special`'s qualified lookup.

They agreed. But nothing *made* them agree, so the agreement was a property of whoever last remembered to check, and a construct added later starts from whichever copy got pasted.

### Why this is worth a PR rather than a cleanup

Extending the rule is exactly what has been going wrong. `eval_symbol` grew a privacy check and versioned-symbol routing; the other six copies did not. So today every construct that reaches into another namespace enforces a different subset of the same rule — which is how #378 needed two follow-up guards for behaviour `eval_symbol` already had, and why it would have been reasonable to assume it didn't.

`Env::resolve_ns_part` and `Env::resolve_ns_or_current` name the rule once. The next thing it has to learn is learned by all of them.

### Scope

No behaviour changes — the extracted body is the copies' body, and `cargo test -p cljrs-runtime` is green, along with fmt and clippy.

`defmethod` is deliberately **not** included: its cross-namespace resolution lands in #378, so it becomes the eighth caller there rather than here. `resolve_protocol_sym`'s `None` arm is left alone too — it looks the whole symbol up rather than falling back to the current namespace, which is a genuinely different rule and not a copy of this one.

### The test

`ns_part_resolution.rs` is the part I'd argue for keeping even if the refactor were rejected. It evaluates the same expression twice — through an alias and through the full namespace name — for every construct that resolves one, and requires the two to agree:

```clojure
{ns}/value                                  ; symbol
@(var {ns}/value)                           ; var form
({ns}/twice 21)                             ; macro call
(str `{ns}/value)                           ; syntax-quote
(binding [{ns}/*knob* :bound] {ns}/*knob*)  ; binding target
(extend-protocol {ns}/Shaped …)             ; protocol name
```

with `{ns}` as `l` and then `some.lib`. Before, each of those was covered separately if at all; the agreement between them was covered nowhere. A construct that stops going through the seam now fails a test instead of quietly diverging.

---

Happy to fold this into #378 instead if you'd rather review one diff — I kept it separate because it's a pure refactor and #378 is a fix.
