### PR TITLE
Top-level (.method x) works under the async evaluator

### DIFF
--- a/crates/cljrs-async/README.md
+++ b/crates/cljrs-async/README.md
@@ -207,6 +207,7 @@ where values cross by copy.
 | `tests/worker_pool.rs` | Phase A2 integration tests: offload, concurrent tasks, handle spawning, LocalSet context, singleton invariant, byte processing round-trip |
 | `tests/isolate_channel_clj.rs` | Clojure-level Phase B2 tests: `isolate-chan` pair, put/poll round-trip, FIFO order, located error on a non-shareable value, async `isolate-take!` |
 | `tests/future_family.rs` | `cljrs.core.experimental`'s `future`/`future-call`/`future?`/`future-done?`/`future-cancelled?`/`future-cancel` on the isolate executor: cooperative start, interleaving, throwing bodies, sticky cancellation, and cancelled-error parity between the tree-walking and compiled await paths |
+| `tests/toplevel_interop.rs` | `(.method target)` / `(.-field target)` under `eval_async` — the path every top-level form takes when the async driver is installed |
 | `tests/reader_conditional_parity.rs` | property + example tests that `#?`/`#?@` resolve identically in `eval_async` and the sync evaluator (containers, `let*`/`loop*` binding vectors) |
 
 ## Public API

--- a/crates/cljrs-async/src/eval_async.rs
+++ b/crates/cljrs-async/src/eval_async.rs
@@ -470,6 +470,27 @@ async fn eval_loop_async(args: &[Form], env: &mut Env) -> EvalResult {
 /// special spreading/atom handling those builtins require. Such calls do not
 /// yield on awaits inside their arguments in Phase B.
 async fn eval_call_async(head: &Form, args: &[Form], whole: &Form, env: &mut Env) -> EvalResult {
+    // Interop: `(.method target args…)` / `(.-field target)`. The head names a
+    // method, not a value, so it must be routed before the callee is
+    // evaluated — `eval` on it raises `UnboundSymbol`. Mirrors `eval_call`;
+    // the target and arguments still take the yielding path, so an `await`
+    // inside either cooperates.
+    if let FormKind::Symbol(s) = &head.kind
+        && cljrs_runtime::interp::apply::is_method_sugar(s)
+    {
+        let Some((target_form, arg_forms)) = args.split_first() else {
+            return Err(EvalError::Runtime(format!("{s} requires a target object")));
+        };
+        let target = Box::pin(eval_async(target_form, env)).await?;
+        let _target_root = cljrs_runtime::env::gc_roots::root_value(&target);
+        let mut argv: Vec<Value> = Vec::with_capacity(arg_forms.len());
+        for a in arg_forms {
+            let _args_root = cljrs_runtime::env::gc_roots::root_values(&argv);
+            argv.push(Box::pin(eval_async(a, env)).await?);
+        }
+        return cljrs_runtime::interp::apply::dispatch_method(&s[1..], &target, &argv);
+    }
+
     let callee = eval(head, env)?;
     match &callee {
         Value::NativeFunction(nf)

--- a/crates/cljrs-async/tests/toplevel_interop.rs
+++ b/crates/cljrs-async/tests/toplevel_interop.rs
@@ -1,0 +1,106 @@
+//! `(.method target)` at the top level, under the async evaluator.
+//!
+//! `session::eval_form` routes every top-level form through
+//! `eval_async` whenever the async driver is installed, which is the default
+//! for the CLI. `eval_call_async` evaluated its head with `eval` before
+//! checking for the interop sugar, and `.toUpperCase` is not a symbol that
+//! resolves to anything — so a bare `(.method x)` failed with
+//! `Unable to resolve symbol: .toUpperCase` while the identical form inside a
+//! `defn` worked, because a function body reaches the sync evaluator or the
+//! IR tier instead.
+//!
+//! These drive the async path directly, which is where the divergence was.
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn globals() -> Arc<GlobalEnv> {
+    cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals()
+}
+
+/// Evaluate `src` the way the CLI does: every top-level form through
+/// `eval_async`, on a `LocalSet`.
+fn eval_async_src(src: &str) -> Result<Value, String> {
+    let globals = globals();
+    let mut env = Env::new(globals, "user");
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, async {
+        let mut result = Value::Nil;
+        for form in &forms {
+            result = cljrs_async::eval_async::eval_async(form, &mut env)
+                .await
+                .map_err(|e| format!("{e:?}"))?;
+        }
+        Ok(result)
+    })
+}
+
+fn value_of(src: &str) -> Value {
+    eval_async_src(src).unwrap_or_else(|e| panic!("{src}\n{e}"))
+}
+
+#[test]
+fn a_top_level_method_call_dispatches() {
+    assert_eq!(
+        value_of(r#"(.toUpperCase "ab")"#),
+        Value::string("AB".to_string())
+    );
+}
+
+#[test]
+fn a_top_level_method_call_passes_its_arguments() {
+    assert_eq!(
+        value_of(r#"(.substring "hello" 1 3)"#),
+        Value::string("el".to_string())
+    );
+}
+
+#[test]
+fn a_top_level_field_read_dispatches() {
+    assert_eq!(
+        value_of("(do (deftype T [x]) (.-x (->T 7)))"),
+        Value::Long(7)
+    );
+}
+
+#[test]
+fn the_target_is_evaluated_not_taken_literally() {
+    assert_eq!(
+        value_of(r#"(let [s "ab"] (.toUpperCase s))"#),
+        Value::string("AB".to_string())
+    );
+}
+
+#[test]
+fn a_method_call_with_no_target_says_so() {
+    let err = eval_async_src("(.toUpperCase)").expect_err("no target");
+    assert!(
+        err.contains("requires a target object"),
+        "unhelpful error: {err}"
+    );
+}
+
+#[test]
+fn an_unknown_method_reports_the_type_not_the_symbol() {
+    // The old failure mode was `Unable to resolve symbol: .nope`, which points
+    // at the head rather than at the target that cannot answer it.
+    let err = eval_async_src(r#"(.nope "ab")"#).expect_err("unknown method");
+    assert!(
+        err.contains("not supported") && !err.contains("resolve symbol"),
+        "unhelpful error: {err}"
+    );
+}

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -1403,7 +1403,7 @@ fn expanded_needs_interpreter(form: &cljrs_reader::Form) -> bool {
                 // either dot-marks them as `CallDirect`s codegen cannot
                 // resolve or rejects them outright.  Run any form
                 // containing one in the interpreted preamble.
-                if (s.len() > 1 && s != ".." && s.starts_with('.'))
+                if cljrs_ir::lower::is_method_sugar(s.as_str())
                     || matches!(s.as_str(), "." | "reify" | "deftype" | "defn-")
                 {
                     return true;

--- a/crates/cljrs-ir/README.md
+++ b/crates/cljrs-ir/README.md
@@ -54,6 +54,9 @@ src/
                   whether a head symbol really is a clojure.core name
     escape.rs   — worklist-based escape analysis; inter-procedural via EscapeContext
     inline.rs   — inlining pass: splices small callees into call sites
+    interop.rs  — `is_method_sugar`: the one definition of the `.method` /
+                  `.-field` head predicate, read by anf.rs, by cljrs-runtime's
+                  evaluator and async evaluator, and by the AOT driver
     known.rs    — symbol → KnownFn resolution, the `clojure.core` qualifier
                   check (core_name) and CoreShadows (what the lowering
                   namespace binds instead of core)

--- a/crates/cljrs-ir/src/lower/anf.rs
+++ b/crates/cljrs-ir/src/lower/anf.rs
@@ -742,7 +742,7 @@ fn lower_list(ctx: &mut LowerCtx, parts: &[Form]) -> R {
         // these to the tree-walker's method dispatch; Cranelift/wasm codegen
         // reject the unknown name, so such functions decline JIT compilation
         // instead of miscompiling to a nil call.
-        _ if sym.starts_with('.') && sym.len() > 1 && sym != ".." => {
+        _ if crate::lower::is_method_sugar(sym) => {
             if args.is_empty() {
                 return Err(LowerError::MalformedSpecialForm(format!(
                     "{sym} requires a target object"

--- a/crates/cljrs-ir/src/lower/interop.rs
+++ b/crates/cljrs-ir/src/lower/interop.rs
@@ -1,0 +1,33 @@
+//! The method-call sugar, recognized once.
+//!
+//! Read by `lower/anf.rs` (which name-marks it as a `CallDirect`), by
+//! `cljrs-compiler`'s AOT driver (which routes a form containing one to the
+//! interpreted preamble) and by the tree-walking interpreter (which dispatches
+//! it directly).
+
+/// True when `head` is the `.method` / `.-field` interop sugar.
+///
+/// Not a member: `..`, which is the threading macro, and a bare `.`, which is
+/// the classic `(. target method args…)` form with a handler of its own.
+pub fn is_method_sugar(head: &str) -> bool {
+    head.len() > 1 && head != ".." && head.starts_with('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_dotted_head_is_method_sugar() {
+        for name in [".toUpperCase", ".-field", ".x"] {
+            assert!(is_method_sugar(name), "{name} must be method sugar");
+        }
+    }
+
+    #[test]
+    fn the_threading_macro_and_the_classic_form_are_not() {
+        for name in ["..", ".", "", "toUpperCase", "clojure.core/inc"] {
+            assert!(!is_method_sugar(name), "{name} must not be method sugar");
+        }
+    }
+}

--- a/crates/cljrs-ir/src/lower/mod.rs
+++ b/crates/cljrs-ir/src/lower/mod.rs
@@ -8,6 +8,7 @@ pub mod async_lower;
 pub mod context;
 pub mod escape;
 pub mod inline;
+pub mod interop;
 pub mod known;
 pub mod optimize;
 pub mod regionalize;
@@ -21,6 +22,7 @@ pub use escape::{
     AnalysisResult, EscapeContext, EscapeState, ExternalDefn, UseInfo, UseKind, analyze,
 };
 pub use inline::inline;
+pub use interop::is_method_sugar;
 pub use known::CoreShadows;
 pub use optimize::{optimize, optimize_with_externals};
 

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -1007,6 +1007,7 @@ implement sentinel operations without hitting the stub errors registered in
 | `eval_with_bindings_star(args, env)` | `with-bindings*` — push binding frame, call f |
 | `eval_send_to_agent(args, env)` | `send` / `send-off` — dispatch action to agent |
 | `dispatch_method(method, target, args)` | `(.method target args…)` — interop method dispatch on an evaluated target (strings, vectors, seqs); on a `TypeInstance` only `.-field` reads are supported (mutable cell first, then the field map) |
+| `is_method_sugar(head)` | re-exported from `cljrs_ir::lower`: whether a head symbol is the `.method` / `.-field` sugar (`..` and a bare `.` are not). One definition, read by `eval_call`, `cljrs-async`'s `eval_call_async`, the ANF lowerer and the AOT driver |
 
 `make_lazy_seq_from_fn(f, globals, ns)` (already public) creates a `LazySeq`
 from a zero-arg callable; the above `make_delay_from_fn` is the analogous

--- a/crates/cljrs-runtime/src/interp/apply.rs
+++ b/crates/cljrs-runtime/src/interp/apply.rs
@@ -226,11 +226,9 @@ pub fn is_form_intercepted(name: &str) -> bool {
 pub fn eval_call(func_form: &Form, arg_forms: &[Form], env: &mut Env) -> EvalResult {
     // Interop: (.methodName target args...) — method call syntax.
     if let FormKind::Symbol(s) = &func_form.kind
-        && let Some(method) = s.strip_prefix('.')
-        && !method.is_empty()
-        && method != "."
+        && is_method_sugar(s)
     {
-        return eval_method_call(method, arg_forms, env);
+        return eval_method_call(&s[1..], arg_forms, env);
     }
 
     // Evaluate the callee first.
@@ -331,6 +329,12 @@ fn eval_method_call(method: &str, arg_forms: &[Form], env: &mut Env) -> EvalResu
 
     dispatch_method(method, &target, &args)
 }
+
+/// The `.method` / `.-field` head predicate.
+///
+/// Re-exported from `cljrs_ir::lower` so the evaluator, the async evaluator,
+/// the ANF lowerer and the AOT driver all read one definition.
+pub use cljrs_ir::lower::is_method_sugar;
 
 /// Dispatch `(.method target args…)` on an already-evaluated target.
 ///


### PR DESCRIPTION
## The bug

```
$ cljrs eval '(.toUpperCase "ab")'
Unable to resolve symbol: .toUpperCase
```

…while the identical form inside a `defn` works fine.

`session::eval_form` routes every top-level form through `eval_async` whenever the async driver is installed, which is the CLI default. `eval_call_async` evaluated its head with `eval` **before** testing for the interop sugar, and `.toUpperCase` is not a symbol that resolves to anything. A function body escapes this because it reaches the sync evaluator or the IR tier instead, so the failure looked arbitrary: same form, different answer depending on where you wrote it.

## The fix

`eval_call_async` now mirrors `eval_call`: recognize the `.method` / `.-field` head first, then evaluate the target and each argument through `eval_async` so an `await` inside either still cooperates, rooting both across the yields.

## The predicate, once

The head test existed in four places in three different spellings:

| site | spelling |
|---|---|
| `interp/apply.rs` | `strip_prefix('.')`, non-empty, `!= "."` |
| `lower/anf.rs` | `starts_with('.') && len > 1 && != ".."` |
| `compiler/aot.rs` | `len > 1 && != ".." && starts_with('.')` |
| `eval_async.rs` | *(missing — this is the bug)* |

All three were extensionally equal, which is exactly the condition under which the fourth site gets written wrong or not at all. `cljrs_ir::lower::interop::is_method_sugar` is now the one definition; the other three read it. `..` (threading macro) and a bare `.` (classic interop form, own handler) stay out of it.

## Tests

`crates/cljrs-async/tests/toplevel_interop.rs` — six cases driving `eval_async` directly, which is where the divergence lived: method dispatch, argument passing, `.-field` on a `deftype`, target evaluation (not taken literally), the no-target error, and that an unknown method now reports the *type* rather than `Unable to resolve symbol` on the head. Plus two unit cases pinning the predicate's boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvnAiUQ3wkvz5zAjBHWkt5