### PR TITLE
The AOT harness calls :rust :init inside unsafe

### DIFF
--- a/crates/cljrs-compiler/README.md
+++ b/crates/cljrs-compiler/README.md
@@ -461,6 +461,18 @@ pub enum OmissionKind { Namespace, EntryForm }
 pub enum OpacityVerdict { Clean, Tolerated, Rejected }
 ```
 
+**The `:rust :init` call is emitted inside `unsafe`** (`native_init_code`, and
+`tests/harness_init_shape.rs`).  An extension's entry point takes a
+`*mut Registry` and dereferences it, so the honest signature is
+`unsafe extern "C" fn` and that is what this workspace's plugin crates declare.
+A bare call to one does not compile (`expected safe fn, found unsafe fn`), which
+made those crates un-AOT-compilable and went unnoticed because no test compiles a
+program with a `:rust :init`.  A safe `extern "C" fn`, the spelling the book
+teaches, is equally accepted: calling it inside `unsafe` is merely redundant, and
+`allow(unused_unsafe)` keeps the generated crate from warning.
+`harness_init_shape.rs` is that emitted shape, compiled against both spellings,
+so it fails to build if either stops working.
+
 ### Source-embedding audit (`--require-fully-compiled`)
 
 Only plain `defn` bodies reach machine code. Forms that `needs_interpreter`

--- a/crates/cljrs-compiler/src/aot.rs
+++ b/crates/cljrs-compiler/src/aot.rs
@@ -2012,6 +2012,42 @@ struct HarnessInputs<'a> {
     async_polls: &'a [AsyncPollEntry],
 }
 
+/// The harness source that calls an extension's `:rust :init` hook, or nothing
+/// when the project configures none.
+///
+/// The call runs before the preamble so native functions are visible to
+/// macro-expanded code at startup.
+///
+/// **The call is wrapped in `unsafe`, and it has to be.** An entry point takes a
+/// `*mut Registry` and dereferences it, so the honest signature is
+/// `unsafe extern "C" fn`, which is what the extension crates in this workspace
+/// declare. Emitting a bare call to one does not compile:
+///
+/// ```text
+/// error[E0308]: mismatched types
+///   expected safe fn, found unsafe fn
+///   found fn item `unsafe extern "C" fn(_) {cljrs_init}`
+/// ```
+///
+/// The book teaches a *safe* `extern "C" fn`, and that spelling still works:
+/// calling a safe fn inside `unsafe` is merely redundant, which the
+/// `allow(unused_unsafe)` silences. Wrapping therefore accepts both, where
+/// demanding a safe fn would reject the plugins this repo ships.
+///
+/// Kept apart from [`build_harness`] so the emitted shape can be asserted
+/// without compiling a whole program; nothing else here is testable that way.
+fn native_init_code(init_fn: Option<&str>) -> String {
+    match init_fn {
+        Some(init_fn) => format!(
+            "\n    // Register native Rust functions via the user crate's init hook.\n    \
+             let mut __registry = cljrs_interop::Registry::new(globals.clone());\n    \
+             #[allow(unused_unsafe)]\n    \
+             unsafe {{\n        {init_fn}(&mut __registry);\n    }}\n"
+        ),
+        None => String::new(),
+    }
+}
+
 fn build_harness(
     out_path: &Path,
     inputs: HarnessInputs<'_>,
@@ -2240,18 +2276,7 @@ edition = "2024"
         ""
     };
 
-    // Emit the native init call when :rust :init is configured.  The init
-    // function has the signature `fn cljrs_init(registry: &mut Registry)`
-    // and is called before the preamble so native functions are visible to
-    // macro-expanded code at startup.
-    let native_init_code = match rust_config.and_then(|rc| rc.init_fn.as_deref()) {
-        Some(init_fn) => format!(
-            "\n    // Register native Rust functions via the user crate's init hook.\n    \
-             let mut __registry = cljrs_interop::Registry::new(globals.clone());\n    \
-             {init_fn}(&mut __registry);\n"
-        ),
-        None => String::new(),
-    };
+    let native_init_code = native_init_code(rust_config.and_then(|rc| rc.init_fn.as_deref()));
 
     // Register AOT-compiled async poll functions: declare each as an external
     // symbol (defined in the linked object), then register it by ns/name/arity
@@ -3214,6 +3239,29 @@ mod tests {
             .parse_all()
             .expect("parse")
             .remove(0)
+    }
+
+    #[test]
+    fn no_rust_init_emits_nothing() {
+        assert_eq!(native_init_code(None), "");
+    }
+
+    /// An extension entry point takes a `*mut Registry` and dereferences it, so
+    /// the honest signature is `unsafe extern "C" fn` and a bare call to one
+    /// does not compile. The emitted call must therefore be wrapped.
+    #[test]
+    fn the_init_call_is_wrapped_in_unsafe() {
+        let emitted = native_init_code(Some("my_project::cljrs_init"));
+        assert!(
+            emitted.contains("unsafe {\n        my_project::cljrs_init(&mut __registry);\n    }"),
+            "init call must be inside an unsafe block, got:\n{emitted}"
+        );
+        // The book teaches a SAFE `extern "C" fn`, which is still accepted; the
+        // allow is what keeps that spelling from warning in the generated crate.
+        assert!(
+            emitted.contains("#[allow(unused_unsafe)]"),
+            "a safe entry point would warn without the allow, got:\n{emitted}"
+        );
     }
 
     #[test]

--- a/crates/cljrs-compiler/tests/harness_init_shape.rs
+++ b/crates/cljrs-compiler/tests/harness_init_shape.rs
@@ -1,0 +1,60 @@
+//! The shape the AOT harness emits for a project's `:rust :init` hook.
+//!
+//! `aot::native_init_code` emits:
+//!
+//! ```ignore
+//! let mut __registry = cljrs_interop::Registry::new(globals.clone());
+//! #[allow(unused_unsafe)]
+//! unsafe {
+//!     my_project::cljrs_init(&mut __registry);
+//! }
+//! ```
+//!
+//! This file *is* that shape, compiled against both spellings an extension may
+//! use for its entry point. It is a compile-time test: if the emitted shape
+//! stops accepting either spelling, this file stops building.
+//!
+//! Before the `unsafe` wrapper, the emitted call was bare, and an extension
+//! declaring the honest `unsafe extern "C" fn` could not be AOT-compiled at
+//! all:
+//!
+//! ```text
+//! error[E0308]: mismatched types
+//!   expected safe fn, found unsafe fn
+//! ```
+//!
+//! Nothing caught it because no test compiles a program with a `:rust :init`.
+
+/// Stands in for `cljrs_interop::Registry`; only the call shape is under test.
+pub struct Registry;
+
+/// The honest signature for a function that dereferences a raw pointer, and
+/// what the extension crates in this workspace declare.
+unsafe extern "C" fn unsafe_init(registry: *mut Registry) {
+    let _ = unsafe { &mut *registry };
+}
+
+/// What `docs/book/src/rust-interop/project-setup.md` teaches.
+extern "C" fn safe_init(registry: *mut Registry) {
+    let _ = unsafe { &mut *registry };
+}
+
+#[test]
+fn the_emitted_shape_accepts_an_unsafe_entry_point() {
+    let mut __registry = Registry;
+    #[allow(unused_unsafe)]
+    unsafe {
+        unsafe_init(&mut __registry);
+    }
+}
+
+/// The `allow(unused_unsafe)` earns its place here: a safe entry point inside
+/// `unsafe` is redundant, and the generated crate would warn without it.
+#[test]
+fn the_emitted_shape_accepts_a_safe_entry_point() {
+    let mut __registry = Registry;
+    #[allow(unused_unsafe)]
+    unsafe {
+        safe_init(&mut __registry);
+    }
+}

--- a/docs/book/src/rust-interop/aot.md
+++ b/docs/book/src/rust-interop/aot.md
@@ -32,7 +32,10 @@ fn main() {
 
     // Native init — registered before any Clojure code runs
     let mut registry = cljrs_interop::Registry::new(globals.clone());
-    my_project::cljrs_init(&mut registry);
+    #[allow(unused_unsafe)]
+    unsafe {
+        my_project::cljrs_init(&mut registry);
+    }
 
     let mut env = cljrs_runtime::tiered::Env::new(globals, "user");
     cljrs_runtime::env::callback::push_eval_context(&env);
@@ -44,6 +47,12 @@ fn main() {
     unsafe { __cljrs_main() };
 }
 ```
+
+The init call is wrapped in `unsafe` because an entry point takes a
+`*mut Registry` and dereferences it, so the honest signature is
+`unsafe extern "C" fn`. A safe `extern "C" fn`, which is what
+[Project Setup](project-setup.md) shows, is equally accepted: calling it inside
+`unsafe` is merely redundant, and the `allow` keeps that from warning.
 
 ## Crate type requirement
 


### PR DESCRIPTION
An extension's init entry point takes a `*mut Registry` and dereferences it, so
the honest signature is `unsafe extern "C" fn`, and that is what both plugin
crates in this workspace declare. The AOT harness emitted a bare call to it:

```rust
let mut __registry = cljrs_interop::Registry::new(globals.clone());
my_project::cljrs_init(&mut __registry);
```

which does not compile against one. Shown with a safe fn-pointer coercion,
which fails iff the callee is `unsafe`:

```console
$ let _f: fn(*mut cljrs_interop::Registry) = cljrs_base64::cljrs_init;
error[E0308]: mismatched types
  expected safe fn, found unsafe fn
  found fn item `unsafe extern "C" fn(_) {cljrs_init}`
```

So `cljrs compile` on a project whose `:rust :init` names an unsafe fn could not
build its own harness, and the error surfaced in generated code rather than in
anything the author wrote. Both in-tree plugins are in exactly that shape, via
their own `cljrs.edn`.

### Why wrap the call rather than make the entry point safe

The other available fix was to make the convention a safe `extern "C" fn` and
change the plugins to match, so the book and the tree agree. That is the wrong
way round. The function dereferences a caller-supplied raw pointer; its
soundness obligation is real and unchanged, and restating it as false to satisfy
a code generator does not remove the obligation, it only stops it being written
down.

Wrapping also turns out to be strictly more compatible. `unsafe { safe_fn() }`
is merely redundant, so the safe spelling [Project Setup](../docs/book/src/rust-interop/project-setup.md)
teaches keeps working untouched, and `#[allow(unused_unsafe)]` keeps the
generated crate from warning about it. The sounder fix is also the one that
accepts more inputs.

### Testing a thing that is compiled somewhere else

The emission moves out of `build_harness` into a pure `native_init_code`,
because the shape could not otherwise be asserted without compiling a whole
program. Three tests where there were none:

- `no_rust_init_emits_nothing`
- `the_init_call_is_wrapped_in_unsafe` — asserts the emitted string
- `tests/harness_init_shape.rs` — **is** the emitted shape, compiled against
  both an `unsafe extern "C" fn` and a safe one. It is a compile-time test: if
  either spelling stops working, the file stops building, which is louder than
  an assertion.

`harness_init_shape.rs` also settled, for free, the `&mut Registry` to
`*mut Registry` argument coercion that had never been exercised. It is fine.

### What this does not fix

Nothing AOT-compiles a program with a `:rust :init` at all. `aot_e2e.rs` covers
AOT compilation but no case supplies a `RustConfig` with an `init_fn`, which is
precisely why a plugin this repo ships could not be AOT-compiled and CI was
silent about it. This PR pins the language-level shape, not the end-to-end path;
the e2e fixture is worth adding separately, and should assert the produced
binary *runs* and that the namespace the init registers is callable, since
asserting only that the harness compiles would miss a registration that silently
does nothing.

`cargo fmt --check`, `cargo clippy --workspace --all-targets` and
`cargo test --workspace` (165 suites, 1510 tests) all clean.
