### PR TITLE
Name each extension's init symbol after its crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ version = "0.1.0"
 dependencies = [
  "cljrs-async",
  "cljrs-base64",
+ "cljrs-blake3",
  "cljrs-charset",
  "cljrs-gc",
  "cljrs-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ cljrs-charset      = { path = "crates/cljrs-charset",      version = "0.1.0", de
 cljrs-lsp          = { path = "crates/cljrs-lsp",          version = "0.1.0" }
 cljrs-nrepl        = { path = "crates/cljrs-nrepl",        version = "0.1.0", default-features = false }
 cljrs-base64       = { path = "crates/cljrs-base64",       version = "0.1.0", default-features = false }
+cljrs-blake3       = { path = "crates/cljrs-blake3",       version = "0.1.0", default-features = false }
 cljrs-tx           = { path = "crates/cljrs-tx",           version = "0.1.0", default-features = false }
 
 tracing            = "0.1.44"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -138,7 +138,7 @@ provenance** (the commit it was built from, registered via
 {:deps
  {my.native.lib {:git/url   "https://github.com/user/my-native-lib"
                  :git/sha   "abc1234ef"
-                 :rust/init "my_native_lib::cljrs_init"
+                 :rust/init "my_native_lib::cljrs_init_my_native_lib"
                  :rust/load :dylib}}}
 ```
 

--- a/crates/cljrs-base64/README.md
+++ b/crates/cljrs-base64/README.md
@@ -8,13 +8,13 @@ Exposes standard and URL-safe Base64 encode/decode functions to Clojure code und
 
 ## Status
 
-Phase 1 — implemented. Linked statically into the `cljrs` binary via the `base64` feature (enabled by default) and also loadable as a dynamic plugin via the `cljrs_init` FFI entry point.
+Phase 1 — implemented. Linked statically into the `cljrs` binary via the `base64` feature (enabled by default) and also loadable as a dynamic plugin via the `cljrs_init_cljrs_base64` FFI entry point.
 
 ## File layout
 
 | File | Description |
 |---|---|
-| `src/lib.rs` | All implementation: byte-conversion helpers, `init`, `register`, and the `cljrs_init` FFI entry point |
+| `src/lib.rs` | All implementation: byte-conversion helpers, `init`, `register`, and the `cljrs_init_cljrs_base64` FFI entry point |
 
 ## Public API
 
@@ -30,7 +30,7 @@ pub fn register(registry: &mut Registry);
 
 /// C-ABI entry point for dynamic plugin loading.
 #[no_mangle]
-pub unsafe extern "C" fn cljrs_init(registry: *mut Registry);
+pub unsafe extern "C" fn cljrs_init_cljrs_base64(registry: *mut Registry);
 ```
 
 ### Clojure functions

--- a/crates/cljrs-base64/cljrs.edn
+++ b/crates/cljrs-base64/cljrs.edn
@@ -3,4 +3,4 @@
  :paths ["src"]
  :test-paths ["test"]
  :rust {:crate "."
-        :init "cljrs_base64::cljrs_init"}}
+        :init "cljrs_base64::cljrs_init_cljrs_base64"}}

--- a/crates/cljrs-base64/src/lib.rs
+++ b/crates/cljrs-base64/src/lib.rs
@@ -126,12 +126,33 @@ pub fn register(registry: &mut Registry) {
     registry.env().mark_loaded("cljrs.base64");
 }
 
+/// C-ABI entry point, loaded dynamically by `cljrs build-native` / `cljrs run`.
+///
+/// `cljrs.edn`:
+/// ```edn
+/// {:rust {:crate "."
+///         :init  "cljrs_base64::cljrs_init_cljrs_base64"}}
+/// ```
+///
+/// The name carries the crate, and that is the whole point of it. This symbol
+/// is `no_mangle`, so every extension crate that spelled it `cljrs_init` would
+/// export the SAME symbol. Two such crates link into one binary without any
+/// error: the linker resolves both references to a single definition, so
+/// `other_crate::cljrs_init` and this one become the same address and one
+/// plugin's registration silently replaces the other's. Naming the symbol after
+/// the crate makes that collision impossible to express rather than merely
+/// unlikely.
+///
+/// Nothing in the loader hardcodes the name: it takes the last `::` segment of
+/// `:rust :init`, so the name is data and an extension may choose any unique
+/// spelling.
+///
 /// # Safety
 /// `registry` must be a valid, non-null `*mut Registry` and must remain
 /// uniquely borrowed for the duration of the call. The cljrs CLI satisfies
 /// both: it allocates the `Registry` on its stack and hands the only pointer
 /// to it across the FFI boundary.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cljrs_init(registry: *mut Registry) {
+pub unsafe extern "C" fn cljrs_init_cljrs_base64(registry: *mut Registry) {
     register(unsafe { &mut *registry });
 }

--- a/crates/cljrs-blake3/README.md
+++ b/crates/cljrs-blake3/README.md
@@ -12,7 +12,7 @@ crate and registers the `blake3` Clojure namespace.
 
 ```
 src/
-  lib.rs                          — NativeObject impl, helper fns, cljrs_init
+  lib.rs                          — NativeObject impl, helper fns, cljrs_init_cljrs_blake3
 test/
   cljrs/
     blake3_test.cljrs             — clojure.test suite (known vectors + properties)
@@ -35,7 +35,7 @@ pub fn register(registry: &mut cljrs_interop::Registry);
 /// C-ABI entry point looked up by `cljrs build-native` / `cljrs run`. Calls
 /// `register` internally.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cljrs_init(registry: *mut cljrs_interop::Registry);
+pub unsafe extern "C" fn cljrs_init_cljrs_blake3(registry: *mut cljrs_interop::Registry);
 ```
 
 ### Clojure namespace: `blake3`
@@ -90,13 +90,13 @@ Add to your `cljrs.edn`:
 ```edn
 {:paths ["src"]
  :rust  {:crate "path/to/cljrs-blake3"
-         :init  "cljrs_blake3::cljrs_init"}}
+         :init  "cljrs_blake3::cljrs_init_cljrs_blake3"}}
 ```
 
 Or call `register` directly from your own init hook:
 
 ```rust
-pub fn cljrs_init(registry: &mut Registry) {
+pub fn cljrs_init_cljrs_blake3(registry: &mut Registry) {
     cljrs_blake3::register(registry);
     // … your own registrations …
 }

--- a/crates/cljrs-blake3/cljrs.edn
+++ b/crates/cljrs-blake3/cljrs.edn
@@ -7,11 +7,11 @@
 ;; :test-paths — directories containing clojure.test namespaces
 ;; :rust       — Rust integration settings
 ;;   :crate    — path to the Cargo crate root (relative to this file)
-;;   :init     — fully-qualified Rust symbol for the cljrs_init hook
+;;   :init     — fully-qualified Rust symbol for the cljrs_init_<crate> hook
 
 {:name       "cljrs-blake3"
  :version    "0.1.0"
  :paths      ["src"]
  :test-paths ["test"]
  :rust       {:crate "."
-              :init  "cljrs_blake3::cljrs_init"}}
+              :init  "cljrs_blake3::cljrs_init_cljrs_blake3"}}

--- a/crates/cljrs-blake3/src/lib.rs
+++ b/crates/cljrs-blake3/src/lib.rs
@@ -110,14 +110,14 @@ fn hash_to_byte_vec(hash: &blake3::Hash) -> Vec<Value> {
         .collect()
 }
 
-// ── cljrs_init ────────────────────────────────────────────────────────────────
+// ── init entry points ─────────────────────────────────────────────────────────
 
 /// Register all `blake3` namespace functions into the Clojure runtime.
 ///
 /// Use this when calling from another Rust crate that holds a `Registry`
 /// directly (e.g. integration tests, AOT-compiled binaries). The dynamic
-/// `cljrs build-native` loader uses the `extern "C"` `cljrs_init` wrapper
-/// below instead.
+/// `cljrs build-native` loader uses the `extern "C"` `cljrs_init_cljrs_blake3`
+/// wrapper below instead.
 pub fn register(registry: &mut Registry) {
     // blake3/hash — one-shot hash of a string or byte vector → 64-char hex
     registry.define(
@@ -232,8 +232,11 @@ pub fn register(registry: &mut Registry) {
 /// `cljrs.edn`:
 /// ```edn
 /// {:rust {:crate "."
-///         :init  "cljrs_blake3::cljrs_init"}}
+///         :init  "cljrs_blake3::cljrs_init_cljrs_blake3"}}
 /// ```
+///
+/// The name carries the crate on purpose; see `cljrs_base64::cljrs_init_cljrs_base64`
+/// for why a shared `cljrs_init` silently collides instead of failing to link.
 ///
 /// # Safety
 /// `registry` must be a valid, non-null `*mut Registry` and must remain
@@ -241,6 +244,6 @@ pub fn register(registry: &mut Registry) {
 /// both: it allocates the `Registry` on its stack and hands the only pointer
 /// to it across the FFI boundary.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cljrs_init(registry: *mut Registry) {
+pub unsafe extern "C" fn cljrs_init_cljrs_blake3(registry: *mut Registry) {
     register(unsafe { &mut *registry });
 }

--- a/crates/cljrs-compiler/Cargo.toml
+++ b/crates/cljrs-compiler/Cargo.toml
@@ -63,6 +63,9 @@ cljrs-io      = { workspace = true }
 cljrs-net     = { workspace = true }
 cljrs-charset = { workspace = true }
 cljrs-base64  = { workspace = true }
+# Linked alongside cljrs-base64 by `extension_init_symbols_are_unique_per_crate`,
+# which is the only place two plugin crates share one binary.
+cljrs-blake3  = { workspace = true }
 tempfile = "3"
 wasmparser = "0.244"
 proptest = "1"

--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -412,6 +412,15 @@ impl CompileSession {
 }
 ```
 
+**Extension init symbols must be unique per crate** (`tests/extension_init_symbols.rs`).
+A plugin crate's C-ABI entry point is `#[no_mangle]`, so two crates that both
+name it `cljrs_init` export the same symbol.  Linking both into one AOT binary
+does *not* fail: the linker resolves every reference to a single definition, so
+`crate_a::cljrs_init` and `crate_b::cljrs_init` become the same address and one
+crate's registration silently replaces the other's.  The convention is therefore
+`cljrs_init_<crate>`, and that test is the only place two plugin crates share a
+binary, which is why `cljrs-blake3` is a dev-dependency here.
+
 `compile_file` and `compile_file_to_wasm` take a `&CompileSession` and call
 `register_all` on the bootstrap environment (so `require` resolves during
 macro expansion) and `harness_init_code` when generating the harness (so the

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -2241,7 +2241,7 @@ edition = "2024"
     };
 
     // Emit the native init call when :rust :init is configured.  The init
-    // function has the signature `fn cljrs_init(registry: &mut Registry)`
+    // function has the signature `fn cljrs_init_<crate>(registry: &mut Registry)`
     // and is called before the preamble so native functions are visible to
     // macro-expanded code at startup.
     let native_init_code = match rust_config.and_then(|rc| rc.init_fn.as_deref()) {

--- a/crates/cljrs-compiler/src/extensions.rs
+++ b/crates/cljrs-compiler/src/extensions.rs
@@ -172,7 +172,7 @@ impl CompileSession {
         }
     }
 
-    /// Depend on the user's Rust crate and call its `cljrs_init` hook before
+    /// Depend on the user's Rust crate and call its `cljrs_init_<crate>` hook before
     /// loading any Clojure code (`:rust` in `cljrs.edn`).
     pub fn rust_config(mut self, config: Option<cljrs_project::config::RustConfig>) -> Self {
         self.rust_config = config;

--- a/crates/cljrs-compiler/tests/extension_init_symbols.rs
+++ b/crates/cljrs-compiler/tests/extension_init_symbols.rs
@@ -1,0 +1,22 @@
+//! Two extension crates must not export the same C-ABI init symbol.
+//!
+//! This is the only test binary that links more than one plugin crate, which is
+//! what the AOT path does when a program pulls in two extensions.
+
+/// A shared `#[no_mangle] cljrs_init` does NOT fail to link. The linker resolves
+/// every reference to a single definition, so both Rust paths become the same
+/// address and one crate's registration silently replaces the other's: the
+/// second namespace is simply never defined, with no diagnostic anywhere.
+///
+/// Naming each export after its crate is what makes that unrepresentable, and
+/// this pins it. Measured before the rename: the two addresses were equal.
+#[test]
+fn extension_init_symbols_are_unique_per_crate() {
+    let base64 = cljrs_base64::cljrs_init_cljrs_base64 as usize;
+    let blake3 = cljrs_blake3::cljrs_init_cljrs_blake3 as usize;
+    assert_ne!(
+        base64, blake3,
+        "two extension crates resolved their init to one address, so one \
+         plugin's registration silently replaces the other's"
+    );
+}

--- a/crates/cljrs-interop/README.md
+++ b/crates/cljrs-interop/README.md
@@ -19,7 +19,7 @@ src/
                  register_provenance! macro
   marshal.rs   — FromValue / IntoValue traits with impls for common Rust types
   register.rs  — wrap_fn0..wrap_fn3, wrap_fn_variadic: auto-marshalling function wrappers
-  registry.rs  — Registry struct and InitFn type alias for cljrs_init convention
+  registry.rs  — Registry struct and InitFn type alias for the cljrs_init_<crate> convention
 ```
 
 The `NativeObject` trait and `NativeObjectBox` wrapper live in `cljrs-value::native_object`
@@ -77,7 +77,7 @@ These accept closures (not just bare `fn` pointers) since `NativeFnFunc` is now
 ### `#[export]` proc-macro and `register_exports`
 
 Annotate any free Rust function with `#[export(ns = "...")]` to register it
-automatically. Then call `register_exports` once inside `cljrs_init`:
+automatically. Then call `register_exports` once inside the init function:
 
 ```rust
 use cljrs_interop::{export, register_exports, Registry};
@@ -88,7 +88,7 @@ pub fn add(a: i64, b: i64) -> Result<i64, String> { Ok(a + b) }
 #[export(ns = "math")]
 pub fn pi() -> f64 { std::f64::consts::PI }
 
-pub fn cljrs_init(registry: &mut Registry) {
+pub fn cljrs_init_my_project(registry: &mut Registry) {
     register_exports(registry);
 }
 ```
@@ -120,14 +120,14 @@ pub struct ProvenanceEntry { pub ns: &'static str, pub commit: &'static str }
 // Declare once per exported namespace (commit typically from build.rs):
 cljrs_interop::register_provenance!("math", env!("CLJRS_PKG_COMMIT"));
 
-// Or imperatively inside cljrs_init:
+// Or imperatively inside the init function:
 registry.set_provenance("math", commit);
 ```
 
 ### Registry and InitFn
 
 The entry point for mixed Rust/Clojure projects.  User crates implement a
-`cljrs_init` function and list it under `:rust :init` in `cljrs.edn`; the
+`cljrs_init_<crate>` function and list it under `:rust :init` in `cljrs.edn`; the
 build toolchain calls it before loading any Clojure source.
 
 ```rust
@@ -171,7 +171,7 @@ impl Registry {
 // user's lib.rs
 use cljrs_interop::{Registry, wrap_fn1, wrap_fn2};
 
-pub fn cljrs_init(registry: &mut Registry) {
+pub fn cljrs_init_my_project(registry: &mut Registry) {
     registry.define("my.project/greet",
         wrap_fn1("greet", |name: String| Ok::<String, String>(format!("Hello, {name}!"))));
     registry.define("my.project/add",
@@ -183,7 +183,7 @@ pub fn cljrs_init(registry: &mut Registry) {
 ;; cljrs.edn
 {:paths ["src"]
  :rust  {:crate "."
-         :init  "my_project::cljrs_init"}}
+         :init  "my_project::cljrs_init_my_project"}}
 ```
 
 ### Versioned symbols and native functions

--- a/crates/cljrs-interop/src/registry.rs
+++ b/crates/cljrs-interop/src/registry.rs
@@ -4,12 +4,12 @@
 //! # Usage
 //!
 //! User crates that embed Rust code alongside Clojure sources implement a
-//! `cljrs_init` function matching the [`InitFn`] signature:
+//! `cljrs_init_<crate>` function matching the [`InitFn`] signature:
 //!
 //! ```rust,ignore
 //! use cljrs_interop::{Registry, wrap_fn1};
 //!
-//! pub fn cljrs_init(registry: &mut Registry) {
+//! pub fn cljrs_init_my_project(registry: &mut Registry) {
 //!     registry.define("my.project/greet", wrap_fn1("greet", |name: String| {
 //!         Ok::<String, String>(format!("Hello, {name}!"))
 //!     }));
@@ -17,7 +17,7 @@
 //! ```
 //!
 //! The `cljrs compile` toolchain reads the `:rust :init` key from `cljrs.edn`
-//! (e.g. `"my_project::cljrs_init"`) and emits a generated `main.rs` that calls
+//! (e.g. `"my_project::cljrs_init_my_project"`) and emits a generated `main.rs` that calls
 //! it before loading any Clojure source.
 
 use std::sync::Arc;
@@ -32,12 +32,12 @@ use crate::exports::register_exports;
 
 /// The expected signature of a Rust-side hook-registration function.
 ///
-/// Name your function `cljrs_init` and list it under `:rust :init` in
+/// Name your function `cljrs_init_<crate>` and list it under `:rust :init` in
 /// `cljrs.edn` so the build toolchain can wire it up automatically:
 ///
 /// ```edn
 /// :rust {:crate "."
-///        :init  "my_crate::cljrs_init"}
+///        :init  "my_crate::cljrs_init_my_crate"}
 /// ```
 pub type InitFn = fn(&mut Registry);
 

--- a/crates/cljrs-project/README.md
+++ b/crates/cljrs-project/README.md
@@ -119,7 +119,7 @@ pub enum TrustedSigner {
 pub struct RustConfig {
     /// Directory containing the user's Cargo.toml (resolved from cljrs.edn dir).
     pub crate_dir: PathBuf,
-    /// Fully-qualified init fn, e.g. "my_project::cljrs_init". Optional.
+    /// Fully-qualified init fn, e.g. "my_project::cljrs_init_my_project". Optional.
     pub init_fn:   Option<Arc<str>>,
 }
 
@@ -222,7 +222,7 @@ pub type VcsResult<T> = Result<T, VcsError>;
   ;; Native dep with opt-in pinned native code (the CLI's `native` module):
   my.native.lib {:git/url   "https://github.com/user/my-native-lib"
                  :git/sha   "abc1234ef"
-                 :rust/init "my_native_lib::cljrs_init"
+                 :rust/init "my_native_lib::cljrs_init_my_native_lib"
                  :rust/load :dylib}}
 
  ;; Optional: embed a Rust crate in this project.
@@ -233,7 +233,7 @@ pub type VcsResult<T> = Result<T, VcsError>;
  :main my.app.core
 
  :rust {:crate "."
-        :init  "my_project::cljrs_init"}
+        :init  "my_project::cljrs_init_my_project"}
 
  :aliases
  {:dev  {:extra-paths ["dev"]}

--- a/crates/cljrs-project/src/config.rs
+++ b/crates/cljrs-project/src/config.rs
@@ -43,7 +43,7 @@ pub struct GitDep {
     pub url: Arc<str>,
     pub sha: Arc<str>,
     /// `:rust/init` — fully-qualified path to the dep's native init function
-    /// (e.g. `"my_crate::cljrs_init"`), when the dep ships Rust code.
+    /// (e.g. `"my_crate::cljrs_init_my_crate"`), when the dep ships Rust code.
     pub rust_init: Option<Arc<str>>,
     /// `:rust/crate` — directory of the dep's Cargo.toml relative to its
     /// repository root (defaults to the root).
@@ -89,7 +89,7 @@ pub struct Alias {
 
 /// Rust-crate configuration for mixed Rust/Clojure projects.
 ///
-/// The `:init` value is a Rust path like `"my_project::cljrs_init"`. The
+/// The `:init` value is a Rust path like `"my_project::cljrs_init_my_project"`. The
 /// first `::` segment is the crate name used in `Cargo.toml` and when
 /// looking for the compiled shared library on disk.
 ///
@@ -97,7 +97,7 @@ pub struct Alias {
 ///
 /// ```edn
 /// :rust {:crate "."                        ; path to directory with Cargo.toml
-///        :init  "my_project::cljrs_init"}  ; optional hook-registration fn
+///        :init  "my_project::cljrs_init_my_project"}  ; optional hook-registration fn
 /// ```
 #[derive(Debug, Clone)]
 pub struct RustConfig {
@@ -105,7 +105,7 @@ pub struct RustConfig {
     /// `cljrs.edn` file.  Defaults to the `cljrs.edn` directory (`"."`).
     pub crate_dir: PathBuf,
     /// Fully-qualified Rust path to the init function, e.g.
-    /// `"my_project::cljrs_init"`.  When present, `cljrs compile` emits a
+    /// `"my_project::cljrs_init_my_project"`.  When present, `cljrs compile` emits a
     /// call to this function in the generated `main.rs` before loading any
     /// Clojure source.  Omit if you rely solely on `#[cljrs::export]`
     /// inventory-based registration (future feature).
@@ -115,7 +115,7 @@ pub struct RustConfig {
 impl RustConfig {
     /// Derive the Rust crate name from the init function path.
     ///
-    /// `"my_project::cljrs_init"` → `Some("my_project")`.
+    /// `"my_project::cljrs_init_my_project"` → `Some("my_project")`.
     /// Returns `None` when `init_fn` is absent.
     pub fn crate_name(&self) -> Option<&str> {
         self.init_fn

--- a/crates/cljrs/src/cli.rs
+++ b/crates/cljrs/src/cli.rs
@@ -152,7 +152,7 @@ pub enum Commands {
     ///
     /// The user crate must declare `crate-type = ["cdylib"]` (or
     /// `["cdylib", "rlib"]`) and export a `#[no_mangle] pub extern "C" fn
-    /// cljrs_init(registry: *mut cljrs_interop::Registry)` entry point.
+    /// cljrs_init_<crate>(registry: *mut cljrs_interop::Registry)` entry point.
     BuildNative(commands::build_native::Args),
     /// Run the clojurust language server (LSP) over stdio.
     ///

--- a/crates/cljrs/src/native/mod.rs
+++ b/crates/cljrs/src/native/mod.rs
@@ -75,7 +75,7 @@ fn target_dir_from_metadata(json: &str) -> Option<PathBuf> {
 }
 
 /// Load the shared library declared by the project's `:rust` config and call
-/// its `cljrs_init`
+/// its `cljrs_init_<crate>`
 /// entry point to register native functions into `globals`.
 ///
 /// A missing library emits a warning and returns — callers of unregistered
@@ -88,7 +88,7 @@ pub fn load_project_lib(rust_config: &cljrs_project::config::RustConfig, globals
     let Some(crate_name) = rust_config.crate_name() else {
         return;
     };
-    // Symbol name is the last segment of the Rust path, e.g. "cljrs_init".
+    // Symbol name is the last segment of the Rust path, e.g. "cljrs_init_my_project".
     let sym_name = init_fn.rsplit("::").next().unwrap_or(init_fn);
 
     let lib_path = native_lib_path(&rust_config.crate_dir, crate_name, false);

--- a/docs/book/src/cli/build-native.md
+++ b/docs/book/src/cli/build-native.md
@@ -24,7 +24,7 @@ mode. Use this when profiling or shipping.
 2. Reads `:rust :crate` (the directory containing the user's `Cargo.toml`)
    and `:rust :init` (the fully-qualified Rust path to the init function).
 3. Derives the crate name from the first `::` segment of the init path —
-   e.g. `"my_project::cljrs_init"` → `my_project`.
+   e.g. `"my_project::cljrs_init_my_project"` → `my_project`.
 4. Runs `cargo build [--release]` in the crate directory.
 5. Prints the output library path on success:
    - Linux: `target/debug/libmy_project.so`

--- a/docs/book/src/cli/compile.md
+++ b/docs/book/src/cli/compile.md
@@ -88,5 +88,5 @@ the compiled program.
 ## Native Rust code
 
 If `cljrs.edn` contains a `:rust` key, `cljrs compile` links the declared Rust
-crate into the binary and calls its `cljrs_init` function before any Clojure
+crate into the binary and calls its init function before any Clojure
 code runs. See [AOT mode](../rust-interop/aot.md) for details.

--- a/docs/book/src/cli/deps.md
+++ b/docs/book/src/cli/deps.md
@@ -94,7 +94,7 @@ valid clojurust EDN:
 
  ; Optional: embed a Rust crate for native interop
  :rust {:crate "."
-        :init  "my_project::cljrs_init"}}
+        :init  "my_project::cljrs_init_my_project"}}
 ```
 
 ### Keys
@@ -121,7 +121,7 @@ are rejected.
 
 ```clojure
 :rust {:crate "."                       ; path to Cargo.toml directory
-       :init  "my_project::cljrs_init"} ; Rust path to the init function
+       :init  "my_project::cljrs_init_my_project"} ; Rust path to the init function
 ```
 
 | Sub-key | Description |

--- a/docs/book/src/embedding/extensions.md
+++ b/docs/book/src/embedding/extensions.md
@@ -88,7 +88,7 @@ and anything that depends on a spawned task will not complete.
 
 The `Registry` is the same object described in [Rust
 interop](../rust-interop/registry.md), but an embedding host constructs it
-directly rather than exporting a `cljrs_init` symbol for a dylib to be loaded
+directly rather than exporting a `cljrs_init_<crate>` symbol for a dylib to be loaded
 through:
 
 ```rust

--- a/docs/book/src/language/versioned-symbols.md
+++ b/docs/book/src/language/versioned-symbols.md
@@ -89,7 +89,7 @@ Rust toolchain at runtime):
 {:deps
  {my.native.lib {:git/url   "https://github.com/user/my-native-lib"
                  :git/sha   "abc1234ef"
-                 :rust/init "my_native_lib::cljrs_init"
+                 :rust/init "my_native_lib::cljrs_init_my_native_lib"
                  :rust/load :dylib}}}
 ```
 

--- a/docs/book/src/rust-interop/aot.md
+++ b/docs/book/src/rust-interop/aot.md
@@ -32,7 +32,7 @@ fn main() {
 
     // Native init — registered before any Clojure code runs
     let mut registry = cljrs_interop::Registry::new(globals.clone());
-    my_project::cljrs_init(&mut registry);
+    my_project::cljrs_init_my_project(&mut registry);
 
     let mut env = cljrs_runtime::tiered::Env::new(globals, "user");
     cljrs_runtime::env::callback::push_eval_context(&env);

--- a/docs/book/src/rust-interop/export-macro.md
+++ b/docs/book/src/rust-interop/export-macro.md
@@ -17,8 +17,8 @@ pub fn add(a: i64, b: i64) -> Result<i64, String> {
 ```
 
 `add` is now visible in Clojure as `math/add` as soon as the shared library is
-loaded or the AOT binary starts. No `cljrs_init` is required unless you have
-other setup to perform (see [When `cljrs_init` is still needed](#when-cljrs_init-is-still-needed)).
+loaded or the AOT binary starts. No init function is required unless you have
+other setup to perform (see [When an init function is still needed](#when-an-init-function-is-still-needed)).
 
 ## Attribute options
 
@@ -118,9 +118,9 @@ pub fn sum(args: &[Value]) -> Result<Value, String> {
 (math/sum 1 2 3 4 5)   ; => 15
 ```
 
-## When `cljrs_init` is still needed
+## When an init function is still needed
 
-`#[export]` handles function registration. A `cljrs_init` is still required when
+`#[export]` handles function registration. An init function is still required when
 you need to:
 
 - Call `mark_loaded` so `require` treats a namespace as built-in rather than
@@ -132,7 +132,7 @@ you need to:
 use cljrs_interop::Registry;
 
 #[no_mangle]
-pub extern "C" fn cljrs_init(registry: *mut Registry) {
+pub extern "C" fn cljrs_init_my_project(registry: *mut Registry) {
     let r = unsafe { &mut *registry };
     // #[export] functions are already registered — Registry::new ran first.
     r.env().mark_loaded("math");
@@ -140,9 +140,9 @@ pub extern "C" fn cljrs_init(registry: *mut Registry) {
 }
 ```
 
-> **Note:** The `*mut Registry` passed to `cljrs_init` is the same `Registry`
+> **Note:** The `*mut Registry` passed to the init function is the same `Registry`
 > created by the runtime before calling your function. All `#[export]` entries
-> are already interned when `cljrs_init` is invoked.
+> are already interned when the init function is invoked.
 
 ## Mixing `#[export]` with manual `define`
 
@@ -161,7 +161,7 @@ pub fn increment(n: i64) -> i64 {
 }
 
 #[no_mangle]
-pub extern "C" fn cljrs_init(registry: *mut Registry) {
+pub extern "C" fn cljrs_init_my_project(registry: *mut Registry) {
     let r = unsafe { &mut *registry };
 
     // Stateful closure that captures a value created at init time.

--- a/docs/book/src/rust-interop/index.md
+++ b/docs/book/src/rust-interop/index.md
@@ -42,7 +42,7 @@ That is the [Embedding](../embedding/index.md) chapter, and it uses the same
 ```clojure
 {:paths ["src"]
  :rust  {:crate "."
-         :init  "my_project::cljrs_init"}}
+         :init  "my_project::cljrs_init_my_project"}}
 ```
 
 **`Cargo.toml` (user crate):**
@@ -59,7 +59,7 @@ cljrs-interop = { path = "/path/to/cljrs/crates/cljrs-interop" }
 use cljrs_interop::{Registry, wrap_fn2};
 
 #[no_mangle]
-pub extern "C" fn cljrs_init(registry: *mut Registry) {
+pub extern "C" fn cljrs_init_my_project(registry: *mut Registry) {
     let r = unsafe { &mut *registry };
     r.define("my.project/add",
         wrap_fn2("add", |a: i64, b: i64| Ok::<i64, String>(a + b)));

--- a/docs/book/src/rust-interop/interpreter.md
+++ b/docs/book/src/rust-interop/interpreter.md
@@ -32,7 +32,7 @@ When `cljrs run` (or `repl`) starts:
    - macOS: `<crate_dir>/target/debug/lib<crate_name>.dylib`
    - Windows: `<crate_dir>/target/debug/<crate_name>.dll`
 3. It opens the library with `dlopen` and looks up the symbol named after the
-   last `::` segment of `:rust :init` (e.g. `"cljrs_init"`).
+   last `::` segment of `:rust :init` (e.g. `"cljrs_init_my_project"`).
 4. It calls the symbol with a `*mut Registry`, which registers all native
    functions into the global namespace table.
 5. The library is kept loaded for the lifetime of the process.

--- a/docs/book/src/rust-interop/project-setup.md
+++ b/docs/book/src/rust-interop/project-setup.md
@@ -1,7 +1,7 @@
 # Project Setup
 
 A mixed Rust/Clojure project needs three things: a `cljrs.edn` that points to
-the Rust crate, a `Cargo.toml` with the right crate type, and a `cljrs_init`
+the Rust crate, a `Cargo.toml` with the right crate type, and an init
 entry point.
 
 ## Directory layout
@@ -11,7 +11,7 @@ my-project/
 ├── cljrs.edn          # Clojure project config (source paths, :rust key)
 ├── Cargo.toml         # Rust crate manifest
 ├── src/
-│   ├── lib.rs         # Rust source — defines cljrs_init and native fns
+│   ├── lib.rs         # Rust source — defines the init fn and native fns
 │   └── main.cljrs     # Clojure entry point
 ```
 
@@ -26,14 +26,14 @@ Add a `:rust` map to the top-level config:
 {:paths ["src"]
 
  :rust {:crate "."                       ; path to Cargo.toml directory
-        :init  "my_project::cljrs_init"} ; Rust path to the init function
+        :init  "my_project::cljrs_init_my_project"} ; Rust path to the init function
 }
 ```
 
 | Key | Required | Description |
 |---|---|---|
 | `:crate` | yes | Path to the directory containing the user's `Cargo.toml`. Relative to `cljrs.edn`. |
-| `:init` | yes | Fully-qualified Rust path to the init function, e.g. `"my_crate::cljrs_init"`. The first `::` segment is used as the crate name. |
+| `:init` | yes | Fully-qualified Rust path to the init function, e.g. `"my_crate::cljrs_init_my_crate"`. The first `::` segment is used as the crate name. |
 
 ## `Cargo.toml`
 
@@ -57,7 +57,7 @@ cljrs-interop = { path = "/path/to/cljrs/crates/cljrs-interop" }
 > `rlib` allows `cljrs compile` to link the crate statically into the AOT
 > binary. Both can coexist in `crate-type`.
 
-## The `cljrs_init` entry point
+## The init entry point
 
 The init function receives a `*mut Registry` pointer and registers all native
 functions. It must have C linkage so the dynamic linker can find it by name:
@@ -66,7 +66,7 @@ functions. It must have C linkage so the dynamic linker can find it by name:
 use cljrs_interop::{Registry, wrap_fn1, wrap_fn2};
 
 #[no_mangle]
-pub extern "C" fn cljrs_init(registry: *mut Registry) {
+pub extern "C" fn cljrs_init_my_project(registry: *mut Registry) {
     let r = unsafe { &mut *registry };
 
     r.define("my.project/greet",
@@ -79,10 +79,30 @@ pub extern "C" fn cljrs_init(registry: *mut Registry) {
 }
 ```
 
-The function name in `:rust :init` (`"my_project::cljrs_init"`) must match the
-Rust function name used in `#[no_mangle]` (`cljrs_init`). The crate prefix
-(`my_project`) is used when generating the AOT harness; it must match the
-`[package] name` in `Cargo.toml` with hyphens replaced by underscores.
+The function name in `:rust :init` (`"my_project::cljrs_init_my_project"`) must
+match the Rust function name used in `#[no_mangle]`
+(`cljrs_init_my_project`). The crate prefix (`my_project`) is used when
+generating the AOT harness; it must match the `[package] name` in `Cargo.toml`
+with hyphens replaced by underscores.
+
+### Name the symbol after your crate
+
+The convention is `cljrs_init_<crate>`, and the reason is `#[no_mangle]`. An
+unmangled symbol is global to the whole process image, so two extension crates
+that both call theirs `cljrs_init` export the *same* symbol.
+
+That does not fail to link, which is what makes it worth a rule. When `cljrs
+compile` links two such extensions into one AOT binary, the linker resolves
+every reference to a single definition: `crate_a::cljrs_init` and
+`crate_b::cljrs_init` become the same address, one crate's registration
+silently replaces the other's, and the second namespace is simply never
+defined. There is no error at build time and none at run time, only a missing
+namespace.
+
+Nothing in cljrs hardcodes the name. The loader takes the last `::` segment of
+`:rust :init` and looks that up, so the symbol name is data: any spelling works
+as long as it is unique across every extension that might share a binary.
+Deriving it from the crate name is the cheapest way to guarantee that.
 
 ## Calling native functions from Clojure
 
@@ -100,5 +120,5 @@ as `my.project/greet`. No `require` is needed unless you want a namespace alias:
 (native/add 3 4)                 ; => 7
 ```
 
-The namespace `my.project` is created automatically when `cljrs_init` is called;
+The namespace `my.project` is created automatically when the init function runs;
 you do not need to create or load a Clojure file for it.

--- a/docs/book/src/rust-interop/registry.md
+++ b/docs/book/src/rust-interop/registry.md
@@ -1,6 +1,6 @@
 # Registry API
 
-The `Registry` type (from `cljrs_interop`) is the handle passed to `cljrs_init`
+The `Registry` type (from `cljrs_interop`) is the handle passed to the init function
 for registering Rust functions as Clojure-visible values.
 
 ## `Registry` methods


### PR DESCRIPTION
An extension crate's C-ABI entry point is `#[no_mangle]`, and both in-tree
plugins spelled it `cljrs_init`. An unmangled symbol is global to the whole
process image, so those are the *same* symbol.

The interesting part is what that does, because it is not what the name
"duplicate symbol" suggests. Linking both crates into one binary does **not**
fail:

```console
$ nm target/debug/deps/<test-binary> | grep cljrs_init
00000000002ef7b0 T cljrs_init          # one definition, not two
```

The linker resolves every reference to a single definition, so
`cljrs_base64::cljrs_init` and `cljrs_blake3::cljrs_init` evaluate to the same
address. One plugin's registration silently replaces the other's and the second
namespace is simply never defined. No error at build time, none at run time,
only a namespace that is missing.

Measured before this change, with both crates linked into one test binary:

```
assertion `left != right` failed
  left: 95096257017776
 right: 95096257017776
```

### Not yet reachable, which is why it is worth fixing now

`cljrs.edn` carries a single `:rust :init`, so today an AOT build links at most
one plugin and nothing collides. It becomes reachable the moment `:rust :init`
accepts more than one crate. Until then the bug is invisible, and when it
arrives it presents as a missing namespace rather than as a link error, which is
a bad thing to debug for the first time under deadline.

### The fix

Name the export after its crate: `cljrs_init_cljrs_base64`,
`cljrs_init_cljrs_blake3`, with the convention documented as
`cljrs_init_<crate>`. Uniqueness then follows from crate names already being
unique, rather than from everyone remembering a rule.

`tests/extension_init_symbols.rs` pins it. It is the only test binary that links
two plugin crates, which is why `cljrs-blake3` is now a dev-dependency of
`cljrs-compiler`:

```console
$ nm target/debug/deps/extension_init_symbols-<hash> | grep cljrs_init
0000000000287bf0 T cljrs_init_cljrs_base64
000000000025a7b0 T cljrs_init_cljrs_blake3
```

### Backwards compatible

Nothing hardcodes the symbol name. `native/mod.rs` takes the last `::` segment
of `:rust :init` and looks *that* up, so the name is data: an existing extension
keeps its own `cljrs_init` and keeps working. Only the convention taught to new
extensions changes.

Docs moved with it: `project-setup.md` gains a "Name the symbol after your
crate" section explaining the shadowing mechanism, and the examples in 11 book
pages, 4 crate READMEs, `VERSIONING.md` and the `:rust :init` doc comments
follow. Both plugins' own `cljrs.edn` are updated, without which the rename
would have broken dylib loading.

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings` and
`cargo test --workspace` (165 suites, 1507 tests) all clean.
