### PR TITLE
System/getenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ docs/book/book/
 # cargo-mutants working directory
 /mutants.out/
 /mutants.out.old/
+# local scratch: agent WIP diffs, perf/PR sandboxes
+/.dev/
+# nREPL server port file, written on every `cljrs nrepl`
+/.nrepl-port

--- a/crates/cljrs-runtime/README.md
+++ b/crates/cljrs-runtime/README.md
@@ -800,6 +800,25 @@ The `System/…` and `Thread/…` names follow the existing `Math/…` conventio
 JVM static's name registered as an ordinary builtin, so portable code that
 reaches for a clock resolves without a reader conditional.
 
+### Process environment (`builtins.rs`)
+
+- `(System/getenv)` — the whole environment, as a map of string to string.
+- `(System/getenv "NAME")` — that variable's value, or `nil` when unset.
+
+Same convention as the clock above, and the same nil-for-unset answer as
+`java.lang.System/getenv`, so `.cljc` that reads an environment variable needs
+no reader conditional.
+
+Reads through `std::env::vars_os` and skips what is not valid UTF-8:
+`std::env::vars()` *panics* on a non-UTF-8 entry, and one stray variable in the
+caller's environment must not take the runtime down. The one-arg form reports
+such a variable as unset, which is `std::env::var`'s own answer rather than a
+guess at an encoding.
+
+`System/getenv` is **denied inside a transaction function** (`env::policy`):
+the environment is process-global state the transaction was not handed as an
+argument, and it can change under it between retries.
+
 ### `eval`
 
 `eval` is registered as a sentinel and intercepted where the environment is

--- a/crates/cljrs-runtime/src/builtins/builtins.rs
+++ b/crates/cljrs-runtime/src/builtins/builtins.rs
@@ -1536,6 +1536,7 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         ("Math/cosh", Arity::Fixed(1), builtin_cosh),
         ("Math/tanh", Arity::Fixed(1), builtin_tanh),
         ("Math/hypot", Arity::Fixed(2), builtin_hypot),
+        ("System/getenv", Arity::Variadic { min: 0 }, builtin_getenv),
         ("log10", Arity::Fixed(1), builtin_log10),
         ("sin", Arity::Fixed(1), builtin_sin),
         ("cos", Arity::Fixed(1), builtin_cos),
@@ -6373,6 +6374,39 @@ fn builtin_slurp(args: &[Value]) -> ValueResult<Value> {
     };
     let content = std::fs::read_to_string(&path).map_err(|e| ValueError::Other(e.to_string()))?;
     Ok(Value::string(content))
+}
+
+/// `(System/getenv)` → a map of the whole environment;
+/// `(System/getenv "NAME")` → that variable's value, or `nil` when unset.
+///
+/// Mirrors `java.lang.System/getenv`, nil-for-unset included, so `.cljc` that
+/// reads an environment variable behaves the same here as on the JVM.
+///
+/// Reads the environment through the OS-string API and skips what is not valid
+/// UTF-8: `std::env::vars()` *panics* on a non-UTF-8 entry, and one stray
+/// variable in the caller's environment must not take the runtime down. The
+/// one-arg form reports such a variable as unset, which is `std::env::var`'s
+/// own answer rather than a guess at an encoding.
+fn builtin_getenv(args: &[Value]) -> ValueResult<Value> {
+    match args.first() {
+        None => {
+            let mut m = PersistentHashMap::empty();
+            for (k, v) in std::env::vars_os() {
+                if let (Some(k), Some(v)) = (k.to_str(), v.to_str()) {
+                    m = m.assoc(Value::string(k.to_string()), Value::string(v.to_string()));
+                }
+            }
+            Ok(Value::Map(MapValue::Hash(GcPtr::new(m))))
+        }
+        Some(Value::Str(s)) => match std::env::var(s.get().as_str()) {
+            Ok(v) => Ok(Value::string(v)),
+            Err(_) => Ok(Value::Nil),
+        },
+        Some(v) => Err(ValueError::WrongType {
+            expected: "string",
+            got: v.type_name().to_string(),
+        }),
+    }
 }
 
 fn builtin_close(args: &[Value]) -> ValueResult<Value> {

--- a/crates/cljrs-runtime/src/env/policy.rs
+++ b/crates/cljrs-runtime/src/env/policy.rs
@@ -92,6 +92,9 @@ pub fn check_native(name: &str) -> EvalResult<()> {
         "Exception.",
         "push-precision!",
         "pop-precision!",
+        // Reads process-global state the transaction did not receive as an
+        // argument, and which can change under it between calls.
+        "System/getenv",
     ];
     if DENIED.contains(&name) {
         Err(forbidden(name))

--- a/crates/cljrs-runtime/tests/getenv.rs
+++ b/crates/cljrs-runtime/tests/getenv.rs
@@ -1,0 +1,90 @@
+//! `System/getenv` — reading the process environment.
+//!
+//! cljrs had no environment accessor at all: `System/getenv` was an unbound
+//! symbol and nothing under `crates/` registered an equivalent. A `.cljrs`
+//! program could not honour `TMPDIR`, `HOME`, `NO_COLOR` or any other ambient
+//! configuration, which is why hive-universe's `native/universe/cli.cljrs`
+//! hardcodes `/tmp` where its `.cljw` twin reads the variable.
+//!
+//! These read variables the test process already has rather than setting any:
+//! `std::env::set_var` is `unsafe` under edition 2024 because the environment
+//! is process-global, and a test that mutates it races every other test in the
+//! same binary.
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+fn eval_fresh(src: &str) -> Result<Value, String> {
+    let (_, mut env) = make_env();
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser.parse_all().map_err(|e| format!("parse: {e:?}"))?;
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, &mut env)
+            .map_err(|e| format!("eval: {e:?}"))?;
+    }
+    Ok(result)
+}
+
+fn value_of(src: &str) -> Value {
+    eval_fresh(src).unwrap_or_else(|e| panic!("{src}\n{e}"))
+}
+
+/// A variable the test process is overwhelmingly likely to have, and which the
+/// harness itself does not touch.
+const PRESENT: &str = "PATH";
+
+/// The one-arg form answers with the value the host reports.
+#[test]
+fn reads_a_variable_that_is_set() {
+    let expected = std::env::var(PRESENT).expect("test host has no PATH");
+    assert_eq!(
+        value_of(&format!(r#"(System/getenv "{PRESENT}")"#)),
+        Value::string(expected)
+    );
+}
+
+/// Unset is `nil`, not an error and not an empty string — the JVM's answer.
+#[test]
+fn an_unset_variable_is_nil() {
+    let absent = "CLJRS_GETENV_TEST_DEFINITELY_UNSET";
+    assert!(std::env::var(absent).is_err(), "test premise broken");
+    assert_eq!(
+        value_of(&format!(r#"(System/getenv "{absent}")"#)),
+        Value::Nil
+    );
+}
+
+/// The no-arg form is the whole environment as a map.
+#[test]
+fn the_no_arg_form_returns_the_environment_as_a_map() {
+    let expected = std::env::var(PRESENT).expect("test host has no PATH");
+    assert_eq!(
+        value_of(&format!(r#"(get (System/getenv) "{PRESENT}")"#)),
+        Value::string(expected)
+    );
+}
+
+/// A non-string name is a type error rather than a silent nil, so a keyword
+/// slipping in where a name belongs is reported at the call.
+#[test]
+fn a_non_string_name_is_a_type_error() {
+    let err = eval_fresh("(System/getenv :PATH)").expect_err("keyword name");
+    assert!(
+        err.contains("string") || err.contains("WrongType"),
+        "unhelpful error: {err}"
+    );
+}

--- a/crates/cljrs-tx/src/lib.rs
+++ b/crates/cljrs-tx/src/lib.rs
@@ -392,6 +392,16 @@ mod tests {
         assert!(matches!(error, TxError::ForbiddenEffect(name) if name == "spit"));
     }
 
+    /// The environment is process-global state the transaction was not handed,
+    /// and it can change under a retry, so reading it is denied like any other
+    /// ambient effect.
+    #[test]
+    fn rejects_reading_the_environment() {
+        let program = TxProgram::parse("(fn [] (System/getenv \"HOME\"))").unwrap();
+        let error = execute(&program, vec![], TxLimits::default()).unwrap_err();
+        assert!(matches!(error, TxError::ForbiddenEffect(name) if name == "System/getenv"));
+    }
+
     #[test]
     fn enforces_gas_limit() {
         let program = TxProgram::parse("(fn [] (loop [x 0] (recur (inc x))))").unwrap();


### PR DESCRIPTION
## The gap

cljrs has no environment accessor at all. `System/getenv` is an unbound symbol, and nothing under `crates/` registers an equivalent — so a `.cljrs` program cannot read `TMPDIR`, `HOME`, `NO_COLOR`, or any other ambient configuration.

This is not hypothetical: hive-universe's `native/universe/cli.cljrs` hardcodes `/tmp` and offers a `--socket` override, where its `.cljw` twin simply reads the variable.

## What this adds

```clojure
(System/getenv)              ;=> {"PATH" "/usr/bin:…", "HOME" "/home/you", …}
(System/getenv "HOME")       ;=> "/home/you"
(System/getenv "NOPE")       ;=> nil
```

Registered under the convention `Math/…`, `System/currentTimeMillis` and `Thread/sleep` already use — a JVM static's name as an ordinary builtin — so portable code resolves it without a reader conditional. Semantics follow `java.lang.System/getenv`, nil-for-unset included.

## Two decisions worth flagging

**Non-UTF-8 is skipped, not fatal.** The no-arg form reads through `std::env::vars_os`, because `std::env::vars()` *panics* on a non-UTF-8 entry — one stray variable in the caller's environment should not take the runtime down. The one-arg form answers `nil` for such a variable, which is `std::env::var`'s own answer rather than a guess at an encoding.

**Denied inside a transaction function.** `env::policy::check_native` gains `System/getenv`. The environment is process-global state a transaction was not handed as an argument, and it can change under the function between retries — the same reason `nanotime` and `rand` are already denied. A capability the policy has not heard of is a hole in the policy, so the deny lands in the same commit as the primitive.

## Tests

`crates/cljrs-runtime/tests/getenv.rs` — set, unset, the whole-environment map, and a non-string name. `cljrs-tx` gains the matching rejection case.

They read variables the process already has rather than setting any: `std::env::set_var` is `unsafe` under edition 2024 precisely because the environment is process-global, and a test that mutates it races every other test in its binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvnAiUQ3wkvz5zAjBHWkt5