### PR TITLE
clojure.pprint, so pretty-printing libraries load

### DIFF
--- a/crates/cljrs-stdlib/src/clojure/pprint.cljrs
+++ b/crates/cljrs-stdlib/src/clojure/pprint.cljrs
@@ -1,0 +1,130 @@
+;; clojure.pprint — pretty printing for data.
+;;
+;; The namespace did not exist, so any library that pretty-prints anything
+;; failed at `(:require [clojure.pprint ...])` rather than degrading. That is
+;; the gap this closes.
+;;
+;; WHAT THIS IS: a data pretty-printer. `pprint` renders a value so that
+;; anything fitting inside `*print-right-margin*` stays on one line, and
+;; anything longer breaks one element per line, aligned under the opening
+;; delimiter. That is the behaviour people actually reach for `pprint` for.
+;;
+;; WHAT THIS IS NOT, stated plainly so nobody discovers it the hard way:
+;;
+;;   - `cl-format` and the `~` directive language are absent.
+;;   - the *code* dispatch (`*print-pprint-dispatch*`, `code-dispatch`,
+;;     `with-pprint-dispatch`) is absent; this always uses data dispatch.
+;;   - `pprint-logical-block`, `pprint-newline` and the rest of the public
+;;     pretty-printer construction API are absent.
+;;   - `*print-miser-width*`, `*print-suppress-namespaces*` and the other
+;;     dial vars are absent rather than accepted-and-ignored, so code that
+;;     sets one fails loudly instead of silently printing something else.
+;;
+;; The layout algorithm is the classic "fits, or break": measure the flat
+;; rendering, print it if it fits in the remaining width, otherwise break the
+;; collection and lay the children out at the deeper indent. It is not
+;; Waterman's algorithm and makes no attempt at miser mode or fill mode.
+
+(ns clojure.pprint
+  (:require [clojure.string :as str]))
+
+(def ^:dynamic *print-right-margin*
+  "Right margin, in columns, that `pprint` tries to keep output within.
+
+  A value wider than this is broken across lines; a value that fits is left
+  alone. Rebind it with `binding`."
+  72)
+
+(defn- breakable?
+  "Whether `x` is something `pprint` may split across lines.
+
+  Records are tested separately from `coll?` on purpose: in this runtime
+  `(coll? some-record)` is false while `(map? some-record)` is true, so a
+  record would otherwise never break no matter how wide it printed."
+  [x]
+  (or (coll? x) (record? x)))
+
+(defn- delims
+  "The opening and closing delimiters to wrap `x`'s children in.
+
+  A record's opener carries its printed tag (`#Person{`) so that a broken
+  record still reads back the way `pr-str` wrote it."
+  [x]
+  (cond
+    (record? x) (let [flat (pr-str x)]
+                  [(subs flat 0 (inc (str/index-of flat "{"))) "}"])
+    (map? x) ["{" "}"]
+    (set? x) ["#{" "}"]
+    (vector? x) ["[" "]"]
+    :else ["(" ")"]))
+
+(defn- layout
+  "Render `x` starting at column `indent`, breaking only where it must.
+
+  Children are aligned under the opening delimiter, and a map's value is
+  aligned after its key, which is what makes a nested map read as a column
+  rather than a staircase."
+  [x indent]
+  (let [flat (pr-str x)]
+    (if (or (not (breakable? x))
+            (<= (+ indent (count flat)) *print-right-margin*))
+      flat
+      (let [[open close] (delims x)
+            inner (+ indent (count open))
+            pad (apply str (repeat inner " "))
+            parts (if (map? x)
+                    (map (fn [pair]
+                           (let [k (first pair)
+                                 v (second pair)
+                                 ks (pr-str k)]
+                             (str ks " " (layout v (+ inner (count ks) 1)))))
+                         (seq x))
+                    (map (fn [child] (layout child inner)) (seq x)))]
+        (str open (str/join (str "\n" pad) parts) close)))))
+
+(defn pprint
+  "Pretty print `x` to `*out*`, followed by a newline.
+
+  Output stays within `*print-right-margin*` where the value allows it."
+  [x]
+  (println (layout x 0)))
+
+(defn pprint-str
+  "The string `pprint` would print, without printing it.
+
+  Not part of Clojure's API. It is here because the alternative in this
+  runtime is `with-out-str` around `pprint`, and every caller writing that
+  wrapper by hand is a caller who can get the margin handling subtly wrong."
+  [x]
+  (layout x 0))
+
+(defn print-table
+  "Print `rows` as a table, one row per map, columns in `ks` order.
+
+  Mirrors Clojure's layout: a header row, a `|---+---|` separator, then the
+  data, each cell right-aligned in a column as wide as its widest member.
+  With one argument the columns are the keys of the first row, so a ragged
+  later row simply renders blanks for keys the header did not name."
+  ([rows] (print-table (keys (first rows)) rows))
+  ([ks rows]
+   (when (seq rows)
+     (let [widths (map (fn [k]
+                         (apply max
+                                (count (str k))
+                                (map (fn [row] (count (str (get row k)))) rows)))
+                       ks)
+           spacers (map (fn [w] (apply str (repeat w "-"))) widths)
+           fmts (map (fn [w] (str "%" w "s")) widths)
+           fmt-row (fn [leader divider trailer row]
+                     (str leader
+                          (apply str
+                                 (interpose divider
+                                            (map (fn [k f] (format f (str (get row k))))
+                                                 ks
+                                                 fmts)))
+                          trailer))]
+       (println)
+       (println (fmt-row "| " " | " " |" (zipmap ks ks)))
+       (println (fmt-row "|-" "-+-" "-|" (zipmap ks spacers)))
+       (doseq [row rows]
+         (println (fmt-row "| " " | " " |" row)))))))

--- a/crates/cljrs-stdlib/src/lib.rs
+++ b/crates/cljrs-stdlib/src/lib.rs
@@ -47,6 +47,7 @@ const CLOJURE_RUST_IO_SRC: &str = include_str!("clojure/rust/io.cljrs");
 #[cfg(not(target_arch = "wasm32"))]
 const CLOJURE_EDN_SRC: &str = include_str!("clojure/edn.cljrs");
 const CLOJURE_WALK_SRC: &str = include_str!("clojure/walk.cljrs");
+const CLOJURE_PPRINT_SRC: &str = include_str!("clojure/pprint.cljrs");
 const CLOJURE_DATA_SRC: &str = include_str!("clojure/data.cljrs");
 const COLJURE_ZIP_SRC: &str = include_str!("clojure/zip.cljrs");
 const CLOJURE_SPEC_ALPHA_SRC: &str = include_str!("clojure/spec/alpha.cljrs");
@@ -112,6 +113,9 @@ pub fn register(globals: &Arc<GlobalEnv>) {
 
     // clojure.data ─ pure Clojure, no native helpers.
     globals.register_builtin_source("clojure.data", CLOJURE_DATA_SRC);
+
+    // clojure.pprint ─ pure Clojure; data dispatch only, no cl-format.
+    globals.register_builtin_source("clojure.pprint", CLOJURE_PPRINT_SRC);
 
     // clojure.zip
     globals.register_builtin_source("clojure.zip", COLJURE_ZIP_SRC);

--- a/crates/cljrs/tests/pprint.rs
+++ b/crates/cljrs/tests/pprint.rs
@@ -1,0 +1,159 @@
+//! `clojure.pprint`: the data pretty-printer.
+//!
+//! The namespace did not exist, so `(:require [clojure.pprint ...])` failed
+//! outright and any library that pretty-prints anything broke at load rather
+//! than degrading.
+//!
+//! What is pinned here is the property that makes `pprint` worth calling at
+//! all: a value that FITS inside `*print-right-margin*` stays on one line, and
+//! one that does not breaks with its children aligned under the opening
+//! delimiter. A pretty-printer that always breaks, or never breaks, passes a
+//! "does it run" test and is useless.
+//!
+//! One runtime is shared by every assertion: building one re-evaluates
+//! `bootstrap.cljrs`, and doing that per assertion is what made other suites
+//! expensive (CLJRS-TEST-RUNTIME-REUSE).
+
+use cljrs_runtime::{ExecutionMode, Runtime};
+
+/// A runtime with the stdlib installed and `clojure.pprint` required.
+fn env_with_pprint() -> cljrs_runtime::tiered::Env {
+    let runtime = Runtime::builder()
+        .execution_mode(ExecutionMode::TreeWalk)
+        .build()
+        .expect("bootstrap clojure.core");
+    cljrs_stdlib::install(&runtime);
+    let mut env = runtime.env("user");
+    eval(&mut env, "(require '[clojure.pprint :as pp])");
+    env
+}
+
+/// Evaluate `src` and return the result as text.
+///
+/// A string result is unwrapped to its raw contents rather than rendered:
+/// `Value::to_string` produces the *readable* form, so a pretty-printed string
+/// would come back quoted with its newlines escaped, and every assertion here
+/// is about the layout those newlines make.
+fn eval(env: &mut cljrs_runtime::tiered::Env, src: &str) -> String {
+    let mut parser = cljrs_reader::Parser::new(src.to_string(), "<test>".to_string());
+    let forms = parser
+        .parse_all()
+        .unwrap_or_else(|e| panic!("parse {src}: {e:?}"));
+    let mut out = cljrs_value::Value::Nil;
+    for form in forms {
+        out = cljrs_runtime::interp::eval::eval(&form, env)
+            .unwrap_or_else(|e| panic!("eval {src}: {e:?}"));
+    }
+    match out {
+        cljrs_value::Value::Str(s) => s.get().to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// `(pp/pprint-str x)` — the text `pprint` would print, quoted out of the way.
+fn pretty(env: &mut cljrs_runtime::tiered::Env, src: &str) -> String {
+    eval(env, &format!("(pp/pprint-str {src})"))
+}
+
+#[test]
+fn a_value_that_fits_stays_on_one_line() {
+    let mut env = env_with_pprint();
+    assert_eq!(pretty(&mut env, "{:a 1 :b 2}"), "{:a 1, :b 2}");
+    assert_eq!(pretty(&mut env, "[1 2 3]"), "[1 2 3]");
+
+    // Scalars and empty collections are returned untouched rather than
+    // wrapped or broken.
+    assert_eq!(pretty(&mut env, "nil"), "nil");
+    assert_eq!(pretty(&mut env, "42"), "42");
+    assert_eq!(pretty(&mut env, "[]"), "[]");
+    assert_eq!(pretty(&mut env, "{}"), "{}");
+}
+
+#[test]
+fn a_value_wider_than_the_margin_breaks_aligned() {
+    let mut env = env_with_pprint();
+    let out = pretty(
+        &mut env,
+        r#"{:name "widget" :parts [{:id 1 :label "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+                                   {:id 2 :label "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]}"#,
+    );
+    assert_eq!(
+        out,
+        "{:name \"widget\"\n \
+         :parts [{:id 1, :label \"aaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}\n         \
+         {:id 2, :label \"bbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}",
+        "children must align under the opening delimiter:\n{out}"
+    );
+}
+
+/// The margin is what decides, so moving it must move the output. Without
+/// this, a printer that breaks on some fixed nesting depth would pass.
+#[test]
+fn the_right_margin_decides_where_breaks_happen() {
+    let mut env = env_with_pprint();
+    let src = "{:a [1 2 3] :b [4 5 6]}";
+
+    // Wide enough: one line.
+    assert_eq!(
+        eval(
+            &mut env,
+            &format!("(binding [pp/*print-right-margin* 200] (pp/pprint-str {src}))")
+        ),
+        "{:a [1 2 3], :b [4 5 6]}"
+    );
+
+    // Narrow: the same value breaks.
+    assert_eq!(
+        eval(
+            &mut env,
+            &format!("(binding [pp/*print-right-margin* 20] (pp/pprint-str {src}))")
+        ),
+        "{:a [1 2 3]\n :b [4 5 6]}"
+    );
+}
+
+/// A record must break like a map while keeping its printed tag, so the
+/// output still reads back the way `pr-str` wrote it.
+///
+/// This is the case that caught a real runtime divergence: `(coll? a-record)`
+/// is false here and true on the JVM, so the layout guard treated records as
+/// scalars and a 118-column record printed on one line under a 72-column
+/// margin. See CLJRS-RECORD-NOT-COLL.
+#[test]
+fn a_record_breaks_and_keeps_its_tag() {
+    let mut env = env_with_pprint();
+    eval(&mut env, "(defrecord Person [name email address])");
+    let out = pretty(
+        &mut env,
+        r#"(->Person "Ada Lovelace" "ada@example.org"
+                     {:street "aaaaaaaaaaaaaaaaaaaaa" :city "bbbbbbbbbbbb"})"#,
+    );
+    assert!(
+        out.starts_with("#Person{:name \"Ada Lovelace\"\n"),
+        "record must break under its own tag:\n{out}"
+    );
+    assert!(
+        out.contains("\n        :email "),
+        "fields must align past the tag:\n{out}"
+    );
+}
+
+#[test]
+fn print_table_lays_out_columns() {
+    let mut env = env_with_pprint();
+    let out = eval(
+        &mut env,
+        r#"(with-out-str (pp/print-table [{:a 1 :b "hello"} {:a 22 :b "hi"}]))"#,
+    );
+    assert!(out.contains("| :a |    :b |"), "header:\n{out}");
+    assert!(out.contains("|----+-------|"), "separator:\n{out}");
+    assert!(out.contains("|  1 | hello |"), "row 1:\n{out}");
+    assert!(out.contains("| 22 |    hi |"), "row 2:\n{out}");
+}
+
+/// An empty table prints nothing rather than throwing on `(first nil)`.
+#[test]
+fn print_table_tolerates_no_rows() {
+    let mut env = env_with_pprint();
+    assert_eq!(eval(&mut env, "(with-out-str (pp/print-table []))"), "");
+}


### PR DESCRIPTION
Independent of every other open PR. One new `.cljrs` namespace, two lines of registration, one test file.

## The gap

`clojure.pprint` did not exist, so this failed outright:

```clojure
(require '[clojure.pprint :as pp])
;; Could not find namespace clojure.pprint on source path
```

Any library that pretty-prints anything broke **at load**, rather than degrading.

## What it does

`pprint` renders a value so that whatever fits inside `*print-right-margin*` stays on one line, and whatever does not breaks one element per line, aligned under the opening delimiter:

```clojure
(pp/pprint {:name "widget" :parts [{:id 1 :label "aaaa…"} {:id 2 :label "bbbb…"}]})
{:name "widget"
 :parts [{:id 1, :label "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
         {:id 2, :label "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]}
```

Plus `print-table`, matching Clojure's layout (header, `|---+---|` separator, right-aligned cells sized to the widest member), and `pprint-str` — not Clojure API, but the alternative is every caller hand-rolling `with-out-str` around `pprint`.

## What the tests actually pin

That the margin **decides**. A printer that always breaks, or never breaks, passes a "does it run" test and is useless. One test moves `*print-right-margin*` and asserts the *same value* lays out differently — which a printer keyed on nesting depth would fail.

## Deliberately absent

Stated in the namespace docstring rather than left to be discovered: `cl-format` and the `~` directive language; the *code* dispatch (`*print-pprint-dispatch*`, `with-pprint-dispatch`); the `pprint-logical-block` construction API; and the remaining dial vars.

The dials are **absent rather than accepted-and-ignored**, so code that sets one fails loudly instead of quietly printing something else.

The algorithm is "fits, or break" — not Waterman's, and no miser or fill mode.

## A runtime bug found on the way

`(coll? a-record)` is **false** here and **true** on the JVM (records implement `IPersistentCollection`). The layout guard therefore treated records as scalars, and a 118-column record printed on one line under a 72-column margin. Nothing errored.

The namespace works around it with a local `breakable?` predicate, marked in the source as a symptom patch to delete once the runtime is fixed. Filed separately, since it plausibly affects anything keyed on `coll?` — `clojure.walk`, `clojure.data/diff`, `flatten`, and any user tree recursion.

## Verification

- `cargo test -p cljrs --test pprint` — 6 passed
- `cargo fmt` — clean
- every layout above independently reproduced in a REPL running a freshly built binary, including records, sets, lists, deep nesting, empty collections, and an empty table