### PR TITLE
nREPL describe: advertise a Clojure language level

### DIFF
--- a/crates/cljrs-nrepl/src/server.rs
+++ b/crates/cljrs-nrepl/src/server.rs
@@ -200,6 +200,15 @@ const OPS: &[&str] = &[
     "ls-sessions",
 ];
 
+/// The Clojure language level this dialect implements, as reported to nREPL
+/// clients.
+///
+/// 1.11 is what the core actually provides: `update-keys`, `update-vals`,
+/// `abs`, `parse-long`, `parse-double` and `random-uuid` are all present, and
+/// no 1.12 addition (`partitionv`, `splitv-at`, …) is. `iteration` is the one
+/// 1.11 name still missing; raise this only when the level below it is whole.
+const CLOJURE_LEVEL: &str = "1.11.0";
+
 fn describe_response(req: &Request) -> Bencode {
     let ops: BTreeMap<Vec<u8>, Bencode> = OPS
         .iter()
@@ -219,6 +228,12 @@ fn describe_response(req: &Request) -> Bencode {
     let mut versions = BTreeMap::new();
     versions.insert(b"cljrs".to_vec(), version(env!("CARGO_PKG_VERSION")));
     versions.insert(b"nrepl".to_vec(), version("1.0.0"));
+    // The Clojure language level this dialect implements. Clients read
+    // `versions.clojure` to decide which version-gated features to enable;
+    // without it CIDER reports "Can't determine Clojure version" and turns
+    // parts of itself off. It answers "which Clojure does this speak", not
+    // "which implementation is this" — that is what `cljrs` above is for.
+    versions.insert(b"clojure".to_vec(), version(CLOJURE_LEVEL));
 
     Response::for_request(&req.clone(), req.session.as_deref().unwrap_or("none"))
         .field("ops", Bencode::Dict(ops))

--- a/crates/cljrs-nrepl/tests/nrepl_server.rs
+++ b/crates/cljrs-nrepl/tests/nrepl_server.rs
@@ -138,6 +138,31 @@ fn client_scenario(port: u16) {
         assert!(ops.contains_key(op.as_bytes()), "missing op {op}");
     }
 
+    // describe: advertises a Clojure language level as well as its own
+    // version. Clients gate features on `versions.clojure`; without it CIDER
+    // reports "Can't determine Clojure version" and turns part of itself off
+    // against a server that otherwise works.
+    let versions = resp[0]
+        .get(b"versions".as_slice())
+        .and_then(|v| v.as_dict())
+        .expect("describe has versions");
+    for key in ["cljrs", "nrepl", "clojure"] {
+        assert!(
+            versions.contains_key(key.as_bytes()),
+            "describe omits versions.{key}"
+        );
+    }
+    let clojure = versions
+        .get(b"clojure".as_slice())
+        .and_then(|v| v.as_dict())
+        .expect("versions.clojure is a dict");
+    for key in ["major", "minor", "incremental", "version-string"] {
+        assert!(
+            clojure.contains_key(key.as_bytes()),
+            "versions.clojure omits {key}"
+        );
+    }
+
     // clone: two independent sessions.
     let resp = c.request(&[("op", "clone")]);
     let session_a = field(&resp, "new-session")


### PR DESCRIPTION
`describe` reports `versions.cljrs` and `versions.nrepl` but no `versions.clojure`. Clients read that key to decide which version-gated features to enable, so connecting CIDER to a perfectly working server gives:

```
;; Connected to nREPL server - nrepl://127.0.0.1:7931
WARNING: Can't determine Clojure version.  The refactor-nrepl middleware requires clojure 1.8.0 (or newer)
```

and it turns part of itself off against a runtime that would have served it.

### Which version

1.11, and measured rather than assumed — `update-keys`, `update-vals`, `abs`, `parse-long`, `parse-double` and `random-uuid` all resolve; no 1.12 addition (`partitionv`, `splitv-at`, `partitionv-all`) does. `iteration` is the one 1.11 name still missing, noted at the constant so the number gets raised only when the level below it is whole.

It answers "which Clojure does this speak", which is a different question from "which implementation is this" — `versions.cljrs` already answers that, and the two shouldn't be conflated into one key.

### Verified against a real client

Server started with `cljrs nrepl`, then `cider-connect-clj` from Emacs (CIDER 2.1.0-snapshot). Before: the warning above. After: `versions.clojure` present in the describe reply —

```
7:clojured11:incrementali0e5:majori1e5:minori11e14:version-string6:1.11.0e
```

The end-to-end test now asserts `versions` carries all three keys and that `clojure` has the four fields a client destructures.
