### PR TITLE
extenders reports the types extending a protocol

### DIFF
--- a/crates/cljrs-runtime/src/builtins/builtins.rs
+++ b/crates/cljrs-runtime/src/builtins/builtins.rs
@@ -375,6 +375,10 @@ const BUILTIN_DOCS: &[(&str, &str)] = &[
     ),
     ("satisfies?", "Returns true if x extends protocol."),
     ("extends?", "Returns true if atype extends protocol."),
+    (
+        "extenders",
+        "Returns a seq of the types extending protocol, or nil if none do.",
+    ),
     ("uuid?", "Returns true if x is a UUID."),
     (
         "native-object?",
@@ -1547,6 +1551,7 @@ pub fn register_all(globals: &Arc<GlobalEnv>, ns: &str) {
         // Protocols & Multimethods
         ("satisfies?", Arity::Fixed(2), builtin_satisfies_q),
         ("extends?", Arity::Fixed(2), builtin_extends_q),
+        ("extenders", Arity::Fixed(1), builtin_extenders),
         ("prefer-method", Arity::Fixed(3), builtin_prefer_method),
         ("remove-method", Arity::Fixed(2), builtin_remove_method),
         ("methods", Arity::Fixed(1), builtin_methods),
@@ -7983,6 +7988,46 @@ fn builtin_extends_q(args: &[Value]) -> ValueResult<Value> {
     };
     let impls = proto.get().impls.lock().unwrap();
     Ok(Value::Bool(impls.contains_key(type_tag.as_ref())))
+}
+
+/// `(extenders protocol)` — the types that extend `protocol`, as symbols.
+///
+/// Mirrors Clojure's `(keys (:impls protocol))`, including its `nil` for a
+/// protocol nothing has extended yet: `keys` of an empty map is `nil`, not an
+/// empty seq, and code that threads the result through `seq`/`when-let`
+/// depends on that.
+///
+/// The tags are sorted. The registry behind them is a `HashMap`, so the
+/// natural iteration order differs between runs of the same program, and a
+/// caller printing or diffing this would see spurious churn. Clojure promises
+/// no particular order either, which makes sorting free to choose and the only
+/// reproducible choice.
+///
+/// A type extended through `:extend-via-metadata` is deliberately absent: it
+/// never enters `impls`, and the metadata carrier is the value, not the type.
+/// Clojure's `extenders` reports the impls map only, for the same reason.
+fn builtin_extenders(args: &[Value]) -> ValueResult<Value> {
+    let proto = match &args[0] {
+        Value::Protocol(p) => p.clone(),
+        v => {
+            return Err(ValueError::WrongType {
+                expected: "protocol",
+                got: v.type_name().to_string(),
+            });
+        }
+    };
+    let mut tags: Vec<Arc<str>> = {
+        let impls = proto.get().impls.lock().unwrap();
+        impls.keys().cloned().collect()
+    };
+    if tags.is_empty() {
+        return Ok(Value::Nil);
+    }
+    tags.sort_unstable();
+    Ok(Value::List(GcPtr::new(PersistentList::from_iter(
+        tags.into_iter()
+            .map(|t| Value::symbol(Symbol::simple(t.as_ref()))),
+    ))))
 }
 
 fn builtin_prefer_method(args: &[Value]) -> ValueResult<Value> {

--- a/crates/cljrs-runtime/tests/extenders.rs
+++ b/crates/cljrs-runtime/tests/extenders.rs
@@ -1,0 +1,134 @@
+//! `extenders`: the types that extend a protocol.
+//!
+//! It was simply unbound, so any code doing protocol introspection — a
+//! registry that reports what it can dispatch, a test asserting an extension
+//! took effect — failed with "unbound symbol: extenders" rather than answering.
+//!
+//! The three properties worth pinning are the ones a naive implementation gets
+//! wrong:
+//!
+//! 1. **nil, not an empty seq, when nothing extends the protocol.** Clojure
+//!    defines `extenders` as `(keys (:impls protocol))`, and `keys` of an empty
+//!    map is `nil`. Callers thread the result through `seq`/`when-let`, which
+//!    treat `()` as truthy.
+//! 2. **A stable order.** The registry is a `HashMap`, so its natural order
+//!    differs between runs of the same program. Anything printing or diffing
+//!    the result would see churn that has nothing to do with the code.
+//! 3. **Agreement with `extends?`.** The two read the same registry and must
+//!    not disagree about any type.
+//!
+//! One environment is shared by every assertion here: building a runtime
+//! re-evaluates `bootstrap.cljrs`, and doing that per assertion is what made
+//! other suites expensive (CLJRS-TEST-RUNTIME-REUSE).
+
+use std::sync::Arc;
+
+use cljrs_reader::Parser;
+use cljrs_runtime::env::env::{Env, GlobalEnv};
+use cljrs_value::Value;
+
+fn make_env() -> (Arc<GlobalEnv>, Env) {
+    let globals = cljrs_runtime::Runtime::builder()
+        .execution_mode(cljrs_runtime::ExecutionMode::TreeWalk)
+        .build()
+        .expect("runtime")
+        .into_globals();
+    let env = Env::new(globals.clone(), "user");
+    (globals, env)
+}
+
+/// Evaluate every form in `src` in `env`; yield the last value.
+fn eval_in(env: &mut Env, src: &str) -> Value {
+    let mut parser = Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser
+        .parse_all()
+        .unwrap_or_else(|e| panic!("parse {src}: {e:?}"));
+    let mut result = Value::Nil;
+    for form in forms {
+        result = cljrs_runtime::interp::eval::eval(&form, env)
+            .unwrap_or_else(|e| panic!("eval {src}: {e:?}"));
+    }
+    result
+}
+
+/// `(pr-str <src>)`, so assertions read as the text a user would see.
+fn printed(env: &mut Env, src: &str) -> String {
+    match eval_in(env, &format!("(pr-str {src})")) {
+        Value::Str(s) => s.get().to_string(),
+        other => panic!("expected a string, got {other:?}"),
+    }
+}
+
+#[test]
+fn extenders_reports_the_types_extending_a_protocol() {
+    let (_g, mut env) = make_env();
+
+    eval_in(
+        &mut env,
+        r#"
+        (defprotocol IShape (area [s]))
+        (defprotocol IUntouched (nothing [s]))
+        (defrecord Sq [n])
+        (defrecord Tri [b h])
+        "#,
+    );
+
+    // (1) nil, not (), before anything extends it.
+    assert_eq!(printed(&mut env, "(extenders IUntouched)"), "nil");
+    assert_eq!(printed(&mut env, "(nil? (extenders IUntouched))"), "true");
+
+    eval_in(
+        &mut env,
+        r#"
+        (extend-type Sq IShape (area [s] (* (:n s) (:n s))))
+        (extend-type Tri IShape (area [s] (/ (* (:b s) (:h s)) 2)))
+        "#,
+    );
+
+    // (2) every extending type, in a stable order.
+    assert_eq!(printed(&mut env, "(extenders IShape)"), "(Sq Tri)");
+    assert_eq!(
+        printed(&mut env, "(= (extenders IShape) (extenders IShape))"),
+        "true"
+    );
+
+    // The elements are symbols, which is what `extends?` accepts.
+    assert_eq!(
+        printed(&mut env, "(every? symbol? (extenders IShape))"),
+        "true"
+    );
+
+    // (3) the two views of the registry agree.
+    assert_eq!(
+        printed(
+            &mut env,
+            "(every? (fn [t] (extends? IShape t)) (extenders IShape))"
+        ),
+        "true"
+    );
+
+    // Extending a protocol later shows up; the answer is not cached.
+    eval_in(
+        &mut env,
+        "(defrecord Circle [r])
+         (extend-type Circle IShape (area [s] (* 3 (:r s) (:r s))))",
+    );
+    assert_eq!(printed(&mut env, "(extenders IShape)"), "(Circle Sq Tri)");
+
+    // A protocol nobody touched is still nil, not polluted by its neighbours.
+    assert_eq!(printed(&mut env, "(extenders IUntouched)"), "nil");
+}
+
+#[test]
+fn extenders_refuses_a_non_protocol() {
+    let (_g, mut env) = make_env();
+    let mut parser = Parser::new("(extenders 42)".to_string(), "<test>".to_string());
+    let forms = parser.parse_all().expect("parse");
+    let err = cljrs_runtime::interp::eval::eval(&forms[0], &mut env)
+        .expect_err("extenders must reject a non-protocol");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("protocol"),
+        "error should name the expected type, got: {msg}"
+    );
+}


### PR DESCRIPTION
Independent of every other open PR. Two files, no existing behaviour touched.

## The gap

`extenders` was simply unbound:

```clojure
(extenders IShape)   ;=> unbound symbol: extenders
```

So protocol introspection — a registry reporting what it can dispatch, a test asserting an extension took effect — failed rather than answering. `extends?` already reads exactly the registry this needs (`proto.impls`); only the enumerating half was missing.

## Three properties a naive version gets wrong

Each is pinned by a test, and each was confirmed in a REPL against a real build before being asserted:

**1. `nil`, not an empty seq, when nothing extends the protocol.** Clojure defines it as `(keys (:impls protocol))`, and `keys` of an empty map is `nil`. Callers thread the result through `seq`/`when-let`, and `()` is truthy — so returning an empty list would quietly change control flow at every call site.

**2. A stable order.** The registry is a `HashMap`, so its natural iteration order differs between runs of *the same program*. Anything printing or diffing this would see churn unrelated to the code. Clojure promises no particular order either, which makes sorting free to choose and the only reproducible choice.

**3. Agreement with `extends?`.** Both read the same registry and must not disagree about any type.

```clojure
(extenders IUntouched)                                  ;=> nil
(extenders IShape)                                      ;=> (Sq Tri)
(extenders IShape)                                      ;=> (Sq Tri)   same, always
(every? (fn [t] (extends? IShape t)) (extenders IShape)) ;=> true
(extenders 42)                    ;=> wrong type: expected protocol, got long
```

Extending later is reflected, so the answer is not cached: after adding `Circle`, `(extenders IShape)` is `(Circle Sq Tri)`.

## Deliberate limitation

A type extended through `:extend-via-metadata` is **absent**. It never enters the `impls` map, and the metadata carrier is the value rather than the type. Clojure's `extenders` reports the impls map only, for the same reason. This is stated in the doc comment rather than left for someone to discover.

## Test cost

The test shares **one** environment across its assertions. Building a runtime re-evaluates `bootstrap.cljrs`, and doing that per assertion is what made other suites expensive (the same shape as the splice-property OOM in #389).

## Verification

- `cargo test -p cljrs-runtime --test extenders` — 2 passed, 11.7s including compile
- `cargo check -p cljrs-runtime` — clean
- every assertion above independently reproduced in a REPL running a freshly built binary