### PR TITLE
The splice properties stop bootstrapping a runtime per assertion

### DIFF
--- a/crates/cljrs-runtime/src/interp/eval.rs
+++ b/crates/cljrs-runtime/src/interp/eval.rs
@@ -916,6 +916,10 @@ mod tests {
         );
     }
 
+    // These properties build ONE env per case and evaluate every spelling in
+    // it. `eval_str` bootstraps a whole runtime per call, and a property that
+    // evaluates a dozen spellings across 48 cases pays that hundreds of times.
+    // Nothing here defines anything, so one env per case is equivalent.
     proptest::proptest! {
         #![proptest_config(proptest::prelude::ProptestConfig::with_cases(48))]
         /// Splicing `#?@(:rust mid)` into any container evaluates to the same
@@ -934,14 +938,15 @@ mod tests {
             let p = kw_run(0, np);
             let m = kw_run(np, nm);
             let s = kw_run(np + nm, ns);
+            let (_g, mut env) = make_env();
             for (open, close, quote) in
                 [("[", "]", ""), ("#{", "}", ""), ("(", ")", "'"), ("(vector ", ")", "")]
             {
                 let spliced = format!("{quote}{open}{p} #?@(:rust [{m}]) {s}{close}");
                 let inlined = format!("{quote}{open}{p} {m} {s}{close}");
                 proptest::prop_assert_eq!(
-                    eval_str(&spliced).unwrap(),
-                    eval_str(&inlined).unwrap(),
+                    eval_src(&spliced, &mut env).unwrap(),
+                    eval_src(&inlined, &mut env).unwrap(),
                     "container {}{}",
                     open,
                     close
@@ -1053,13 +1058,14 @@ mod tests {
         ) {
             let (written, inlined) = render_slots(&slots, &kw_unit);
             let even = inlined.split_whitespace().count().is_multiple_of(2);
+            let (_g, mut env) = make_env();
             for (open, close) in [("[", "]"), ("#{", "}"), ("{", "}")] {
                 if open == "{" && !even {
                     continue;
                 }
                 for prefix in ["", "'", "`"] {
-                    let got = eval_str(&format!("{prefix}{open}{written}{close}"));
-                    let want = eval_str(&format!("{prefix}{open}{inlined}{close}"));
+                    let got = eval_src(&format!("{prefix}{open}{written}{close}"), &mut env);
+                    let want = eval_src(&format!("{prefix}{open}{inlined}{close}"), &mut env);
                     proptest::prop_assert_eq!(
                         got.map_err(|e| e.to_string()),
                         want.map_err(|e| e.to_string()),
@@ -1069,8 +1075,8 @@ mod tests {
             }
             // Data lists have no evaluated spelling; check both quoted forms.
             for prefix in ["'", "`"] {
-                let got = eval_str(&format!("{prefix}({written})"));
-                let want = eval_str(&format!("{prefix}({inlined})"));
+                let got = eval_src(&format!("{prefix}({written})"), &mut env);
+                let want = eval_src(&format!("{prefix}({inlined})"), &mut env);
                 proptest::prop_assert_eq!(
                     got.map_err(|e| e.to_string()),
                     want.map_err(|e| e.to_string()),
@@ -1092,9 +1098,10 @@ mod tests {
                 .map(str::to_string)
                 .collect();
             let body = format!("[{}]", names.join(" "));
+            let (_g, mut env) = make_env();
             for head in ["let*", "loop*"] {
-                let got = eval_str(&format!("({head} [{written}] {body})"));
-                let want = eval_str(&format!("({head} [{inlined}] {body})"));
+                let got = eval_src(&format!("({head} [{written}] {body})"), &mut env);
+                let want = eval_src(&format!("({head} [{inlined}] {body})"), &mut env);
                 proptest::prop_assert_eq!(
                     got.map_err(|e| e.to_string()),
                     want.map_err(|e| e.to_string()),


### PR DESCRIPTION
`cargo test --workspace` has been killing the CI runner. It is reported as
`The runner has received a shutdown signal`, which reads like flaky
infrastructure, but it is reproducible and it is ours: the job runs out of
memory.

Three splice properties in `interp/eval.rs` call `eval_str`, and `eval_str`
builds a **whole runtime per call** — a fresh GC heap plus a re-evaluation of
`bootstrap.cljrs`. Each property evaluates up to eleven spellings across 48
cases, so that is several hundred full bootstraps per property, and the memory
is not returned in between.

Measured on those three properties alone, single-threaded:

| | peak RSS | wall |
|---|---|---|
| before | 17.4 GB | 3m34s |
| after | 0.33 GB | 3.0s |

A GitHub runner does not have 17.4 GB.

Each property now builds **one env per case** and evaluates every spelling in
it, via `eval_src` instead of `eval_str`. These properties evaluate literal
containers and binding vectors, which define nothing, so a shared env is
equivalent by construction rather than by luck. Same assertions, same case
count, no `#[ignore]`.

The effect is not confined to the properties. The whole `cljrs-runtime` lib
suite, same 238 tests:

```console
before:  test result: ok. 238 passed ... finished in 135.38s
after:   test result: ok. 238 passed ... finished in 1.60s
```

This also explains the other shape the failure took. Runs that survived the OOM
instead failed two background-lowering tests, which assert on a debug line
emitted by a worker thread: a machine that is thrashing does not schedule that
thread before the child process exits. One cause, two symptoms.

Verified locally: `cargo fmt --check` clean, `cargo clippy --workspace -- -D warnings`
clean, `cargo test -p cljrs-runtime` green.
